### PR TITLE
2054 Generalized Path Expressions

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -2567,7 +2567,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   </g:production>
   
   <g:production name="JNodeType" >
-    <g:string process-value="yes">jnode</g:string>
+    <g:string process-value="yes">jnode-type</g:string>
     <g:string>(</g:string>
     <g:optional>
       <g:ref name="SequenceType"/>

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1954,13 +1954,15 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   </g:production>
 
   <g:production name="Lookup" if="xpath40 xquery40 xslt40-patterns">
-    <g:choice>
+    <g:string>?</g:string>
+    <g:ref name="KeySpecifier"/>
+    <!--<g:choice>
       <g:ref name="ShallowLookup"/>
       <g:ref name="DeepLookup"/>
-    </g:choice>
+    </g:choice>-->
   </g:production>
   
-  <g:production name="ShallowLookup">
+  <!--<g:production name="ShallowLookup">
     <g:string>?</g:string>
     <g:choice>
       <g:string>..</g:string>
@@ -1973,14 +1975,14 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
         <g:ref name="KeySpecifier"/>
       </g:sequence>
     </g:choice>
-  </g:production>
+  </g:production>-->
   
-  <g:production name="DeepLookup">
+  <!--<g:production name="DeepLookup">
     <g:string>??</g:string>  
     <g:ref name="KeySpecifier"/>
-  </g:production>
+  </g:production>-->
   
-  <g:production name="JAxis" if="xpath40 xquery40 xslt40-patterns">
+  <!--<g:production name="JAxis" if="xpath40 xquery40 xslt40-patterns">
     <g:choice>
       <g:string>ancestor</g:string>
       <g:string>ancestor-or-self</g:string>
@@ -1990,7 +1992,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
       <g:string>parent</g:string>
       <g:string>self</g:string>
     </g:choice>
-  </g:production>
+  </g:production>-->
   
   <g:production name="KeySpecifier" if="xpath40 xquery40 xslt40-patterns">
     <g:choice>
@@ -2000,15 +2002,15 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
       <g:ref name="VarRef"/>
       <g:ref name="ParenthesizedExpr"/>
       <g:ref name="LookupWildcard"/>
-      <g:ref name="TypeSpecifier"/>
+      <!--<g:ref name="TypeSpecifier"/>-->
     </g:choice>
   </g:production>
   
-  <g:production name="TypeSpecifier">
+  <!--<g:production name="TypeSpecifier">
     <g:string>~[</g:string>
     <g:ref name="SequenceType"/>
     <g:string>]</g:string>
-  </g:production>
+  </g:production>-->
   
   <g:production name="LookupWildcard" if="xpath40 xquery40 xslt40-patterns">
     <g:string process-value="yes">*</g:string>

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -2561,13 +2561,13 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   </g:production>
   
   <g:production name="GNodeType" >
-    <g:string process-value="yes">GNode</g:string>
+    <g:string process-value="yes">gnode</g:string>
     <g:string>(</g:string>
     <g:string>)</g:string>   
   </g:production>
   
   <g:production name="JNodeType" >
-    <g:string process-value="yes">JNode</g:string>
+    <g:string process-value="yes">jnode</g:string>
     <g:string>(</g:string>
     <g:optional>
       <g:ref name="SequenceType"/>

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -217,7 +217,17 @@ apply.
         <g:ref name="ForwardAxisP"/>
         <g:ref name="NodeTest"/>
       </g:sequence>
-      <g:ref name="AbbrevForwardStep"/>
+      <g:ref name="AbbrevForwardStepP"/>
+    </g:choice>
+  </g:production>
+  
+  <g:production name="AbbrevForwardStepP" if=" xslt40-patterns">
+    <g:choice>
+      <g:sequence>
+        <g:string process-value="yes">@</g:string>
+        <g:ref name="NodeTest"/>
+      </g:sequence>
+      <g:ref name="SimpleNodeTest"/>
     </g:choice>
   </g:production>
   
@@ -1748,27 +1758,24 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   </g:production>
 
   <g:production name="AxisStep">
-    <g:choice name="ForwardOrReverseStep">
-      <g:ref name="ReverseStep" lookahead="2"/>
-      <g:ref name="ForwardStep"/>
+    <g:choice>
+      <g:ref name="AbbreviatedStep" lookahead="2"/>
+      <g:ref name="FullStep"/>
     </g:choice>
     <g:zeroOrMore>
       <g:ref name="Predicate"/>
     </g:zeroOrMore>
   </g:production>
 
-  <g:production name="ForwardStep" node-type="void">
-    <g:choice name="ForwardAxisOrAbbrev">
-      <g:sequence lookahead="2">
-        <g:ref name="ForwardAxis"/>
-        <g:ref name="NodeTest"/>
-      </g:sequence>
-      <g:ref name="AbbrevForwardStep"/>
-    </g:choice>
+  <g:production name="FullStep">
+      <g:ref name="Axis"/>
+      <g:ref name="NodeTest"/>
   </g:production>
   
-  <g:production name="ForwardAxis">
-    <g:choice break="true" name="ForwardAxisNames">
+  <g:production name="Axis">
+    <g:choice>
+      <g:string process-value="yes">ancestor</g:string>
+      <g:string process-value="yes">ancestor-or-self</g:string>
       <g:string process-value="yes">attribute</g:string>
       <g:string process-value="yes">child</g:string>
       <g:string process-value="yes">descendant</g:string>
@@ -1778,6 +1785,11 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
       <g:string process-value="yes">following-sibling</g:string>
       <g:string process-value="yes">following-sibling-or-self</g:string>
       <g:string process-value="yes" if="xpath40 xslt40-patterns">namespace</g:string>
+      <g:string process-value="yes">parent</g:string>
+      <g:string process-value="yes">preceding</g:string>
+      <g:string process-value="yes">preceding-or-self</g:string>
+      <g:string process-value="yes">preceding-sibling</g:string>
+      <g:string process-value="yes">preceding-sibling-or-self</g:string>
       <g:string process-value="yes">self</g:string>
     </g:choice>         
     <g:string>::</g:string>
@@ -1785,41 +1797,15 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
 
  
 
-  <g:production name="AbbrevForwardStep">
+  <g:production name="AbbreviatedStep">
     <g:choice>
       <g:sequence>
+        <g:string>..</g:string>
         <g:string process-value="yes">@</g:string>
         <g:ref name="NodeTest"/>
       </g:sequence>
       <g:ref name="SimpleNodeTest"/>
     </g:choice>
-  </g:production>
-
-  <g:production name="ReverseStep" node-type="void">
-    <g:choice name="ReverseAxisOrAbbrev">
-      <g:sequence>
-        <g:ref name="ReverseAxis"/>
-        <g:ref name="NodeTest"/>
-      </g:sequence>
-      <g:ref name="AbbrevReverseStep" if="xpath40 xquery40  xslt40-patterns"/>
-    </g:choice>
-  </g:production>
-
-  <g:production name="ReverseAxis">
-    <g:choice break="true" name="ReverseAxisNames">
-      <g:string process-value="yes">ancestor</g:string>
-      <g:string process-value="yes">ancestor-or-self</g:string>   
-      <g:string process-value="yes">parent</g:string>     
-      <g:string process-value="yes">preceding</g:string> 
-      <g:string process-value="yes">preceding-or-self</g:string>
-      <g:string process-value="yes">preceding-sibling</g:string>
-      <g:string process-value="yes">preceding-sibling-or-self</g:string>
-    </g:choice>
-    <g:string>::</g:string>
-  </g:production>
-
-  <g:production name="AbbrevReverseStep">
-    <g:string>..</g:string>
   </g:production>
   
   <g:production name="NodeTest">
@@ -1831,18 +1817,41 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   
   <g:production name="UnionNodeTest">
     <g:string>(</g:string>
-    <g:ref name="SimpleNodeTest"/>
-    <g:zeroOrMore>
-      <g:string>|</g:string>
+    <g:oneOrMore separator="|">
       <g:ref name="SimpleNodeTest"/>
-    </g:zeroOrMore>
+    </g:oneOrMore>
     <g:string>)</g:string>
   </g:production>
 
   <g:production name="SimpleNodeTest">
     <g:choice name="KindOrNameTest">
-      <g:ref name="KindTest" lookahead="2"/>
-      <g:ref name="NameTest"/>
+      <g:ref name="TypeTest"/>
+      <g:ref name="Selector"/>
+    </g:choice>
+  </g:production>
+  
+  <g:production name="TypeTest">
+    <g:choice>
+      <g:ref name="RegularItemType"/>
+      <g:sequence>
+        <g:string>type</g:string>
+        <g:string>(</g:string>
+        <g:ref name="SequenceType"/>
+        <g:string>)</g:string>
+      </g:sequence>
+    </g:choice>
+  </g:production>
+  
+  <g:production name="Selector">
+    <g:choice>
+      <g:ref name="EQName"/>
+      <g:ref name="Wildcard"/>
+      <g:sequence>
+        <g:string>get</g:string>
+        <g:string>(</g:string>
+        <g:ref name="Expr"/>
+        <g:string>)</g:string>
+      </g:sequence>
     </g:choice>
   </g:production>
 
@@ -2523,9 +2532,16 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
 
   <g:production name="ItemType" >
     <g:choice break="false" name="ItemTypeChoice">
-      <g:ref name="AnyItemTest" lookahead="2"/>
+      <g:ref name="RegularItemType"/>
       <g:ref name="TypeName" if="xpath40 xquery40 xslt40-patterns"/>
-      <g:ref name="KindTest" lookahead="2"/>
+      <g:ref name="ChoiceItemType" if="xpath40 xquery40  xslt40-patterns"/>
+    </g:choice>
+  </g:production>
+  
+  <g:production name="RegularItemType">
+    <g:choice>
+      <g:ref name="AnyItemTest" lookahead="2"/>
+      <g:ref name="NodeKindTest" lookahead="2"/>
       <g:ref name="GNodeType"/>
       <g:ref name="JNodeType"/>
       <g:ref name="FunctionType" lookahead="2" if="xpath40 xquery40  xslt40-patterns"/>
@@ -2533,7 +2549,6 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
       <g:ref name="ArrayType" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
       <g:ref name="RecordType" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
       <g:ref name="EnumerationType" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
-      <g:ref name="ChoiceItemType" if="xpath40 xquery40  xslt40-patterns"/>
     </g:choice>
   </g:production>
   
@@ -2559,8 +2574,8 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   </g:production>
 
  
-  <g:production name="KindTest" node-type="void">
-    <g:choice break="true" name="KindTestChoice">
+  <g:production name="NodeKindTest" node-type="void">
+    <g:choice break="true" name="NodeKindTestChoice">
       <g:ref name="DocumentTest" />
       <g:ref name="ElementTest" />
       <g:ref name="AttributeTest" />
@@ -2570,11 +2585,11 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
       <g:ref name="CommentTest"/>
       <g:ref name="TextTest"/>
       <g:ref name="NamespaceNodeTest" if="xpath40 xquery40  xslt40-patterns"/>
-      <g:ref name="AnyKindTest"/>
+      <g:ref name="AnyNodeKindTest"/>
     </g:choice>
   </g:production>
 
-  <g:production name="AnyKindTest">
+  <g:production name="AnyNodeKindTest">
     <g:string>node</g:string>
     <g:string>(</g:string>
     <g:string>)</g:string>

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1946,15 +1946,28 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
 
   <g:production name="Lookup" if="xpath40 xquery40 xslt40-patterns">
     <g:choice>
+      <g:ref name="ShallowLookup"/>
+      <g:ref name="DeepLookup"/>
+    </g:choice>
+  </g:production>
+  
+  <g:production name="ShallowLookup">
+    <g:string>?</g:string>
+    <g:choice>
+      <g:string>..</g:string>
+      <g:string>.</g:string>
       <g:sequence>
-        <g:string>?</g:string>
         <g:optional>
           <g:ref name="JAxis"/>
           <g:string>::</g:string>
         </g:optional>
+        <g:ref name="KeySpecifier"/>
       </g:sequence>
-       <g:string>??</g:string>
     </g:choice>
+  </g:production>
+  
+  <g:production name="DeepLookup">
+    <g:string>??</g:string>  
     <g:ref name="KeySpecifier"/>
   </g:production>
   

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -2535,6 +2535,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   <g:production name="ItemType" >
     <g:choice break="false" name="ItemTypeChoice">
       <g:ref name="RegularItemType"/>
+      <g:ref name="FunctionType" lookahead="2" if="xpath40 xquery40  xslt40-patterns"/>
       <g:ref name="TypeName" if="xpath40 xquery40 xslt40-patterns"/>
       <g:ref name="ChoiceItemType" if="xpath40 xquery40  xslt40-patterns"/>
     </g:choice>
@@ -2546,7 +2547,6 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
       <g:ref name="NodeKindTest" lookahead="2"/>
       <g:ref name="GNodeType"/>
       <g:ref name="JNodeType"/>
-      <g:ref name="FunctionType" lookahead="2" if="xpath40 xquery40  xslt40-patterns"/>
       <g:ref name="MapType" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
       <g:ref name="ArrayType" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
       <g:ref name="RecordType" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1946,22 +1946,27 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
 
   <g:production name="Lookup" if="xpath40 xquery40 xslt40-patterns">
     <g:choice>
-      <g:string>?</g:string>
-      <g:string>??</g:string>
+      <g:sequence>
+        <g:string>?</g:string>
+        <g:optional>
+          <g:ref name="JAxis"/>
+          <g:string>::</g:string>
+        </g:optional>
+      </g:sequence>
+       <g:string>??</g:string>
     </g:choice>
-    <g:optional>
-      <g:ref name="Modifier"/>
-      <g:string>::</g:string>
-    </g:optional>
     <g:ref name="KeySpecifier"/>
   </g:production>
   
-  <g:production name="Modifier" if="xpath40 xquery40 xslt40-patterns">
+  <g:production name="JAxis" if="xpath40 xquery40 xslt40-patterns">
     <g:choice>
-      <g:string>pairs</g:string>
-      <g:string>keys</g:string>
-      <g:string>values</g:string>
-      <g:string>items</g:string>
+      <g:string>ancestor</g:string>
+      <g:string>ancestor-or-self</g:string>
+      <g:string>child</g:string>
+      <g:string>descendant</g:string>
+      <g:string>descendant-or-self</g:string>
+      <g:string>parent</g:string>
+      <g:string>self</g:string>
     </g:choice>
   </g:production>
   
@@ -2508,6 +2513,8 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
       <g:ref name="AnyItemTest" lookahead="2"/>
       <g:ref name="TypeName" if="xpath40 xquery40 xslt40-patterns"/>
       <g:ref name="KindTest" lookahead="2"/>
+      <g:ref name="GNodeType"/>
+      <g:ref name="JNodeType"/>
       <g:ref name="FunctionType" lookahead="2" if="xpath40 xquery40  xslt40-patterns"/>
       <g:ref name="MapType" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
       <g:ref name="ArrayType" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
@@ -2518,9 +2525,24 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   </g:production>
   
   <g:production name="AnyItemTest" >
-      <g:string process-value="yes">item</g:string>
-      <g:string>(</g:string>
-      <g:string>)</g:string>   
+    <g:string process-value="yes">item</g:string>
+    <g:string>(</g:string>
+    <g:string>)</g:string>   
+  </g:production>
+  
+  <g:production name="GNodeType" >
+    <g:string process-value="yes">GNode</g:string>
+    <g:string>(</g:string>
+    <g:string>)</g:string>   
+  </g:production>
+  
+  <g:production name="JNodeType" >
+    <g:string process-value="yes">GNode</g:string>
+    <g:string>(</g:string>
+    <g:optional>
+      <g:ref name="SequenceType"/>
+    </g:optional>
+    <g:string>)</g:string>   
   </g:production>
 
  

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1799,8 +1799,8 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
 
   <g:production name="AbbreviatedStep">
     <g:choice>
-      <g:sequence>
-        <g:string>..</g:string>
+      <g:string>..</g:string>
+      <g:sequence>       
         <g:string process-value="yes">@</g:string>
         <g:ref name="NodeTest"/>
       </g:sequence>

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -2537,7 +2537,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   </g:production>
   
   <g:production name="JNodeType" >
-    <g:string process-value="yes">GNode</g:string>
+    <g:string process-value="yes">JNode</g:string>
     <g:string>(</g:string>
     <g:optional>
       <g:ref name="SequenceType"/>

--- a/specifications/image-sources/item-types.xml
+++ b/specifications/image-sources/item-types.xml
@@ -12,53 +12,61 @@
         </p>
       </item>
       <item role="abstract node">
-        <p><phrase>node</phrase><phrase role="kind"> (node)</phrase></p>
+        <p><phrase>GNode</phrase><phrase role="kind"> (node)</phrase></p>
         <ulist>
-          <item role="node">
-            <p><phrase>attribute</phrase><phrase role="kind"> (node)</phrase></p>
+          <item role="abstract node">
+            <p><phrase>XNode</phrase><phrase role="kind"> (node)</phrase></p>
             <ulist>
-              <item role="node user-defined">
-                <p>
-                   <phrase>user-defined attribute types</phrase>
-                   <phrase role="kind"> (user-defined)</phrase>
-                </p>
+              <item role="node">
+                <p><phrase>attribute</phrase><phrase role="kind"> (node)</phrase></p>
+                <ulist>
+                  <item role="node user-defined">
+                    <p>
+                       <phrase>user-defined attribute types</phrase>
+                       <phrase role="kind"> (user-defined)</phrase>
+                    </p>
+                  </item>
+                </ulist>
               </item>
+              <item role="node">
+                <p><phrase>document</phrase><phrase role="kind"> (node)</phrase></p>
+                <ulist>
+                  <item role="node user-defined">
+                     <p>
+                        <phrase>user-defined document types</phrase>
+                        <phrase role="kind"> (user-defined)</phrase>
+                     </p>
+                  </item>
+                </ulist>
+              </item>
+              <item role="node">
+                <p><phrase>element</phrase><phrase role="kind"> (node)</phrase></p>
+                <ulist>
+                  <item role="node user-defined">
+                     <p>
+                        <phrase>user-defined element types</phrase>
+                        <phrase role="kind"> (user-defined)</phrase>
+                     </p>
+                  </item>
+                </ulist>
+              </item>
+              <item role="node">
+                <p><phrase>text</phrase><phrase role="kind"> (node)</phrase></p>
+              </item>            
+              <item role="node">
+                <p><phrase>comment</phrase><phrase role="kind"> (node)</phrase></p>
+              </item>            
+              <item role="node">
+                <p><phrase>processing-instruction</phrase><phrase role="kind"> (node)</phrase></p>
+              </item>            
+              <item role="node">
+                <p><phrase>namespace</phrase><phrase role="kind"> (node)</phrase></p>
+              </item>            
             </ulist>
           </item>
           <item role="node">
-            <p><phrase>document</phrase><phrase role="kind"> (node)</phrase></p>
-            <ulist>
-              <item role="node user-defined">
-                 <p>
-                    <phrase>user-defined document types</phrase>
-                    <phrase role="kind"> (user-defined)</phrase>
-                 </p>
-              </item>
-            </ulist>
+            <p><phrase>JNode</phrase><phrase role="kind"> (node)</phrase></p>
           </item>
-          <item role="node">
-            <p><phrase>element</phrase><phrase role="kind"> (node)</phrase></p>
-            <ulist>
-              <item role="node user-defined">
-                 <p>
-                    <phrase>user-defined element types</phrase>
-                    <phrase role="kind"> (user-defined)</phrase>
-                 </p>
-              </item>
-            </ulist>
-          </item>
-          <item role="node">
-            <p><phrase>text</phrase><phrase role="kind"> (node)</phrase></p>
-          </item>            
-          <item role="node">
-            <p><phrase>comment</phrase><phrase role="kind"> (node)</phrase></p>
-          </item>            
-          <item role="node">
-            <p><phrase>processing-instruction</phrase><phrase role="kind"> (node)</phrase></p>
-          </item>            
-          <item role="node">
-            <p><phrase>namespace</phrase><phrase role="kind"> (node)</phrase></p>
-          </item>            
         </ulist>
       </item>
       <item role="abstract function">

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -6223,7 +6223,7 @@ return
             <term>·selector·</term>="a". Its <code>dm:j-children</code> accessor returns an empty sequence.</p></item>
             <item><p><var>J2</var> is a leaf node. It has <term>·parent·</term>=<var>R</var>, <term>·content·</term>=("x", "y"), <term>·position·</term>=1, and
             <term>·selector·</term>="b". Its <code>dm:j-children</code> accessor returns an empty sequence.</p></item>
-            <item><p><var>J3</var> has ·parent·=<var>R</var>, ·content·=[(10, 20), 30], <term>·position·</term>=1, and
+            <item><p><var>J3</var> has <term>·parent·</term>=<var>R</var>, <term>·content·</term>=[(10, 20), 30], <term>·position·</term>=1, and
             <term>·selector·</term>="c". Its <code>dm:j-children</code> accessor returns a sequence of two
               JNodes <var>J/31</var> and <var>J/32</var>, representing the two members of the contained
               array, as follows:</p>
@@ -6234,7 +6234,8 @@ return
                  <term>·selector·</term>="2". Its <code>dm:j-children</code> accessor returns an empty sequence.</p></item>
               </ulist>
             </item>
-            <item><p><var>J4</var> has <term>·parent·</term>=<var>R</var>, <term>·content·</term>=([10, 20], 30), <term>·position·</term>=1, and
+            <item><p><var>J4</var> has <term>·parent·</term>=<var>R</var>, 
+              <term>·content·</term>=(10, [20, 30]), <term>·position·</term>=1, and
             <term>·selector·</term>="d". Its <code>dm:j-children</code> accessor returns a sequence of two
               JNodes <var>J/41</var> and <var>J/42</var>, representing the two members of the
               contained array, as follows:</p>

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -997,7 +997,7 @@ constraints of the selected version of XML.</p></item>
       types characterized by the node name and type annotation.</p>
     
       <p>JNodes are newly introduced in 4.0 for the purpose of navigating trees of maps and arrays,
-      typically derived by parsing JSON.</p>
+      typically derived by parsing JSON. A JNode wraps a value (which may be any sequence). </p>
     </item>
     
     <item><p>Every <termref def="dt-function-item"/> is an instance of the generic type <code>function(*)</code>,
@@ -1408,15 +1408,16 @@ an attribute node that has no parent.</p>
     <head>Generic Nodes (GNodes)</head>
     
     <changes>
-      <change issue="2025">
+      <change issue="2025" PR="2031" date="2025-06-11">
         JNodes are introduced to represent nodes in a JSON tree. The term XNode is introduced
         when we need to distinguish XML nodes from JSON nodes; and the term GNode (for <term>generic node</term>)
         is used as a collective term for XNodes and JNodes.
       </change>
     </changes>
     <p><termdef id="dt-GNode" term="GNode">The term <term>generic node</term> or <term>GNode</term>
-    is a collective term for XNodes (more commonly called simply nodes) representing
-    the parts of an XML document, and JNodes, representing the parts of a JSON document.</termdef>
+    is a collective term for <termref def="dt-XNode">XNodes</termref> (more commonly called simply nodes) representing
+    the parts of an XML document, and <termref def="dt-JNode">JNodes</termref>, 
+    often used to represent the parts of a JSON document.</termdef>
     </p>
     
     <p><termdef id="dt-XNode" term="XNode">An <term>XNode</term>, more commonly referred
@@ -1432,16 +1433,15 @@ an attribute node that has no parent.</p>
     GNodes have unique identity, and the GNodes within a tree have an ordering called
     document order.</p>
     
-    <p><termdef id="dt-root-node" term="root node">The <term>root GNode</term> is the 
-      topmost node of a tree, the GNode with no
-    parent.</termdef>
+    <p><termdef id="dt-root-GNode" term="root GNode">The term <term>root GNode</term> refers to the 
+      topmost GNode of a tree, that is, a GNode with no parent.</termdef>
     Every tree has exactly one root GNode and every other node can be reached
     from exactly one root node.
   </p>
 
-<note><p>The term <term>root</term> means any GNode that has no parent. 
-  It may be any kind of GNode. In the XPath 1.0 datamodel only document nodes
-  could be parentless, so the term <emph>root node</emph> always meant a document node.</p>
+<note><p>In the XPath 1.0 datamodel only document nodes
+  could be parentless, so the term <emph>root node</emph> was synonymous with <emph>document node</emph>.
+  The term has now been generalized.</p>
 </note>
     
     <note diff="add" at="2022-11-05"><p>Generally, the term <term>tree</term>
@@ -1453,31 +1453,41 @@ an attribute node that has no parent.</p>
     <termref def="dt-XNode"/> is referred to as an <term>XTree</term>.</termdef>
     All the nodes in an XTree are XNodes.</p>
     
+    <note><p>The term <term>tree</term> is often used without qualification
+    to refer to an <termref def="dt-XTree"/>, when the context makes this clear.</p></note>
+    
     <p><termdef id="dt-JTree" term="JTree">A tree that is rooted at a parentless
     <termref def="dt-JNode"/> is referred to as a <term>JTree</term>.</termdef>
     All the nodes in a JTree are JNodes.</p>
+    
+    <note><p>A JNode encapsulates an arbitrary <termref def="dt-value"/>, which may
+    contain any items including <termref def="dt-XNode">XNodes</termref>. These XNodes
+    are not regarded as part of the JTree.</p></note>
 
  <div2 id="node-identity">
     <head>Node Identity</head>
     
-    <p>Each GNode has a unique identity.
+    <p>Each <termref def="dt-GNode"/> has a unique identity.</p>
     
-    The identity of
-    a GNode is distinct from its value or other intrinsic properties; nodes may be
+    <p>The identity of a <termref def="dt-GNode"/> is distinct from its value or other intrinsic properties; nodes may be
     distinct even when they have the same values for all intrinsic
-    properties other than their identity.
-    (The
+    properties other than their identity.</p>
+    
+   <note><p>The
     identity of <termref def="dt-atomic-item">atomic items</termref>, by contrast, is determined solely by their
     intrinsic properties. No two distinct integers, for example, have the
     same value;
     every instance of the value “5” as an integer is identical to every
-    other instance of the value “5” as an integer.)
-    </p>
+    other instance of the value “5” as an integer.
+    </p></note>
     
     <note>
     <p>The concept of node identity should not be confused with the
-    concept of a unique ID, which is a unique name assigned to an element
-    by the author to represent references using ID/IDREF correlation.</p>
+    idea that the string value of an element or attribute node can act as 
+    a unique identifier for its parent
+    element within the containing document, typically because it has been validated
+    against a schema or DTD that declares it as an ID. Such an element or attribute
+    node will have its <function>is-id</function> property set to true.</p>
     </note>
     </div2>
     
@@ -1499,28 +1509,31 @@ transformation, even if this order is implementation-dependent.</termdef></p>
 
 <olist>
 <item>
-<p>The root XNode is the first node.
+<p>The root <termref def="dt-XNode"/> precedes any other XNode.
 </p>
 </item>
 
 <item>
-<p>Every XNode occurs before all of its children and descendants.</p>
+<p>Every XNode precedes all of its children (and therefore precedes all of its descendants).</p>
 </item>
 
 <item>
-<p>&namespaceNode;s immediately follow the &elementNode; with which
-they are associated. The relative order of &namespaceNode;s is
+<p>Namespace nodes associated with an element node <var>E</var> occur after
+  <var>E</var> and before any attributes or children of <var>E</var>. 
+  The relative order of these namespace nodes is
 stable but implementation-dependent.</p>
-<imp-dep-feature>The relative order of &namespaceNode;s nodes is
+<imp-dep-feature>The relative order of namespace nodes is
 stable but implementation-dependent.</imp-dep-feature>
+  <note><p>Every element node has at least one associated namespace node,
+  that for the XML namespace.</p></note>
 </item>
 
 <item>
-<p>&attributeNode;s immediately follow the &namespaceNode;s of the
-&elementNode; with which they are associated, if any; otherwise they immediately
-follow the &elementNode;; with which they are associated. The relative order of &attributeNode;s is
+<p>Attribute nodes associated with an element node <var>E</var> 
+  occur after the namespace nodes of <var>E</var>,
+  and before any children of <var>E</var>.The relative order of attribute nodes is
 stable but implementation-dependent.</p>
-<imp-dep-feature>The relative order of &attributeNode;s nodes is
+<imp-dep-feature>The relative order of attribute nodes is
 stable but implementation-dependent.</imp-dep-feature>
 </item>
 
@@ -1530,40 +1543,43 @@ the &dm.prop.children; property of their parent node.</p>
 </item>
 
 <item>
-<p>Children and descendants occur before following siblings.</p>
+<p>If <var>P</var> and <var>Q</var> are both children of an element node <var>E</var>, and
+  if <var>P</var> precedes <var>Q</var>, then the children (and therefore the descendants) 
+  of <var>P</var> precede <var>Q</var>.</p>
 </item>
 </olist>
       
-      <p>Similarly, within an <termref def="dt-JTree"/>, document order satisfies the following constraints:</p>
+      <p>Similarly, within a <termref def="dt-JTree"/>, document order satisfies the following constraints:</p>
 
       <olist>
         <item>
-        <p>The root JNode is the first node.
+        <p>The root <termref def="dt-JNode"/> precedes any other JNode.
         </p>
         </item>
       
         <item>
-          <p>Every JNode occurs before all of its children.</p>
+          <p>Every JNode occurs before all of its children (and therefore, before all of its descendants).</p>
         </item>
         
         <item>
-          <p>For a JNode that encapsulates an array (see <specref ref="array-items"/>),
-          the ordering of its children reflects the ordering of the array members.</p>
-        </item>
-        
-        <item>
-          <p>For a JNode that encapsulates a map (see <specref ref="map-items"/>),
-          the ordering of its children reflects the ordering of the map entries.</p>
-        </item>
+<p>The relative order of siblings is the order in which they occur in
+the <emph role='dm-node-property'>j-children</emph> property of their parent JNode.</p>
+</item>
+
+<item>
+<p>If <var>P</var> and <var>Q</var> are both children of a JNode node <var>J</var>, and
+  if <var>P</var> precedes <var>Q</var>, then the children (and therefore the descendants) 
+  of <var>P</var> precede <var>Q</var>.</p>
+</item>
       </olist>
         
 
 
 <p>The relative order of GNodes in distinct trees is stable but
 implementation-dependent, subject to the following constraint: If
-any node in a given tree, <code>T1</code>, occurs before any node in a different
-tree, <code>T2</code>, then all GNodes in <code>T1</code> are before all GNodes in
-<code>T2</code>.</p>
+any GNode in a given GTree <var>T1</var> precedes any node in a different
+tree <var>T2</var>, then all GNodes in <var>T1</var> are before all GNodes in
+<var>T2</var>.</p>
 <imp-dep-feature>The relative order of distinct trees is
 stable but implementation-dependent.</imp-dep-feature>
 </div2>
@@ -6020,47 +6036,241 @@ position, in the range 1 to the size of the array.</p>
     <div2 id="id-JNodes">
     <head>JNodes</head>
     <changes>
-      <change issue="2025">
+      <change issue="2025" PR="2031" date="2025-06-11">
         Introduced the concept of JNodes.
       </change>
     </changes>
     
-    <p>A <termref def="dt-JNode"/> is a kind of item: specifically, JNode is a subtype of GNode (a generic node).
+    <p>A <termref def="dt-JNode"/> is a kind of item: specifically, JNode is a subtype of 
+      <termref def="dt-GNode"/> (a generic node).
     JNodes have identity, and are organized into trees called <termref def="dt-JTree">JTrees</termref>.</p>
       
-      <p>A <termref def="dt-JNode"/> has (potentially) three properties (aside from its identity):</p>
-    
+      <p>Every <termref def="dt-JNode"/> has a property <term>¶value</term> which is an 
+        arbitrary <termref def="dt-value"/> (that is, in general, a <termref def="dt-sequence"/>).</p>
+      
+      <p>In addition a JNode that is not a root JNode has the following properties:</p>
+      
+      <slist>
+        <sitem><term>¶parent</term>: a JNode</sitem>
+        <sitem><term>¶position</term>: a positive integer</sitem>
+        <sitem><term>¶selector</term>: an atomic item</sitem>
+      </slist>
+      
+      <p>The accessor <code>j-children</code>, applied to a JNode <var>$P</var>, returns a sequence
+      of non-root JNodes representing the children of <var>$P</var>.</p>
+      
+
+      
+      
+      <p>Values are classified as <term>leaf</term> or <term>non-leaf</term>. A value is classified
+        as <term>non-leaf</term> if and only if at least one item in the value
+      is a non-empty map or array. If the ¶value property of a JNode is classified as <term>leaf</term>, then
+      the <code>j-children</code> accessor returns an empty sequence.</p>
+      
+      <note><p>If the <code>j-children</code> accessor of a JNode returns an empty sequence,
+      then it is necessary to examine the ¶value property in order to distinguish whether
+      the value is (for example) an empty sequence, an atomic item, an empty map,
+      or an empty array.</p></note>
+      
+      <p>If the ¶value property of a JNode <var>P</var> is classified as <term>non-leaf</term>, then
+      the <code>j-children</code> accessor returns a sequence of JNodes that includes
+        one JNode for each member of an array in <var>J</var> and one JNode for each entry
+        of a map in <var>J</var>. More specifically, the result is determined
+        by the expression below. This expression uses
+        the following notation:</p>
+      
       <ulist>
-        <item><p><term>¶value</term>: an arbitrary <termref def="dt-value"/> (that is, in general, a
-        <termref def="dt-sequence"/>) encapsulated by the JNode.</p></item>
-        <item><p><term>¶parent</term>: another JNode acting as the parent of this JNode in a 
-        <termref def="dt-JTree"/>. The <code>¶value</code> of the <code>¶parent</code> JNode
-        will always be either a map or an array.</p></item>
-        <item><p><term>¶selector</term>: an <termref def="dt-atomic-item"/> that uniquely identifies
-          this JNode within its parent JNode. </p>
-          <ulist><item><p>If the <code>¶value</code> of the <code>¶parent</code> JNode
-            is an array, this will be an integer representing the 1-based index of a member in the parent array, 
-            and the <code>¶value</code> of this JNode will be the corresponding member.</p></item>
-            <item><p>If the <code>¶value</code> of the <code>¶parent</code> JNode
-            is a map, this will be an atomic item representing the key of an a entry in the parent map, 
-            and the <code>¶value</code> of this JNode will be the value corresponding to this key.</p></item>
-          </ulist></item>
+        <item><p>The function
+        <code>dm:j-value</code> is used to access the ¶value property of a JNode</p></item>
+        <item><p>The function <code>dm:JNode</code> is used to construct (or obtain)
+        a JNode whose properties correspond to the names of the argument keywords.</p></item>
       </ulist>
+      
+      <eg>         
+for $item at $pos in dm:j-value($P)
+return
+  if ($item instance of array(*))
+  then for member $member at $index in $item
+       return dm:JNode(parent := $P,
+                       position := $pos,
+                       selector := $index,
+                       value := $member)
+  else if ($item instance of map(*))
+  then for key $key value $value in $item
+       return dm:JNode(parent := $P,
+                       position := $pos,
+                       selector := $key
+                       value := $value)
+  else ()
+</eg>  
+  
+      <example>
+        <head>A JTree derived by parsing JSON</head>
+        <p>In a JTree derived from JSON, every member of an array will always be either a single item
+          (a string, number, boolean, array, or map),
+        or an empty sequence representing the JSON value <code>null</code>. Similarly, every entry
+        in a map will have a key that is a single <code>xs:string</code>, and a corresponding
+        value that is either a single item (as above) or an empty sequence representing <code>null</code>.</p>
         
-          <p>For a JNode representing the root of a JTree, the <code>¶parent</code> and <code>¶value</code>
-          properties will always be absent. For a non-root JNode, both these properties will be present.</p>
+        <p>Consider a tree constructed by parsing the following JSON input:</p>
+        
+        <eg role="json">[
+  {"a": 1, "b": "XXX", "c": true, "d": null},
+  {"a": 2, "b": "YYY", "c": false, "d": null}
+]
+  </eg>
+        <p>Then:</p>
+        <ulist>
+          <item><p>The root JNode <var>R</var> has a ¶value property that is an 
+            array of two maps.</p></item>
+          <item><p>The 
+            result of the <code>dm:j-children</code> accessor applied to <var>R</var> is a sequence of two 
+            JNodes <var>M1</var> and <var>M2</var>, each
+            representing one of the two maps.</p></item>
+          <item><p>For <var>M1</var>:</p>
+            <ulist>
+              <item><p><term>¶parent</term> is <var>R</var>.</p></item>
+              <item><p><term>¶value</term> is the first map.</p></item>
+              <item><p><term>¶position</term> is 1.</p></item>
+              <item><p><term>¶selector</term> is 1.</p></item>
+              <item><p>The <emph>dm:j-children</emph> accessor returns a sequence of four
+              JNodes, as follows:</p>
+              <ulist>
+                <item><p>All four have <term>¶parent</term> set to <var>M1</var>.</p></item>
+                <item><p>The <term>¶value</term> properties are respectively <code>1</code>,
+                  <code>"XXX"</code>, <code>true()</code>, and <code>()</code>.</p></item>
+                <item><p>The <term>¶position</term> properties are all set to 1.</p></item>
+                <item><p>The <term>¶selector</term> properties are respectively <code>"a"</code>
+                <code>"b"</code>, <code>"c"</code>, and <code>"d"</code>.</p></item>
+                <item><p>For each of these JNodes, the <emph>dm:j-children</emph> accessor returns
+                an empty sequence.</p></item>
+              </ulist></item>
+            </ulist>
+          </item>
+          <item><p>For <var>M2</var>:</p>
+            <ulist>
+              <item><p><term>¶parent</term> is <var>R</var>.</p></item>
+              <item><p><term>¶value</term> is the second map.</p></item>
+              <item><p><term>¶position</term> is 1.</p></item>
+              <item><p><term>¶selector</term> is 2.</p></item>
+              <item><p>The <emph>dm:j-children</emph> accessor returns a sequence of four
+              JNodes, as follows:</p>
+              <ulist>
+                <item><p>All four have <term>¶parent</term> set to <var>M2</var>.</p></item>
+                <item><p>The <term>¶value</term> properties are respectively <code>2</code>,
+                  <code>"YYY"</code>, <code>false()</code>, and <code>()</code>.</p></item>
+                <item><p>The <term>¶position</term> properties are all set to 1.</p></item>
+                <item><p>The <term>¶selector</term> properties are respectively <code>"a"</code>
+                <code>"b"</code>, <code>"c"</code>, and <code>"d"</code>.</p></item>
+                <item><p>For each of these JNodes, the <emph>dm:j-children</emph> accessor returns
+                an empty sequence.</p></item>
+              </ulist></item>
+            </ulist>
+          </item>
+        </ulist>
+        <p>Note that all JNodes in a JTree that represents parsed JSON input will have the
+        <term>¶position</term> property set to 1. This is because every construct in JSON 
+        (arrays, objects, strings, number, booleans, and <code>null</code>) maps to an XDM sequence
+        of length 0 or 1.</p>
+      </example>
+      
+      <example>
+        <head>A JTree representing arbitrary XDM content</head>
+        <p>Consider a JTree that wraps a map constructed by the following XQuery expression:</p>
+        
+        <eg><![CDATA[{
+   "a": 1,
+   "b": ("x", "y"),
+   "c": [(10, 20), 30],
+   "d": (10, [20, 30]),
+   "e": (<p/>, <q/>)
+}]]></eg>
+        
+        <p>Then:</p>
+        <ulist>
+          <item><p>The root JNode <var>R</var> has a ¶value property that is a 
+            map with five entries.</p></item>
+          <item><p>The result of the <code>dm:j-children</code> accessor applied to <var>R</var>
+          is a sequence of five JNodes <var>J1</var>, <var>J2</var>, <var>J3</var>, <var>J4</var>, and <var>J5</var>,
+          as follows:</p>
+          <ulist>
+            <item><p><var>J1</var> is a leaf node. It has ¶parent=<var>R</var>, ¶value=1, ¶position=1, and
+            ¶selector="a". Its <code>dm:j-children</code> accessor returns an empty sequence.</p></item>
+            <item><p><var>J2</var> is a leaf node. It has ¶parent=<var>R</var>, ¶value=("x", "y"), ¶position=1, and
+            ¶selector="b". Its <code>dm:j-children</code> accessor returns an empty sequence.</p></item>
+            <item><p><var>J3</var> has ¶parent=<var>R</var>, ¶value=[(10, 20), 30], ¶position=1, and
+            ¶selector="c". Its <code>dm:j-children</code> accessor returns a sequence of two
+              JNodes <var>J/31</var> and <var>J/32</var>, representing the two members of the contained
+              array, as follows:</p>
+              <ulist>
+                <item><p><var>J/31</var> is a leaf node. It has ¶parent=<var>J3</var>, ¶value=(10, 20), ¶position=1, and
+                 ¶selector="1". Its <code>dm:j-children</code> accessor returns an empty sequence.</p></item>
+                <item><p><var>J/32</var> is a leaf node. It has ¶parent=<var>J3</var>, ¶value=30, ¶position=1, and
+                 ¶selector="2". Its <code>dm:j-children</code> accessor returns an empty sequence.</p></item>
+              </ulist>
+            </item>
+            <item><p><var>J4</var> has ¶parent=<var>R</var>, ¶value=([10, 20], 30), ¶position=1, and
+            ¶selector="d". Its <code>dm:j-children</code> accessor returns a sequence of two
+              JNodes <var>J/41</var> and <var>J/42</var>, representing the two members of the
+              contained array, as follows:</p>
+              <ulist>
+                <item><p><var>J/41</var> is a leaf node. It has ¶parent=<var>J4</var>, ¶value=20, ¶position=2, and
+                 ¶selector="1". Its <code>dm:j-children</code> accessor returns an empty sequence.</p></item>
+                <item><p><var>J/42</var> is a leaf node. It has ¶parent=<var>J4</var>, ¶value=30, ¶position=2, and
+                 ¶selector="2". Its <code>dm:j-children</code> accessor returns an empty sequence.</p></item>
+              </ulist>
+            </item>
+            <item><p><var>J5</var> is a leaf node. It has ¶parent=<var>R</var>, a ¶value that is a sequence
+              of two element nodes named <code>p</code> and <code>q</code>, ¶position=1, and
+            ¶selector="e". Its <code>dm:j-children</code> accessor returns an empty sequence.</p></item>
+          </ulist>
+          </item>
+        </ulist>
+          
+          <note><p>Sequences (as distinct from maps and arrays) are not represented by an 
+          extra layer of JNodes in the tree. This is because the structure is designed primarily to
+          assist navigation of JTrees derived from JSON processing, in which sequence-valued nodes
+          never arise. Generally, JTrees are easier to manipulate if none of the contained arrays
+          or maps contain sequence-valued members or entries. JTrees containing non-homogenous
+          content (for example, sequences that mix arrays, maps, and other items) can be represented
+          using JNodes without loss of information, but may be difficult to navigate.</p></note>
+          
+      </example>
+      
+      
+        
+          <p>For a JNode representing the root of a JTree, the <code>¶parent</code>, <code>¶position</code>,
+            and <code>¶selector</code>
+          properties will always be absent. For a non-root JNode, these properties will always be present.</p>
           
           <p>The identity of a root JNode is established when the root JNode is constructed, so that
           every operation that constructs a root JNode returns a JNode with distinct identity. The
-          identity of a non-root JNode is a function of its <code>¶parent</code> and <code>¶selector</code>
+          identity of a non-root JNode is a function of its <code>¶parent</code>, <code>¶position</code>, and <code>¶selector</code>
           properties: two non-root JNodes are identical by definition if and only if their
-            <code>¶parent</code>s are identical and their <code>¶selector</code>s are equal as
-          determined by the <function>atomic-equal</function> function.</p>
+            <code>¶parent</code>s are identical and their <code>¶position</code> and <code>¶selector</code>
+            properties are equal as determined by the <function>atomic-equal</function> function.</p>
           
           <p>A root JNode is constructed, wrapping a map or array, by a call on the <function>pin</function>
           function applied to that map or array. This can be called explicitly, but it is also called
           implicitly when a map or array is used as the left-hand operand of a lookup expression (using the
           <code>?</code> or <code>??</code> operator).</p>
+      
+      <note><p>An efficient implementation is likely to construct JNodes lazily, as and when a map or
+      array is reached by downward navigation using XPath lookup operators, which implicitly invoke
+      the <code>dm:j-children</code> accessor. Typical implementations of maps and arrays do not
+      include parent pointers to a containing map or array; these are contained only transiently
+      in the JNode that wraps a map or array reached by downward navigation in the JTree.
+      A benefit of not storing parent pointers is that a map or array does not need to be copied
+      in order to participate in multiple trees.</p>
+      
+      <p>This implementation strategy mirrors the concept of a <term>Zipper</term> data structure
+      commonly encountered in other functional programming languages. The general idea is that
+      while the core data structure maintains references in one direction only (in this case from
+      parent to child), an operation that navigates the data structure can retain additional information
+      about the path that was followed, effectively allowing access to nodes of the structure
+      that were visited <emph>en route</emph>. This additional information is reified in the
+      <code>¶parent</code>, <code>¶position</code>, and <code>¶selector</code> properties
+      of a non-root JNode.</p></note>
       
       
   </div2>

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -6056,8 +6056,8 @@ position, in the range 1 to the size of the array.</p>
         <sitem><term>¶selector</term>: an atomic item</sitem>
       </slist>
       
-      <p>The accessor <code>j-children</code>, applied to a JNode <var>$P</var>, returns a sequence
-      of non-root JNodes representing the children of <var>$P</var>.</p>
+      <p><termdef id="dt-j-children" term="j-children">The accessor <code>j-children</code>, applied to a JNode <var>$P</var>, returns a sequence
+      of non-root JNodes representing the children of <var>$P</var>.</termdef></p>
       
 
       

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -5776,13 +5776,13 @@ values, only on keys. The semantics of equality when comparing keys are describe
   <p><termdef id="dt-empty-map" term="empty map">A map containing no entries 
     is referred to as an <term>empty map</term>.</termdef></p>
   
-  <note>
+  <!--<note>
 <p>Maps have no intrinsic identity separate from their content. A map can be given
   a transient identity, represented by an <code>id</code> property in its label, by applying the
   <code>fn:pin</code> function. This property is expected to be used in defining
   operations for deep update of maps.
 </p>
-</note>
+</note>-->
 
 
   
@@ -5950,12 +5950,12 @@ position, in the range 1 to the size of the array.</p>
   <p><termdef id="dt-empty-array" term="empty array">An array containing no members 
     is referred to as an <term>empty array</term>.</termdef></p>
 
-  <note><p>Arrays have no intrinsic identity separate from their content. An array can be given
+  <!--<note><p>Arrays have no intrinsic identity separate from their content. An array can be given
     a transient identity, represented by an <code>id</code> property in its label, by applying the
     <code>fn:pin</code> function. This property is expected to be used in defining
     operations for deep update of arrays.
   </p></note>
-
+-->
 <p>Constructor and accessor functions for arrays are defined in the following sections.</p>
   
   <div3 id="dm-empty-array">

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -445,12 +445,16 @@ membership of different item types is overlapping.</p>
   </div2>
     <div2 id="sequences">
 <head>Sequences</head>
-
+ 
 <p>An important characteristic of the data model is that there is no
 distinction between an <termref def="dt-item"/> (a node, function, or <termref def="dt-atomic-item"/>) and a
 singleton <termref def="dt-sequence"/> containing that item. An item is
 equivalent to a singleton sequence containing that item and vice
 versa.</p>
+      
+      <p><termdef id="dt-singleton" term="singleton">A <term>singleton</term>
+      sequence is a <termref def="dt-sequence"/> of length one, that is, a sequence
+      containing exactly one item.</termdef></p>
 
 <p>A sequence may contain any mixture of nodes, functions, and 
   <termref def="dt-atomic-item">atomic items</termref>. When a node is added to a sequence its
@@ -1415,18 +1419,20 @@ an attribute node that has no parent.</p>
       </change>
     </changes>
     <p><termdef id="dt-GNode" term="GNode">The term <term>generic node</term> or <term>GNode</term>
-    is a collective term for <termref def="dt-XNode">XNodes</termref> (more commonly called simply nodes) representing
+    is a collective term for <termref def="dt-XNode">XNodes</termref> (more commonly called simply
+      <termref def="dt-node">nodes</termref>) representing
     the parts of an XML document, and <termref def="dt-JNode">JNodes</termref>, 
     often used to represent the parts of a JSON document.</termdef>
     </p>
     
-    <p><termdef id="dt-XNode" term="XNode">An <term>XNode</term>, more commonly referred
-      to simply as a node, represents a construct found in an XML document. There are seven
+    <p>An <termref def="dt-XNode">XNode</termref>, more commonly referred
+      to simply as a <termref def="dt-node"/>, represents a construct found in an XML document. There are seven
       kinds: document nodes, element nodes, attribute nodes, text nodes, comment nodes,
-      processing instruction nodes, and namespace nodes</termdef></p>
-    <p><termdef id="dt-JNode" term="JNode">A <term>JNode</term> represents an encapsulation
-      of a value in a tree of maps and arrays, such as might be obtained by parsing a JSON
-      document. XDM maps and arrays, however, are more general than those found in JSON.</termdef></p>
+      processing instruction nodes, and namespace nodes.</p>
+    <p>A <termref def="dt-JNode">JNode</termref> represents an encapsulation
+      of a value in a tree of <termref def="dt-map-item">maps</termref> and 
+      <termref def="dt-array-item">arrays</termref>, such as might be obtained by parsing a JSON
+      document. XDM maps and arrays, however, are more general than those found in JSON.</p>
     
     <p>Both kinds of GNode (XNodes and JNodes) form part of a tree structure. Each GNode, other
     than the root of a tree, has a single parent GNode and zero or more child GNodes.
@@ -1593,8 +1599,16 @@ stable but implementation-dependent.</imp-dep-feature>
   
   <head>XML Nodes</head>
   
-  <p>XNodes, commonly referred to simply as <term>nodes</term>, 
-    are used to represent the structure of an XML document in the form of a tree.</p>
+  <p><termdef id="dt-XNode" term="XNode">An <term>XNode</term>
+  is an <termref def="dt-item"/> that represents one of the seven kinds
+  of construct found in an XML document: elements, attributes, text nodes,
+  comment nodes, processing instructions, namespaces, and the document node itself.</termdef></p>
+  
+  <p><termdef id="dt-node" term="node">For continuity, and because the term is
+  used in many other specifications, the term <term>node</term> is used as a synonym
+  for <termref def="dt-XNode"/> in cases where the meaning is clear from the context.</termdef></p>
+  
+  <p>XNodes are used to represent the structure of an XML document in the form of a tree.</p>
 
 <p>Every node is one of the seven kinds of nodes defined in <specref
 ref="node-kinds"/>. Nodes form a tree. Each node has at most one parent
@@ -1603,19 +1617,14 @@ nodes that are reachable directly or indirectly
 via the <function>children</function>,
 <function>attributes</function>, and
 <function>namespace-nodes</function> accessors.</p>
-<!--<p><termdef id="dt-root-node" term="root node">The
-<term>root node</term> is the topmost node of a tree, the node with no
-parent.</termdef>
-Every tree has exactly one root node and every other node can be reached
-from exactly one root node.
-</p>-->
+
 
 <note><p>The term <term>root node</term> means any node that has no parent. 
   It may be any kind of node. In the XPath 1.0 datamodel only document nodes
   could be parentless, so the term root node always meant a document node.</p>
 </note>
     
-    <note diff="add" at="2022-11-05"><p>Generally, the term <term>tree</term>
+    <note><p>Generally, the term <term>tree</term>
     is used to refer to a complete tree rooted at a parentless node. On occasions,
     which should be clear from the context, the same term is used to refer
     to a subtree, that is, a tree forming part of a larger tree.</p></note>
@@ -2183,15 +2192,15 @@ not attempted or did not succeed, the
   <div2 id="node-kinds">
 <head>Node Kinds</head>
 
-<p><termdef id="dt-node" term="node">There are seven kinds of
-<term>nodes</term> in the data model:
+<p>There are seven kinds of
+<termref def="dt-node">nodes</termref> in the data model:
 <loc href="#DocumentNode">document</loc>,
 <loc href="#ElementNode">element</loc>,
 <loc href="#AttributeNode">attribute</loc>,
 <loc href="#TextNode">text</loc>,
 <loc href="#NamespaceNode">namespace</loc>,
 <loc href="#ProcessingInstructionNode">processing instruction</loc>, and
-<loc href="#CommentNode">comment</loc>.</termdef> Each kind of
+<loc href="#CommentNode">comment</loc>. Each kind of
 node is described in the following sections.</p>
 
 <p>Each section consists of an overview of the node, followed by 
@@ -5581,7 +5590,8 @@ is returned.</p>
 
 <p>
 <termdef term="function item" id="dt-function-item">
-  A <term>function item</term> is an item that can be <term>called</term>.
+  A <term>function item</term> is an <termref def="dt-item"/> that can be called with zero or more
+  arguments to return a result.
 </termdef>
 Function items <phrase diff="del" at="2023-05-25">cannot be compared for
 identity, equality, or otherwise, and</phrase> have no serialization.
@@ -5599,15 +5609,14 @@ identity, equality, or otherwise, and</phrase> have no serialization.
 <ulist>
   <item>
     <p>
-      <term>name</term>
-      <phrase>(<code>xs:QName</code>)</phrase>:
+      <term role="property-definition" id="prop-function-name">name</term>:
       An expanded QName, possibly
       <termref def="dt-absent">absent</termref>. 
     </p>
   </item>
   <item>
     <p diff="add" at="2023-05-25">
-      <term>identity</term>: An abstract property that can be used to test whether
+      <term role="property-definition" id="prop-function-identity">identity</term>: An abstract property that can be used to test whether
       two variables refer to the same function or to different functions. This property
       is exposed only for this purpose.
     </p>
@@ -5619,7 +5628,7 @@ identity, equality, or otherwise, and</phrase> have no serialization.
   
   <item>
     <p>
-      <term>signature</term>
+      <term role="property-definition" id="prop-function-signature">signature</term>
       <termdef term="function signature" id="dt-signature">
         A <term>function signature</term>
         represents the type of a
@@ -5634,7 +5643,7 @@ identity, equality, or otherwise, and</phrase> have no serialization.
   </item>
   <item>
     <p>
-      <term>annotations</term>
+      <term role="property-definition" id="prop-function-annotations">annotations</term>
       A sequence of zero or more <term>function annotations</term>. 
       <termdef term="function annotation" id="dt-function-annotation">A <term>function annotation</term> 
       consists of an annotation name (an instance of <code>xs:QName</code>) and an annotation value
@@ -5644,7 +5653,7 @@ identity, equality, or otherwise, and</phrase> have no serialization.
   </item>
   <item>
     <p>
-      <term>body</term>
+      <term role="property-definition" id="prop-function-body">body</term>
       The body of a function provides the logic
       to map the arguments supplied in a function call into an instance of 
       the function’s result type.</p>
@@ -5672,7 +5681,7 @@ identity, equality, or otherwise, and</phrase> have no serialization.
   </item>
   <item>
     <p>
-      <term>captured context</term> This includes a static and dynamic context for evaluation
+      <term role="property-definition" id="prop-function-captured-context">captured context</term> This includes a static and dynamic context for evaluation
       of the function body, as described in <xspecref spec="XP40" ref="context"/>. In particular
       it includes a set of <term>nonlocal variable bindings</term>
       (a mapping from <code>xs:QName</code> to <code>item()*</code>),
@@ -5792,13 +5801,12 @@ values, only on keys. The semantics of equality when comparing keys are describe
   <p><termdef id="dt-empty-map" term="empty map">A map containing no entries 
     is referred to as an <term>empty map</term>.</termdef></p>
   
-  <!--<note>
-<p>Maps have no intrinsic identity separate from their content. A map can be given
-  a transient identity, represented by an <code>id</code> property in its label, by applying the
-  <code>fn:pin</code> function. This property is expected to be used in defining
-  operations for deep update of maps.
-</p>
-</note>-->
+
+<note>
+<p>Note the distinction between a <termref def="dt-singleton"/> map, which is a sequence
+    of length one containing a single map item, and a <termref def="dt-single-entry-map"/>,
+    which is a map containing exactly one <termref def="dt-entry"/>.</p>
+</note>
 
 
   
@@ -5966,12 +5974,10 @@ position, in the range 1 to the size of the array.</p>
   <p><termdef id="dt-empty-array" term="empty array">An array containing no members 
     is referred to as an <term>empty array</term>.</termdef></p>
 
-  <!--<note><p>Arrays have no intrinsic identity separate from their content. An array can be given
-    a transient identity, represented by an <code>id</code> property in its label, by applying the
-    <code>fn:pin</code> function. This property is expected to be used in defining
-    operations for deep update of arrays.
-  </p></note>
--->
+  <note><p>Note the distinction between a <termref def="dt-singleton"/> array, which is a sequence
+    of length one containing a single array item, and a <termref def="dt-single-member-array"/>,
+    which is a map containing exactly one <termref def="dt-member"/>.</p></note>
+
 <p>Constructor and accessor functions for arrays are defined in the following sections.</p>
   
   <div3 id="dm-empty-array">
@@ -6041,20 +6047,36 @@ position, in the range 1 to the size of the array.</p>
       </change>
     </changes>
     
-    <p>A <termref def="dt-JNode"/> is a kind of item: specifically, JNode is a subtype of 
-      <termref def="dt-GNode"/> (a generic node).
-    JNodes have identity, and are organized into trees called <termref def="dt-JTree">JTrees</termref>.</p>
+    <p><termdef id="dt-JNode" term="JNode">A <term>JNode</term> is a kind of <termref def="dt-item"/>
+      used to represent a value within the context of a tree of <termref def="dt-map-item">maps</termref>
+      and <termref def="dt-array-item">arrays</termref>. A root <term>JNode</term> represents
+      a map or array; a non-root <term>JNode</term> represents a <termref def="dt-member"/> of an 
+      array or an <termref def="dt-entry"/> in a map.</termdef></p> 
       
-      <p>Every <termref def="dt-JNode"/> has a property <term>¶value</term> which is an 
-        arbitrary <termref def="dt-value"/> (that is, in general, a <termref def="dt-sequence"/>).</p>
+      <p>The type JNode is a subtype of 
+      <termref def="dt-GNode"/> (a generic node).
+    JNodes have identity, and are organized into trees called <termref def="dt-JTree">JTrees</termref>.
+    </p>
+      <p><termdef id="prop-jnode-value" term="value">Every <termref def="dt-JNode"/> has a property <term>·content·</term> which is an 
+        arbitrary <termref def="dt-value"/> (that is, in general, a <termref def="dt-sequence"/>).</termdef></p>
       
       <p>In addition a JNode that is not a root JNode has the following properties:</p>
       
       <slist>
-        <sitem><term>¶parent</term>: a JNode</sitem>
-        <sitem><term>¶position</term>: a positive integer</sitem>
-        <sitem><term>¶selector</term>: an atomic item</sitem>
+        <sitem><term>·parent·</term>: a JNode</sitem>
+        <sitem><term>·position·</term>: a positive integer</sitem>
+        <sitem><term>·selector·</term>: an atomic item</sitem>
       </slist>
+      
+      <p>In effect, there are four kinds of JNode (though they are not distinguished
+      as different types in the type system):</p>
+      
+      <ulist>
+        <item><p>A root JNode that represents a map.</p></item>
+        <item><p>A root JNode that represents an array.</p></item>
+        <item><p>A non-root JNode that represents an entry in a map.</p></item>
+        <item><p>A non-root JNode that represents a member of an array.</p></item>
+      </ulist>
       
       <p><termdef id="dt-j-children" term="j-children">The accessor <code>j-children</code>, applied to a JNode <var>$P</var>, returns a sequence
       of non-root JNodes representing the children of <var>$P</var>.</termdef></p>
@@ -6064,15 +6086,15 @@ position, in the range 1 to the size of the array.</p>
       
       <p>Values are classified as <term>leaf</term> or <term>non-leaf</term>. A value is classified
         as <term>non-leaf</term> if and only if at least one item in the value
-      is a non-empty map or array. If the ¶value property of a JNode is classified as <term>leaf</term>, then
+      is a non-empty map or array. If the ·content· property of a JNode is classified as <term>leaf</term>, then
       the <code>j-children</code> accessor returns an empty sequence.</p>
       
       <note><p>If the <code>j-children</code> accessor of a JNode returns an empty sequence,
-      then it is necessary to examine the ¶value property in order to distinguish whether
+      then it is necessary to examine the ·content· property in order to distinguish whether
       the value is (for example) an empty sequence, an atomic item, an empty map,
       or an empty array.</p></note>
       
-      <p>If the ¶value property of a JNode <var>P</var> is classified as <term>non-leaf</term>, then
+      <p>If the ·content· property of a JNode <var>P</var> is classified as <term>non-leaf</term>, then
       the <code>j-children</code> accessor returns a sequence of JNodes that includes
         one JNode for each member of an array in <var>J</var> and one JNode for each entry
         of a map in <var>J</var>. More specifically, the result is determined
@@ -6081,7 +6103,7 @@ position, in the range 1 to the size of the array.</p>
       
       <ulist>
         <item><p>The function
-        <code>dm:j-value</code> is used to access the ¶value property of a JNode</p></item>
+        <code>dm:j-value</code> is used to access the ·content· property of a JNode</p></item>
         <item><p>The function <code>dm:JNode</code> is used to construct (or obtain)
         a JNode whose properties correspond to the names of the argument keywords.</p></item>
       </ulist>
@@ -6124,7 +6146,7 @@ return
   </eg>
         <p>Then:</p>
         <ulist>
-          <item><p>The root JNode <var>R</var> has a ¶value property that is an 
+          <item><p>The root JNode <var>R</var> has a ·content· property that is an 
             array of two maps.</p></item>
           <item><p>The 
             result of the <code>dm:j-children</code> accessor applied to <var>R</var> is a sequence of two 
@@ -6132,18 +6154,18 @@ return
             representing one of the two maps.</p></item>
           <item><p>For <var>M1</var>:</p>
             <ulist>
-              <item><p><term>¶parent</term> is <var>R</var>.</p></item>
-              <item><p><term>¶value</term> is the first map.</p></item>
-              <item><p><term>¶position</term> is 1.</p></item>
-              <item><p><term>¶selector</term> is 1.</p></item>
+              <item><p><term>·parent·</term> is <var>R</var>.</p></item>
+              <item><p><term>·content·</term> is the first map.</p></item>
+              <item><p><term>·position·</term> is 1.</p></item>
+              <item><p><term>·selector·</term> is 1.</p></item>
               <item><p>The <emph>dm:j-children</emph> accessor returns a sequence of four
               JNodes, as follows:</p>
               <ulist>
-                <item><p>All four have <term>¶parent</term> set to <var>M1</var>.</p></item>
-                <item><p>The <term>¶value</term> properties are respectively <code>1</code>,
+                <item><p>All four have <term>·parent·</term> set to <var>M1</var>.</p></item>
+                <item><p>The <term>·content·</term> properties are respectively <code>1</code>,
                   <code>"XXX"</code>, <code>true()</code>, and <code>()</code>.</p></item>
-                <item><p>The <term>¶position</term> properties are all set to 1.</p></item>
-                <item><p>The <term>¶selector</term> properties are respectively <code>"a"</code>
+                <item><p>The <term>·position·</term> properties are all set to 1.</p></item>
+                <item><p>The <term>·selector·</term> properties are respectively <code>"a"</code>
                 <code>"b"</code>, <code>"c"</code>, and <code>"d"</code>.</p></item>
                 <item><p>For each of these JNodes, the <emph>dm:j-children</emph> accessor returns
                 an empty sequence.</p></item>
@@ -6152,18 +6174,18 @@ return
           </item>
           <item><p>For <var>M2</var>:</p>
             <ulist>
-              <item><p><term>¶parent</term> is <var>R</var>.</p></item>
-              <item><p><term>¶value</term> is the second map.</p></item>
-              <item><p><term>¶position</term> is 1.</p></item>
-              <item><p><term>¶selector</term> is 2.</p></item>
+              <item><p><term>·parent·</term> is <var>R</var>.</p></item>
+              <item><p><term>·content·</term> is the second map.</p></item>
+              <item><p><term>·position·</term> is 1.</p></item>
+              <item><p><term>·selector·</term> is 2.</p></item>
               <item><p>The <emph>dm:j-children</emph> accessor returns a sequence of four
               JNodes, as follows:</p>
               <ulist>
-                <item><p>All four have <term>¶parent</term> set to <var>M2</var>.</p></item>
-                <item><p>The <term>¶value</term> properties are respectively <code>2</code>,
+                <item><p>All four have <term>·parent·</term> set to <var>M2</var>.</p></item>
+                <item><p>The <term>·content·</term> properties are respectively <code>2</code>,
                   <code>"YYY"</code>, <code>false()</code>, and <code>()</code>.</p></item>
-                <item><p>The <term>¶position</term> properties are all set to 1.</p></item>
-                <item><p>The <term>¶selector</term> properties are respectively <code>"a"</code>
+                <item><p>The <term>·position·</term> properties are all set to 1.</p></item>
+                <item><p>The <term>·selector·</term> properties are respectively <code>"a"</code>
                 <code>"b"</code>, <code>"c"</code>, and <code>"d"</code>.</p></item>
                 <item><p>For each of these JNodes, the <emph>dm:j-children</emph> accessor returns
                 an empty sequence.</p></item>
@@ -6172,7 +6194,7 @@ return
           </item>
         </ulist>
         <p>Note that all JNodes in a JTree that represents parsed JSON input will have the
-        <term>¶position</term> property set to 1. This is because every construct in JSON 
+        <term>·position·</term> property set to 1. This is because every construct in JSON 
         (arrays, objects, strings, number, booleans, and <code>null</code>) maps to an XDM sequence
         of length 0 or 1.</p>
       </example>
@@ -6191,41 +6213,41 @@ return
         
         <p>Then:</p>
         <ulist>
-          <item><p>The root JNode <var>R</var> has a ¶value property that is a 
+          <item><p>The root JNode <var>R</var> has a ·content· property that is a 
             map with five entries.</p></item>
           <item><p>The result of the <code>dm:j-children</code> accessor applied to <var>R</var>
           is a sequence of five JNodes <var>J1</var>, <var>J2</var>, <var>J3</var>, <var>J4</var>, and <var>J5</var>,
           as follows:</p>
           <ulist>
-            <item><p><var>J1</var> is a leaf node. It has ¶parent=<var>R</var>, ¶value=1, ¶position=1, and
-            ¶selector="a". Its <code>dm:j-children</code> accessor returns an empty sequence.</p></item>
-            <item><p><var>J2</var> is a leaf node. It has ¶parent=<var>R</var>, ¶value=("x", "y"), ¶position=1, and
-            ¶selector="b". Its <code>dm:j-children</code> accessor returns an empty sequence.</p></item>
-            <item><p><var>J3</var> has ¶parent=<var>R</var>, ¶value=[(10, 20), 30], ¶position=1, and
-            ¶selector="c". Its <code>dm:j-children</code> accessor returns a sequence of two
+            <item><p><var>J1</var> is a leaf node. It has <term>·parent·</term>=<var>R</var>, <term>·content·</term>=1, <term>·position·</term>=1, and
+            <term>·selector·</term>="a". Its <code>dm:j-children</code> accessor returns an empty sequence.</p></item>
+            <item><p><var>J2</var> is a leaf node. It has <term>·parent·</term>=<var>R</var>, <term>·content·</term>=("x", "y"), <term>·position·</term>=1, and
+            <term>·selector·</term>="b". Its <code>dm:j-children</code> accessor returns an empty sequence.</p></item>
+            <item><p><var>J3</var> has ·parent·=<var>R</var>, ·content·=[(10, 20), 30], <term>·position·</term>=1, and
+            <term>·selector·</term>="c". Its <code>dm:j-children</code> accessor returns a sequence of two
               JNodes <var>J/31</var> and <var>J/32</var>, representing the two members of the contained
               array, as follows:</p>
               <ulist>
-                <item><p><var>J/31</var> is a leaf node. It has ¶parent=<var>J3</var>, ¶value=(10, 20), ¶position=1, and
-                 ¶selector="1". Its <code>dm:j-children</code> accessor returns an empty sequence.</p></item>
-                <item><p><var>J/32</var> is a leaf node. It has ¶parent=<var>J3</var>, ¶value=30, ¶position=1, and
-                 ¶selector="2". Its <code>dm:j-children</code> accessor returns an empty sequence.</p></item>
+                <item><p><var>J/31</var> is a leaf node. It has <term>·parent·</term>=<var>J3</var>, <term>·content·</term>=(10, 20), <term>·position·</term>=1, and
+                 <term>·selector·</term>="1". Its <code>dm:j-children</code> accessor returns an empty sequence.</p></item>
+                <item><p><var>J/32</var> is a leaf node. It has <term>·parent·</term>=<var>J3</var>, <term>·content·</term>=30, <term>·position·</term>=1, and
+                 <term>·selector·</term>="2". Its <code>dm:j-children</code> accessor returns an empty sequence.</p></item>
               </ulist>
             </item>
-            <item><p><var>J4</var> has ¶parent=<var>R</var>, ¶value=([10, 20], 30), ¶position=1, and
-            ¶selector="d". Its <code>dm:j-children</code> accessor returns a sequence of two
+            <item><p><var>J4</var> has <term>·parent·</term>=<var>R</var>, <term>·content·</term>=([10, 20], 30), <term>·position·</term>=1, and
+            <term>·selector·</term>="d". Its <code>dm:j-children</code> accessor returns a sequence of two
               JNodes <var>J/41</var> and <var>J/42</var>, representing the two members of the
               contained array, as follows:</p>
               <ulist>
-                <item><p><var>J/41</var> is a leaf node. It has ¶parent=<var>J4</var>, ¶value=20, ¶position=2, and
-                 ¶selector="1". Its <code>dm:j-children</code> accessor returns an empty sequence.</p></item>
-                <item><p><var>J/42</var> is a leaf node. It has ¶parent=<var>J4</var>, ¶value=30, ¶position=2, and
-                 ¶selector="2". Its <code>dm:j-children</code> accessor returns an empty sequence.</p></item>
+                <item><p><var>J/41</var> is a leaf node. It has <term>·parent·</term>=<var>J4</var>, <term>·content·</term>=20, <term>·position·</term>=2, and
+                 <term>·selector·</term>="1". Its <code>dm:j-children</code> accessor returns an empty sequence.</p></item>
+                <item><p><var>J/42</var> is a leaf node. It has ·parent·=<var>J4</var>, <term>·content·</term>=30, <term>·position·</term>=2, and
+                 <term>·selector·</term>="2". Its <code>dm:j-children</code> accessor returns an empty sequence.</p></item>
               </ulist>
             </item>
-            <item><p><var>J5</var> is a leaf node. It has ¶parent=<var>R</var>, a ¶value that is a sequence
-              of two element nodes named <code>p</code> and <code>q</code>, ¶position=1, and
-            ¶selector="e". Its <code>dm:j-children</code> accessor returns an empty sequence.</p></item>
+            <item><p><var>J5</var> is a leaf node. It has ·parent·=<var>R</var>, a <term>·content·</term> that is a sequence
+              of two element nodes named <code>p</code> and <code>q</code>, <term>·position·</term>=1, and
+            <term>·selector·</term>="e". Its <code>dm:j-children</code> accessor returns an empty sequence.</p></item>
           </ulist>
           </item>
         </ulist>
@@ -6242,24 +6264,24 @@ return
       
       
         
-          <p>For a JNode representing the root of a JTree, the <code>¶parent</code>, <code>¶position</code>,
-            and <code>¶selector</code>
+          <p>For a JNode representing the root of a JTree, the <term>·parent·</term>, <term>·position·</term>,
+            and <term>·selector·</term>
           properties will always be absent. For a non-root JNode, these properties will always be present.</p>
           
           <p>The identity of a root JNode is established when the root JNode is constructed, so that
           every operation that constructs a root JNode returns a JNode with distinct identity. The
-          identity of a non-root JNode is a function of its <code>¶parent</code>, <code>¶position</code>, and <code>¶selector</code>
+          identity of a non-root JNode is a function of its <term>·parent·</term>, <term>·position·</term>, and <term>·selector·</term>
           properties: two non-root JNodes are identical by definition if and only if their
-            <code>¶parent</code>s are identical and their <code>¶position</code> and <code>¶selector</code>
+            <term>·parent·</term>s are identical and their <term>·position·</term> and <term>·selector·</term>
             properties are equal as determined by the <function>atomic-equal</function> function.</p>
           
-          <p>A root JNode is constructed, wrapping a map or array, by a call on the <function>pin</function>
+          <p>A root JNode is constructed, wrapping a map or array, by a call on the <function>jnode</function>
           function applied to that map or array. This can be called explicitly, but it is also called
-          implicitly when a map or array is used as the left-hand operand of a lookup expression (using the
-          <code>?</code> or <code>??</code> operator).</p>
+          implicitly in a number of situations: for example when a map or array is used as the left-hand 
+          operand of the path operator <code>/</code>.</p>
       
       <note><p>An efficient implementation is likely to construct JNodes lazily, as and when a map or
-      array is reached by downward navigation using XPath lookup operators, which implicitly invoke
+      array is reached by downward navigation using XPath axis steps, which implicitly invoke
       the <code>dm:j-children</code> accessor. Typical implementations of maps and arrays do not
       include parent pointers to a containing map or array; these are contained only transiently
       in the JNode that wraps a map or array reached by downward navigation in the JTree.
@@ -6272,7 +6294,7 @@ return
       parent to child), an operation that navigates the data structure can retain additional information
       about the path that was followed, effectively allowing access to nodes of the structure
       that were visited <emph>en route</emph>. This additional information is reified in the
-      <code>¶parent</code>, <code>¶position</code>, and <code>¶selector</code> properties
+      <term>·parent·</term>, <term>·position·</term>, and <term>·selector·</term> properties
       of a non-root JNode.</p></note>
       
       

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -542,58 +542,7 @@ therefore can also be contained within sequences.</p>
   </div3>
 </div2>
 
-  <div2 id="id-LabeledItems">
-    <head>Labeled Items</head>
-    <changes>
-      <change issue="960" PR="988" date="2024-02-27">
-        Introduced the concept of labeled items.
-      </change>
-    </changes>
-    <p><termdef id="dt-labeled-item" term="labeled item">A <term>labeled item</term>
-    is a pair (<var>S</var>, <var>L</var>) where <var>S</var> (called the subject)
-    is any item, and <var>L</var> (called the label) is a map containing supplementary
-    information about the item.</termdef>.</p>
-    <p>The keys in the map are always instances of <code>xs:string</code>, and the associated values
-    can be arbitrary values.</p>
-    <p>There are currently no constructs in the language that would cause either 
-      the subject or the label of a labeled item to
-      itself be a labeled item. Nor is there anything that would cause the 
-      label to contain a labeled item.</p>
-    <p>Operations on labeled items fall into three categories:</p>
-    <ulist>
-      <item><p>Operations that select items which are present in their input return the
-      labeled item unchanged (including its label). 
-      Examples are filter expressions, axis expressions, lookup
-      expressions, and functions such as <function>fn:head</function>, <code>fn:tail</code>,
-      and <code>fn:subsequence</code>.</p></item>
-      <item><p>Operations that construct new values from their input treat the labeled
-      item exactly as if the operation were applied directly to the subject. That is,
-      the label is ignored. Examples are arithmetic and comparison operators, operators
-      such as <code>is</code> and <code>instance of</code>, cast expressions, atomization,
-      and functions such as 
-      <code>fn:avg</code> or <code>fn:index-of</code>.</p></item>
-      <item><p>The <code>fn:label</code> function is a special case: it returns the
-      label of a labeled item, as a map. If applied to an item that is not labeled, it 
-      returns an empty map.</p></item>
-    </ulist>
-    <note><p>Two items representing the same node (such that <code>$n1 is $n2</code> returns
-    true) may nevertheless have different labels. It is perhaps helpful to think of such items
-    not as nodes, but as references to nodes, which are automatically dereferenced by the majority
-    of operations.</p></note>
-    <note><p>A labeled item matches a type if its subject matches the type; labels are thus extraneous
-    to the type system.</p></note>
-    <p>Labeled items are returned by certain operations, such as the lookup operators <code>?</code> 
-      and <code>??</code>. As a result, the lookup operation can be treated at one level as if it
-    returned a simple value (an entry found in a map or array), but applications that need extra
-    information about the value can find this by examining the label: for example, they can identify
-    the associated key value.</p>
-    <p>The function <code>fn:pin</code> takes a map or array <var>J</var> as its argument, and returns
-    a labeled map or array with <var>J</var> as its subject (or the subject of <var>J</var>, if <var>J</var>
-    is itself a labeled item), and with a map <var>M</var> as its label, where <var>M</var> contains
-    a single entry having the key <code>"pinned"</code> (as an <code>xs:string</code>) and an associated
-    <code>xs:boolean</code> value <code>true</code>. An item <code>$item</code> 
-      satisfying <code>$item[label(.)?pinned]</code> is referred to as a <term>pinned</term> item.</p>
-  </div2>
+  
   </div1>
   <div1 id="schemas-and-types">
     <head>Schemas and Types</head>
@@ -1025,17 +974,32 @@ constraints of the selected version of XML.</p></item>
     an instance of one or more <termref def="dt-item-type">item types</termref>:</p>
   
   <ulist diff="chg" at="2022-11-05">
-    <item><p>All items are instances of the type <code>item()</code>.</p></item>
-    <item><p>Every <termref def="dt-node"/> is an instance of the type <code>node()</code>, and more
-      specifically it is an instance of one of seven node kinds: <code>document()</code>,
-      <code>element(*)</code>, <code>attribute(*)</code>, <code>text()</code>,
-      <code>comment()</code>, <code>processing-instruction()</code>, or
-      <code>namespace()</code>. Nodes may also be instances of more specific
-      types characterized by the node name and type annotation.</p></item>
+    <item><p>All items are instances of the type <code>item()</code>. There are three kinds of
+    item: atomic items, generic nodes (GNodes), and function items.</p></item>
+    
     <item><p>Every <termref def="dt-atomic-item"/> is an instance of a specific <termref def="dt-atomic-type"/>
       determined by its <termref def="dt-type-annotation"/>; it is also an instance of every type from which that
       type is derived by restriction (directly or indirectly), and of every union type that
       includes that type as a member type.</p></item>
+    
+    <item><p>A generic node (GNode) is either an XNode (for "XML node"), or a JNode (for "JSON node").
+      For continuity reasons, throughout these specifications the term <term>node</term>, when
+      used without qualification, means an XNode; furthermore the item type <code>node()</code>
+      refers exclusively to an XNode. The term <term>XNode</term> is used only when there
+      is a need to distinguish clearly from JNodes.</p>
+      
+      <p>XNodes represent the constructs found in an XML document.
+        Every <termref def="dt-node"/> (that is, every XNode) is an instance of the type <code>node()</code>, and more
+      specifically it is an instance of one of seven node kinds: <code>document()</code>,
+      <code>element(*)</code>, <code>attribute(*)</code>, <code>text()</code>,
+      <code>comment()</code>, <code>processing-instruction()</code>, or
+      <code>namespace()</code>. Nodes may also be instances of more specific
+      types characterized by the node name and type annotation.</p>
+    
+      <p>JNodes are newly introduced in 4.0 for the purpose of navigating trees of maps and arrays,
+      typically derived by parsing JSON.</p>
+    </item>
+    
     <item><p>Every <termref def="dt-function-item"/> is an instance of the generic type <code>function(*)</code>,
       and also of a specific function type defining the types of the function's parameters and the
       type of the result.</p>
@@ -1439,103 +1403,108 @@ an attribute node that has no parent.</p>
 </div2>
 
   </div1>
+  
+  <div1 id="generic-nodes">
+    <head>Generic Nodes (GNodes)</head>
+    
+    <changes>
+      <change issue="2025">
+        JNodes are introduced to represent nodes in a JSON tree. The term XNode is introduced
+        when we need to distinguish XML nodes from JSON nodes; and the term GNode (for <term>generic node</term>)
+        is used as a collective term for XNodes and JNodes.
+      </change>
+    </changes>
+    <p><termdef id="dt-GNode" term="GNode">The term <term>generic node</term> or <term>GNode</term>
+    is a collective term for XNodes (more commonly called simply nodes) representing
+    the parts of an XML document, and JNodes, representing the parts of a JSON document.</termdef>
+    </p>
+    
+    <p><termdef id="dt-XNode" term="XNode">An <term>XNode</term>, more commonly referred
+      to simply as a node, represents a construct found in an XML document. There are seven
+      kinds: document nodes, element nodes, attribute nodes, text nodes, comment nodes,
+      processing instruction nodes, and namespace nodes</termdef></p>
+    <p><termdef id="dt-JNode" term="JNode">A <term>JNode</term> represents an encapsulation
+      of a value in a tree of maps and arrays, such as might be obtained by parsing a JSON
+      document. XDM maps and arrays, howver, are more general than those found in JSON.</termdef></p>
+    
+    <p>Both kinds of GNode (XNodes and JNodes) form part of a tree structure. Each GNode, other
+    than the root of a tree, has a single parent GNode and zero or more child GNodes.
+    GNodes have unique identity, and the GNodes within a tree have an ordering called
+    document order.</p>
+    
+    <p><termdef id="dt-root-node" term="root node">The <term>root GNode</term> is the 
+      topmost node of a tree, the GNode with no
+    parent.</termdef>
+    Every tree has exactly one root GNode and every other node can be reached
+    from exactly one root node.
+  </p>
 
-<div1 id="documents-and-nodes">
-  <head>Documents and Nodes</head>
-  
-  
-<div2 id="nodes">
-  
-  <head>Nodes</head>
-  
-  <p>Nodes are used to represent the structure of an XML document in the form of a tree.</p>
-
-<p>Every node is one of the seven kinds of nodes defined in <specref
-ref="node-kinds"/>. Nodes form a tree. Each node has at most one parent
-(reachable via the <function>parent</function> accessor) and zero or more descendant
-nodes that are reachable directly or indirectly
-via the <function>children</function>,
-<function>attributes</function>, and
-<function>namespace-nodes</function> accessors.</p>
-<p><termdef id="dt-root-node" term="root node">The
-<term>root node</term> is the topmost node of a tree, the node with no
-parent.</termdef>
-Every tree has exactly one root node and every other node can be reached
-from exactly one root node.
-</p>
-
-<note><p>The term <term>root node</term> means any node that has no parent. 
-  It may be any kind of node. In the XPath 1.0 datamodel only document nodes
-  could be parentless, so the term root node always meant a document node.</p>
+<note><p>The term <term>root</term> means any GNode that has no parent. 
+  It may be any kind of GNode. In the XPath 1.0 datamodel only document nodes
+  could be parentless, so the term <emph>root node</emph> always meant a document node.</p>
 </note>
     
     <note diff="add" at="2022-11-05"><p>Generally, the term <term>tree</term>
     is used to refer to a complete tree rooted at a parentless node. On occasions,
     which should be clear from the context, the same term is used to refer
     to a subtree, that is, a tree forming part of a larger tree.</p></note>
+    
+    <p><termdef id="dt-XTree" term="XTree">A tree that is rooted at a parentless
+    <termref def="dt-XNode"/> is referred to as an <term>XTree</term>.</termdef>
+    All the nodes in an XTree are XNodes.</p>
+    
+    <p><termdef id="dt-JTree" term="JTree">A tree that is rooted at a parentless
+    <termref def="dt-JNode"/> is referred to as a <term>JTree</term>.</termdef>
+    All the nodes in a JTree are JNodes.</p>
 
-<p><termdef id="dt-document" term="document">A
-tree whose root node is a &documentNode; is referred to as a
-<term>document</term>.</termdef></p>
-
-<p><termdef id="dt-fragment"
-term="fragment">A tree whose root node is not a &documentNode; is
-referred to as a <term>fragment</term>.</termdef></p>
-
-
-
-</div2>
-
-
-
-<div2 id="node-identity">
-<head>Node Identity</head>
-
-<p>Each node has a unique identity.
-
-The identity of
-a node is distinct from its value or other intrinsic properties; nodes may be
-distinct even when they have the same values for all intrinsic
-properties other than their identity.
-(The
-identity of <termref def="dt-atomic-item">atomic items</termref>, by contrast, is determined solely by their
-intrinsic properties. No two distinct integers, for example, have the
-same value;
-every instance of the value “5” as an integer is identical to every
-other instance of the value “5” as an integer.)
-</p>
-
-<note>
-<p>The concept of node identity should not be confused with the
-concept of a unique ID, which is a unique name assigned to an element
-by the author to represent references using ID/IDREF correlation.</p>
-</note>
-</div2>
-
-<div2 id="document-order">
+ <div2 id="node-identity">
+    <head>Node Identity</head>
+    
+    <p>Each GNode has a unique identity.
+    
+    The identity of
+    a GNode is distinct from its value or other intrinsic properties; nodes may be
+    distinct even when they have the same values for all intrinsic
+    properties other than their identity.
+    (The
+    identity of <termref def="dt-atomic-item">atomic items</termref>, by contrast, is determined solely by their
+    intrinsic properties. No two distinct integers, for example, have the
+    same value;
+    every instance of the value “5” as an integer is identical to every
+    other instance of the value “5” as an integer.)
+    </p>
+    
+    <note>
+    <p>The concept of node identity should not be confused with the
+    concept of a unique ID, which is a unique name assigned to an element
+    by the author to represent references using ID/IDREF correlation.</p>
+    </note>
+    </div2>
+    
+    <div2 id="document-order">
 <head>Document Order</head>
 
 <p><termdef id="dt-document-order" term="document order">A
-<term>document order</term> is defined among all the nodes
+<term>document order</term> is defined among all the GNodes
 accessible during a given query or transformation. Document order is a
-total ordering, although the relative order of some nodes is
+total ordering, although the relative order of some GNodes is
 implementation-dependent. Informally, document order is the order in
-which nodes appear in the XML serialization of a document.</termdef>
+which GNodes appear in the XML or JSON serialization of a document.</termdef>
 <termdef id="dt-stable" term="stable">Document order is
 <term>stable</term>, which means that the relative order of two
-nodes will not change during the processing of a given query or
+GNodes will not change during the processing of a given query or
 transformation, even if this order is implementation-dependent.</termdef></p>
 
-<p>Within a tree, document order satisfies the following constraints:</p>
+<p>Within an <termref def="dt-XTree"/>, document order satisfies the following constraints:</p>
 
 <olist>
 <item>
-<p>The root node is the first node.
+<p>The root XNode is the first node.
 </p>
 </item>
 
 <item>
-<p>Every node occurs before all of its children and descendants.</p>
+<p>Every XNode occurs before all of its children and descendants.</p>
 </item>
 
 <item>
@@ -1564,15 +1533,93 @@ the &dm.prop.children; property of their parent node.</p>
 <p>Children and descendants occur before following siblings.</p>
 </item>
 </olist>
+      
+      <p>Similarly, within an <termref def="dt-JTree"/>, document order satisfies the following constraints:</p>
 
-<p>The relative order of nodes in distinct trees is stable but
+      <olist>
+        <item>
+        <p>The root JNode is the first node.
+        </p>
+        </item>
+      
+        <item>
+          <p>Every JNode occurs before all of its children.</p>
+        </item>
+        
+        <item>
+          <p>For a JNode that encapsulates an array (see <specref ref="array-items"/>),
+          the ordering of its children reflects the ordering of the array members.</p>
+        </item>
+        
+        <item>
+          <p>For a JNode that encapsulates a map (see <specref ref="map-items"/>),
+          the ordering of its children reflects the ordering of the map entries.</p>
+        </item>
+      </olist>
+        
+
+
+<p>The relative order of GNodes in distinct trees is stable but
 implementation-dependent, subject to the following constraint: If
 any node in a given tree, <code>T1</code>, occurs before any node in a different
-tree, <code>T2</code>, then all nodes in <code>T1</code> are before all nodes in
+tree, <code>T2</code>, then all GNodes in <code>T1</code> are before all GNodes in
 <code>T2</code>.</p>
 <imp-dep-feature>The relative order of distinct trees is
 stable but implementation-dependent.</imp-dep-feature>
 </div2>
+  </div1>
+
+<div1 id="documents-and-nodes">
+  <head>XML Documents and Nodes</head>
+  
+  
+<div2 id="nodes">
+  
+  <head>XML Nodes</head>
+  
+  <p>XNodes, commonly referred to simply as <term>nodes</term>, 
+    are used to represent the structure of an XML document in the form of a tree.</p>
+
+<p>Every node is one of the seven kinds of nodes defined in <specref
+ref="node-kinds"/>. Nodes form a tree. Each node has at most one parent
+(reachable via the <function>parent</function> accessor) and zero or more descendant
+nodes that are reachable directly or indirectly
+via the <function>children</function>,
+<function>attributes</function>, and
+<function>namespace-nodes</function> accessors.</p>
+<!--<p><termdef id="dt-root-node" term="root node">The
+<term>root node</term> is the topmost node of a tree, the node with no
+parent.</termdef>
+Every tree has exactly one root node and every other node can be reached
+from exactly one root node.
+</p>-->
+
+<note><p>The term <term>root node</term> means any node that has no parent. 
+  It may be any kind of node. In the XPath 1.0 datamodel only document nodes
+  could be parentless, so the term root node always meant a document node.</p>
+</note>
+    
+    <note diff="add" at="2022-11-05"><p>Generally, the term <term>tree</term>
+    is used to refer to a complete tree rooted at a parentless node. On occasions,
+    which should be clear from the context, the same term is used to refer
+    to a subtree, that is, a tree forming part of a larger tree.</p></note>
+
+<p><termdef id="dt-document" term="document">An
+<termref def="dt-XTree"/> whose root node is a &documentNode; is referred to as a
+<term>document</term>.</termdef></p>
+
+<p><termdef id="dt-fragment"
+term="fragment">An <termref def="dt-XTree"/> whose root node is not a &documentNode; is
+referred to as a <term>fragment</term>.</termdef></p>
+
+
+
+</div2>
+
+
+
+
+
 
 
 <div2 id="namespace-names">
@@ -1624,7 +1671,8 @@ valid URIs or IRIs, but they are <emph>not required</emph> to do so.
 <div2 id="construction">
 <head>Document Construction</head>
 
-<p>This section describes the constraints on documents (that is, trees of nodes).</p>
+<p>This section describes the constraints on <termref def="dt-document">documents</termref> 
+  (that is, trees of nodes).</p>
 
 <p>The data model supports well-formed XML documents conforming to
 <bibref ref="xml-names"/> or <bibref ref="xml-names11"/>.
@@ -5968,6 +6016,56 @@ position, in the range 1 to the size of the array.</p>
 
     
 </div2>
+    
+    <div2 id="id-JNodes">
+    <head>JNodes</head>
+    <changes>
+      <change issue="2025">
+        Introduced the concept of JNodes.
+      </change>
+    </changes>
+    
+    <p>A <termref def="dt-JNode"/> is a kind of item: specifically, JNode is a subtype of GNode (a generic node).
+    JNodes have identity, and are organized into trees called <termref def="dt-JTree">JTrees</termref>.</p>
+      
+      <p>A <termref def="dt-JNode"/> has (potentially) three properties (aside from its identity):</p>
+    
+      <ulist>
+        <item><p><term>¶value</term>: an arbitrary <termref def="dt-value"/> (that is, in general, a
+        <termref def="dt-sequence"/>) encapsulated by the JNode.</p></item>
+        <item><p><term>¶parent</term>: another JNode acting as the parent of this JNode in a 
+        <termref def="dt-JTree"/>. The <code>¶value</code> of the <code>¶parent</code> JNode
+        will always be either a map or an array.</p></item>
+        <item><p><term>¶selector</term>: an <termref def="dt-atomic-item"/> that uniquely identifies
+          this JNode within its parent JNode. </p>
+          <ulist><item><p>If the <code>¶value</code> of the <code>¶parent</code> JNode
+            is an array, this will be an integer representing the 1-based index of a member in the parent array, 
+            and the <code>¶value</code> of this JNode will be the corresponding member.</p></item>
+            <item><p>If the <code>¶value</code> of the <code>¶parent</code> JNode
+            is a map, this will be an atomic item representing the key of an a entry in the parent map, 
+            and the <code>¶value</code> of this JNode will be the value corresponding to this key.</p></item>
+          </ulist></item>
+      </ulist>
+        
+          <p>For a JNode representing the root of a JTree, the <code>¶parent</code> and <code>¶value</code>
+          properties will always be absent. For a non-root JNode, both these properties will be present.</p>
+          
+          <p>The identity of a root JNode is established when the root JNode is constructed, so that
+          every operation that constructs a root JNode returns a JNode with distinct identity. The
+          identity of a non-root JNode is a function of its <code>¶parent</code> and <code>¶selector</code>
+          properties: two non-root JNodes are identical by definition if and only if their
+            <code>¶parent</code>s are identical and their <code>¶selector</code>s are equal as
+          determined by the <function>atomic-equal</function> function.</p>
+          
+          <p>A root JNode is constructed, wrapping a map or array, by a call on the <function>pin</function>
+          function applied to that map or array. This can be called explicitly, but it is also called
+          implicitly when a map or array is used as the left-hand operand of a lookup expression (using the
+          <code>?</code> or <code>??</code> operator).</p>
+      
+      
+  </div2>
+    
+    
   </div1>
 
 

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -1425,7 +1425,7 @@ an attribute node that has no parent.</p>
       processing instruction nodes, and namespace nodes</termdef></p>
     <p><termdef id="dt-JNode" term="JNode">A <term>JNode</term> represents an encapsulation
       of a value in a tree of maps and arrays, such as might be obtained by parsing a JSON
-      document. XDM maps and arrays, howver, are more general than those found in JSON.</termdef></p>
+      document. XDM maps and arrays, however, are more general than those found in JSON.</termdef></p>
     
     <p>Both kinds of GNode (XNodes and JNodes) form part of a tree structure. Each GNode, other
     than the root of a tree, has a single parent GNode and zero or more child GNodes.
@@ -1489,7 +1489,7 @@ an attribute node that has no parent.</p>
 accessible during a given query or transformation. Document order is a
 total ordering, although the relative order of some GNodes is
 implementation-dependent. Informally, document order is the order in
-which GNodes appear in the XML or JSON serialization of a document.</termdef>
+which GNodes appear when serialized.</termdef>
 <termdef id="dt-stable" term="stable">Document order is
 <term>stable</term>, which means that the relative order of two
 GNodes will not change during the processing of a given query or

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -6102,7 +6102,10 @@ return
                        selector := $key
                        value := $value)
   else ()
-</eg>  
+</eg> 
+      
+      <p>The order of JNodes returned by the <code>j-children</code> accessor is significant, and is
+      as defined by the above expression.</p>
   
       <example>
         <head>A JTree derived by parsing JSON</head>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -820,11 +820,14 @@
          <p>If <code>$value</code> is the empty sequence, the function returns the zero-length
             string.</p>
 
-         <p>If <code>$value</code> is a node, the function returns the string value of the node, as obtained using the
+         <p>If <code>$value</code> is an <xtermref spec="DM40" ref="dt-XNode"/>, 
+            the function returns the string value of the node, as obtained using the
                      <code>dm:string-value</code> accessor defined in <bibref
                ref="xpath-datamodel-31"/> (see <xspecref spec="DM40" ref="dm-string-value"/>).</p>
          
-         <p>If <code>$value</code> is a JNode, the function returns the result of <code>string(unpin($value))</code>.</p>
+         <p>If <code>$value</code> is a <xtermref spec="DM40" ref="dt-JNode"/>, 
+            the function returns the result of <code>string(JNode-value($value))</code>.
+         This will fail in the case where <code>$value</code> is a map or an array.</p>
 
          <p>If <code>$value</code> is an atomic item, the function returns the result of the expression <code>$value cast
                      as xs:string</code> (see <specref
@@ -884,6 +887,10 @@
             <fos:test>
                <fos:expression>string(abs#1)</fos:expression>
                <fos:error-result error-code="FOTY0014"/>
+            </fos:test>
+            <fos:test>
+               <fos:expression>string(JNode({"x": [10, 20, 30]}) ? x ? 3)</fos:expression>
+               <fos:result>"30"</fos:result>
             </fos:test>
          </fos:example>
          <fos:variable id="v-string-para" name="para"
@@ -8211,7 +8218,7 @@ satisfies compare($t, replace($token, '^\s*|\s*$', ''), $collation) eq 0
                   (a generalized node), <function>fn:boolean</function> returns <code>true</code>.</p>
             </item>
             <item>
-               <p>If <code>$input</code> is a singleton value of type <code>xs:boolean</code> or a
+               <p>If <code>$input</code> is a singleton value of type <code>xs:boolean</code> or of a type 
                   derived from <code>xs:boolean</code>, <function>fn:boolean</function> returns
                      <code>$input</code>.</p>
             </item>
@@ -13950,8 +13957,8 @@ Himmlische, dein Heiligtum.
    </fos:function>
    <fos:function name="root" prefix="fn">
       <fos:signatures>
-         <fos:proto name="root" return-type="node()?">
-            <fos:arg name="node" type="node()?" default="." usage="inspection"/>
+         <fos:proto name="root" return-type="GNode()?">
+            <fos:arg name="node" type="GNode()?" default="." usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -13967,15 +13974,21 @@ Himmlische, dein Heiligtum.
          <fos:property>special-streaming-rules</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns the root of the tree to which <code>$node</code> belongs. This will usually, but
-            not necessarily, be a document node.</p>
+         <p>Returns the root of the tree to which <code>$node</code> belongs. The
+         function can be applied both to <xtermref spec="DM40" ref="dt-XNode">XNodes</xtermref>
+         and to <xtermref spec="DM40" ref="dt-JNode">JNodes</xtermref>.</p>
       </fos:summary>
       <fos:rules>
          <p>If the function is called without an argument, the context value (<code>.</code>) is used
             as the default argument.</p>
 
-         <p>The function returns the value of the expression
-               <code>($arg/ancestor-or-self::node())[1]</code>.</p>
+         <p>If the (explicit or implicit) argument is a <xtermref spec="DM40" ref="dt-XNode"/>,
+         the function returns the value of the expression
+               <code>$arg/ancestor-or-self::node()[last()]</code>.</p>
+         
+         <p>If the (explicit or implicit) argument is a <xtermref spec="DM40" ref="dt-JNode"/>,
+         the function returns the value of the expression
+               <code>$arg?ancestor-or-self::*[last()]</code>.</p>
       </fos:rules>
       <fos:errors>
          <p>The following errors may be raised when <code>$node</code> is omitted:</p>
@@ -13987,8 +14000,9 @@ Himmlische, dein Heiligtum.
                      class="DY" code="0002" type="type"/></p>
             </item>
             <item>
-               <p>If the context value is not an instance of the sequence type <code>node()?</code>, type error <xerrorref spec="XP" class="TY"
-                     code="0004" type="type"/>.</p>
+               <p>If the context value is not an instance of the sequence type
+               <code>GNode()?</code>, type error
+               <xerrorref spec="XP" class="TY" code="0004" type="type"/>.</p>
             </item>
          </ulist>
       </fos:errors>
@@ -16644,9 +16658,8 @@ declare function equal-strings(
 }]]></eg>
          <p>The rules for deciding whether two items <code>$i1</code> and <code>$i2</code> are deep-equal
             are as follows.</p>
-         <p>Labels (see <xspecref spec="DM40" ref="id-LabeledItems"/>) are ignored. Specifically, if
-         <code>$i1</code> or <code>$i2</code> is a labeled item then it is replaced by its subject.</p>
-         <p>The two items are next compared using the function supplied in the <code>items-equal</code>
+         
+         <p>The two items are first compared using the function supplied in the <code>items-equal</code>
             option. If this returns <code>true</code> then the items are deep-equal. If it returns
             <code>false</code> then the items are not deep-equal. If it returns an empty sequence
             (which is always the case if the option is not explicitly specified)
@@ -16776,8 +16789,8 @@ declare function equal-strings(
             <item>
                <p>All the following conditions are true:</p>
                <olist>
-                  <item><p><code>$i1</code> is a node.</p></item>
-                  <item><p><code>$i2</code> is a node.</p></item>
+                  <item><p><code>$i1</code> is a node (specifically, an XNode).</p></item>
+                  <item><p><code>$i2</code> is a node (specifically, an XNode).</p></item>
                   <item><p>Both nodes have the same node kind.</p></item>
                   <item><p>Either the <code>base-uri</code> option is <code>false</code>, or both nodes have the same value
                      for their base URI property, or both nodes have an absent base URI.</p></item>
@@ -16992,10 +17005,26 @@ declare function equal-strings(
                         </item>
                   </olist>
                   </item>
-                  
+                  </olist>
+            </item>
+            <item>
+               <p>All the following conditions are true:</p>
+               <olist>
+                  <item><p><code>$i1</code> is a JNode.</p></item>
+                  <item><p><code>$i2</code> is a JNode.</p></item>
+                  <item><p>The <code>¶value</code> property of <code>$i1</code>
+                  is deep-equal to the <code>¶value</code> property of <code>$i2</code>.</p>
+                  <note><p>The other properties of the two JNodes, such as <code>¶parent</code>
+                  and <code>¶selector</code>, are ignored. As with XNodes, deep equality
+                  considers only the subtree rooted at the node, and not its position within
+                  a containing tree.</p></note>
+                  </item>
                </olist>
             </item>
-         </olist>
+                  
+               
+            
+          </olist>
          <p>In all other cases the result is <code>false</code>.</p>
       </fos:rules>
       <fos:errors>
@@ -21799,9 +21828,7 @@ return function-arity($initial)</eg></fos:expression>
 	      and <code>fn:function-identity($f2)</code> are codepoint-equal if and only if <code>$f1</code>
 	      and <code>$f2</code> have the same function identity. Apart from this property, the
 	      result is <termref def="implementation-dependent"/>.</p>
-	     <p>Any label attached to a function item is ignored (see <xspecref spec="DM40" ref="id-LabeledItems"/>).
-	     Specifically, if <var>L</var> is a labeled item then <code>fn:function-identity(<var>L</var>)</code> returns
-	     the function identity of the subject of <var>L</var>.</p>
+	     
 	     <p>In the case of maps and arrays, the result follows the following rule:
 	        If <code>$X</code> and <code>$Y</code> are both maps or arrays then <code>fn:function-identity($X)</code>
 	        <rfc2119>must not</rfc2119> be codepoint-equal to <code>fn:function-identity($Y)</code> unless
@@ -21828,10 +21855,7 @@ return function-arity($initial)</eg></fos:expression>
 	        whether <code>abs#1</code> and <code>abs(?)</code> return the same function item.</p>
 	     <p>Similarly, <code>function-identity({ 1:() }) eq function-identity(map:entry(1, ()))</code>
 	     may be either <code>true</code> or <code>false</code>.</p>
-	     <p>Labels on function items are ignored because they typically represent information about how the
-	     function item was retrieved, rather than about the item itself. For example, a function item held in a map
-	     might be retrieved using a variety of lookup expressions, which may return the same function item but with
-	     different labels.</p>
+	     
 	  </fos:notes>
       <fos:examples>
          <fos:example>
@@ -35187,9 +35211,9 @@ return $result
       </fos:changes>
    </fos:function>
    
-   <fos:function name="pin" prefix="fn">
+   <fos:function name="JNode" prefix="fn">
       <fos:signatures>
-         <fos:proto name="pin" return-type="JNode(map(*)|array(*))">
+         <fos:proto name="JNode" return-type="JNode(map(*)|array(*))">
             <fos:arg name="input" type="(map(*)|array(*))"/>
          </fos:proto>
       </fos:signatures>
@@ -35199,37 +35223,54 @@ return $result
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Adapts a map or array so that retrieval operations retain additional information.</p>
+         <p>Delivers a root <xtermref spec="DM40" ref="dt-JNode"/> wrapping 
+            a map or array, enabling the use of lookup expression
+            to navigate a <xtermref spec="DM40" ref="dt-JTree"/> rooted at that map or array.</p>
       </fos:summary>
       <fos:rules>
          <p>The function creates <xtermref spec="DM40" ref="JNode"/>
             that wraps the supplied map or array. Specifically, it creates a root JNode
             whose <code>¶value</code> property is <code>$input</code>, and whose
-            <code>¶parent</code> and <code>¶selector</code> properties are absent.</p>
+            <code>¶parent</code>, <code>¶position</code>, <code>¶selector</code> 
+            properties are absent.</p>
          
          <p>This has the effect that lookup expressions starting from this JNode retain
             information for subsequent navigation.</p>
          
-         <p>A JNode has unique identity. It is <termref def="implementation-defined"/>
-         whether two calls of <code>pin</code> with the same argument return the
-         same JNode: it is <rfc2119>recommended</rfc2119> that they should do so,
-         but because the notion of being the "same argument" is not precisely defined
-         for maps and arrays, this cannot be guaranteed.</p>
+         <p>A JNode has unique identity. If two maps or arrays <var>M1</var> and
+            <var>M2</var> have the same function identity, as determined by the
+            <function>function-identity</function> function, then
+            <code>JNode(<var>M1</var>) is JNode(<var>M2</var>)</code> must
+            return true: that is, the same JNode must be
+            delivered for both.</p>
+         <note><p>It is to some extent <termref def="implementation-defined"/>
+         whether two maps or arrays have the same function identity. Processors
+         <rfc2119>should</rfc2119> ensure as a minimum that when 
+            a variable <code>$m</code> is bound to a map or array,
+         calling <code>JNode($m)</code> more than once (with the same variable reference)
+         will deliver the same JNode each time.</p></note>
          
       </fos:rules>
       <fos:notes>
-         <p>The effect of the coercion rules is that if an existing JNode is supplied as input,
-         it will first be unpinned, and the result will be a new JNode that wraps the same value.</p>
+         <p>The effect of the coercion rules is technically that if an existing JNode is supplied as <code>$input</code>,
+         the wrapped value will be extracted, and then rewrapped as a JNode: in practice,
+         this can be short-circuited by returning the supplied JNode unchanged.</p>
          
-         <p>The effect of calling <code>pin</code> on a map or array is that subsequent retrieval operations
-         within the pinned map or array return results that retain useful information about
+         <p>Although <function>fn:JNode</function> is available as a function for user applications
+         to call explicitly, it is also invoked implicitly by some expressions, notably when
+         a lookup expression is written in a form such as <code>$map?child::*</code>. Specifically,
+         if the left-hand operand of the lookup operator is a map or array, and the right-hand side
+         uses an explicit axis such as <code>child::</code>, then the supplied map or array is implicitly
+         wrapped in a JNode.</p>
+         
+         <p>The effect of applying <code>fn:JNode</code> to a map or array is that subsequent retrieval operations
+         within the wrapped map or array return results that retain useful information about
          where the results were found. For example, an expression such as <code>json-doc($source)??name</code>
-         will return the values of all entries in the JSON tree having the key <code>"name"</code>; but very little
-         can be done with this information because the result is simply a sequence of (typically) strings 
-         with no context. By contrast, the result of <code>pin(json-doc($source)) ? descendant::name</code> 
-            is a sequence of JNodes encapsulating the same set
-         of strings, but retaining information about where they were found. For example, if <code>$result</code>
-            is the result of the expression <code>json-doc($source) ? descendant::name</code>, then:</p>
+         returns a set of JNodes representing all entries in the JTree having the key <code>"name"</code>; 
+         each of these JNodes contains not only the value of the relevant <code>"name"</code> entry,
+            but also the key (which in this simple example is always <code>"name"</code>
+            and the containing map. This means, for example, if <code>$result</code>
+            is the result of the expression <code>json-doc($source) ?? name</code>, then:</p>
          
          <ulist>
             <item><p><code>$result ? .. ? ssn</code> locates the map that contained each
@@ -35241,7 +35282,7 @@ return $result
   
          </ulist>
          
-         <p>An alternative way of pinning a map or array, rather than calling <code>pin($X)</code>,
+         <p>An alternative way of wrapping a map or array, rather than calling <code>JNode($X)</code>,
          is to use the lookup expression <code>$X?.</code>.</p>
          
          
@@ -35249,13 +35290,13 @@ return $result
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>pin([ "a", "b", "c" ]) ? child::1 ? parent::* ! array:foot(.)</fos:expression>
+               <fos:expression>JNode([ "a", "b", "c" ]) ? child::1 ? parent::* ! array:foot(.)</fos:expression>
                <fos:result>"c"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>pin([ "a", "b", "c", "d" ]) ? child::* => selector()</fos:expression>
+               <fos:expression>JNode([ "a", "b", "c", "d" ]) ? child::* => selector()</fos:expression>
                <fos:result>1, 2, 3, 4</fos:result>
             </fos:test>
          </fos:example>
@@ -35265,20 +35306,20 @@ return $result
   "fr": { "capital": "Paris", "languages": [ "French" ] }, 
   "de": { "capital": "Berlin", "languages": [ "German" ] }
 }
-return pin($data) ? descendant::languages[. = 'German'] ? .. ? capital)[1]</eg></fos:expression>
+return JNode($data) ? descendant::languages[. = 'German'] ? .. ? capital)[1]</eg></fos:expression>
                <fos:result>"Berlin"</fos:result>
             </fos:test>
          </fos:example>
          
       </fos:examples>
       <fos:changes>
-         <fos:change issue="960" PR="988" date="2024-02-27"><p>New in 4.0</p></fos:change>
+         <fos:change issue="2025" PR="2031" date="2025-06-12"><p>New in 4.0</p></fos:change>
       </fos:changes>
    </fos:function>
    
-   <fos:function name="selector" prefix="fn">
+   <fos:function name="JNode-selector" prefix="fn">
       <fos:signatures>
-         <fos:proto name="selector" return-type="xs:anyAtomicType?">
+         <fos:proto name="JNode-selector" return-type="xs:anyAtomicType?">
             <fos:arg name="input" type="JNode()"/>
          </fos:proto>
       </fos:signatures>
@@ -35294,23 +35335,26 @@ return pin($data) ? descendant::languages[. = 'German'] ? .. ? capital)[1]</eg><
          <p>If <code>$input</code> is an empty sequence, the function returns an empty sequence.</p>
          <p>If <code>$input</code> is a root JNode (one in which the <code>¶selector</code> property is
             absent), the function returns an empty sequence.</p>
-         <p>Otherwise, the function returns the <code>¶selector</code> property of <code>$input</code>.</p>
+         <p>Otherwise, the function returns the <code>¶selector</code> property of <code>$input</code>.
+         In the case where the parent JNode wraps a map, this will be the key of the relevant entry
+         within that map; in the case where the parent JNode wraps an array, it will be the 1-based
+         index of the relevant member of the array.</p>
       </fos:rules>   
       <fos:examples>
          <fos:example>
             <fos:test>
                <fos:expression><eg>let $array := [1, 3, 4.5, 7, "eight", 10]
-return $array ? child::~xs:integer =!> selector()</eg></fos:expression>
+return $array ? child::~xs:integer =!> JNode-selector()</eg></fos:expression>
                <fos:result>1, 2, 4, 6</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>let $map := {'Mo': 'Monday', 'Tu': 'Tuesday', 'We': 'Wednesday'}
-return $map ? child::("Mo", "We", "Fr", "Su") =!> selector()</eg></fos:expression>
+return $map ? child::("Mo", "We", "Fr", "Su") =!> JNode-selector()</eg></fos:expression>
                <fos:result>"Mo", "We"</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>let $array := [[4, 18], [30, 4, 22]]
-return $array ? descendant::*[. gt 25][1] ? ancestor::* =!> selector() => reverse()</eg></fos:expression>
+return $array ? descendant::*[. gt 25][1] ? ancestor::* =!> JNode-selector() => reverse()</eg></fos:expression>
                <fos:result>2, 1</fos:result>
             </fos:test>
          </fos:example>
@@ -35318,13 +35362,97 @@ return $array ? descendant::*[. gt 25][1] ? ancestor::* =!> selector() => revers
       </fos:examples>
       
       <fos:changes>
-         <fos:change issue="960" PR="988" date="2024-02-27"><p>New in 4.0</p></fos:change>
+         <fos:change issue="2025" PR="2031" date="2025-06-12"><p>New in 4.0</p></fos:change>
       </fos:changes>
    </fos:function>
    
-   <fos:function name="unpin" prefix="fn">
+   <fos:function name="JNode-position" prefix="fn">
       <fos:signatures>
-         <fos:proto name="unpin" return-type="item()*">
+         <fos:proto name="JNode-position" return-type="xs:anyAtomicType?">
+            <fos:arg name="input" type="JNode()"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:summary>
+         <p>Returns the <code>¶position</code> property of a JNode.</p>
+      </fos:summary>
+      <fos:rules>
+         <p>If <code>$input</code> is an empty sequence, the function returns an empty sequence.</p>
+         <p>If <code>$input</code> is a root JNode (one in which the <code>¶position</code> property is
+            absent), the function returns an empty sequence.</p>
+         <p>Otherwise, the function returns the <code>¶position</code> property of <code>$input</code>.
+            The value of this property will be 1 (one) except in cases where the parent JNode wraps
+            a map or array whose relevant entry contains a sequence of maps or arrays; in such cases
+            the position will be the 1-based position of the relevant map or array.</p>
+      </fos:rules>  
+      <fos:notes>
+         <p>This function is relevant only when processing maps whose entries contain sequences
+         of maps and arrays, or arrays whose members contain sequences of maps and arrays.
+         Such structures are uncommon (and never arise from parsing of JSON source text).
+         It is generally best to avoid such structures: using arrays rather than sequences
+         within array and map content typically makes processing easier.</p>
+         <p>If an entry within a map, or a member of an array, contains a sequence of items
+         that mixes arrays and maps with other content (for example the array
+          <code>[1, 2, ([1,2], [3,4], 5))</code>, then a lookup <code>child::*</code>
+         will only </p>
+      </fos:notes>
+      <fos:examples>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>let $input := {
+   "a": [10, 20, 30], 
+   "b": ([40, 50, 60], [70, 80, 90])
+}
+return $input ? child::b ? * 
+       ! { "position": JNode-position(.),
+           "index": JNode-selector(.)
+           "value": JNode-value(.)
+         }</eg></fos:expression>
+               <fos:result><eg>{
+{ "position": 1, "index": 1, "value": 40 },
+{ "position": 1, "index": 2, "value": 50 },
+{ "position": 1, "index": 3, "value": 60 },
+{ "position": 2, "index": 1, "value": 70 },
+{ "position": 2, "index": 2, "value": 80 },
+{ "position": 2, "index": 3, "value": 90 }</eg></fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>let $input := {
+   "a": {"x": 10, "y": 20, "z": 30}, 
+   "b": ( {"x": 40, "y": 50, "z": 60}, 
+          {"x": 50, "y": 60, "z": 70})
+}
+return $input ? child::b ? * 
+       ! { "position": JNode-position(.),
+           "key": JNode-selector(.)
+           "value": JNode-value(.)
+         }</eg></fos:expression>
+               <fos:result><eg>{
+{ "position": 1, "key": "x", "value": 40 },
+{ "position": 1, "key": "y", "value": 50 },
+{ "position": 1, "key": "z", "value": 60 },
+{ "position": 2, "key": "x", "value": 70 },
+{ "position": 2, "key": "y", "value": 80 },
+{ "position": 2, "key": "z", "value": 90 }</eg></fos:result>
+            </fos:test>
+
+            
+         </fos:example>
+         
+      </fos:examples>
+      
+      <fos:changes>
+         <fos:change issue="2025" PR="2031" date="2025-06-12"><p>New in 4.0</p></fos:change>
+      </fos:changes>
+   </fos:function>
+   
+   <fos:function name="JNode-value" prefix="fn">
+      <fos:signatures>
+         <fos:proto name="JNode-value" return-type="item()*">
             <fos:arg name="input" type="JNode()"/>
          </fos:proto>
       </fos:signatures>
@@ -35341,32 +35469,33 @@ return $array ? descendant::*[. gt 25][1] ? ancestor::* =!> selector() => revers
          <p>Otherwise, the function returns the <code>¶value</code> property of <code>$input</code>.</p>
       </fos:rules>
       <fos:notes>
-         <p>In many cases it is unnecessary to make an explicit call on <code>unpin</code>, because
+         <p>In many cases it is unnecessary to make an explicit call on <code>JNode-value</code>, because
          the coercion rules will take care of this automatically. For example, in an expression
          such as <code>$X ? descendant::name [matches(., '^J')]</code>, the call on
-         <code>matches</code> is supplied with a JNode as its first argument; atomization
-         ensures that the actual value being passed is the atomized value of the 
+         <function>matches</function> is supplied with a JNode as its first argument; atomization
+         ensures that the actual value being passed to the first argument of <function>matches</function>
+            is the atomized value of the 
           <code>¶value</code> property.</p>
          <p>One case where the function call may be needed is when computing the effective boolean
          value. As with XNodes, writing <code>if (?child::*[1]) ...</code> tests for the existence
-         of a child, it does not test its value. To test its value, write <code>if (unpin(?child::*[1])) ...</code>,
+         of a child, it does not test its value. To test its value, write <code>if (JNode-value(?child::*[1])) ...</code>,
          or equivalently <code>if (xs:boolean(?child::*[1])) ...</code>.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
             <fos:test>
                <fos:expression><eg>let $array := [1, 3, 4.5, 7, "eight", 10]
-return $array ? child::~xs:integer =!> unpin()</eg></fos:expression>
+return $array ? child::~xs:integer =!> JNode-value()</eg></fos:expression>
                <fos:result>1, 3, 7, 10</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>let $map := {'Mo': 'Monday', 'Tu': 'Tuesday', 'We': 'Wednesday'}
-return $map ? child::("Mo", "We", "Fr", "Su") =!> unpin()</eg></fos:expression>
+return $map ? child::("Mo", "We", "Fr", "Su") =!> JNode-value()</eg></fos:expression>
                <fos:result>"Monday", "Wednesday"</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>let $array := [[4, 18], [30, 4, 22]]
-return $array ? descendant::*[. gt 25][1] ? ancestor-or-self::* =!> unpin() => reverse()</eg></fos:expression>
+return $array ? descendant::*[. gt 25][1] ? ancestor-or-self::* =!> JNode-value() => reverse()</eg></fos:expression>
                <fos:result>[[4, 18], [30, 4, 22]], [30, 4, 22], 30</fos:result>
             </fos:test>
          </fos:example>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -926,12 +926,18 @@
                <p>If the item is an atomic item, it is appended to the result sequence.</p>
             </item>
             <item>
-               <p>If the item is a node, the typed value of the node is appended to the result
+               <p>If the item is an <xtermref spec="DM40" ref="dt-XNode"/>, 
+                  the typed value of the node is appended to the result
                   sequence. The typed value is a sequence of zero or more atomic items:
                   specifically, the result of the <code>dm:typed-value</code> accessor as defined in
                      <bibref
                      ref="xpath-datamodel-31"/> (See <xspecref spec="DM40" ref="dm-typed-value"
                   />).</p>
+            </item>
+            <item>
+               <p>If the item is a <xtermref spec="DM40" ref="dt-JNode"/>,
+               the atomized value of its <code>¶value</code> property is appended to
+               the result sequence.</p>
             </item>
             <item>
                <p>If the item is an array, the result of applying <function>fn:data</function> to
@@ -8199,8 +8205,8 @@ satisfies compare($t, replace($token, '^\s*|\s*$', ''), $collation) eq 0
                      <code>false</code>.</p>
             </item>
             <item>
-               <p>If <code>$input</code> is a sequence whose first item is a node,
-                     <function>fn:boolean</function> returns <code>true</code>.</p>
+               <p>If <code>$input</code> is a sequence whose first item is a <xtermref spec="DM40" ref="dt-GNode"/>
+                  (a generalized node), <function>fn:boolean</function> returns <code>true</code>.</p>
             </item>
             <item>
                <p>If <code>$input</code> is a singleton value of type <code>xs:boolean</code> or a
@@ -19641,7 +19647,7 @@ return { "width": $int16-at($loc + 5),
    <fos:function name="generate-id" prefix="fn">
       <fos:signatures>
          <fos:proto name="generate-id" return-type="xs:string">
-            <fos:arg name="node" type="node()?" usage="inspection" default="."/>
+            <fos:arg name="node" type="GNode()?" usage="inspection" default="."/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -19655,7 +19661,7 @@ return { "width": $int16-at($loc + 5),
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>This function returns a string that uniquely identifies a given node. </p>
+         <p>This function returns a string that uniquely identifies a given GNode. </p>
       </fos:summary>
       <fos:rules>
          <p>If the argument is omitted, it defaults to the context value (<code>.</code>).<phrase diff="del" at="2022-11-29"> The
@@ -19685,21 +19691,21 @@ return { "width": $int16-at($loc + 5),
                      class="DY" code="0002" type="type"/></p>
             </item>
             <item>
-               <p>If the context value is not an instance of the sequence type <code>node()?</code>, type error <xerrorref spec="XP" class="TY"
-                     code="0004" type="type"/>.</p>
+               <p>If the context value is not an instance of the sequence type
+               <code>GNode()?</code>, type error <xerrorref spec="XP" class="TY" code="0004" type="type"/>.</p>
             </item>
          </ulist>
 
       </fos:errors>
       <fos:notes>
          <p>An implementation is free to generate an identifier in any convenient way provided that
-            it always generates the same identifier for the same node and that different identifiers
-            are always generated from different nodes. An implementation is under no obligation to
+            it always generates the same identifier for the same GNode and that different identifiers
+            are always generated from different GNodes. An implementation is under no obligation to
             generate the same identifiers each time a document is transformed or queried.</p>
          <p>There is no guarantee that a generated unique identifier will be distinct from any
             unique IDs specified in the source document.</p>
-         <p>There is no inverse to this function; it is not directly possible to find the node with
-            a given generated ID. Of course, it is possible to search a given sequence of nodes
+         <p>There is no inverse to this function; it is not directly possible to find the GNode with
+            a given generated ID. Of course, it is possible to search a given sequence of GNodes
             using an expression such as <code>$nodes[generate-id()=$id]</code>.</p>
          <p>It is advisable, but not required, for implementations to generate IDs that are distinct
             even when compared using a case-blind collation.</p>
@@ -25959,6 +25965,39 @@ return map:build($titles/title, fn($title) { $title/ix })
                of its <function>fn:generate-id</function> value:</p>
             <eg>map:build(//*, generate-id#1)</eg>
          </fos:example>
+         <fos:example>
+            <p>The following expression creates a map allowing efficient access to values in a recorsive JSON tree
+               using hierarchic paths:</p>
+            <eg>let $tree := {
+  "type": "package",
+  "name": "org",
+  "content": [
+      { "type": "package",
+        "name": "xml,
+        "content: [
+            { "type": "package",
+              "name": "sax",
+              "content": [
+                  { "type": "class",
+                    "name": "Attributes"},
+                  { "type": "class",
+                    "name": "ContentHandler"},
+                  { "type": "class",
+                    "name": "XMLReader"}
+               ]
+            }]
+       }]
+   }
+   return map:build($tree ? descendant::~record(type, name, *),
+                    fn{?ancestor-or-self::name => reverse() => string-join(,)},
+                    fn{`{?type} {?name}`})
+            </eg>
+            <p>The result is the map:</p>
+            <eg>{ "org.xml.sax.Attributes": "class Attributes",
+  "org.xml.sax.ContentHandler": "class ContentHandler",
+  "org.xml.saxon.XMLReader": "class XMLReader" }</eg>
+         </fos:example>
+         
       </fos:examples>
       <fos:changes>
          <fos:change issue="151" PR="203" date="2022-10-18"><p>New in 4.0</p></fos:change>
@@ -35137,7 +35176,7 @@ return $result
    
    <fos:function name="pin" prefix="fn">
       <fos:signatures>
-         <fos:proto name="pin" return-type="(map(*)|array(*))">
+         <fos:proto name="pin" return-type="JNode(map(*)|array(*))">
             <fos:arg name="input" type="(map(*)|array(*))"/>
          </fos:proto>
       </fos:signatures>
@@ -35150,143 +35189,58 @@ return $result
          <p>Adapts a map or array so that retrieval operations retain additional information.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function creates a deep copy of the supplied map or array, adapted so that
-         navigation within the deep copy returns items that are labeled with additional
-         information about their position within the containing tree structure.</p>
-         <note><p>The formal specification of the function describes it as constructing
-         a deep copy of the entire tree, but a practical implementation is likely to
-         use a lazy evaluation strategy, so the only costs incurred are for items
-         actually selected within the tree.</p></note>
-         <p>The function makes use of the concept of <term>labeled items</term>, an extension
-            to the data model described in <xspecref spec="DM40" ref="id-LabeledItems"/>.</p>
-         <p>The supplied value of <code>$input</code> must be either a map or an array.</p>
-         <p>The result is as follows:</p>
-         <olist>
-            <item><p>If <code>$input</code> is a map <var>M</var>, the result is a map <var>M'</var>
-            derived from <var>M</var> as follows:</p>
-            <olist>
-               <item><p>Any existing label on <var>M</var> is discarded.</p></item>
-               <item><p><var>M'</var> acquires a label having the property <code>pinned</code>
-               set to the value <code>true</code>, and the property <code>id</code> set to
-               an arbitrary <code>xs:string</code> value that is unique within the execution scope.</p></item>
-               <item><p>For every key-value pair (<var>K</var>, <var>V</var>) in <var>M</var>,
-                  <var>M'</var> will have a key-value pair (<var>K</var>, <var>V'</var>)
-               in which the key <var>K</var> is unchanged, and the value <var>V'</var>
-               is derived from <var>V</var> by applying the function <code>derived-value(M', K, V)</code>,
-                  defined below.</p>
-               </item>
-               <item><p>The <xtermref spec="DM40" ref="dt-entry-order"/>
-               of <var>M</var> is retained in <var>M'</var>.</p></item>
-            </olist>
-            </item>
-            <item><p>If <code>$input</code> is an array <var>A</var>, the result is an array <var>A'</var>
-               derived from <var>A</var> as follows:</p>
-               <olist>
-                  <item><p>Any existing label on <var>A</var> is discarded.</p></item>
-                  <item><p><var>A'</var> acquires a label having the property <code>pinned</code>
-                     set to the value <code>true</code>, and the property <code>id</code> set to
-                     an arbitrary <code>xs:string</code> value that is unique within the execution scope.</p></item>
-                  <item><p>For every member <var>V</var> in <var>A</var>,
-                     whose 1-based index position in <var>A</var> is <var>X</var>,
-                     <var>A'</var> will have a member <var>V'</var>
-                     derived from <var>V</var> by applying the function <code>derived-value(A', X, V)</code>,
-                     defined below.</p>
-                  </item>
-               </olist>
-            </item>
-            <item><p>The <code>id</code> property described in the previous paragraphs is allocated
-            only to the top-level map or array (the one supplied as an explicit argument to the
-               <function>fn:pin</function> function). The function is <emph>not</emph>
-                  <termref def="dt-deterministic">deterministic</termref>: that is, if the function is called
-                  twice with the same arguments, it is <termref def="implementation-dependent"
-                     >implementation-dependent</termref> whether the same <code>id</code> property is allocated on both
-                  occasions.</p></item>
-            <item><p>If <code>$input</code> is anything other than a map or an array, a type
-               error is raised.</p>
-            </item>
-            <item><p>The function <code>derived-value(P, K, V)</code> has the following logic.
-               For every item <var>J</var>
-                  in <var>V</var>, <var>V'</var> will contain an item <var>J'</var> that is derived from
-                     <var>J</var> as follows:</p>
-                   <olist>
-                      <item>
-                         <p>Let <var>TEMP</var> be:</p>
-                         <olist>
-                            <item><p>If <var>J</var> is a map or array, then <code>fn:pin(J)</code>.</p>
-                               <note><p>Note however that
-                                  the <code>id</code> property of <var>TEMP</var> is not used, 
-                                  so there is no need to generate it.</p></note></item>
-                            <item><p>Otherwise, <var>J</var>.</p></item>
-                         </olist>
-                      </item>
-                      <item><p><var>J'</var> is then a labeled item having the same subject as <var>TEMP</var>,
-                      together with a label having the following properties:</p>
-                         <glist>
-                            <gitem>
-                               <label>pinned</label>
-                               <def><p><code>true</code></p></def>
-                            </gitem>
-                            <gitem>
-                               <label>key</label>
-                               <def><p><var>K</var></p></def>
-                            </gitem>
-                            <gitem>
-                               <label>position</label>
-                               <def><p>The 1-based position of <code>J</code> within <code>V</code>.</p></def>
-                            </gitem>
-                            <gitem>
-                               <label>parent</label>
-                               <def><p><var>P</var></p></def>
-                            </gitem>
-                            <gitem>
-                               <label>ancestors</label>
-                               <def><p>A zero-arity function item delivering the value of <code>(?parent, ?parent ! label(.)?ancestors())</code>.</p></def>
-                            </gitem>
-                           <gitem>
-                              <label>path</label>
-                              <def><p>A zero-arity function item delivering the value of <code>(?parent ! label(.)?path(), ?key)</code>.</p></def>
-                           </gitem>
-                        </glist>
-                      </item>
-                     
-                  </olist>
-               </item>
-         </olist>
+         <p>The function creates <xtermref spec="DM40" ref="JNode"/>
+            that wraps the supplied map or array. Specifically, it creates a root JNode
+            whose <code>¶value</code> property is <code>$input</code>, and whose
+            <code>¶parent</code> and <code>¶selector</code> properties are absent.</p>
+         
+         <p>This has the effect that lookup expressions starting from this JNode retain
+            information for subsequent navigation.</p>
+         
+         <p>A JNode has unique identity. It is <termref def="implementation-defined"/>
+         whether two calls of <code>pin</code> with the same argument return the
+         same JNode: it is <rfc2119>recommended</rfc2119> that they should do so,
+         but because the notion of being the "same argument" is not precisely defined
+         for maps and arrays, this cannot be guaranteed.</p>
+         
       </fos:rules>
       <fos:notes>
+         <p>The effect of the coercion rules is that if an existing JNode is supplied as input,
+         it will first be unpinned, and the result will be a new JNode that wraps the same value.</p>
+         
          <p>The effect of calling <code>pin</code> on a map or array is that subsequent retrieval operations
-         within the pinned map or array return labeled results, whose labels contain useful information about
+         within the pinned map or array return results that retain useful information about
          where the results were found. For example, an expression such as <code>json-doc($source)??name</code>
          will return the values of all entries in the JSON tree having the key <code>"name"</code>; but very little
          can be done with this information because the result is simply a sequence of (typically) strings 
-         with no context. By contrast, the result of <code>pin(json-doc($source))??name</code> is the same set
-         of strings, labeled with information about where they were found. For example, if <code>$result</code>
-            is the result of the expression <code>pin(json-doc($source))??name</code>, then:</p>
+         with no context. By contrast, the result of <code>pin(json-doc($source)) ? descendant::name</code> 
+            is a sequence of JNodes encapsulating the same set
+         of strings, but retaining information about where they were found. For example, if <code>$result</code>
+            is the result of the expression <code>pin(json-doc($source)) ? descendant::name</code>, then:</p>
          
          <ulist>
-            <item><p><code>$result => label()?parent?ssn</code> locates the map that contained each
+            <item><p><code>$result => . ? parent::* ? ssn</code> locates the map that contained each
                <code>name</code>, and returns the value of the <code>ssn</code> entry in that map.</p></item>
-            <item><p><code>$result => label()?ancestors()?course</code> returns the values of any
+            <item><p><code>$result => . ? ancestor::course</code> returns the values of any
             <code>course</code> entries in containing maps.</p></item>
-            <item><p><code>$result => label()?path()</code> returns a sequence of map keys and array index
+            <item><p><code>$result => . ? ancestor::* => selector() </code> returns a sequence of map keys and array index
             values representing the location of the found entries within the JSON structure.</p></item>
-            <item><p><code></code></p></item>
+  
          </ulist>
          
-         <ednote><edtext>The <code>id</code> property on the root of a pinned map or array is
-         intended to support deep update operations, which have not yet been defined.</edtext></ednote>
+         
       </fos:notes>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>pin([ "a", "b", "c" ])?1 ! label(.)?parent ! array:foot(.)</fos:expression>
+               <fos:expression>pin([ "a", "b", "c" ]) ? child::1 ? parent::* ! array:foot(.)</fos:expression>
                <fos:result>"c"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>pin([ "a", "b", "c", "d" ]) ! array:remove(., 2)?* ! label(.)?key</fos:expression>
-               <fos:result>1, 3, 4</fos:result>
+               <fos:expression>pin([ "a", "b", "c", "d" ]) ? child::* => selector()</fos:expression>
+               <fos:result>1, 2, 3, 4</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -35295,8 +35249,8 @@ return $result
   "fr": { "capital": "Paris", "languages": [ "French" ] }, 
   "de": { "capital": "Berlin", "languages": [ "German" ] }
 }
-return pin($data)??languages[. = 'German'] ! label(.)?path()[1]</eg></fos:expression>
-               <fos:result>"de"</fos:result>
+return pin($data) ? descendant::languages[. = 'German'] ? parent::* ?capital)[1]</eg></fos:expression>
+               <fos:result>"Berlin"</fos:result>
             </fos:test>
          </fos:example>
          
@@ -35306,10 +35260,10 @@ return pin($data)??languages[. = 'German'] ! label(.)?path()[1]</eg></fos:expres
       </fos:changes>
    </fos:function>
    
-   <fos:function name="label" prefix="fn">
+   <fos:function name="selector" prefix="fn">
       <fos:signatures>
-         <fos:proto name="label" return-type="map(xs:string, item()*)?">
-            <fos:arg name="input" type="item()?"/>
+         <fos:proto name="selector" return-type="xs:anyAtomicType?">
+            <fos:arg name="input" type="JNode()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -35318,26 +35272,90 @@ return pin($data)??languages[. = 'German'] ! label(.)?path()[1]</eg></fos:expres
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns the label associated with a labeled item, as a map.</p>
+         <p>Returns the <code>¶selector</code> property of a JNode.</p>
       </fos:summary>
       <fos:rules>
          <p>If <code>$input</code> is an empty sequence, the function returns an empty sequence.</p>
-         <p>If <code>$input</code> is an item that has no label, the function returns an empty map.</p>
-         <p>If <code>$input</code> is a labeled item, the function returns the label, as a map.</p>
+         <p>If <code>$input</code> is a root JNode (one in which the <code>¶selector</code> property is
+            absent), the function returns an empty sequence.</p>
+         <p>Otherwise, the function returns the <code>¶selector</code> property of <code>$input</code>.</p>
       </fos:rules>   
-      <fos:notes>
-         <p>The function makes use of the concept of <term>labeled items</term>, an extension
-            to the data model described in <xspecref spec="DM40" ref="id-LabeledItems"/>.</p>
-         <p>The data model allows any item to be labeled, and allows the label to be any map
-            with string-valued keys. Currently the only operation that creates labeled values is
-         the <function>fn:pin</function> function. For examples illustrating the use of <function>fn:label</function>,
-         see <function>fn:pin</function>.</p>
+      <fos:examples>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>let $array := [1, 3, 4.5, 7, "eight", 10]
+return $array ? child::~xs:integer =!> selector()</eg></fos:expression>
+               <fos:result>1, 2, 4, 6</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>let $map := {'Mo': 'Monday', 'Tu': 'Tuesday', 'We': 'Wednesday'}
+return $map ? child::("Mo", "We", "Fr", "Su") =!> selector()</eg></fos:expression>
+               <fos:result>"Mo", "We"</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>let $array := [[4, 18], [30, 4, 22]]
+return $array ? descendant::*[. gt 25][1] ? ancestor::* =!> selector() => reverse()</eg></fos:expression>
+               <fos:result>2, 1</fos:result>
+            </fos:test>
+         </fos:example>
          
-      </fos:notes>
+      </fos:examples>
       
       <fos:changes>
          <fos:change issue="960" PR="988" date="2024-02-27"><p>New in 4.0</p></fos:change>
       </fos:changes>
+   </fos:function>
+   
+   <fos:function name="unpin" prefix="fn">
+      <fos:signatures>
+         <fos:proto name="unpin" return-type="item()*">
+            <fos:arg name="input" type="JNode()"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:summary>
+         <p>Returns the <code>¶value</code> property of a JNode.</p>
+      </fos:summary>
+      <fos:rules>
+         <p>If <code>$input</code> is an empty sequence, the function returns an empty sequence.</p>
+         <p>Otherwise, the function returns the <code>¶selector</code> property of <code>$input</code>.</p>
+      </fos:rules>
+      <fos:notes>
+         <p>In many cases it is unnecessary to make an explicit call on <code>unpin</code>, because
+         the coercion rules will take care of this automatically. For example, in an expression
+         such as <code>$X ? descendant::name [matches(., '^J')]</code>, the call on
+         <code>matches</code> is supplied with a JNode as its first argument; atomization
+         ensures that the actual value being passed is the atomized value of the 
+          <code>¶value</code> property.</p>
+         <p>One case where the function call may be needed is when computing the effective boolean
+         value. As with XNodes, writing <code>if (?child::*[1]) ...</code> tests for the existence
+         of a child, it does not test its value. To test its value, write <code>if (unpin(?child::*[1])) ...</code>,
+         or equivalently <code>if (data(?child::*[1])) ...</code>.</p>
+      </fos:notes>
+      <fos:examples>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>let $array := [1, 3, 4.5, 7, "eight", 10]
+return $array ? child::~xs:integer =!> unpin()</eg></fos:expression>
+               <fos:result>1, 3, 7, 10</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>let $map := {'Mo': 'Monday', 'Tu': 'Tuesday', 'We': 'Wednesday'}
+return $map ? child::("Mo", "We", "Fr", "Su") =!> unpin()</eg></fos:expression>
+               <fos:result>"Monday", "Wednesday"</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>let $array := [[4, 18], [30, 4, 22]]
+return $array ? descendant::*[. gt 25][1] ? ancestor-or-self::* =!> unpin() => reverse()</eg></fos:expression>
+               <fos:result>[[4, 18], [30, 4, 22]], [30, 4, 22], 30</fos:result>
+            </fos:test>
+         </fos:example>
+         
+      </fos:examples>
    </fos:function>
    
 </fos:functions>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -823,6 +823,8 @@
          <p>If <code>$value</code> is a node, the function returns the string value of the node, as obtained using the
                      <code>dm:string-value</code> accessor defined in <bibref
                ref="xpath-datamodel-31"/> (see <xspecref spec="DM40" ref="dm-string-value"/>).</p>
+         
+         <p>If <code>$value</code> is a JNode, the function returns the result of <code>string(unpin($value))</code>.</p>
 
          <p>If <code>$value</code> is an atomic item, the function returns the result of the expression <code>$value cast
                      as xs:string</code> (see <specref
@@ -14158,8 +14160,8 @@ let $newi := $o/tool</eg>
    
    <fos:function name="distinct-ordered-nodes" prefix="fn">
       <fos:signatures>
-         <fos:proto name="distinct-ordered-nodes" return-type="node()*">
-            <fos:arg name="nodes" type="node()*" usage="navigation"/>
+         <fos:proto name="distinct-ordered-nodes" return-type="GNode()*">
+            <fos:arg name="nodes" type="GNode()*" usage="navigation"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -14169,17 +14171,19 @@ let $newi := $o/tool</eg>
          <fos:property>special-streaming-rules</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Removes duplicate nodes and sorts the input into document order.</p>
+         <p>Removes duplicate GNodes and sorts the input into document order.</p>
       </fos:summary>
       <fos:rules>
-         <p>Any duplicate nodes in the input (based on node identity) are discarded. The remaining nodes
+         <p>Any duplicate GNodes (that is, XNodes or JNodes) in the input 
+            (based on node identity) are discarded. The remaining GNodes
          are returned in <xtermref spec="XP40" ref="dt-document-order">document order</xtermref>.</p>
       </fos:rules>
       <fos:notes>
          <p>Document order is <termref def="implementation-dependent"/> (but stable) for
-         nodes in different documents. If some node in document <var>A</var>
-         precedes some node in document <var>B</var>, then every node in <var>A</var> precedes
-         every node in <var>B</var>.</p>
+         GNodes in different trees. If some GNode in tree <var>A</var>
+         precedes some GNode in tree <var>B</var>, then every GNode in <var>A</var> precedes
+         every GNode in <var>B</var>.</p>
+
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -14190,6 +14194,15 @@ return distinct-ordered-nodes(($x//c, $x//b, $x//a, $x//b)) ! name()]]></eg></fo
                <fos:postamble>The two <code>$x//b</code> expressions select the same node; one of these
                is eliminated as a duplicate. The <code>$x//c</code> expression selects two nodes
                that have distinct identity, so both are retained.</fos:postamble>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg><![CDATA[let $x := {"a":{"a":{"a":1}}}
+return distinct-ordered-nodes(
+           $x ? descendant::a ? descendant::a) 
+       => count() ]]></eg></fos:expression>
+               <fos:result>3</fos:result>
+               <fos:postamble>The innermost map entry <code>"a":1</code> is selected by two different
+                  routes; the lookup operator does not eliminate duplicate JNodes.</fos:postamble>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -25966,9 +25979,9 @@ return map:build($titles/title, fn($title) { $title/ix })
             <eg>map:build(//*, generate-id#1)</eg>
          </fos:example>
          <fos:example>
-            <p>The following expression creates a map allowing efficient access to values in a recorsive JSON tree
+            <p>The following expression creates a map allowing efficient access to values in a recursive JSON structure
                using hierarchic paths:</p>
-            <eg>let $tree := {
+            <eg>let $tree := parse-json('{
   "type": "package",
   "name": "org",
   "content": [
@@ -25987,15 +26000,15 @@ return map:build($titles/title, fn($title) { $title/ix })
                ]
             }]
        }]
-   }
-   return map:build($tree ? descendant::~record(type, name, *),
+   }')
+   return map:build($tree ? descendant::~[record(type, name, *)],
                     fn{?ancestor-or-self::name => reverse() => string-join(,)},
                     fn{`{?type} {?name}`})
             </eg>
             <p>The result is the map:</p>
             <eg>{ "org.xml.sax.Attributes": "class Attributes",
   "org.xml.sax.ContentHandler": "class ContentHandler",
-  "org.xml.saxon.XMLReader": "class XMLReader" }</eg>
+  "org.xml.sax.XMLReader": "class XMLReader" }</eg>
          </fos:example>
          
       </fos:examples>
@@ -35216,17 +35229,20 @@ return $result
          with no context. By contrast, the result of <code>pin(json-doc($source)) ? descendant::name</code> 
             is a sequence of JNodes encapsulating the same set
          of strings, but retaining information about where they were found. For example, if <code>$result</code>
-            is the result of the expression <code>pin(json-doc($source)) ? descendant::name</code>, then:</p>
+            is the result of the expression <code>json-doc($source) ? descendant::name</code>, then:</p>
          
          <ulist>
-            <item><p><code>$result => . ? parent::* ? ssn</code> locates the map that contained each
+            <item><p><code>$result ? .. ? ssn</code> locates the map that contained each
                <code>name</code>, and returns the value of the <code>ssn</code> entry in that map.</p></item>
-            <item><p><code>$result => . ? ancestor::course</code> returns the values of any
+            <item><p><code>$result ? ancestor::course</code> returns the values of any
             <code>course</code> entries in containing maps.</p></item>
-            <item><p><code>$result => . ? ancestor::* => selector() </code> returns a sequence of map keys and array index
+            <item><p><code>$result ? ancestor::* => selector() </code> returns a sequence of map keys and array index
             values representing the location of the found entries within the JSON structure.</p></item>
   
          </ulist>
+         
+         <p>An alternative way of pinning a map or array, rather than calling <code>pin($X)</code>,
+         is to use the lookup expression <code>$X?.</code>.</p>
          
          
       </fos:notes>
@@ -35249,7 +35265,7 @@ return $result
   "fr": { "capital": "Paris", "languages": [ "French" ] }, 
   "de": { "capital": "Berlin", "languages": [ "German" ] }
 }
-return pin($data) ? descendant::languages[. = 'German'] ? parent::* ?capital)[1]</eg></fos:expression>
+return pin($data) ? descendant::languages[. = 'German'] ? .. ? capital)[1]</eg></fos:expression>
                <fos:result>"Berlin"</fos:result>
             </fos:test>
          </fos:example>
@@ -35322,7 +35338,7 @@ return $array ? descendant::*[. gt 25][1] ? ancestor::* =!> selector() => revers
       </fos:summary>
       <fos:rules>
          <p>If <code>$input</code> is an empty sequence, the function returns an empty sequence.</p>
-         <p>Otherwise, the function returns the <code>¶selector</code> property of <code>$input</code>.</p>
+         <p>Otherwise, the function returns the <code>¶value</code> property of <code>$input</code>.</p>
       </fos:rules>
       <fos:notes>
          <p>In many cases it is unnecessary to make an explicit call on <code>unpin</code>, because
@@ -35334,7 +35350,7 @@ return $array ? descendant::*[. gt 25][1] ? ancestor::* =!> selector() => revers
          <p>One case where the function call may be needed is when computing the effective boolean
          value. As with XNodes, writing <code>if (?child::*[1]) ...</code> tests for the existence
          of a child, it does not test its value. To test its value, write <code>if (unpin(?child::*[1])) ...</code>,
-         or equivalently <code>if (data(?child::*[1])) ...</code>.</p>
+         or equivalently <code>if (xs:boolean(?child::*[1])) ...</code>.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -612,7 +612,7 @@
          </olist>
          <p>The string representing the type of an individual item <var>J</var> is constructed as follows:</p>
          <olist>
-            <item><p>If <var>J</var> is a node, the result is one of the following
+            <item><p>If <var>J</var> is an <xtermref spec="DM40" ref="dt-XNode"/>, the result is one of the following
             strings, determined by the node kind of the node (see <xspecref spec="DM40" ref="dm-node-kind"/>):</p>
             <p><slist>
                <sitem><code>"document-node()"</code></sitem>
@@ -623,6 +623,10 @@
                <sitem><code>"comment()"</code></sitem>
                <sitem><code>"namespace-node()"</code></sitem>
             </slist></p>
+            </item>
+            <item><p>If <var>J</var> is a <xtermref spec="DM40" ref="dt-JNode"/>, the result is in
+            the form <code>JNode(<var>T</var>)</code>, where <var>T</var> is the result of
+            applying the <function>type-of</function> function to the ¶value property of <var>J</var>.</p>
             </item>
             <item>
                <p>If <var>J</var> is an atomic item, the result is a string chosen as follows:</p>
@@ -731,6 +735,10 @@
                <fos:expression>type-of(type-of#1)</fos:expression>
                <fos:result>"function(*)"</fos:result>
             </fos:test>
+            <fos:test>
+               <fos:expression>type-of(JNode([]))</fos:expression>
+               <fos:result>"JNode(array(*))"</fos:result>
+            </fos:test>
          </fos:example>
       </fos:examples>
       <fos:changes>
@@ -827,7 +835,7 @@
          
          <p>If <code>$value</code> is a <xtermref spec="DM40" ref="dt-JNode"/>, 
             the function returns the result of <code>string(JNode-value($value))</code>.
-         This will fail in the case where <code>$value</code> is a map or an array.</p>
+         This will fail in the case where <code>JNode-value($value)</code> is a map or an array.</p>
 
          <p>If <code>$value</code> is an atomic item, the function returns the result of the expression <code>$value cast
                      as xs:string</code> (see <specref
@@ -859,8 +867,11 @@
       <fos:notes>
          <p>Every node has a string value, even an element with element-only
             content (which has no typed value). Moreover, casting an atomic item to a string always
-            succeeds. Functions, maps, and arrays have no string value, so these are the
-            only arguments that satisfy the type signature but cause failure.</p>
+            succeeds. Functions, maps, and arrays have no string value, so these 
+            satisfy the type signature but cause failure. Applying the <function>string</function>
+            function to a JNode succeeds if the JNode wraps a simple value such as a string, number,
+         or boolean, or if it wraps an XNode, but it fails in the case where the JNode wraps a map
+         or an array.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -35228,10 +35239,10 @@ return $result
             to navigate a <xtermref spec="DM40" ref="dt-JTree"/> rooted at that map or array.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function creates <xtermref spec="DM40" ref="JNode"/>
+         <p>The function creates a <xtermref spec="DM40" ref="dt-JNode"/>
             that wraps the supplied map or array. Specifically, it creates a root JNode
             whose <code>¶value</code> property is <code>$input</code>, and whose
-            <code>¶parent</code>, <code>¶position</code>, <code>¶selector</code> 
+            <code>¶parent</code>, <code>¶position</code>, and <code>¶selector</code> 
             properties are absent.</p>
          
          <p>This has the effect that lookup expressions starting from this JNode retain
@@ -35243,15 +35254,17 @@ return $result
             <code>JNode(<var>M1</var>) is JNode(<var>M2</var>)</code> must
             return true: that is, the same JNode must be
             delivered for both.</p>
-         <note><p>It is to some extent <termref def="implementation-defined"/>
+         
+         
+      </fos:rules>
+      <fos:notes>
+         <p>It is to some extent <termref def="implementation-defined"/>
          whether two maps or arrays have the same function identity. Processors
          <rfc2119>should</rfc2119> ensure as a minimum that when 
             a variable <code>$m</code> is bound to a map or array,
          calling <code>JNode($m)</code> more than once (with the same variable reference)
-         will deliver the same JNode each time.</p></note>
+         will deliver the same JNode each time.</p>
          
-      </fos:rules>
-      <fos:notes>
          <p>The effect of the coercion rules is technically that if an existing JNode is supplied as <code>$input</code>,
          the wrapped value will be extracted, and then rewrapped as a JNode: in practice,
          this can be short-circuited by returning the supplied JNode unchanged.</p>
@@ -35261,12 +35274,13 @@ return $result
          a lookup expression is written in a form such as <code>$map?child::*</code>. Specifically,
          if the left-hand operand of the lookup operator is a map or array, and the right-hand side
          uses an explicit axis such as <code>child::</code>, then the supplied map or array is implicitly
-         wrapped in a JNode.</p>
+         wrapped in a JNode. The same is true when the deep lookup operator <code>??</code> is used.</p>
          
-         <p>The effect of applying <code>fn:JNode</code> to a map or array is that subsequent retrieval operations
+         <p>The effect of applying <function>fn:JNode</function> to a map or array is that subsequent retrieval operations
          within the wrapped map or array return results that retain useful information about
-         where the results were found. For example, an expression such as <code>json-doc($source)??name</code>
-         returns a set of JNodes representing all entries in the JTree having the key <code>"name"</code>; 
+         where the results were found. For example, consider an expression such as <code>json-doc($source)??name</code>.
+            In this case the call on <function>fn:JNode</function> is implicit.
+         This expression returns a set of JNodes representing all entries in the JTree having the key <code>"name"</code>; 
          each of these JNodes contains not only the value of the relevant <code>"name"</code> entry,
             but also the key (which in this simple example is always <code>"name"</code>
             and the containing map. This means, for example, if <code>$result</code>
@@ -35306,7 +35320,7 @@ return $result
   "fr": { "capital": "Paris", "languages": [ "French" ] }, 
   "de": { "capital": "Berlin", "languages": [ "German" ] }
 }
-return JNode($data) ? descendant::languages[. = 'German'] ? .. ? capital)[1]</eg></fos:expression>
+return JNode($data) ?? languages[. = 'German'] ? .. ? capital) => string()</eg></fos:expression>
                <fos:result>"Berlin"</fos:result>
             </fos:test>
          </fos:example>
@@ -35385,59 +35399,65 @@ return $array ? descendant::*[. gt 25][1] ? ancestor::* =!> JNode-selector() => 
          <p>If <code>$input</code> is a root JNode (one in which the <code>¶position</code> property is
             absent), the function returns an empty sequence.</p>
          <p>Otherwise, the function returns the <code>¶position</code> property of <code>$input</code>.
-            The value of this property will be 1 (one) except in cases where the parent JNode wraps
-            a map or array whose relevant entry contains a sequence of maps or arrays; in such cases
+            The value of this property will be 1 (one) except in cases where 
+            the value of an entry in a map, or a member in an array, is a sequence that contains
+            multiple items including maps and/or arrays; in such cases
             the position will be the 1-based position of the relevant map or array.</p>
       </fos:rules>  
       <fos:notes>
-         <p>This function is relevant only when processing maps whose entries contain sequences
-         of maps and arrays, or arrays whose members contain sequences of maps and arrays.
-         Such structures are uncommon (and never arise from parsing of JSON source text).
-         It is generally best to avoid such structures: using arrays rather than sequences
-         within array and map content typically makes processing easier.</p>
+         <p>This function is relevant only when there are maps whose entries are multi-item
+            sequences that include maps and arrays, or arrays whose members include
+            such multi-item sequences.
+         Such structures are uncommon, and never arise from parsing of JSON source text.
+         It is generally best to avoid such structures by using arrays rather than sequences
+         within array and map content; apart from other considerations, this allows the
+         data to be serialized in JSON format.</p>
          <p>If an entry within a map, or a member of an array, contains a sequence of items
          that mixes arrays and maps with other content (for example the array
-          <code>[1, 2, ([1,2], [3,4], 5))</code>, then a lookup <code>child::*</code>
-         will only </p>
+          <code>[1, 2, ([1,2], [3,4], 5))</code>, then a lookup using the
+            child axis will only construct JNodes in respect of those items that are
+            non-empty maps or arrays. This may leave gaps in the position numbering sequence,
+            as illustrated in the examples below.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
             <fos:test>
                <fos:expression><eg>let $input := {
    "a": [10, 20, 30], 
-   "b": ([40, 50, 60], [70, 80, 90])
+   "b": ([40, 50, 60], [], 0, [70, 80, (90, 100)])
 }
 return $input ? child::b ? * 
        ! { "position": JNode-position(.),
            "index": JNode-selector(.)
            "value": JNode-value(.)
          }</eg></fos:expression>
-               <fos:result><eg>{
+               <fos:result><eg>
 { "position": 1, "index": 1, "value": 40 },
 { "position": 1, "index": 2, "value": 50 },
 { "position": 1, "index": 3, "value": 60 },
-{ "position": 2, "index": 1, "value": 70 },
-{ "position": 2, "index": 2, "value": 80 },
-{ "position": 2, "index": 3, "value": 90 }</eg></fos:result>
+{ "position": 4, "index": 1, "value": 70 },
+{ "position": 4, "index": 2, "value": 80 },
+{ "position": 4, "index": 3, "value": (90, 100) }</eg></fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>let $input := {
    "a": {"x": 10, "y": 20, "z": 30}, 
-   "b": ( {"x": 40, "y": 50, "z": 60}, 
-          {"x": 50, "y": 60, "z": 70})
+   "b": ( {"x": 40, "y": 50, "z": 60},
+          {},
+          {"x": 70, "y": 80, "z": (90, 100)})
 }
 return $input ? child::b ? * 
        ! { "position": JNode-position(.),
            "key": JNode-selector(.)
            "value": JNode-value(.)
          }</eg></fos:expression>
-               <fos:result><eg>{
+               <fos:result><eg>
 { "position": 1, "key": "x", "value": 40 },
 { "position": 1, "key": "y", "value": 50 },
 { "position": 1, "key": "z", "value": 60 },
-{ "position": 2, "key": "x", "value": 70 },
-{ "position": 2, "key": "y", "value": 80 },
-{ "position": 2, "key": "z", "value": 90 }</eg></fos:result>
+{ "position": 3, "key": "x", "value": 70 },
+{ "position": 3, "key": "y", "value": 80 },
+{ "position": 3, "key": "z", "value": (90, 100) }</eg></fos:result>
             </fos:test>
 
             

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -35251,7 +35251,7 @@ return $result
          <p>A JNode has unique identity. If two maps or arrays <var>M1</var> and
             <var>M2</var> have the same function identity, as determined by the
             <function>function-identity</function> function, then
-            <code>jnode(<var>M1</var>) is jnode-(<var>M2</var>)</code> <rfc2119>must</rfc2119>
+            <code>jnode(<var>M1</var>) is jnode(<var>M2</var>)</code> <rfc2119>must</rfc2119>
             return true: that is, the same JNode must be
             delivered for both.</p>
          

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -625,8 +625,8 @@
             </slist></p>
             </item>
             <item><p>If <var>J</var> is a <xtermref spec="DM40" ref="dt-JNode"/>, the result is in
-            the form <code>JNode(<var>T</var>)</code>, where <var>T</var> is the result of
-            applying the <function>type-of</function> function to the ¶value property of <var>J</var>.</p>
+            the form <code>jnode(<var>T</var>)</code>, where <var>T</var> is the result of
+            applying the <function>type-of</function> function to the <term>·content·</term> property of <var>J</var>.</p>
             </item>
             <item>
                <p>If <var>J</var> is an atomic item, the result is a string chosen as follows:</p>
@@ -736,8 +736,8 @@
                <fos:result>"function(*)"</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>type-of(JNode([]))</fos:expression>
-               <fos:result>"JNode(array(*))"</fos:result>
+               <fos:expression>type-of(jnode([]))</fos:expression>
+               <fos:result>"jnode(array(*))"</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -834,8 +834,8 @@
                ref="xpath-datamodel-31"/> (see <xspecref spec="DM40" ref="dm-string-value"/>).</p>
          
          <p>If <code>$value</code> is a <xtermref spec="DM40" ref="dt-JNode"/>, 
-            the function returns the result of <code>string(JNode-value($value))</code>.
-         This will fail in the case where <code>JNode-value($value)</code> is a map or an array.</p>
+            the function returns the result of <code>string(jnode-content($value))</code>.
+         This will fail in the case where <code>jnode-content($value)</code> is a map or an array.</p>
 
          <p>If <code>$value</code> is an atomic item, the function returns the result of the expression <code>$value cast
                      as xs:string</code> (see <specref
@@ -900,7 +900,7 @@
                <fos:error-result error-code="FOTY0014"/>
             </fos:test>
             <fos:test>
-               <fos:expression>string(JNode({"x": [10, 20, 30]}) ? x ? 3)</fos:expression>
+               <fos:expression>string({"x": [10, 20, 30]} / x / *[3])</fos:expression>
                <fos:result>"30"</fos:result>
             </fos:test>
          </fos:example>
@@ -956,7 +956,7 @@
             </item>
             <item>
                <p>If the item is a <xtermref spec="DM40" ref="dt-JNode"/>,
-               the atomized value of its <code>¶value</code> property is appended to
+               the atomized value of its <term>·content·</term> property is appended to
                the result sequence.</p>
             </item>
             <item>
@@ -13968,8 +13968,8 @@ Himmlische, dein Heiligtum.
    </fos:function>
    <fos:function name="root" prefix="fn">
       <fos:signatures>
-         <fos:proto name="root" return-type="GNode()?">
-            <fos:arg name="node" type="GNode()?" default="." usage="inspection"/>
+         <fos:proto name="root" return-type="gnode()?">
+            <fos:arg name="node" type="gnode()?" default="." usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -13993,13 +13993,10 @@ Himmlische, dein Heiligtum.
          <p>If the function is called without an argument, the context value (<code>.</code>) is used
             as the default argument.</p>
 
-         <p>If the (explicit or implicit) argument is a <xtermref spec="DM40" ref="dt-XNode"/>,
-         the function returns the value of the expression
-               <code>$arg/ancestor-or-self::node()[last()]</code>.</p>
+         <p>The function returns the value of the expression
+               <code>$node/ancestor-or-self::gnode()[last()]</code>.</p>
          
-         <p>If the (explicit or implicit) argument is a <xtermref spec="DM40" ref="dt-JNode"/>,
-         the function returns the value of the expression
-               <code>$arg?ancestor-or-self::*[last()]</code>.</p>
+        
       </fos:rules>
       <fos:errors>
          <p>The following errors may be raised when <code>$node</code> is omitted:</p>
@@ -14012,7 +14009,7 @@ Himmlische, dein Heiligtum.
             </item>
             <item>
                <p>If the context value is not an instance of the sequence type
-               <code>GNode()?</code>, type error
+               <code>gnode()?</code>, type error
                <xerrorref spec="XP" class="TY" code="0004" type="type"/>.</p>
             </item>
          </ulist>
@@ -14185,8 +14182,8 @@ let $newi := $o/tool</eg>
    
    <fos:function name="distinct-ordered-nodes" prefix="fn">
       <fos:signatures>
-         <fos:proto name="distinct-ordered-nodes" return-type="GNode()*">
-            <fos:arg name="nodes" type="GNode()*" usage="navigation"/>
+         <fos:proto name="distinct-ordered-nodes" return-type="gnode()*">
+            <fos:arg name="nodes" type="gnode()*" usage="navigation"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -14221,13 +14218,13 @@ return distinct-ordered-nodes(($x//c, $x//b, $x//a, $x//b)) ! name()]]></eg></fo
                that have distinct identity, so both are retained.</fos:postamble>
             </fos:test>
             <fos:test>
-               <fos:expression><eg><![CDATA[let $x := {"a":{"a":{"a":1}}}
+               <fos:expression><eg><![CDATA[let $x := [1, "a", true()]}}
 return distinct-ordered-nodes(
-           $x ? descendant::a ? descendant::a) 
+           ($x/*[1], $x/type(xs:integer)) 
        => count() ]]></eg></fos:expression>
-               <fos:result>3</fos:result>
-               <fos:postamble>The innermost map entry <code>"a":1</code> is selected by two different
-                  routes; the lookup operator does not eliminate duplicate JNodes.</fos:postamble>
+               <fos:result>1</fos:result>
+               <fos:postamble>The first array member is selected by two different
+                  routes; duplicate JNodes are eliminated.</fos:postamble>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -14481,8 +14478,8 @@ return empty($break)
    
    <fos:function name="siblings" prefix="fn">
       <fos:signatures>
-         <fos:proto name="siblings" return-type="node()*">
-            <fos:arg name="node" type="node()?" default="." usage="navigation"/>
+         <fos:proto name="siblings" return-type="gnode()*">
+            <fos:arg name="node" type="gnode()?" default="." usage="navigation"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -14496,15 +14493,16 @@ return empty($break)
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns the supplied node together with its siblings, in document order.</p>
+         <p>Returns the supplied GNode together with its siblings, in document order.</p>
       </fos:summary>
       <fos:rules>
          <p>If the <code>$node</code> argument is omitted, it defaults to the context value (<code>.</code>).</p>
          
          <p>If the value of <code>$node</code> is an empty sequence, the function returns an empty sequence.</p>
          
-         <p>If <code>$node</code> is a child of some parent node <var>P</var>, the function returns all the
-         children of <var>P</var> (including <code>$node</code>), in document order.</p>
+         <p>If <code>$node</code> is a child of some parent GNode <var>P</var>, the function returns all the
+         children of <var>P</var> (including <code>$node</code>), in document order, as determined
+            by the value of <code>$node/child::gnode()</code>.</p>
          
          <p>Otherwise (specifically, if <code>$node</code> is parentless, or if it is an attribute or namespace node),
          the function returns <code>$node</code>.</p>
@@ -17023,10 +17021,10 @@ declare function equal-strings(
                <olist>
                   <item><p><code>$i1</code> is a JNode.</p></item>
                   <item><p><code>$i2</code> is a JNode.</p></item>
-                  <item><p>The <code>¶value</code> property of <code>$i1</code>
-                  is deep-equal to the <code>¶value</code> property of <code>$i2</code>.</p>
-                  <note><p>The other properties of the two JNodes, such as <code>¶parent</code>
-                  and <code>¶selector</code>, are ignored. As with XNodes, deep equality
+                  <item><p>The <term>·content·</term> property of <code>$i1</code>
+                  is deep-equal to the <term>·content·</term> property of <code>$i2</code>.</p>
+                  <note><p>The other properties of the two JNodes, such as <term>·parent·</term>
+                  and <term>·selector·</term>, are ignored. As with XNodes, deep equality
                   considers only the subtree rooted at the node, and not its position within
                   a containing tree.</p></note>
                   </item>
@@ -19700,7 +19698,7 @@ return { "width": $int16-at($loc + 5),
    <fos:function name="generate-id" prefix="fn">
       <fos:signatures>
          <fos:proto name="generate-id" return-type="xs:string">
-            <fos:arg name="node" type="GNode()?" usage="inspection" default="."/>
+            <fos:arg name="node" type="gnode()?" usage="inspection" default="."/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -19745,7 +19743,7 @@ return { "width": $int16-at($loc + 5),
             </item>
             <item>
                <p>If the context value is not an instance of the sequence type
-               <code>GNode()?</code>, type error <xerrorref spec="XP" class="TY" code="0004" type="type"/>.</p>
+               <code>gnode()?</code>, type error <xerrorref spec="XP" class="TY" code="0004" type="type"/>.</p>
             </item>
          </ulist>
 
@@ -23419,9 +23417,9 @@ return sort-with($persons/person, (
    
    <fos:function name="transitive-closure" prefix="fn">
       <fos:signatures>
-         <fos:proto name="transitive-closure" return-type="node()*">
-            <fos:arg name="node" type="node()?"/>
-            <fos:arg name="step" type="fn(node()) as node()*"/>
+         <fos:proto name="transitive-closure" return-type="gnode()*">
+            <fos:arg name="node" type="gnode()?"/>
+            <fos:arg name="step" type="fn(gnode()) as gnode()*"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -23431,26 +23429,28 @@ return sort-with($persons/person, (
          
       </fos:properties>
       <fos:summary>
-         <p>Returns all the nodes reachable from a given start node by applying a supplied function repeatedly.</p>
+         <p>Returns all the GNodes reachable from a given start GNode by applying a supplied function repeatedly.</p>
       </fos:summary>
       <fos:rules>
+         
+         <p>The function works with both XNodes and JNodes.</p>
          
          <p>The value of <code>$node</code> is a node from which navigation starts. If <code>$node</code> is an
          empty sequence, the function returns an empty sequence.
          </p>
-         <p>The value of <code>$step</code> is a function that takes a single node as input, and returns a set of nodes as its result.</p> 
-         <p>The result of the <function>fn:transitive-closure</function> function is the set of nodes that are reachable from
+         <p>The value of <code>$step</code> is a function that takes a single GNode as input, and returns a set of GNodes as its result.</p> 
+         <p>The result of the <function>fn:transitive-closure</function> function is the set of GNodes that are reachable from
             <code>$node</code> by applying the <code>$step</code> function one or more times.</p>
          
-         <p>Although <code>$step</code> may return any sequence of nodes, the result is treated as a set: the order of nodes
+         <p>Although <code>$step</code> may return any sequence of GNodes, the result is treated as a set: the order of GNodes
             in the sequence is ignored, and duplicates are ignored. The result of of the
-            <code>transitive-closure</code> function will always be a sequence of nodes in document order with no duplicates.</p>
+            <code>transitive-closure</code> function will always be a sequence of GNodes in document order with no duplicates.</p>
       </fos:rules>
       <fos:equivalent style="xquery-function">
 declare %private function tc-inclusive(
-  $nodes as node()*,
-  $step  as fn(node()) as node()*
-) as node()* {
+  $nodes as gnode()*,
+  $step  as fn(gnode()) as gnode()*
+) as gnode()* {
   let $nextStep := $nodes/$step(.)
   let $newNodes := $nextStep except $nodes
   return if (exists($newNodes))
@@ -23459,35 +23459,35 @@ declare %private function tc-inclusive(
 };
 
 declare function transitive-closure (
-  $node as node(),
-  $step as fn(node()) as node()*
-) as node()* {
+  $node as gnode(),
+  $step as fn(gnode()) as gnode()*
+) as gnode()* {
   tc-inclusive($node/$step(.), $step)
 };
 
 (: Explanation:
 
-   The private helper function tc-inclusive takes a set of nodes as input,
-   and calls the $step function on each one of those nodes; if the result 
-   includes nodes that are not already present in the input, then it makes 
-   a recursive call to find nodes reachable from these new nodes, and returns
-   the union of the supplied nodes and the nodes returned from the recursive
-   call (which will always include the new nodes selected in the first step).
+   The private helper function tc-inclusive takes a set of GNodes as input,
+   and calls the $step function on each one of those GNodes; if the result 
+   includes GNodes that are not already present in the input, then it makes 
+   a recursive call to find GNodes reachable from these new GNodes, and returns
+   the union of the supplied GNodes and the GNodes returned from the recursive
+   call (which will always include the new GNodes selected in the first step).
    
-   If there are no new nodes, the recursion ends, returning the nodes that 
+   If there are no new GNodes, the recursion ends, returning the GNodes that 
    have been found up to this point.
    
    The main function fn:transitive-closure finds the nodes that are reachable 
-   from the start node in a single step, and then invokes the helper function 
-   tc-inclusive to add nodes that are reachable in multiple steps.
+   from the start GNodes in a single step, and then invokes the helper function 
+   tc-inclusive to add GNodes that are reachable in multiple steps.
 :)   
       </fos:equivalent>
       <fos:notes>
          <p>Cycles in the data are not a problem; 
-            the function stops searching when it finds no new nodes.</p>
+            the function stops searching when it finds no new GNodes.</p>
          <p>The function may fail to terminate if the supplied <code>$step</code> function constructs and returns
-         new nodes. A processor <rfc2119>may</rfc2119> detect this condition but is not required to do so.</p>
-         <p>The <code>$node</code> node is not included in the result, unless it is reachable by applying
+         new GNodes. A processor <rfc2119>may</rfc2119> detect this condition but is not required to do so.</p>
+         <p>The <code>$node</code> GNodes is not included in the result, unless it is reachable by applying
          the <code>$step</code> function one or more times. If a result is required that does include <code>$node</code>,
          it can be readily added to the result using the union operator:
             <code>$node | transitive-closure($node, $step)</code>.</p>
@@ -28905,8 +28905,8 @@ return document {
                      The default representation of <code>null</code> is an empty sequence, which works
                      well in cases where setting a property of an object to <code>null</code> has the
                      same meaning as omitting the property. It works less well in cases where <code>null</code>
-                     is used with some other meaning, because expressions such as the lookup operators
-                     <code>?</code> and <code>??</code> flatten the result to a single sequence of items,
+                     is used with some other meaning, because expressions such as the lookup operator
+                     <code>?</code> flatten the result to a single sequence of items,
                      which means that any entries whose value is an empty sequence effectively disappear.
                      The property can be set to any XDM value; a suggested value is the <code>xs:QName</code>
                      value <code>fn:QName("http://www.w3.org/2005/xpath-functions", "null")</code>,
@@ -35222,9 +35222,9 @@ return $result
       </fos:changes>
    </fos:function>
    
-   <fos:function name="JNode" prefix="fn">
+   <fos:function name="jnode" prefix="fn">
       <fos:signatures>
-         <fos:proto name="JNode" return-type="JNode(map(*)|array(*))">
+         <fos:proto name="jnode" return-type="jnode(map(*)|array(*))">
             <fos:arg name="input" type="(map(*)|array(*))"/>
          </fos:proto>
       </fos:signatures>
@@ -35241,8 +35241,8 @@ return $result
       <fos:rules>
          <p>The function creates a <xtermref spec="DM40" ref="dt-JNode"/>
             that wraps the supplied map or array. Specifically, it creates a root JNode
-            whose <code>¶value</code> property is <code>$input</code>, and whose
-            <code>¶parent</code>, <code>¶position</code>, and <code>¶selector</code> 
+            whose <term>·content·</term> property is <code>$input</code>, and whose
+            <term>·parent·</term>, <term>·position·</term>, and <term>·selector·</term> 
             properties are absent.</p>
          
          <p>This has the effect that lookup expressions starting from this JNode retain
@@ -35251,7 +35251,7 @@ return $result
          <p>A JNode has unique identity. If two maps or arrays <var>M1</var> and
             <var>M2</var> have the same function identity, as determined by the
             <function>function-identity</function> function, then
-            <code>JNode(<var>M1</var>) is JNode(<var>M2</var>)</code> must
+            <code>jnode(<var>M1</var>) is jnode(<var>M2</var>)</code> <rfc2119>must</rfc2119>
             return true: that is, the same JNode must be
             delivered for both.</p>
          
@@ -35262,55 +35262,55 @@ return $result
          whether two maps or arrays have the same function identity. Processors
          <rfc2119>should</rfc2119> ensure as a minimum that when 
             a variable <code>$m</code> is bound to a map or array,
-         calling <code>JNode($m)</code> more than once (with the same variable reference)
+         calling <code>jnode($m)</code> more than once (with the same variable reference)
          will deliver the same JNode each time.</p>
          
          <p>The effect of the coercion rules is technically that if an existing JNode is supplied as <code>$input</code>,
          the wrapped value will be extracted, and then rewrapped as a JNode: in practice,
          this can be short-circuited by returning the supplied JNode unchanged.</p>
          
-         <p>Although <function>fn:JNode</function> is available as a function for user applications
+         <p>Although <function>fn:jnode</function> is available as a function for user applications
          to call explicitly, it is also invoked implicitly by some expressions, notably when
-         a lookup expression is written in a form such as <code>$map?child::*</code>. Specifically,
-         if the left-hand operand of the lookup operator is a map or array, and the right-hand side
-         uses an explicit axis such as <code>child::</code>, then the supplied map or array is implicitly
-         wrapped in a JNode. The same is true when the deep lookup operator <code>??</code> is used.</p>
+         a path expression is written in a form such as <code>$map/child::*</code>. Specifically,
+         if the left-hand operand of the <code>/</code> operator is a map or array, 
+            then the supplied map or array is implicitly wrapped in a JNode. </p>
          
-         <p>The effect of applying <function>fn:JNode</function> to a map or array is that subsequent retrieval operations
+         <p>The effect of applying <function>fn:jnode</function> to a map or array is that subsequent retrieval operations
          within the wrapped map or array return results that retain useful information about
-         where the results were found. For example, consider an expression such as <code>json-doc($source)??name</code>.
-            In this case the call on <function>fn:JNode</function> is implicit.
+         where the results were found. For example, consider an expression such as <code>json-doc($source)//name</code>.
+      
          This expression returns a set of JNodes representing all entries in the JTree having the key <code>"name"</code>; 
          each of these JNodes contains not only the value of the relevant <code>"name"</code> entry,
             but also the key (which in this simple example is always <code>"name"</code>
             and the containing map. This means, for example, if <code>$result</code>
-            is the result of the expression <code>json-doc($source) ?? name</code>, then:</p>
+            is the result of the expression <code>json-doc($source) // name</code>, then:</p>
          
          <ulist>
-            <item><p><code>$result ? .. ? ssn</code> locates the map that contained each
+            <item><p><code>$result / .. / ssn</code> locates the map that contained each
                <code>name</code>, and returns the value of the <code>ssn</code> entry in that map.</p></item>
-            <item><p><code>$result ? ancestor::course</code> returns the values of any
+            <item><p><code>$result / ancestor::course</code> returns any
             <code>course</code> entries in containing maps.</p></item>
-            <item><p><code>$result ? ancestor::* => selector() </code> returns a sequence of map keys and array index
+            <item><p><code>$result / ancestor::* => jnode-selector() </code> returns a sequence of map keys and array index
             values representing the location of the found entries within the JSON structure.</p></item>
   
          </ulist>
          
-         <p>An alternative way of wrapping a map or array, rather than calling <code>JNode($X)</code>,
-         is to use the lookup expression <code>$X?.</code>.</p>
+         <p>An alternative way of wrapping a map or array, rather than calling <code>jnode($X)</code>,
+         is to use the path expression <code>$X/.</code>.</p>
          
          
       </fos:notes>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>JNode([ "a", "b", "c" ]) ? child::1 ? parent::* ! array:foot(.)</fos:expression>
+               <fos:expression>jnode([ "a", "b", "c" ])/*[1]/../*[last()] => string()</fos:expression>
                <fos:result>"c"</fos:result>
+               <fos:postamble>The call on <code>fn:jnode</code> would happen automatically</fos:postamble>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>JNode([ "a", "b", "c", "d" ]) ? child::* => selector()</fos:expression>
+               <fos:expression>jnode([ "a", "b", "c", "d" ])/* => jnode-selector()</fos:expression>
                <fos:result>1, 2, 3, 4</fos:result>
             </fos:test>
          </fos:example>
@@ -35320,7 +35320,7 @@ return $result
   "fr": { "capital": "Paris", "languages": [ "French" ] }, 
   "de": { "capital": "Berlin", "languages": [ "German" ] }
 }
-return JNode($data) ?? languages[. = 'German'] ? .. ? capital) => string()</eg></fos:expression>
+return jnode($data)//languages[. = 'German']/../capital) => string()</eg></fos:expression>
                <fos:result>"Berlin"</fos:result>
             </fos:test>
          </fos:example>
@@ -35331,10 +35331,10 @@ return JNode($data) ?? languages[. = 'German'] ? .. ? capital) => string()</eg><
       </fos:changes>
    </fos:function>
    
-   <fos:function name="JNode-selector" prefix="fn">
+   <fos:function name="jnode-selector" prefix="fn">
       <fos:signatures>
-         <fos:proto name="JNode-selector" return-type="xs:anyAtomicType?">
-            <fos:arg name="input" type="JNode()"/>
+         <fos:proto name="jnode-selector" return-type="xs:anyAtomicType?">
+            <fos:arg name="input" type="jnode()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -35343,13 +35343,13 @@ return JNode($data) ?? languages[. = 'German'] ? .. ? capital) => string()</eg><
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns the <code>¶selector</code> property of a JNode.</p>
+         <p>Returns the <term>·selector·</term> property of a JNode.</p>
       </fos:summary>
       <fos:rules>
          <p>If <code>$input</code> is an empty sequence, the function returns an empty sequence.</p>
-         <p>If <code>$input</code> is a root JNode (one in which the <code>¶selector</code> property is
+         <p>If <code>$input</code> is a root JNode (one in which the <term>·selector·</term> property is
             absent), the function returns an empty sequence.</p>
-         <p>Otherwise, the function returns the <code>¶selector</code> property of <code>$input</code>.
+         <p>Otherwise, the function returns the <term>·selector·</term> property of <code>$input</code>.
          In the case where the parent JNode wraps a map, this will be the key of the relevant entry
          within that map; in the case where the parent JNode wraps an array, it will be the 1-based
          index of the relevant member of the array.</p>
@@ -35358,17 +35358,17 @@ return JNode($data) ?? languages[. = 'German'] ? .. ? capital) => string()</eg><
          <fos:example>
             <fos:test>
                <fos:expression><eg>let $array := [1, 3, 4.5, 7, "eight", 10]
-return $array ? child::~xs:integer =!> JNode-selector()</eg></fos:expression>
+return $array / child::type(xs:integer) =!> jnode-selector()</eg></fos:expression>
                <fos:result>1, 2, 4, 6</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>let $map := {'Mo': 'Monday', 'Tu': 'Tuesday', 'We': 'Wednesday'}
-return $map ? child::("Mo", "We", "Fr", "Su") =!> JNode-selector()</eg></fos:expression>
+return $map / child::("Mo", "We", "Fr", "Su") =!> jnode-selector()</eg></fos:expression>
                <fos:result>"Mo", "We"</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>let $array := [[4, 18], [30, 4, 22]]
-return $array ? descendant::*[. gt 25][1] ? ancestor::* =!> JNode-selector() => reverse()</eg></fos:expression>
+return $array / descendant::*[. gt 25][1] / ancestor::* =!> jnode-selector() => reverse()</eg></fos:expression>
                <fos:result>2, 1</fos:result>
             </fos:test>
          </fos:example>
@@ -35380,10 +35380,10 @@ return $array ? descendant::*[. gt 25][1] ? ancestor::* =!> JNode-selector() => 
       </fos:changes>
    </fos:function>
    
-   <fos:function name="JNode-position" prefix="fn">
+   <fos:function name="jnode-position" prefix="fn">
       <fos:signatures>
-         <fos:proto name="JNode-position" return-type="xs:anyAtomicType?">
-            <fos:arg name="input" type="JNode()"/>
+         <fos:proto name="jnode-position" return-type="xs:anyAtomicType?">
+            <fos:arg name="input" type="jnode()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -35392,13 +35392,13 @@ return $array ? descendant::*[. gt 25][1] ? ancestor::* =!> JNode-selector() => 
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns the <code>¶position</code> property of a JNode.</p>
+         <p>Returns the <term>·position·</term> property of a JNode.</p>
       </fos:summary>
       <fos:rules>
          <p>If <code>$input</code> is an empty sequence, the function returns an empty sequence.</p>
-         <p>If <code>$input</code> is a root JNode (one in which the <code>¶position</code> property is
+         <p>If <code>$input</code> is a root JNode (one in which the <term>·position·</term> property is
             absent), the function returns an empty sequence.</p>
-         <p>Otherwise, the function returns the <code>¶position</code> property of <code>$input</code>.
+         <p>Otherwise, the function returns the <term>·position·</term> property of <code>$input</code>.
             The value of this property will be 1 (one) except in cases where 
             the value of an entry in a map, or a member in an array, is a sequence that contains
             multiple items including maps and/or arrays; in such cases
@@ -35426,10 +35426,10 @@ return $array ? descendant::*[. gt 25][1] ? ancestor::* =!> JNode-selector() => 
    "a": [10, 20, 30], 
    "b": ([40, 50, 60], [], 0, [70, 80, (90, 100)])
 }
-return $input ? child::b ? * 
-       ! { "position": JNode-position(.),
-           "index": JNode-selector(.)
-           "value": JNode-value(.)
+return $input / child::b / * 
+       ! { "position": jnode-position(.),
+           "index": jnode-selector(.)
+           "value": jnode-content(.)
          }</eg></fos:expression>
                <fos:result><eg>
 { "position": 1, "index": 1, "value": 40 },
@@ -35446,10 +35446,10 @@ return $input ? child::b ? *
           {},
           {"x": 70, "y": 80, "z": (90, 100)})
 }
-return $input ? child::b ? * 
-       ! { "position": JNode-position(.),
-           "key": JNode-selector(.)
-           "value": JNode-value(.)
+return $input / child::b / * 
+       ! { "position": jnode-position(.),
+           "key": jnode-selector(.)
+           "value": jnode-content(.)
          }</eg></fos:expression>
                <fos:result><eg>
 { "position": 1, "key": "x", "value": 40 },
@@ -35470,10 +35470,10 @@ return $input ? child::b ? *
       </fos:changes>
    </fos:function>
    
-   <fos:function name="JNode-value" prefix="fn">
+   <fos:function name="jnode-content" prefix="fn">
       <fos:signatures>
-         <fos:proto name="JNode-value" return-type="item()*">
-            <fos:arg name="input" type="JNode()"/>
+         <fos:proto name="jnode-content" return-type="item()*">
+            <fos:arg name="input" type="jnode()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -35482,40 +35482,40 @@ return $input ? child::b ? *
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns the <code>¶value</code> property of a JNode.</p>
+         <p>Returns the <term>·content·</term> property of a JNode.</p>
       </fos:summary>
       <fos:rules>
          <p>If <code>$input</code> is an empty sequence, the function returns an empty sequence.</p>
-         <p>Otherwise, the function returns the <code>¶value</code> property of <code>$input</code>.</p>
+         <p>Otherwise, the function returns the <term>·content·</term> property of <code>$input</code>.</p>
       </fos:rules>
       <fos:notes>
-         <p>In many cases it is unnecessary to make an explicit call on <code>JNode-value</code>, because
+         <p>In many cases it is unnecessary to make an explicit call on <code>jnode-content</code>, because
          the coercion rules will take care of this automatically. For example, in an expression
-         such as <code>$X ? descendant::name [matches(., '^J')]</code>, the call on
+         such as <code>$X / descendant::name [matches(., '^J')]</code>, the call on
          <function>matches</function> is supplied with a JNode as its first argument; atomization
          ensures that the actual value being passed to the first argument of <function>matches</function>
             is the atomized value of the 
-          <code>¶value</code> property.</p>
+          <term>·content·</term> property.</p>
          <p>One case where the function call may be needed is when computing the effective boolean
-         value. As with XNodes, writing <code>if (?child::*[1]) ...</code> tests for the existence
-         of a child, it does not test its value. To test its value, write <code>if (JNode-value(?child::*[1])) ...</code>,
-         or equivalently <code>if (xs:boolean(?child::*[1])) ...</code>.</p>
+         value. As with XNodes, writing <code>if ($array/child::*[1]) ...</code> tests for the existence
+         of a child, it does not test its value. To test its value, write <code>if (jnode-content($array/child::*[1])) ...</code>,
+         or equivalently <code>if (xs:boolean($array/child::*[1])) ...</code>.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
             <fos:test>
                <fos:expression><eg>let $array := [1, 3, 4.5, 7, "eight", 10]
-return $array ? child::~xs:integer =!> JNode-value()</eg></fos:expression>
+return $array / child::type(xs:integer) =!> jnode-content()</eg></fos:expression>
                <fos:result>1, 3, 7, 10</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>let $map := {'Mo': 'Monday', 'Tu': 'Tuesday', 'We': 'Wednesday'}
-return $map ? child::("Mo", "We", "Fr", "Su") =!> JNode-value()</eg></fos:expression>
+return $map / child::get("Mo", "We", "Fr", "Su") =!> jnode-content()</eg></fos:expression>
                <fos:result>"Monday", "Wednesday"</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>let $array := [[4, 18], [30, 4, 22]]
-return $array ? descendant::*[. gt 25][1] ? ancestor-or-self::* =!> JNode-value() => reverse()</eg></fos:expression>
+return $array / descendant::*[. gt 25][1] / ancestor-or-self::* =!> jnode-content() => reverse()</eg></fos:expression>
                <fos:result>[[4, 18], [30, 4, 22]], [30, 4, 22], 30</fos:result>
             </fos:test>
          </fos:example>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -625,7 +625,7 @@
             </slist></p>
             </item>
             <item><p>If <var>J</var> is a <xtermref spec="DM40" ref="dt-JNode"/>, the result is in
-            the form <code>jnode(<var>T</var>)</code>, where <var>T</var> is the result of
+            the form <code>jnode-type(<var>T</var>)</code>, where <var>T</var> is the result of
             applying the <function>type-of</function> function to the <term>·content·</term> property of <var>J</var>.</p>
             </item>
             <item>
@@ -736,8 +736,8 @@
                <fos:result>"function(*)"</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>type-of(jnode([]))</fos:expression>
-               <fos:result>"jnode(array(*))"</fos:result>
+               <fos:expression>type-of(jnode-type([]))</fos:expression>
+               <fos:result>"jnode-type(array(*))"</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -35224,7 +35224,7 @@ return $result
    
    <fos:function name="jnode" prefix="fn">
       <fos:signatures>
-         <fos:proto name="jnode" return-type="jnode(map(*)|array(*))">
+         <fos:proto name="jnode" return-type="jnode-type(map(*)|array(*))">
             <fos:arg name="input" type="(map(*)|array(*))"/>
          </fos:proto>
       </fos:signatures>
@@ -35251,7 +35251,7 @@ return $result
          <p>A JNode has unique identity. If two maps or arrays <var>M1</var> and
             <var>M2</var> have the same function identity, as determined by the
             <function>function-identity</function> function, then
-            <code>jnode(<var>M1</var>) is jnode(<var>M2</var>)</code> <rfc2119>must</rfc2119>
+            <code>jnode(<var>M1</var>) is jnode-(<var>M2</var>)</code> <rfc2119>must</rfc2119>
             return true: that is, the same JNode must be
             delivered for both.</p>
          
@@ -35334,7 +35334,7 @@ return jnode($data)//languages[. = 'German']/../capital) => string()</eg></fos:e
    <fos:function name="jnode-selector" prefix="fn">
       <fos:signatures>
          <fos:proto name="jnode-selector" return-type="xs:anyAtomicType?">
-            <fos:arg name="input" type="jnode()"/>
+            <fos:arg name="input" type="jnode-type()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -35383,7 +35383,7 @@ return $array / descendant::*[. gt 25][1] / ancestor::* =!> jnode-selector() => 
    <fos:function name="jnode-position" prefix="fn">
       <fos:signatures>
          <fos:proto name="jnode-position" return-type="xs:anyAtomicType?">
-            <fos:arg name="input" type="jnode()"/>
+            <fos:arg name="input" type="jnode-type()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -35473,7 +35473,7 @@ return $input / child::b / *
    <fos:function name="jnode-content" prefix="fn">
       <fos:signatures>
          <fos:proto name="jnode-content" return-type="item()*">
-            <fos:arg name="input" type="jnode()"/>
+            <fos:arg name="input" type="jnode-type()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -10456,29 +10456,31 @@ map( xs:string,
          <p>A <xtermref spec="DM40" ref="dt-JNode"/> is a wrapper around a map or array, or around a value
          that appears within the content of a map or array. JNodes are described 
          at <xspecref spec="DM40" ref="id-JNodes"/>. Wrapping a map or array in a JNode enables
-         the use of XPath lookup expressions such as <code>$jnode?descendant::title</code>, as described
-         at <xspecref spec="XP40" ref="id-lookup"/>.</p>
+         the use of path expressions such as <code>$jnode/descendant::title</code>, as described
+         at <xspecref spec="XP40" ref="id-path-expressions"/>.</p>
          
          <p>In addition to the functions defined in this section, functions that operate on JNodes include:</p>
          
-         <slist>
-            <sitem><function>fn:root</function></sitem>
-            <sitem><function>fn:generate-id</function></sitem>
+         <slist>        
             <sitem><function>fn:distinct-ordered-nodes</function></sitem>
+            <sitem><function>fn:generate-id</function></sitem>
+            <sitem><function>fn:root</function></sitem>
+            <sitem><function>fn:siblings</function></sitem>
+            <sitem><function>fn:transitive-closure</function></sitem>
          </slist>
          <div2 id="functions-on-jnodes">
             <head>Functions on JNodes</head>
-            <div3 id="func-JNode">
-               <head><?function fn:JNode?></head>
+            <div3 id="func-jnode">
+               <head><?function fn:jnode?></head>
             </div3>
-            <div3 id="func-JNode-value">
-               <head><?function fn:JNode-value?></head>
+            <div3 id="func-jnode-content">
+               <head><?function fn:jnode-content?></head>
             </div3>
-            <div3 id="func-JNode-selector">
-               <head><?function fn:JNode-selector?></head>
+            <div3 id="func-jnode-selector">
+               <head><?function fn:jnode-selector?></head>
             </div3>
-            <div3 id="func-JNode-position">
-               <head><?function fn:JNode-position?></head>
+            <div3 id="func-jnode-position">
+               <head><?function fn:jnode-position?></head>
             </div3>
          </div2>
          
@@ -10906,7 +10908,7 @@ The form of the constructor function for an atomic type
                         </proto>
                     </item>
                     <item>
-                        <proto name="untypedAtomic" return-type="xs:untypedAtomic?"
+                        <proto name="untypedAtomic" return-type="xs:untypedAtomic"
                             returnEmptyOk="yes" isSchema="yes" prefix="xs" role="example">
                             <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -7722,11 +7722,14 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                <head><?function fn:xml-to-json?></head>
             </div3>
             
-            <div3 id="func-pin" diff="add" at="A">
+            <div3 id="func-pin">
                <head><?function fn:pin?></head>
             </div3>
-            <div3 id="func-label" diff="add" at="A">
-               <head><?function fn:label?></head>
+            <div3 id="func-unpin">
+               <head><?function fn:unpin?></head>
+            </div3>
+            <div3 id="func-selector">
+               <head><?function fn:selector?></head>
             </div3>
          </div2>
          <div2 id="csv-functions">

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -7722,15 +7722,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                <head><?function fn:xml-to-json?></head>
             </div3>
             
-            <div3 id="func-pin">
-               <head><?function fn:pin?></head>
-            </div3>
-            <div3 id="func-unpin">
-               <head><?function fn:unpin?></head>
-            </div3>
-            <div3 id="func-selector">
-               <head><?function fn:selector?></head>
-            </div3>
+
          </div2>
          <div2 id="csv-functions">
             <head>Functions on CSV Data</head>
@@ -10451,6 +10443,45 @@ map( xs:string,
 
             
          </div2>
+         
+      </div1>
+      
+      <div1 id="processing-jnodes">
+         <head>Processing JNodes</head>
+         <changes>
+            <change issue="2025" PR="2031" date="2025-06-11">
+              Introduced the concept of JNodes.
+            </change>
+         </changes>
+         <p>A <xtermref spec="DM40" ref="dt-JNode"/> is a wrapper around a map or array, or around a value
+         that appears within the content of a map or array. JNodes are described 
+         at <xspecref spec="DM40" ref="id-JNodes"/>. Wrapping a map or array in a JNode enables
+         the use of XPath lookup expressions such as <code>$jnode?descendant::title</code>, as described
+         at <xspecref spec="XP40" ref="id-lookup"/>.</p>
+         
+         <p>In addition to the functions defined in this section, functions that operate on JNodes include:</p>
+         
+         <slist>
+            <sitem><function>fn:root</function></sitem>
+            <sitem><function>fn:generate-id</function></sitem>
+            <sitem><function>fn:distinct-ordered-nodes</function></sitem>
+         </slist>
+         <div2 id="functions-on-jnodes">
+            <head>Functions on JNodes</head>
+            <div3 id="func-JNode">
+               <head><?function fn:JNode?></head>
+            </div3>
+            <div3 id="func-JNode-value">
+               <head><?function fn:JNode-value?></head>
+            </div3>
+            <div3 id="func-JNode-selector">
+               <head><?function fn:JNode-selector?></head>
+            </div3>
+            <div3 id="func-JNode-position">
+               <head><?function fn:JNode-position?></head>
+            </div3>
+         </div2>
+         
          
       </div1>
       
@@ -14699,7 +14730,7 @@ ISBN 0 521 77752 6.</bibl>
            </item>
 
            <item diff="add" at="issue1725">
-              <p>When <function>fn:put</function> replaces an entry in a map with a new value for an
+              <p>When <function>map:put</function> replaces an entry in a map with a new value for an
               existing key, in the case where the existing key and the new key differ (for example,
               if they have different type annotations), it is no longer guaranteed that the new
               entry includes the new key rather than the existing key.</p>

--- a/specifications/xquery-40/src/ebnf.xml
+++ b/specifications/xquery-40/src/ebnf.xml
@@ -912,7 +912,7 @@
       <sitem>get</sitem>
       <sitem>if</sitem>
       <sitem>item</sitem>
-      <sitem>jnode</sitem>
+      <sitem>jnode-type</sitem>
       <sitem>map</sitem>
       <sitem>record</sitem>
       <sitem>switch</sitem>

--- a/specifications/xquery-40/src/ebnf.xml
+++ b/specifications/xquery-40/src/ebnf.xml
@@ -904,10 +904,17 @@
     <p>Names used as syntactic keywords:</p>
     
     <slist>
+      <sitem>array</sitem>
+      <sitem>enum</sitem>
       <sitem>fn</sitem>
       <sitem>function</sitem>
+      <sitem>gnode</sitem>
       <sitem>get</sitem>
       <sitem>if</sitem>
+      <sitem>item</sitem>
+      <sitem>jnode</sitem>
+      <sitem>map</sitem>
+      <sitem>record</sitem>
       <sitem>switch</sitem>
       <sitem>type</sitem>
       <sitem>typeswitch</sitem>

--- a/specifications/xquery-40/src/ebnf.xml
+++ b/specifications/xquery-40/src/ebnf.xml
@@ -886,7 +886,7 @@
     can appear, followed by a left parenthesis, at the start of an XPath or XQuery expression that
     is not a function call.</p>
     
-    <p>Names used in <nt def="KindTest">KindTests</nt>:</p>
+    <p>Names used in <nt def="TypeTest">NodeKindTests</nt>:</p>
       
       <slist>
         <sitem>attribute</sitem>
@@ -906,15 +906,17 @@
     <slist>
       <sitem>fn</sitem>
       <sitem>function</sitem>
+      <sitem>get</sitem>
       <sitem>if</sitem>
       <sitem>switch</sitem>
+      <sitem>type</sitem>
       <sitem>typeswitch</sitem>
     </slist>
       
  
     <note role="xpath">
       <p> Although the keywords <code>switch</code> and <code>typeswitch</code> are not used in
-        XPath, they are considered reserved function names for compatibility with XQuery. </p>
+        XPath, they are designated as reserved function names for compatibility with XQuery. </p>
     </note>
     
     

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -12109,12 +12109,33 @@ return if (every $r in $R satisfies $r instance of GNode())
                one or more of the values returned by the selector expression,
                under the rules of the <function>fn:atomic-equal</function> function.</p>
                
-               <p>For example, <code>child::get("date of birth")</code> selects
-               an entry in a map whose key is the string <code>"date of birth"</code>,
-                  while <code>child::get(3)</code> selects the third member
-                  of an array. The expression <code>child::get(current-date())</code>
+               <p>For example:</p>
+               
+               <ulist>
+                  <item><p><code>child::code</code> selects
+               an entry in a map whose key is the string <code>"code"</code></p></item>
+                  <item><p><code>child::get("date of birth")</code> selects
+               an entry in a map whose key is the string <code>"date of birth"</code></p></item>
+                  <item><p><code>child::get(3)</code> selects the third member
+                  of an array</p></item>
+                  <item><p><code>child::get(1 to 3)</code> selects the first three members
+                  of an array, in document order.</p>
+                  <note><p><code>child::get(3, 2, 1)</code> also returns the first three
+                  members in document order.</p></note></item>
+                  <item><p><code>child::get(current-date())</code>
                selects an entry in a map whose key is an <code>xs:date</code> value
-               equal to the current date.</p>
+               equal to the current date.</p></item>
+                  <item><p><code>child::get(array:size(.))</code> gets the last
+                  member of an array. The same can be achieved using
+                  <code>child::*[last()]</code>.</p></item>
+                  <item><p><code></code></p></item>
+                  <item><p><code>child::Q{}code</code> selects
+               an entry in a map whose key is the no-namespace QName 
+                     with local name <code>"code"</code>.</p></item>
+               </ulist>
+               
+               <p>All the above expressions return a sequence of JNodes. If the containing
+               expression expects atomic values, then the JNodes are automatically atomized.</p>
             </div4>
             <div4 id="id-type-tests">
                <head>Type Tests</head>
@@ -12441,7 +12462,7 @@ return if (every $r in $R satisfies $r instance of GNode())
             </note>
 
             <p>Here are some examples of <termref def="dt-axis-step"
-               >axis steps</termref> that contain predicates:</p>
+               >axis steps</termref> that contain predicates to select XNodes:</p>
 
             <ulist>
 
@@ -12513,8 +12534,8 @@ fact that the final result of the step is always in document order.</p>
                a union expression, so nodes are counted in document order.</p>
             </note>
             
-            <p>When the context value for evaluation of a step includes multiple nodes, the step is evaluated
-            separately for each of those nodes, and the results are combined without reordering. This means, for example, that
+            <p>When the context value for evaluation of a step includes multiple GNodes, the step is evaluated
+            separately for each of those GNodes, and the results are combined without reordering. This means, for example, that
             if the context value contains three <code>list</code> nodes, and each of those nodes has multiple
                <code>item</code> children, then the step <code>item[1]</code> will deliver a sequence of three <code>item</code>
                elements, namely the first <code>item</code> from each <code>list</code>, retaining the order of the
@@ -12869,6 +12890,14 @@ last <code>chapter</code> or <code>appendix</code> child of the context node.</p
     that the latter expression contains both an axis specification and
     a <termref
                         def="dt-node-test">node test</termref>.</p>
+                  
+                  <p>Similarly, within a JTree rooted at an array, the expression <code>get(1)/parts/get(2)/part-no</code>
+                  gets the first member of the top-level array (presumably a map), then the <code>"parts"</code>
+                  entry within this map (presumably an array), then the second member of this array (presumably
+                  a map), and finally the <code>part-no</code> entry within this map.</p>
+                  <note><p>The same selection could be made using the lookup expression <code>?1?parts?2?part-no</code>.
+                  The difference is that path expressions offer more flexibility in being able to navigate around
+                  the containing JTree.</p></note>
                   <note diff="add" at="2022-12-13"><p>An abbreviated axis step that omits the axis name must use a
                   <nt def="SimpleNodeTest">SimpleNodeTest</nt> rather than a <nt def="UnionNodeTest">UnionNodeTest</nt>.
                   This means that a construct such as <code>(ul|ol)</code>
@@ -12877,7 +12906,7 @@ last <code>chapter</code> or <code>appendix</code> child of the context node.</p
                </item>
 
 
-               <item>
+               <!--<item>
                   <p> Each non-initial occurrence of <code>//</code> is effectively replaced by  <code>/descendant-or-self::node()/</code> during processing of a path expression. For example, <code
                         role="parse-test">div1//para</code> is
 short for <code role="parse-test"
@@ -12891,15 +12920,21 @@ expression <code
 selects all descendant <code>para</code> elements that are the first <code>para</code> children of their respective parents.</p>
                   </note>
                </item>
-
+-->
 
                <item>
                   <p>A step consisting
 of <code role="parse-test">..</code> is short
 for <code
-                        role="parse-test">parent::node()</code>. For example, <code
+                        role="parse-test">parent::GNode()</code>. For example (assuming the context
+                     item is an XNode), <code
                         role="parse-test">../title</code> is short for <code role="parse-test"
-                        >parent::node()/child::title</code> and so will select the <code>title</code> children of the parent of the context node.</p>
+                        >parent::GNode()/child::title</code> and so will select the 
+                     <code>title</code> children of the parent of the context node.</p>
+                  
+                  <p>Similarly, if <code>$dateOfBirth</code> is a JNode resulting from the expression
+                  <code>$map/get("date of birth")</code>, then <code>$dateOfBirth/../gender</code>
+                  will select the entry having key <code>"gender"</code> within $map.</p>
                   <note>
                      <p>The expression <code>.</code>, known as a <term>context value
    reference</term>, is a <termref
@@ -12914,7 +12949,7 @@ for <code
 
 
             <p>Here are some examples of path expressions that use the abbreviated
-syntax. These examples assume that the context value is a single node, referred to as the context node:</p>
+syntax. These examples assume that the context value is a single XNode, referred to as the context node:</p>
 
             <ulist>
 
@@ -13109,6 +13144,158 @@ every <code>section</code> element that has a parent that is either a <code>chap
                      >document order</termref>, with duplicates eliminated based on node identity.</p>
                </item>
             </ulist>
+            
+            <p>The following examples use abbreviated paths to access data within the JTree
+               obtained by parsing the JSON text:</p>
+            
+            <eg>[
+{ "first": "John", "last": "Baker", "date of birth": "2003-04-19", "occupation": "cook"}, 
+{ "first": "Mary", "last": "Smith", "date of birth": "2006-08-12", "occupation": "teacher"},                 
+            ]</eg>
+            
+            <ulist>
+               <item><p><code>get(1)/first</code> returns a JNode whose <code>¶value</code>
+               is the string <code>"John"</code>.</p></item>
+               <item><p><code>//first[. = "Mary"]/../last</code> returns a JNode whose <code>¶value</code>
+               is the string <code>"Smith"</code>.</p></item>
+               <item><p><code>//first[. = "Mary"]/../get("date of birth")</code> returns a JNode whose <code>¶value</code>
+               is the string <code>"2006-08-12"</code>.</p></item>
+               <item><p><code>//*[occupation = "cook"]!`{first} {last}`</code> returns the
+               string <code>"John Baker"</code>.</p></item>
+               <item><p><code>//*[occupation = "cook"]/following-sibling::*[1]!`{first} {last}`</code> returns the
+               string <code>"Mary Smith"</code>.</p></item>
+               <item><p><code>//*[last = "Smith"]/../get(1)/last</code> returns the
+               string <code>"Baker"</code>.</p></item>
+               <item><p><code>//record(first, last, *) ! string(last)</code> returns the sequence of two
+               strings <code>"Baker"</code>, <code>"Smith"</code>.</p></item>
+            </ulist>
+         </div3>
+         <div3 id="comparison-with-JSONPath">
+            <head>Comparison with JSONPath</head>
+            
+            <p>Path expressions applied to a JTree offer similar capability to
+            JSONPath, which is an XPath-like language design for querying JSON.</p>
+            
+            <example>
+            <head>Comparison with JSONPath</head>
+                  <p>This example provides XPath equivalents to some examples given in the
+                  JSONPath specification. [TODO: add a reference].</p>
+                  <p>The examples query the result of parsing the following JSON value, representing
+                     a store whose stock consists of four books and a bicycle:</p>
+                  <eg><![CDATA[{
+  "store": {
+    "book": [
+      {
+        "category": "reference",
+        "author": "Nigel Rees",
+        "title": "Sayings of the Century",
+        "price": 8.95
+      },
+      {
+        "category": "fiction",
+        "author": "Evelyn Waugh",
+        "title": "Sword of Honour",
+        "price": 12.99
+      },
+      {
+        "category": "fiction",
+        "author": "Herman Melville",
+        "title": "Moby Dick",
+        "isbn": "0-553-21311-3",
+        "price": 8.99
+      },
+      {
+        "category": "fiction",
+        "author": "J. R. R. Tolkien",
+        "title": "The Lord of the Rings",
+        "isbn": "0-395-19395-8",
+        "price": 22.99
+      }
+    ],
+    "bicycle": {
+      "color": "red",
+      "price": 399
+    }
+  }
+}]]></eg>
+                  <p>The following table illustrates some queries on this data, expressed
+                  both in JSONPath and in &language;.</p>
+                  <table role="small" width="100%">
+                     <caption>JSONPath vs &language; Comparison</caption>
+                     <col width="40%"/>
+                     <col width="30%"/>
+                     <col width="30%"/>
+                     <thead>
+                        <tr>
+                           <th>Query</th>
+                           <th>JSONPath</th>
+                           <th>&language;</th>
+                        </tr>
+                     </thead>
+                     <tbody>
+                        <tr>
+                           <td valign="top">The authors of all books in the store</td>
+                           <td valign="top"><code>$.store.book[*].author</code></td>
+                           <td valign="top"><code>/store/book//author</code></td>
+                        </tr>
+                        <tr>
+                           <td valign="top">All authors</td>
+                           <td valign="top"><code>$..author</code></td>
+                           <td valign="top"><code>//author</code></td>
+                        </tr>
+                        <tr>
+                           <td valign="top">All things in store (four books and a red bicycle)</td>
+                           <td valign="top"><code>$.store.*  </code></td>
+                           <td valign="top"><code>/store/*</code></td>
+                        </tr>
+                        <tr>
+                           <td valign="top">The prices of everything in the store</td>
+                           <td valign="top"><code>$.store..price</code></td>
+                           <td valign="top"><code>/store//price</code></td>
+                        </tr>
+                        <tr>
+                           <td valign="top">The third book</td>
+                           <td valign="top"><code>$..book[2]  </code></td>
+                           <td valign="top"><code>//book/get(3)</code></td>
+                        </tr>
+                        <tr>
+                           <td valign="top">The third book's author</td>
+                           <td valign="top"><code>$..book[2].author</code></td>
+                           <td valign="top"><code>//book/get(3)/author</code></td>
+                        </tr>
+                        <tr>
+                           <td valign="top">The third book's publisher (empty result)</td>
+                           <td valign="top"><code>$..book[2].publisher</code></td>
+                           <td valign="top"><code>//book/get(3)/publisher</code></td>
+                        </tr>
+                        <tr>
+                           <td valign="top">The last book (in order)</td>
+                           <td valign="top"><code>$..book[-1]</code></td>
+                           <td valign="top"><code>//book/*[last()]</code></td>
+                        </tr>
+                        <tr>
+                           <td valign="top">The first two books</td>
+                           <td valign="top"><code>$..book[0,1]</code></td>
+                           <td valign="top"><code>//book/get(1,2)</code></td>
+                        </tr>
+                        <tr>
+                           <td valign="top">All books with an ISBN</td>
+                           <td valign="top"><code>$..book[?@.isbn]</code></td>
+                           <td valign="top"><code>//book[isbn]</code></td>
+                        </tr>
+                        <tr>
+                           <td valign="top">All books cheaper than 10</td>
+                           <td valign="top"><code>$..book[?@.price&lt;10]</code></td>
+                           <td valign="top"><code>//book[price lt 10]</code></td>
+                        </tr>
+                        <tr>
+                           <td valign="top">All member values and array elements contained in the input value</td>
+                           <td valign="top"><code>$..*</code></td>
+                           <td valign="top"><code>??*</code></td>
+                        </tr>
+                     </tbody>
+                  </table>
+               </example>
          </div3>
       </div2>
       <div2 id="id-sequence-expressions">

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -119,6 +119,11 @@ of <bibref
             <change issue="1337" PR="1361" date="2024-08-02">
                The term <term>atomic value</term> has been replaced by <termref def="dt-atomic-item"/>.
             </change>
+            <change issue="2025" PR="2031" date="2025-06-13">
+               The terms <term>XNode</term> and <code>JNode</code> are introduced; the existing
+               term <term>node</term> remains in use as a synonym for <term>XNode</term> where
+               the context does not specify otherwise.
+            </change>
          </changes>
       
       <p>
@@ -142,14 +147,18 @@ or a <termref def="dt-function-item">function item</termref>.</termdef></p>
 	 type</term>, as defined in <bibref
                ref="XMLSchema10"/>  or <bibref ref="XMLSchema11"/>.</termdef></p>
          
-         <p><termdef id="dt-node" term="node"
-               >A <term>node</term> is an instance of one of the
+         <p><termdef id="dt-XNode" term="XNode"
+               >An <term>XNode</term> is an instance of one of the
 	  <term>node kinds</term> defined in <xspecref
-               spec="DM40" ref="Node"
+               spec="DM40" ref="nodes"
             />.</termdef>
-Each node has a unique <term>node identity</term>, a <term>typed value</term>, and a <term>string value</term>. In addition, some nodes have a <term>name</term>. The <term>typed value</term> of a node is a sequence
-	 of zero or more atomic items. The <term>string value</term> of a node is a
-	 value of type <code>xs:string</code>. The <term>name</term> of a node is a value of type <code>xs:QName</code>.</p>
+Each XNode has a unique <term>node identity</term>, a <term>typed value</term>, and a <term>string value</term>. 
+            In addition, some XNodes have a <term>name</term>. The <term>typed value</term> of an XNode is a sequence
+	 of zero or more atomic items. The <term>string value</term> of an XNode is a
+	 value of type <code>xs:string</code>. The <term>name</term> of an XNode is a value of type <code>xs:QName</code>.</p>
+         
+         <p><termdef id="dt-node" term="node">Except where the context indicates otherwise, the term
+         <term>node</term> is used as a synonym for <termref def="dt-XNode"/>.</termdef></p>
          
          <p><termdef id="dt-function-item" term="function item">A <term>function item</term> is an item that can
          be called using a <termref def="dt-dynamic-function-call"/>.</termdef></p>
@@ -3104,12 +3113,19 @@ would raise an error because it has an <code>id</code> child whose value is not 
          <div3 id="id-document-order">
             <head>Document Order</head>
 
-            <p>An ordering called <term>document order</term> is defined among all the nodes accessible during processing of a given <phrase
+            <p>An ordering called <term>document order</term> is defined among all the 
+               nodes accessible during processing of a given <phrase
                   role="xquery">query</phrase>
                <phrase role="xpath"
-                  >expression</phrase>, which may consist of one or more <term>trees</term> (documents or fragments). 
+                  >expression</phrase>, which may consist of one or more <term>trees</term> (documents or fragments).</p>
+            
+            <p>Document order applies both to <termref def="dt-XNode">XNodes</termref> (typically
+               corresponding to nodes in an XML document, and generally referred to simply as <term>nodes</term>),
+               and also to <xtermref spec="DM40" ref="dt-JNode">JNodes</xtermref>, often corresponding to the contents
+               of a JSON source text. These are known collectively as 
+               <xtermref spec="DM40" ref="dt-GNode">GNodes</xtermref> (for "generalized node").</p>
 
-Document order is defined in <xspecref
+            <p>Document order is defined in <xspecref
                   spec="DM40" ref="document-order"
                   />, and its definition is repeated here for convenience. 
 
@@ -3128,19 +3144,24 @@ Document order is a total ordering, although the relative order of some nodes is
                      >The node ordering that is the reverse of document order is called <term>reverse document order</term>.</termdef>
             </p>
 
-            <p>Within a tree, document order satisfies the following constraints:</p>
+            <p>Within an <xtermref spec="DM40" ref="dt-XTree"/>,
+               (that is, a tree consisting of XNodes), document order satisfies the following constraints:</p>
 
             <olist>
 
 
                <item>
-                  <p>The root node is the first node.</p>
+                  <p>The root node precedes all other nodes.</p>
                </item>
 
 
 
                <item>
-                  <p>Every node occurs before all of its children and descendants.</p>
+                  <p>A parent node precedes its children (and therefore its descendants).</p>
+               </item>
+               
+               <item>
+                  <p>The children of a node <var>N</var> precede the following siblings of <var>N</var>.</p>
                </item>
 
 
@@ -3155,9 +3176,8 @@ stable but <termref
 
 
                <item>
-                  <p>Attribute nodes immediately follow the <phrase role="xpath"
-                        >namespace nodes of the
-</phrase> element node with which they are associated. The relative order of
+                  <p>Attribute nodes immediately follow the namespace nodes of the
+element node with which they are associated. The relative order of
 attribute nodes is stable but <termref
                         def="dt-implementation-dependent">implementation-dependent</termref>.</p>
                </item>
@@ -3169,9 +3189,35 @@ attribute nodes is stable but <termref
 in the <code>children</code> property of their parent node.</p>
                </item>
 
+
+            </olist>
+            
+            <p>Similarly, within a an <xtermref spec="DM40" ref="dt-JTree"/>,
+               (that is, a tree consisting of JNodes), document order satisfies the following constraints:</p>
+            
+            <olist>
                <item>
-                  <p>Children and descendants occur before following siblings.</p>
+                  <p>The root JNode precedes all other JNodes.</p>
                </item>
+               
+               <item>
+                  <p>A parent JNode precedes its children (and therefore its descendants).</p>
+               </item>
+               
+               <item>
+                  <p>The children of a JNode <var>N</var> precede the following siblings of <var>N</var>.</p>
+               </item>
+               
+               <item>
+                  <p>The children of a JNode that wraps an array follow the ordering of the members of the array.</p>
+               </item>
+               
+               <item>
+                  <p>The children of a JNode that wraps a map follow the ordering of the entries in the map.</p>
+               </item>
+
+
+               
             </olist>
 
             <p>The relative order of nodes in distinct trees is stable but
@@ -3187,7 +3233,8 @@ tree T2.</p>
          <div3 id="id-typed-value">
             <head>Typed Value and String Value</head>
             
-            <p>Every node has a <term>typed value</term> and a <term>string value</term>, except for nodes whose value is <xtermref
+            <p>Every node (that is, every <xtermref spec="DM40" ref="dt-XNode"/>)
+               has a <term>typed value</term> and a <term>string value</term>, except for nodes whose value is <xtermref
                spec="DM40" ref="dt-absent"/>.
                
                <termdef term="typed value" id="dt-typed-value"
@@ -3425,7 +3472,7 @@ returned.</p>
                </item>
 
                <item>
-                  <p>If the item is a node (specifically, an <xtermref spec="DM40" ref="dt-XNode"/>),
+                  <p>If the item is a node (specifically, an <termref def="dt-XNode"/>),
 its <termref def="dt-typed-value"
                         >typed value</termref> is returned (a <termref def="dt-type-error"
                         >type error</termref>
@@ -3453,8 +3500,8 @@ its <termref def="dt-typed-value"
                </item>
 
             </ulist>
-            <p>Atomization is  used in
-processing the following types of expressions: </p>
+            <p>Atomization is used in
+processing many expressions that are designed to operate on atomic items, including: </p>
             <ulist>
 
                <item>
@@ -3492,6 +3539,10 @@ processing the following types of expressions: </p>
                </item>
 
             </ulist>
+            
+            <p>Atomization plays an important role in the <termref def="dt-coercion-rules"/> used
+            when converting a supplied argument in a function call to the type declared
+            in the function signature.</p>
          </div3>
 
 
@@ -3604,8 +3655,9 @@ defined in <xspecref
                      >effective boolean
   value</termref> is <emph>not</emph> used when casting a value to the
   type <code>xs:boolean</code>, for example in a <code>cast</code>
-  expression or when passing a value to a function whose expected
-  parameter is of type <code>xs:boolean</code>.</p>
+  expression. It also plays no role in the <termref def="dt-coercion-rules"/>
+  used when passing a value to a function whose signature declares a
+  parameter of type <code>xs:boolean</code>.</p>
             </note>
 
          </div3>
@@ -3714,7 +3766,8 @@ defined in <xspecref
                have <termref def="dt-atomic-type">atomic types</termref> such as <code>xs:string</code>,
                <code>xs:boolean</code>, and <code>xs:integer</code>. These types are taken directly
                from their definitions in <bibref ref="XMLSchema10"/> or <bibref ref="XMLSchema11"/>.</p></item>
-            <item><p>Nodes (which are another kind of <termref def="dt-item"/>) have a property
+            <item><p><termref def="dt-XNode">XNodes</termref> 
+               (which are another kind of <termref def="dt-item"/>) have a property
             called a <termref def="dt-type-annotation"/> which determines the type of their content.
             The type annotation is a <termref def="dt-schema-type"/>. The type annotation of a node
             must not be confused with the item type of the node. For example, an element 
@@ -5997,13 +6050,13 @@ declare record Particle (
             <div3 id="id-generalized-node-types">
                <head>Generalized Node Types</head>
                <changes>
-                  <change issue="2025">
+                  <change issue="2025" PR="2031" date="2025-06-13">
                      JNodes are introduced
                   </change>
                </changes>
                
                <p>A <nt def="GNodeType">GNodeType</nt> matches a generalized node (GNode):
-                  that is, it matches any <xtermref spec="DM40" ref="dt-XNode"/>
+                  that is, it matches any <termref def="dt-XNode"/>
                   or <xtermref spec="DM40" ref="dt-JNode"/>.</p>
                
                <scrap>
@@ -7136,7 +7189,11 @@ declare record Particle (
 
                <p>
       The following examples are some possible ways to define <code>subtype-assertions()</code> for some
-      implementation defined assertions in the <code>local</code> namespace. These examples assume that some implementation uses annotations to label functions as deterministic or nondeterministic, and treats deterministic functions as a subset of nondeterministic functions. In this implementation, nondeterministic functions are not a subset of deterministic functions.
+      implementation defined assertions in the <code>local</code> namespace. These examples 
+                  assume that some implementation uses annotations to label functions as 
+                  deterministic or nondeterministic, and treats deterministic functions 
+                  as a subset of nondeterministic functions. In this implementation, 
+                  nondeterministic functions are not a subset of deterministic functions.
     </p>
 
                <ulist>
@@ -7508,15 +7565,17 @@ declare record Particle (
                   </item>
                   
                   <item>
-                     <p>If <var>J</var> is a <xtermref spec="DM40" ref="dt-JNode"/> and <var>R</var>
-                     is <nt def="ArrayType">ArrayType</nt> or <nt def="MapType">MapType</nt>,
+                     <p>If <var>J</var> is a <xtermref spec="DM40" ref="dt-JNode"/> and does not
+                        match <var>R</var>,
                      then each item in the ¶value of <var>J</var> is coerced to type <var>R</var>
-                     by applying these rules recursively.</p>
+                     by applying the coercion rules recursively.</p>
                      
                      <note><p>For example, if <code>$A</code> is an array and the members
                      of the array are maps, then <code>$A?child::*</code> returns a sequence
-                     of JNodes that encapsulate maps, and the size of these maps can be obtained 
-                     using the expression <code>$A?child::* ! map:size(.)</code>.</p></note>
+                     of JNodes that encapsulate maps, and the average size of these maps can be obtained 
+                     using the expression <code>avg($A?child::* ! map:size(.))</code>. The first
+                     argument of <code>map:size</code> does not accept a JNode directly, but
+                     it does (in effect) accept a JNode that encapsulates a map.</p></note>
                   </item>
                               
                   <item diff="add" at="A">
@@ -10124,7 +10183,9 @@ At evaluation time, the value of a variable reference is the value to which the 
             <example>
                                     <head>Derived Types and Nonlocal Variable Bindings</head>
                                     <p>
-                                       <code>$incr</code> is a nonlocal variable that is available within the function because its variable binding has been added to the variable values of the function..  Even though the parameter and return type of this function are both <code>xs:decimal</code>,
+                                       <code>$incr</code> is a nonlocal variable that is available within the function because 
+                                       its variable binding has been added to the variable values of the function.  
+                                       Even though the parameter and return type of this function are both <code>xs:decimal</code>,
                                   the more specific type <code>xs:integer</code> is preserved in both cases.</p>
                                     <eg role="parse-test"><![CDATA[
 let $incr := 1
@@ -13223,7 +13284,7 @@ the results are the same.
             <p>The following example demonstrates the use of the <code>except</code> operator
             with JNodes:</p>
             
-            <eg>let $m := pin($map)
+            <eg>let $m := JNode($map)
 for $e in $m?child::* except $m?child::xx 
 return ...</eg>
             
@@ -14313,7 +14374,7 @@ of this value comparison is <code>true</code>.</p>
          <div3 id="id-node-comparisons">
             <head>GNode Comparisons</head>
             <p>GNode comparisons are used to compare two <xtermref spec="DM40" ref="dt-GNode">GNodes</xtermref>
-               (that is, <xtermref spec="DM40" ref="dt-XNode">XNodes</xtermref> or
+               (that is, <termref def="dt-XNode">XNodes</termref> or
                <xtermref spec="DM40" ref="dt-JNode">JNodes</xtermref>), by their identity or by their <termref
                   def="dt-document-order"
                >document order</termref>. The result of a GNode comparison is defined by the following rules:</p>
@@ -20343,7 +20404,7 @@ processing with JSON processing.</p>
                   values of that type only. This is especially useful when processing
                   trees of maps and arrays, as encountered when processing JSON input.
                </change>
-               <change issue="2025">
+               <change issue="2025" PR="2031" date="2025-06-13">
                   The "?" operator can now be followed by an axis step, such as <code>child::*</code>
                   or <code>descendant::*</code>. This returns a sequence of JNodes, which
                   allow access to the key used for selection, and to parents and ancestors 
@@ -20376,9 +20437,9 @@ processing with JSON processing.</p>
                   defines the scope of a search for the required data, and
                   the <code>KeySelector</code> defines the search criteria.</p>
                
-               <p>First some very simple cases: given an array <code>$A</code> of maps:</p>
+               <p>First a very simple example: given an array <code>$A</code> of maps:</p>
                
-               <eg>[ { "John": 3, "Jill": 5}, {"Peter": 8, "Mary": 6}]</eg>
+               <eg>[ { "John": 3, "Jill": 5}, {"Peter": 8, "Mary": 6} ]</eg>
                
                <ulist>
                   <item><p><code>$A ? 1 ? John</code> returns <code>3</code></p></item>
@@ -20386,17 +20447,26 @@ processing with JSON processing.</p>
                   <item><p><code>$A ? * ? *</code> returns <code>(3, 5, 8, 6)</code></p></item>
                   <item><p><code>$A ? * ? Peter</code> returns <code>8</code></p></item>
                   <item><p><code>$A ? 2 ? *</code> returns (8, 6)</p></item>
-                  <item><p><code>$A ?? *</code> returns <code>({ "John": 3, "Jill": 5}, 3, 5, {"Peter": 8, "Mary": 6}, 8, 6)</code></p></item>
-                  <item><p><code>$A ?? ~[xs:integer]</code> returns <code>(3, 5, 8, 6)</code></p></item>
+                  <!--<item><p><code>$A ?? *</code> returns <code>({ "John": 3, "Jill": 5}, 3, 5, {"Peter": 8, "Mary": 6}, 8, 6)</code></p></item>
+                  <item><p><code>$A ?? ~[xs:integer]</code> returns <code>(3, 5, 8, 6)</code></p></item>-->
                </ulist>
                
-               <p>The expression <code>$A ? ..</code> is an abbreviation for <code>$A ? parent::*</code>.</p>
+               <p>The above examples do not include a <code>JAxis</code>. For purposes of exposition,
+               however, we will consider cases in the following order:</p>
                
-               <p>The expression <code>$A ? .</code> is an abbreviation for <code>$A ? self::*</code>.</p>
+               <ulist>
+                  <item><p><specref ref="id-lookup-with-jaxis"/></p></item>
+                  <item><p><specref ref="id-keyspecifiers"/></p></item>
+                  <item><p><specref ref="id-abbreviated-lookup"/></p></item>
+                  <item><p><specref ref="id-lookup-sans-jaxis"/></p></item>
+               </ulist>
+               
+               <div5 id="id-lookup-with-jaxis">
+                  <head>Lookup Expressions using a JAxis</head>
+                  
                
                <p>We will start by giving the rules for the case where a <code>JAxis</code>
-               is included (either explicitly, or by use of the abbreviated forms <code>.</code> or <code>..</code>), 
-               and then explain what happens when it is omitted.</p>
+               is included.</p>
                
                <p>An expression such as <code>$A ? child::<var>KS</var></code> (where <code>child</code>
                   might be replaced by any other <code>JAxis</code>) is evaluated as follows:</p>
@@ -20408,11 +20478,12 @@ processing with JSON processing.</p>
                      which is then evaluated using the rules below.</p></item>
                   
                   <item><p>If the value of <code>$a</code> is anything other than a map,
-                  an array, or a JNode, then a type error is raised <errorref class="TY" code="0004"/>.</p></item>
+                  an array, or a <xtermref spec="DM40" ref="dt-JNode"/>, then a type 
+                     error is raised <errorref class="TY" code="0004"/>.</p></item>
                  
                   <item><p>If the value of <code>$a</code> is a map or an array, then it
                   is wrapped in a root <xtermref spec="DM40" ref="dt-JNode"/> by applying
-                  the <function>pin</function> function, and the expression is then
+                  the <function>fn:JNode</function> function, and the expression is then
                   evaluated using the rules below.</p></item>
                   
                   <item><p>If the value of <code>$a</code> is a <xtermref spec="DM40" ref="dt-JNode"/>,
@@ -20420,7 +20491,8 @@ processing with JSON processing.</p>
                   of JNodes.</p></item>
                   
                   <item><p>This sequence of JNodes is filtered and potentially reordered, retaining 
-                     only those JNodes that satisfy the <code>KeySpecifier</code> <var>KS</var>.</p></item>
+                     only those JNodes that satisfy the <code>KeySpecifier</code> <var>KS</var>,
+                  as described in <specref ref="id-keyspecifiers"/>.</p></item>
                </ulist>
                
                <p>A <code>JAxis</code> is essentially a function that takes a JNode as its input
@@ -20437,57 +20509,85 @@ processing with JSON processing.</p>
                      that is, it returns the <code>¶parent</code>, then the <code>¶parent</code>
                      of the <code>¶parent</code>,
                      and so on until the root JNode (which has no parent) is reached. 
-                     The result is in reverse document order.</p></item>
+                     The result is in reverse <termref def="dt-document-order"/>.</p></item>
                   <item><p>The <code>ancestor-or-self</code> <code>JAxis</code>, applied to a JNode <var>N</var>,
                      returns <var>N</var> followed by the content of the <code>ancestor</code> <code>JAxis</code>.
-                     The result is in reverse document order.</p></item>
+                     The result is in reverse <termref def="dt-document-order"/>.</p></item>
                   <item><p>The <code>child</code> <code>JAxis</code>, applied to a JNode <var>N</var>,
-                  applies the following processing to each item <var>C</var>
-                     in the <code>¶value</code> of <var>N</var>
-                  and returns the <termref def="dt-sequence-concatenation"/> of the result.</p>
-                  <ulist>
-                     <item><p>If <var>C</var> is an array, it constructs a JNode
-                     for each member of the array. The <code>¶parent</code> property of this JNode
-                     is set to <var>N</var>; the <code>¶selector</code> property is set to
-                     the 1-based index of the member within the array; and the <code>¶value</code>
-                     property is set to the member itself.</p></item>
-                     <item><p>If <var>C</var> is a map, it constructs a JNode
-                     for each entry (key-value pair) in the map. The <code>¶parent</code> property of this JNode
-                     is set to <var>N</var>; the <code>¶selector</code> property is set to
-                     the entry's key; and the <code>¶value</code>
-                     property is set to the entry's value.</p></item>
-                     <item><p>If <var>C</var> is of any other type, it returns an empty sequence.</p></item>
-                  </ulist>
+                     returns the result of the <xtermref spec="DM40" ref="dt-j-children"/> accessor
+                     function defined in the data model. The effect of this accessor applied to a JNode <var>$N</var>
+                     is repeated here for convenience, assuming the existence of a function <code>dm:JNode</code>
+                     that returns a JNode with given values for its ¶parent, ¶position, ¶selector, and ¶value
+                     properties:</p> <eg>         
+for $item at $pos in JNode-value($N)
+return
+  if ($item instance of array(*))
+  then for member $member at $index in $item
+       return dm:JNode(parent := $P,
+                       position := $pos,
+                       selector := $index,
+                       value := $member)
+  else if ($item instance of map(*))
+  then for key $key value $value in $item
+       return dm:JNode(parent := $P,
+                       position := $pos,
+                       selector := $key
+                       value := $value)
+  else ()
+</eg> 
                      <p>The order of the result reflects the order of members in an array or of entries
                      within a map, and this is in document order by definition.</p>
                   </item>
                   <item><p>The <code>descendant</code> <code>JAxis</code>, applied to a JNode <var>N</var>,
                      returns the transitive closure of the <code>child</code> <code>JAxis</code>. The result
-                     is in document order.</p></item>
+                     is in document order.</p>
+                     <p>More specifically, the descendant axis returns the result of the recursive XQuery function:</p>
+                     <eg>
+  function descendants($root as JNode()) as JNode()* {
+     for $c in $root ? child::*
+     return ($c, if ($c instance of JNode(array(*)|map(*))) 
+                 then descendants($c)
+                 else ())
+  }
+                     </eg>
+                  </item>
                   <item><p>The <code>descendant-or-self</code> <code>JAxis</code>, applied to a JNode <var>N</var>,
                      returns <var>N</var> followed by the content of the <code>descendant</code> <code>JAxis</code>.
                      The result is in document order.</p></item>
             
                </ulist>
+                  
+               </div5>
+               
+               <div5 id="id-keyspecifiers">
+                  <head>Key Specifiers</head>
                
                
-               <p>The <code>KeySpecifier</code> filters and potentially reorders the result 
-                  (referred to below as the <term>raw result</term>), as follows:</p>
+               
+               <p>The <code>KeySpecifier</code> filters and potentially reorders the sequence
+                  of JNodes selected by the axis (referred to below as the <term>raw result</term>), 
+                  as follows:</p>
                
                <ulist>
-                  <item><p>If the <code>KeySpecifier</code> is a <code>LookupWildcard</code>, 
+                  <item><p>If the <code>KeySpecifier</code> is a <code>LookupWildcard</code>
+                     (that is, <code>*</code>)
                      then the raw result is returned unchanged.</p></item>
                   
                   <item><p>If the <code>KeySpecifier</code> is a <code>TypeSpecifier</code>, 
                      then the raw result is filtered to retain only those JNodes 
                      whose <code>¶value</code> property is an instance of
                      the sequence type defined by the <code>KeySpecifier</code>.</p>
+                     <p>For example, the expression <code>$array?child::~[array(*)]</code>
+                     selects only those members of an array that are themselves arrays.</p>
                   </item>
 
                   <item><p>If the <code>KeySpecifier</code> is an NCName, then the raw
-                     result if filtered to retain only those JNodes whose <code>¶selector</code> property 
+                     result is filtered to retain only those JNodes whose <code>¶selector</code> property 
                      is equal to the NCName
                      under the rules of the <function>atomic-equal</function> function.</p>
+                     <p>For example, the expression <code>$map?child::status</code> returns a JNode
+                     that wraps the map entry having the key <code>"status"</code>, if such an entry
+                     exists.</p>
                      <note><p>There may be more than one such JNode in the case of a <code>JAxis</code>
                      other than <code>child</code>.</p></note>
                   </item>
@@ -20498,7 +20598,7 @@ processing with JSON processing.</p>
                       by evaluating the expression:</p>
                      <eg>
 for $k in data($K)
-return $RR[atomic-equal($k, selector(.))] 
+return $RR[atomic-equal($k, JNode-selector(.))] 
                      </eg>
                      
                         <note><p>This expression will never raise a type error, nor will it raise
@@ -20510,6 +20610,10 @@ return $RR[atomic-equal($k, selector(.))]
                         <p>returns JNodes representing the entries <code>3:30</code>
                            and <code>1:10</code> in that order; the index <code>82</code>
                         selects nothing.</p>
+                     
+                        <note><p>In a practical implementation one might reasonably expect
+                        that the entry for a particular key in a map can be accessed without
+                        a sequential search of all entries, as this pseudo-code would suggest.</p></note>
                      </item>   
                   
                   
@@ -20517,9 +20621,33 @@ return $RR[atomic-equal($k, selector(.))]
                
                <p>The lookup operator <code>?</code> (unlike the path operator <code>/</code>)
                does not force the results into document order, nor does it eliminate duplicates.
-               If this is required, it can be achieved by a call on the <code>distinct-ordered-nodes</code>
+               If this is required, it can be achieved by a call on the <function>distinct-ordered-nodes</function>
                function (or more concisely, with the union operator: <code>$X|()</code> has the same effect
                as <code>distinct-ordered-nodes($X)</code>).</p>
+                  
+               </div5>
+               
+               <div5 id="id-abbreviated-lookup">
+                  <head>Abbreviated Lookup Expressions</head>
+                  
+                  
+               
+                  <p>The expression <code>$A ? ..</code> is an abbreviation for <code>$A ? parent::*</code>.
+                  If <code>$A</code> is a root JNode (a JNode with no parent), or if it is a map or array
+                     (which is implicitly wrapped in a root JNode) then the expression returns an empty sequence;
+                  otherwise it returns the ¶parent property of <code>$A</code>. If <code>$A</code> is a
+                  sequence with multiple items, it returns the sequence concatenation of the results.</p>
+                  
+                  <p>The expression <code>$A ? .</code> is an abbreviation for <code>$A ? self::*</code>.
+                  If <code>$A</code> is a JNode, it returns that JNode unchanged; otherwise, it returns
+                  the result of <code>fn:JNode($A)</code>. If <code>$A</code> is a sequence containing
+                  multiple items, it returns the sequence concatenation of the result.</p>
+                  
+               </div5>
+               
+               <div5 id="id-lookup-sans-jaxis">
+                  <head>Lookup Expressions with no Explicit JAxis</head>
+               
                
                <p>In the absence of an <code>JAxis</code>, a shallow lookup expression
                <code>$C ? <var>KS</var></code> is evaluated as follows:</p> 
@@ -20528,21 +20656,26 @@ return $RR[atomic-equal($k, selector(.))]
 for $c in $C
 return if ($c instance of JNode())
        then $c ? child::KS
-       else pin($c) ? child::KS =!> unpin()
+       else JNode($c) ? child::KS =!> JNode-value()
                </eg>
                
                <p>The effect of this is that when the left-hand operand of the expression
-               contains a JNode, the result will contain a JNode. But when the left-hand
-               operand is a simple (unpinned) map or array, the result will contain
+               contains a JNode, the result will be a sequence of JNodes. But when the left-hand
+               operand is a simple map or array, the result will contain
                simple values, flattened by <termref def="dt-sequence-concatenation"/>.</p>
+                  
+               <p>For example, if <code>$m</code> is the map <code>{ "a":1, "b": 2 }</code>,
+               then <code>$m?b</code> returns the <code>xs:integer</code> value 2. In contrast,
+               <code>JNode($m)?b</code> returns a JNode having <code>¶parent=JNode($m)</code>, <code>¶selector="b"</code>,
+               <code>¶position=1</code>, and <code>¶value=2</code>.</p>   
                
                <note>
-                  <p>The effect of unpinning the result is to lose information.
+                  <p>The effect of returning a simple value as the result is to lose information.
                   This happens in two ways.
                   Firsly, no information is retained about the parent map or array,
                   or about the key that was used to make the selection, which means
                   it is not possible to navigate around the containing tree to obtain
-                  properties of other JNodes. Secondly, the results are flattened
+                  properties of other related JNodes. Secondly, the results are flattened
                   into a single sequence: for example, the result of the lookup
                   expression <code>[ 1, 2, (), 4 ] ? *</code> is the sequence
                   <code>( 1, 2, 4 )</code>, losing any information about the third
@@ -20551,16 +20684,21 @@ return if ($c instance of JNode())
                   <p>This effect can be avoided in a number of ways:</p>
                   
                   <ulist>
-                     <item><p>Use of an explicit call on <function>pin</function>, 
-                     for example <code>pin($A)?K</code></p></item>
+                     <item><p>Use of an explicit call on <function>fn:JNode</function>
+                        on the left-hand side, 
+                     for example <code>JNode($A) ? K</code></p></item>
                      <item><p>Use of an explicit axis, for example
-                     <code>$A?child::K</code></p></item>
-                     <item><p>Implicit pinning using the step <code>.</code>,
-                     for example <code>$A?.?K</code>. This is equivalent
-                     to <code>$A?self::*?K</code>, which (because it uses an
+                     <code>$A ? child::K</code></p></item>
+                     <item><p>Implicit wrapping using the step <code>.</code>,
+                     for example <code>$A ? . ? K</code>. This is equivalent
+                     to <code>$A ? self::* ? K</code>, which (because it uses an
                         explicit axis) ensures that the left-hand operand of the second <code>?</code>
-                     operator is a JNode.</p></item>
+                     operator is a JNode, and therefore the result of the final expression
+                     is also a JNode.</p></item>
                   </ulist>
+                  
+                  <p>The reason for the design choice is primarily for backwards compatibility; but
+                  it also has the benefit of keeping common cases simple.</p>
                </note>
                
                
@@ -20579,31 +20717,31 @@ return if ($c instance of JNode())
                   </thead>
                   <tbody>
                      <tr>
-                        <td><code>$A ? *</code></td>
-                        <td><eg>("a", "b", "c", "d", "e", "f", 42)</eg></td>
+                        <td valign="top"><code>$A ? *</code></td>
+                        <td valign="top"><eg>("a", "b", "c", "d", "e", "f", 42)</eg></td>
                      </tr>
                      
                      <tr>
-                        <td><code>$A ? 2</code></td>
-                        <td><eg>("c", "d")</eg></td>
+                        <td valign="top"><code>$A ? 2</code></td>
+                        <td valign="top"><eg>("c", "d")</eg></td>
                      </tr>                   
                      <tr>
-                        <td><code>$A ? (3, 1)</code></td>
-                        <td><eg>("e", "f", "a", "b")</eg></td>
+                        <td valign="top"><code>$A ? (3, 1)</code></td>
+                        <td valign="top"><eg>("e", "f", "a", "b")</eg></td>
                      </tr> 
                      <tr>
-                        <td><code>$A ? 82</code></td>
-                        <td><eg>()</eg>
+                        <td valign="top"><code>$A ? 82</code></td>
+                        <td valign="top"><eg>()</eg>
                         <note><p>There is no array bound checking.</p></note></td>
                      </tr> 
                      <tr>
-                        <td><code>$A ? xyz</code></td>
-                        <td><eg>()</eg>
+                        <td valign="top"><code>$A ? xyz</code></td>
+                        <td valign="top"><eg>()</eg>
                         <note><p>No type error is raised.</p></note></td>
                      </tr>
                      <tr>
-                        <td><code>$A ? ~[xs:integer]</code></td>
-                        <td><eg>42</eg></td>
+                        <td valign="top"><code>$A ? ~[xs:integer]</code></td>
+                        <td valign="top"><eg>42</eg></td>
                      </tr>
                   </tbody>
                </table>
@@ -20622,20 +20760,20 @@ return if ($c instance of JNode())
                   </thead>
                   <tbody>
                      <tr>
-                        <td><code>$M ? *</code></td>
-                        <td><eg>("a", "b", "c", "d", "e", "f", 42)</eg></td>
+                        <td valign="top"><code>$M ? *</code></td>
+                        <td valign="top"><eg>("a", "b", "c", "d", "e", "f", 42)</eg></td>
                      </tr>
                      <tr>
-                        <td><code>$M ? Y</code></td>
-                        <td><eg>("c", "d")</eg></td>
+                        <td valign="top"><code>$M ? Y</code></td>
+                        <td valign="top"><eg>("c", "d")</eg></td>
                      </tr>
                      <tr>
-                        <td><code>$M ? ("Z", "X")</code></td>
-                        <td><eg>("e", "f", "a", "b")</eg></td>
+                        <td valign="top"><code>$M ? ("Z", "X")</code></td>
+                        <td valign="top"><eg>("e", "f", "a", "b")</eg></td>
                      </tr>
                      <tr>
-                        <td><code>$M ? ~[xs:integer]</code></td>
-                        <td><eg>42</eg></td>
+                        <td valign="top"><code>$M ? ~[xs:integer]</code></td>
+                        <td valign="top"><eg>42</eg></td>
                      </tr>                    
                   </tbody>
                </table>
@@ -20677,7 +20815,7 @@ return if ($c instance of JNode())
                   </tbody>
                </table>
                
-               
+               </div5>
            
             </div4>   
                
@@ -20698,6 +20836,11 @@ return if ($c instance of JNode())
                <p>The unary lookup expression <code>?axis::KS</code> is defined to be equivalent to the postfix lookup
                   expression <code>.?axis::KS</code> which has the context value (<code>.</code>) as the implicit first operand.
                   See <specref ref="id-postfix-lookup"/> for the postfix lookup operator.</p>
+               
+               <p>Similarly, <code>?.</code> is equivalent to <code>.?.</code>, 
+               <code>?..</code> is equivalent to <code>.?..</code>, and <code>?<var>KS</var></code> (where 
+               <var>KS</var> is some <code>KeySpecifier</code>) is equivalent to
+               <code>.?<var>KS</var></code>.</p>
                
                
                <p>Examples:</p>
@@ -20725,7 +20868,7 @@ return if ($c instance of JNode())
                      <note><p>Writing <code>? * ? postcode</code> would raise a type error, 
                         because the result of the initial
                         step <code>? *</code> includes an item (the string <code>"John Smith"</code>) 
-                        that is neither a map nor an array. Writing <code>?? postcode</code>
+                        that is neither a map nor an array. Adding the <code>TypeSpecifier</code>
                         avoids this problem.</p></note>
                   </item>
                   <item>
@@ -20809,108 +20952,60 @@ return if ($c instance of JNode())
                is evaluated as follows:</p>
                
                <p><code>$C ?? <var>KS</var></code> is equivalent to 
-                  <code>$C ? descendant::KS =!> unpin()</code></p>
+                  <code>$C ? descendant::KS</code></p>
                
-               <ednote><edtext>Should we drop the <code>unpin()</code>? The result is much more
-               useful if we can use it as a basis for further navigation.</edtext></ednote>
+               <p>Unlike the shallow lookup operator <code>?</code>, the deep lookup
+               operator always returns a sequence of JNodes.</p>
                
-               <!--<p>First we define the <term>recursive content</term> of an item as follows:</p>
+               <p>The unary form is also available: the expression <code>?? <var>KS</var></code> is equivalent
+               to <code>. ?? <var>KS</var></code>.</p>
                
-               <eg><![CDATA[declare function immediate-content($item as item()) as record(key, value)* {
-  if ($item instance of map(*)) {
-    map:pairs($item)
-  } else if ($item instance of array(*)) {
-    for member $m at $p in $item
-    return { "key": $p, "value": $m }
-  }
-};    
-
-declare function recursive-content($item as item()) as record(key, value)* {
-  immediate-content($item) ! (., ?items::value ! recursive-content(.))
-};]]>
-               </eg>
-               
-               <note><p>Explanation: the immediate content of a map is obtained by splitting it
-               into a sequence of key-value pairs, each representing one entry. The immediate
-               content of an array is obtained by constructing a sequence of key-value pairs,
-               one for each array member, where the key is the array index and the
-               value is the corresponding member. Each key-value pair is of type
-               <code>record(key as xs:anyAtomicType, value as item()*)</code>.
-                  The recursive content of an item contains
-               the key-value pairs in its immediate content, each followed by the recursive
-               content obtained by expanding any maps or arrays in the immediate content.
-               </p></note>
+               <example id="ex-deep-lookup-array">
+                  <head>Deep Lookup Expressions applied to an Array</head>
                
 
-               <p>It is then useful to represent the recursive content as a sequence of
-               <xtermref spec="DM40" ref="dt-single-entry-map">single-entry-maps</xtermref>: 
-                  so each pair <code>{ "key": $K, "value": $V }</code>
-               is converted to the form <code>{ $K: $V }</code>. This can be achieved
-               using the expression <code>recursive-content($V) ! { ?key: ?value }</code>.</p>
-               
-               <p>In addition we define the function <code>array-or-map</code> as follows:</p>
-               
-               <eg><![CDATA[declare function array-or-map($item as item()) {
-  typeswitch ($item) {
-    case array(*) | map(*) return $item
-    default return error( #err:XPTY0004 )
-  }
-}]]></eg>
-
-               
-               <p>The result of the expression <code>E??pairs::KS</code>, where <code>E</code> is any expression
-               and <code>KS</code> is any <code>KeySpecifier</code>, is then:</p>
-
-               <eg>(<var>E</var> ! array-or-map(.) -> recursive-content(.) ! { ?key: ?value })
-?pairs::<var>KS</var></eg>
-
-               <note>
-                  <p>This is best explained by considering examples.</p>
-
-                  <p>Consider the expression <code>let $V := [ { "first": "John", "last": "Smith" }, { "first": "Mary", "last": "Evans" } ]</code>.</p>
-                  <p>The recursive content of this array is the sequence of six maps:</p>
+                  <p>Let <code>$V</code> be the array <code> [ { "first": "John", "last": "Smith" }, { "first": "Mary", "last": "Evans" } ]</code>.</p>
+                  <p>The result of <code>$V ?? * => JNode-value()</code> is a sequence of six values:</p>
+                  <ulist>
+                     <item><p><code>{ "first": "John", "last": "Smith" }</code></p></item>
+                     <item><p><code>"John"</code></p></item>
+                     <item><p><code>"Smith"</code></p></item>
+                     <item><p><code>{ "key": "last", "value": "Smith" }</code></p></item>
+                     <item><p><code>"Mary"</code></p></item>
+                     <item><p><code>"Evans"</code></p></item>
+                  </ulist>
+                  
+                  <p>The associated selectors can be included in the result by forming a sequence
+                     of key-value pair records, using the
+                  expression <code>$V ?? * ! { "key": JNode-selector(.), "value": JNode-value(.) }</code>,
+                  which returns:</p>
+                                      
                   <olist>
-                     <item><p><code>{ "key": 1, "value": { "first": "John", "last": "Smith" } }</code></p></item>
-                     <item><p><code>{ "key": 2, "value": { "first": "Mary", "last": "Evans" } }</code></p></item>
+                     <item><p><code>{ "key": 1, "value": { "first": "John", "last": "Smith" } }</code></p></item>                    
                      <item><p><code>{ "key": "first", "value": "John" }</code></p></item>
                      <item><p><code>{ "key": "last", "value": "Smith" }</code></p></item>
+                     <item><p><code>{ "key": 2, "value": { "first": "Mary", "last": "Evans" } }</code></p></item>
                      <item><p><code>{ "key": "first", "value": "Mary" }</code></p></item>
                      <item><p><code>{ "key": "last", "value": "Evans" }</code></p></item>
                   </olist>
-                  <p>The expression <code>$V??pairs::*</code> returns this sequence.</p>
-                  <p>With some other <code>KeySpecifier</code> <code>KS</code>, <code>$V??pairs::KS</code> returns
-                     selected items from this sequence that match <code>KS</code>.
-                     Formally this is achieved by converting the key-value pairs to 
-                     <xtermref spec="DM40" ref="dt-single-entry-map">single-entry maps</xtermref>,
-                     applying the <code>KeySpecifier</code> to the sequence of single-entry maps,
-                     and then converting the result back into a sequence of key-value pairs.</p>
-                  <p>For example, given the expression <code>$V??pairs::first</code>, the selection from
-                     the converted sequence will include the two <xtermref spec="DM40" ref="dt-single-entry-map">single
-                     entry maps</xtermref>
-                     <code>{ "first" : "John" }</code> and <code>{ "first" : "Mary" }</code>,
-                  which will be delivered in key-value pair form as 
-                     <code>{ "key": "first", "value": "John" }, { "key": "first", "value": "Mary" }</code>.</p>
-               </note>
-               
-               <p>The effect of using modifiers other than <code>pairs</code> is the same as with
-                  shallow lookup expressions:</p>
-               
-               <ulist>
-                  <item><p>If the modifier is <code>items</code> (explicitly or by default), the result of
-                     <code>$V??items::KS</code> is the same as the result of 
-                     <code>$V??pairs::KS ! map:get(., "value")</code>; that is,
-                  it is the <termref def="dt-sequence-concatenation"/> of the value parts.</p></item>
                   
-                  <item><p>If the modifier is <code>values</code>, the result of
-                     <code>$V??values::KS</code> is the same as the result of 
-                     <code>$V??pairs::KS ! array { map:get(., "value") }</code>.</p></item>
-                  
-                  <item><p>If the modifier is <code>keys</code>, the result of
-                     <code>$V??keys::KS</code> is the same as the result of 
-                     <code>$V??pairs::KS ! map:get(., "key")</code>.</p></item>
-               </ulist>
+                  <p>The surnames of all people with first name "John" can be found using the expression:</p>
                
-               <note>
+                  <eg>$V ?? first [. = "John"] ? .. ? last => string()</eg>
+                  
+                  <p>The call on <code>string()</code> here achieves the same effect as a call on 
+                  <code>JNode-value</code>, because the <function>string</function> function, when
+                  applied to a JNode, extracts the ¶value property and converts it to a string.
+                  Indeed the predicate <code>[. = "John"]</code> is also implicitly extracting
+                  the ¶value property of a JNode: this happens automatically when a JNode is 
+                  atomized, as required by the <code>=</code> operator.</p>
+               
+               </example>
+                  
+                  
+               
+               <!--<note>
+
                   <p>This means that with the example given earlier:</p>
                   <ulist>
                      <item><p>The expression <code>$V ?? first</code> 
@@ -20937,7 +21032,7 @@ declare function recursive-content($item as item()) as record(key, value)* {
                      contrast, the semantics are defined in terms of a map lookup, in which 
                      <code>xs:untypedAtomic</code> items are always treated as strings.
                   </p>
-               </note>
+               </note>-->
                <note>
                   <p>The definition of the <code>recursive-content</code> function is such that items
                   in the top-level value that are not maps or arrays are ignored, whereas items that
@@ -20947,6 +21042,7 @@ declare function recursive-content($item as item()) as record(key, value)* {
                   deep in the tree.</p>
                </note>
                <note>
+
                   <p>An expression involving multiple deep lookup operators may return duplicates.
                      For example, the result of the expression 
                      <code>[ [ [ "a" ], [ "b" ] ], [ [ "c" ], [ "d" ] ] ] ?? 1 ?? 1</code>
@@ -20957,17 +21053,13 @@ declare function recursive-content($item as item()) as record(key, value)* {
                   selects members in position 1 within each of these values, which results in the string
                   <code>"a"</code> being selected twice.</p>
                </note>
-               <note>
-                  <p>A type error is raised if the value of the left-hand expression includes an item
-                  that is neither a map nor an array.</p>
-               </note>
-               
+            
  
                
-               <example id="ex-deep-lookup">
-                  <head>Examples of Deep Lookup Expressions</head>
+               <example id="ex-deep-lookup-map">
+                  <head>Deep Lookup Expressions applied to a Map</head>
                   <p>Consider the tree <code>$tree</code> of maps and arrays that results from applying the <function>fn:parse-json</function>
-                  function to the following input:</p>
+                  function to the following JSON input:</p>
                   <eg><![CDATA[
 {
   "desc"    : "Distances between several cities, in kilometers.",
@@ -21003,13 +21095,28 @@ declare function recursive-content($item as item()) as record(key, value)* {
                   two cities can be obtained with the expression:</p> 
                      
 
-                     <eg>$tree ?? $from ?? ~[record(to, distance)][?to = $to] ? distance</eg>
+                     <eg>$tree ?? $from ?? ~[record(to, distance)] [?to = $to] ? distance</eg>
                  
                   <p>The names of all pairs of cities whose distance is represented in the data
                   can be obtained with the expression:</p>
                   
-                  <eg>$tree ?? $cities
-=> map:for-each(fn($key, $val) { $val ?? to ! ($key || "-" || .) })</eg>
+                  <eg>$tree ?? "to" ! `{JNode-selector(?..?..)} to {.}`</eg>
+                  
+                  <p>The JNodes returned by the initial lookup <code>$tree ?? "to</code>
+                  wrap values such as <code>"London"</code>. The first <code>?..</code> selection
+                  from such a value returns a JNode wrapping a value such as the map
+                  <code>{ "to": "London", "distance": 322 }</code>. The second <code>?..</code>
+                  selection returns the containing array. The selector for this array is a key
+                  in the containing map, such as <code>"Brussels"</code>.</p>
+                  <note><p>The quotation marks around the key <code>"to"</code> are not needed,
+                  but are included here to improve readability.</p></note>
+                  
+                  <p>An alternative way to deliver the same result would be:</p>
+                  
+                  <eg>for key $from value $array in $tree ? cities
+for $to in $array ?? "to"
+return `{$from} to {$to}`</eg>
+
                </example>
                <example>
                   <head>Comparison with JSONPath</head>
@@ -21057,6 +21164,9 @@ declare function recursive-content($item as item()) as record(key, value)* {
                   both in JSONPath and in &language;.</p>
                   <table role="small" width="100%">
                      <caption>JSONPath vs &language; Comparison</caption>
+                     <col width="40%"/>
+                     <col width="30%"/>
+                     <col width="30%"/>
                      <thead>
                         <tr>
                            <th>Query</th>
@@ -21066,68 +21176,68 @@ declare function recursive-content($item as item()) as record(key, value)* {
                      </thead>
                      <tbody>
                         <tr>
-                           <td>The authors of all books in the store</td>
-                           <td><code>$.store.book[*].author</code></td>
-                           <td><code>$m?store?book??author</code></td>
+                           <td valign="top">The authors of all books in the store</td>
+                           <td valign="top"><code>$.store.book[*].author</code></td>
+                           <td valign="top"><code>?store?book??author</code></td>
                         </tr>
                         <tr>
-                           <td>All authors</td>
-                           <td><code>$..author</code></td>
-                           <td><code>$m??author</code></td>
+                           <td valign="top">All authors</td>
+                           <td valign="top"><code>$..author</code></td>
+                           <td valign="top"><code>??author</code></td>
                         </tr>
                         <tr>
-                           <td>All things in store (four books and a red bicycle)</td>
-                           <td><code>$.store.*  </code></td>
-                           <td><code>$m?store?*</code></td>
+                           <td valign="top">All things in store (four books and a red bicycle)</td>
+                           <td valign="top"><code>$.store.*  </code></td>
+                           <td valign="top"><code>?store?*</code></td>
                         </tr>
                         <tr>
-                           <td>The prices of everything in the store</td>
-                           <td><code>$.store..price</code></td>
-                           <td><code>$m?store??price</code></td>
+                           <td valign="top">The prices of everything in the store</td>
+                           <td valign="top"><code>$.store..price</code></td>
+                           <td valign="top"><code>?store??price</code></td>
                         </tr>
                         <tr>
-                           <td>The third book</td>
-                           <td><code>$..book[2]  </code></td>
-                           <td><code>$m??book?3</code></td>
+                           <td valign="top">The third book</td>
+                           <td valign="top"><code>$..book[2]  </code></td>
+                           <td valign="top"><code>??book?3</code></td>
                         </tr>
                         <tr>
-                           <td>The third book's author</td>
-                           <td><code>$..book[2].author</code></td>
-                           <td><code>$m??book?3?author</code></td>
+                           <td valign="top">The third book's author</td>
+                           <td valign="top"><code>$..book[2].author</code></td>
+                           <td valign="top"><code>??book?3?author</code></td>
                         </tr>
                         <tr>
-                           <td>The third book's publisher (empty result)</td>
-                           <td><code>$..book[2].publisher</code></td>
-                           <td><code>$m??book?3?publisher</code></td>
+                           <td valign="top">The third book's publisher (empty result)</td>
+                           <td valign="top"><code>$..book[2].publisher</code></td>
+                           <td valign="top"><code>??book?3?publisher</code></td>
                         </tr>
                         <tr>
-                           <td>The last book (in order)</td>
-                           <td><code>$..book[-1]</code></td>
-                           <td><code>$m??book => array:foot()</code></td>
+                           <td valign="top">The last book (in order)</td>
+                           <td valign="top"><code>$..book[-1]</code></td>
+                           <td valign="top"><code>??book?*[last()]</code></td>
                         </tr>
                         <tr>
-                           <td>The first two books</td>
-                           <td><code>$..book[0,1]</code></td>
-                           <td><code>$m??book?(1, 2)</code></td>
+                           <td valign="top">The first two books</td>
+                           <td valign="top"><code>$..book[0,1]</code></td>
+                           <td valign="top"><code>??book?(1,2)</code></td>
                         </tr>
                         <tr>
-                           <td>All books with an ISBN</td>
-                           <td><code>$..book[?@.isbn]</code></td>
-                           <td><code>$m??book[?isbn]</code></td>
+                           <td valign="top">All books with an ISBN</td>
+                           <td valign="top"><code>$..book[?@.isbn]</code></td>
+                           <td valign="top"><code>??book[?isbn]</code></td>
                         </tr>
                         <tr>
-                           <td>All books cheaper than 10</td>
-                           <td><code>$..book[?@.price&lt;10]</code></td>
-                           <td><code>$m??book[?price lt 10]</code></td>
+                           <td valign="top">All books cheaper than 10</td>
+                           <td valign="top"><code>$..book[?@.price&lt;10]</code></td>
+                           <td valign="top"><code>??book[?price lt 10]</code></td>
                         </tr>
                         <tr>
-                           <td>All member values and array elements contained in the input value</td>
-                           <td><code>$..*</code></td>
-                           <td><code>$m??*</code></td>
+                           <td valign="top">All member values and array elements contained in the input value</td>
+                           <td valign="top"><code>$..*</code></td>
+                           <td valign="top"><code>??*</code></td>
                         </tr>
                      </tbody>
                   </table>
-               </example>-->
+               </example>
             </div4>
             
             <div4 id="id-implausible-lookup-expressions" diff="add" at="Issue602">
@@ -21261,89 +21371,7 @@ return $map?[?key ge 2]</eg>
             </note>
          </div3>
          
-         <!--<div3 id="id-pinned-maps-and-arrays">
-            <head>Pinned Maps and Arrays</head>
-            <p>Unlike navigation within node trees derived from XML, navigation within a tree of maps and
-               arrays derived from JSON is normally “downwards only”: there is no equivalent of the parent
-            or ancestor axis. This means, for example, that having selected leav nodes in the tree
-            with an expression such as <code>??name</code>, there is no way of navigating from 
-               the items in the result to any related items. 
-               Pinned maps and arrays provide a solution to this problem; if a map or array
-            is pinned (by calling the <function>fn:pin</function> function), then values found by navigating
-            within the map or array are <term>labeled</term>, which provides supplementary information
-            about their location within the containing tree structure.</p>
-            
-            <p>For further information about pinned and labeled values 
-               see <xspecref spec="DM40" ref="id-LabeledItems"/>. </p>
-           
-            
-            <p>More specifically, if a map <code>$M</code> or an array <code>$A</code> is pinned,
-            then any value returned by <code>map:get($M, $key)</code> or <code>array:get($A, $index)</code>
-            will be a sequence of labeled items. The label can be obtained by calling the function
-            <function>fn:label</function>, and the result will be a map having the following properties:</p>
-            
-            <ulist>
-               <item><p><code>pinned</code>: set to <code>true</code>. This means that any
-               further selections from this value (if it is itself a map or array) will
-               also deliver labeled items.</p></item>
-               <item><p><code>parent</code>: the containing map (<code>$M</code>) or array
-               (<code>$A</code>).</p></item>
-               <item><p><code>key</code>: the key (<code>$key</code>) or index (<code>$index</code>)
-               that was used to select the item.</p></item>
-               <item><p><code>position</code>: in the general case the value returned by
-               <function>map:get</function> or <function>array:get</function> is a sequence, and each item in the
-                  sequence is labeled with its 1-based position in that sequence.</p></item>
-               <item><p><code>ancestors</code>: a zero-arity function that delivers the item’s parent (its
-               containing map or array), that item’s parent, and so on, recursively, up to
-               the map or array that was the root of the selection. The sequence is in upwards
-               navigation order (the immediate parent comes first).</p></item>
-               <item><p><code>path</code>: a zero-arity function that delivers the sequence of
-               keys (in the case of maps) or integer indexes (in the case of arrays) by which the
-               item was reached. The sequence is in downwards navigation order (the immediate
-               key or index of the item comes last).</p></item>
-            </ulist>
-            
-            <p>The formal model for the <function>fn:pin</function> is that it returns a deep copy of the 
-               supplied map or array in which all items in the recursive content have been labeled.
-            This is a useful model because it avoids the need to specify the effect of each individual
-            function and operator on the structure. For example, the rule has the consequence that the result of
-            <code>pin([ 11, 12, 13, 14 ]) => array:remove(3) => array:for-each(fn { label(.)?key })</code> is
-            <code>[ 1, 2, 4 ]</code>. In a practical implementation, however, it is likely that labels
-            will be attached to items lazily, at the time they are retrieved. Such an implementation will need
-            to recognize pinned maps and arrays and treat them specially when operations such as
-            <function>array:get</function>, <function>array:remove</function>, <function>array:for-each</function>,
-            <function>array:subarray</function>, and their map counterparts, are evaluated.</p>
-            
-           
-            <p>Because maps and arrays selected from a pinned map or array are themselves pinned,
-            deep lookup operations (whether conducted using the deep lookup operator <code>??</code>,
-            or the <function>map:find</function> function, or by user-written recursive code) will deliver
-            a labeled value whose <code>parent</code> or <code>ancestor</code> properties can 
-               be used to navigate back up through the tree.</p>
-            
-            <p>For example, given the example map shown in <specref ref="id-map-constructors"/>,
-            the expression <code>$map??last[. = "Suciu"]</code> selects the map entry with key 
-            <code>"last"</code> and value <code>"Suciu"</code>, but by itself gives no information
-            about where this entry was found. By first pinning the map, this extra information
-            can be made available through the label on the result. For example you can select
-            all co-authors of "Suciu" by writing:</p>
-            
-            <eg>pin($map)??last[. = "Suciu"] => label()?ancestors()?author??last</eg>
-            
-            <note><p>When an entry in a map, or a member of an array, has the empty sequence
-            as its value, the value contains no items and is therefore unchanged in the pinned
-            version of the containing structure. In addition, the lookup operators <code>?</code>
-            and <code>??</code> flatten their result to a single sequence, so any empty values
-            are effectively discarded from the result. For this reason, pinned arrays and maps
-            work best when all values in arrays and maps are <termref def="dt-singleton"/> 
-               items. An option is therefore provided
-            on the <function>fn:parse-json</function> and <function>fn:json-doc</function> functions to change
-            the representation of JSON <code>null</code> values (whose default is an empty
-            sequence, <code>()</code>) to a user-supplied value.</p></note>
-            
-            <ednote><edtext>That note is anticipating a proposal in a separate PR.</edtext></ednote>
-            
-         </div3>-->
+         
       
          
       </div2>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -3425,12 +3425,17 @@ returned.</p>
                </item>
 
                <item>
-                  <p>If the item is a node,
+                  <p>If the item is a node (specifically, an <xtermref spec="DM40" ref="dt-XNode"/>),
 its <termref def="dt-typed-value"
                         >typed value</termref> is returned (a <termref def="dt-type-error"
                         >type error</termref>
                      <xerrorref spec="FO40" class="TY" code="0012"
                      /> is raised if the node has no typed value.)</p>
+               </item>
+               
+               <item>
+                  <p>If the item is a <xtermref spec="DM40" ref="dt-JNode"/>,
+                  its <code>¶value</code> property is atomized and the result is returned.</p>
                </item>
 
                <item>
@@ -3492,7 +3497,7 @@ processing the following types of expressions: </p>
 
          <div3 id="id-ebv">
             <head>Effective Boolean Value</head>
-            <p>Under certain circumstances (listed below), it is necessary to find
+            <p>Under certain circumstances (some of which are listed below), it is necessary to find
 the <termref
                   def="dt-ebv">effective boolean value</termref> of a
 value. <termdef id="dt-ebv"
@@ -3513,7 +3518,9 @@ defined in <xspecref
                </item>
 
                <item>
-                  <p>If its operand is a sequence whose first item is a node, <function>fn:boolean</function> returns <code>true</code>.</p>
+                  <p>If its operand is a sequence whose first item is a 
+                     <xtermref spec="DM40" ref="dt-GNode"/>, <function>fn:boolean</function> returns 
+                     <code>true</code>.</p>
                </item>
 
                <item>
@@ -5986,6 +5993,34 @@ declare record Particle (
 
             </div4>
          </div3>
+            
+            <div3 id="id-generalized-node-types">
+               <head>Generalized Node Types</head>
+               <changes>
+                  <change issue="2025">
+                     JNodes are introduced
+                  </change>
+               </changes>
+               
+               <p>A <nt def="GNodeType">GNodeType</nt> matches a generalized node (GNode):
+                  that is, it matches any <xtermref spec="DM40" ref="dt-XNode"/>
+                  or <xtermref spec="DM40" ref="dt-JNode"/>.</p>
+               
+               <scrap>
+                  <prodrecap ref="GNodeType"/>
+               </scrap>
+               
+               <p>A <nt def="JNodeType">JNodeType</nt> matches a <xtermref spec="DM40" ref="dt-JNode"/>.</p>
+               
+               <scrap>
+                  <prodrecap ref="JNodeType"/>
+               </scrap>
+               
+               <p>The form <code>JNode()</code> matches any JNode. The form
+               <code>JNode(<var>T</var>)</code> matches a JNode whose ¶value is an instance
+               of the sequence type <var>T</var>.</p>
+               
+            </div3>
             <div3 id="id-xs-error">
                <head>The type <code>xs:error</code></head>
                <p>The item type <code>xs:error</code> has an empty value space; 
@@ -6425,6 +6460,20 @@ declare record Particle (
                               <head>Example:</head>
                               <p><code>processing-instruction('pi') ⊆ processing-instruction()</code></p>
                            </example>
+                        </item>
+                        <item>
+                           <p><var>A</var> is a <nt def="JNodeType">JNodeType</nt> and <var>B</var> is a <nt def="GNodeType">GNodeType</nt>.</p>
+                        </item>
+                        <item>
+                           <p><var>A</var> is <code>JNode(<var>T</var>)</code> and <var>B</var> is <code>JNode()</code>, for any sequence type 
+                              <var>T</var>.</p>
+                        </item>
+                        <item>
+                           <p><var>A</var> is <code>JNode(<var>T</var>)</code>, <var>B</var> is <code>JNode(<var>U</var>)</code>, 
+                              and <code>T ⊑ U</code>.</p>
+                        </item>
+                        <item>
+                           <p><var>A</var> is a <nt def="NodeTest">NodeTest</nt> and <var>B</var> is a <nt def="GNodeType">GNodeType</nt></p>
                         </item>
                         
                      </olist>
@@ -7456,6 +7505,18 @@ declare record Particle (
                      the required type is <code>enum("red", "green", "blue")</code>, the value will be
                         accepted and will be relabeled as an instance of <code>enum("green")</code>.</p></note>
                   
+                  </item>
+                  
+                  <item>
+                     <p>If <var>J</var> is a <xtermref spec="DM40" ref="dt-JNode"/> and <var>R</var>
+                     is <nt def="ArrayType">ArrayType</nt> or <nt def="MapType">MapType</nt>,
+                     then each item in the ¶value of <var>J</var> is coerced to type <var>R</var>
+                     by applying these rules recursively.</p>
+                     
+                     <note><p>For example, if <code>$A</code> is an array and the members
+                     of the array are maps, then <code>$A?child::*</code> returns a sequence
+                     of JNodes that encapsulate maps, and the size of these maps can be obtained 
+                     using the expression <code>$A?child::* ! map:size()</code>.</p></note>
                   </item>
                               
                   <item diff="add" at="A">
@@ -13049,43 +13110,43 @@ every integer between the two operands, in increasing order. </p>
 
 
          <div3 id="combining_seq">
-            <head>Combining Node Sequences</head>
+            <head>Combining GNode Sequences</head>
             <scrap>
                <prodrecap ref="UnionExpr"/>
             </scrap>
             <p>&language; provides the following operators for combining sequences of
-nodes:</p>
+GNodes:</p>
             <ulist>
 
                <item>
                   <p>The <code>union</code> and <code>|</code> operators are equivalent. They take two node sequences as operands and
-return a sequence containing all the nodes that occur in either of the
+return a sequence containing all the GNodes that occur in either of the
 operands.</p>
                </item>
 
                <item>
-                  <p>The <code>intersect</code> operator takes two node sequences as operands and returns a sequence
-containing all the nodes that occur in both operands.</p>
+                  <p>The <code>intersect</code> operator takes two GNodes sequences as operands and returns a sequence
+containing all the GNodes that occur in both operands.</p>
                </item>
 
                <item>
                   <p>The <code>except</code> operator takes two node sequences as operands and returns a sequence
-containing all the nodes that occur in the first operand but not in the second
+containing all the GNodes that occur in the first operand but not in the second
 operand.</p>
                </item>
             </ulist>
-            <p>All these operators eliminate duplicate nodes from their result sequences based on node identity. 
+            <p>All these operators eliminate duplicate GNodes from their result sequences based on GNodes identity. 
                The resulting sequence is returned in <termref
                      def="dt-document-order">document order</termref>.
             </p>
             <p>If an operand
-of <code>union</code>, <code>intersect</code>, or <code>except</code> contains an item that is not a node, a <termref
+of <code>union</code>, <code>intersect</code>, or <code>except</code> contains an item that is not a GNode, a <termref
                   def="dt-type-error">type error</termref> is raised <errorref class="TY"
                   code="0004"/>.</p>
 
             <p>
-If an <code>IntersectExceptExpr</code> contains more than two <code>InstanceofExprs,
-they are grouped from left to right.</code>
+If an <code>IntersectExceptExpr</code> contains more than two <code>InstanceofExpr</code>s,
+they are grouped from left to right.
 With a <code>UnionExpr</code>, it makes no difference how operands are grouped,
 the results are the same.
 </p>
@@ -13158,6 +13219,14 @@ the results are the same.
                   </item>
                </ulist>
             </example>
+            
+            <p>The following example demonstrates the use of the <code>except</code> operator
+            with JNodes:</p>
+            
+            <eg>let $m := pin($map)
+for $e in $m?child::* except $m?child::xx 
+return ...</eg>
+            
             <p>In addition to the sequence operators described here, see <xspecref spec="FO40"
                   ref="sequence-functions"/> for functions defined on sequences.
 </p>
@@ -13785,7 +13854,7 @@ declare function local:prize-message($a) as xs:string {
          <head>Comparison Expressions</head>
          <p>Comparison expressions allow two values to be compared. &language; provides
 three kinds of comparison expressions, called value comparisons, general
-comparisons, and node comparisons.</p>
+comparisons, and GNode comparisons.</p>
          <scrap>
             <prodrecap ref="ComparisonExpr"/>
          </scrap>
@@ -14242,17 +14311,19 @@ of this value comparison is <code>true</code>.</p>
             </ulist>
          </div3>
          <div3 id="id-node-comparisons">
-            <head>Node Comparisons</head>
-            <p>Node comparisons are used to compare two nodes, by their identity or by their <termref
+            <head>GNode Comparisons</head>
+            <p>GNode comparisons are used to compare two <xtermref spec="DM40" ref="dt-GNode">GNodes</xtermref>
+               (that is, <xtermref spec="DM40" ref="dt-XNode">XNodes</xtermref> or
+               <xtermref spec="DM40" ref="dt-JNode">JNodes</xtermref>), by their identity or by their <termref
                   def="dt-document-order"
-               >document order</termref>. The result of a node comparison is defined by the following rules:</p>
+               >document order</termref>. The result of a GNode comparison is defined by the following rules:</p>
 
 
             <olist>
 
 
                <item>
-                  <p>The operands of a node comparison are evaluated in <termref
+                  <p>The operands of a GNode comparison are evaluated in <termref
                         def="dt-implementation-dependent"
                      >implementation-dependent</termref> order.</p>
                </item>
@@ -14268,21 +14339,23 @@ of this value comparison is <code>true</code>.</p>
 
 
                <item>
-                  <p> Each operand must be either a single node or an empty sequence; otherwise
+                  <p> Each operand must be either a single GNode or an empty sequence; otherwise
 a <termref
                         def="dt-type-error">type error</termref> is raised <errorref class="TY"
                         code="0004"/>.</p>
                </item>
 
                <item>
-                  <p>A comparison with the <code>is</code> operator is <code>true</code> if the two operand nodes are the same node; otherwise it
+                  <p>A comparison with the <code>is</code> operator is <code>true</code> if 
+                     the values of two operands are the same GNode; otherwise it
 is <code>false</code>. See <bibref
-                        ref="xpath-datamodel-40"/> for  the definition of node identity.</p>
+                        ref="xpath-datamodel-40"/> for  the definition of GNode identity.</p>
                </item>
 
 
                <item>
-                  <p>A comparison with the <code>&lt;&lt;</code> operator returns <code>true</code> if the left operand node precedes the right operand node in
+                  <p>A comparison with the <code>&lt;&lt;</code> operator returns <code>true</code> 
+                     if the left operand GNode precedes the right operand GNode in
 <termref
                         def="dt-document-order"
                         >document order</termref>; otherwise it returns <code>false</code>.</p>
@@ -14290,13 +14363,14 @@ is <code>false</code>. See <bibref
 
 
                <item>
-                  <p>A comparison with the <code>&gt;&gt;</code> operator returns <code>true</code> if the left operand node follows the right operand node in
+                  <p>A comparison with the <code>&gt;&gt;</code> operator returns 
+                     <code>true</code> if the left operand GNode follows the right operand GNode in
 <termref
                         def="dt-document-order"
                         >document order</termref>; otherwise it returns <code>false</code>.</p>
                </item>
             </olist>
-            <p>Here are some examples of node comparisons:</p>
+            <p>Here are some examples of GNode comparisons:</p>
 
             <ulist>
 
@@ -14320,6 +14394,15 @@ evaluate to exactly the same single node:</p>
 side occurs before the node identified by the right side in document order:</p>
                   <eg role="parse-test"
                      >/transactions/purchase[parcel = "28-451"] &lt;&lt; /transactions/sale[parcel = "33-870"]</eg>
+               </item> 
+               
+               <item>
+                  <p>The following comparison is true only if the first integer 
+                     among the members of an array precedes the first string. This expression
+                     compares two JNodes:</p>
+                  
+                  <eg role="parse-test">let $A := ["Q", 3, "E", "R", "T", 5, "Y"]
+return $A ? child::~[xs:integer][1] &lt;&lt; $A ? child::~[xs:string][1]</eg>
                </item>
             </ulist>
          </div3>
@@ -20282,18 +20365,151 @@ processing with JSON processing.</p>
                   <prodrecap ref="LookupExpr"/>
                </scrap>
                
-               <p>A <code>Lookup</code> has two parts: the <code>KeySpecifier</code>
-               determines which entries (in a map) or members (in an array) are
-               selected, and the <code>Modifier</code> determines how they are
-               delivered in the result. The default modifier is <code>items</code>,
-               which delivers the result as a flattened sequence of items.</p>
+               <p>A postfix <code>Lookup</code> has three parts: the left hand operand
+                  selects maps or arrays to be searched. The <code>JAxis</code>
+                  defines the scope of a search for the required data, and
+                  the <code>KeySelector</code> defines the search criteria.</p>
                
-               <p>To take a simple example, given <code>$A</code> as an array
+               <p>First some very simple cases: given an array <code>$A</code> of maps:</p>
+               
+               <eg>[ { "John": 3, "Jill": 5}, {"Peter": 8, "Mary": 6}]</eg>
+               
+               <ulist>
+                  <item><p><code>$A ? 1 ? John</code> returns <code>3</code></p></item>
+                  <item><p><code>$A ? 2 ? Mary</code> returns <code>6</code></p></item>
+                  <item><p><code>$A ? * ? *</code> returns <code>(3, 5, 8, 6)</code></p></item>
+                  <item><p><code>$A ? * ? Peter</code> returns <code>8</code></p></item>
+                  <item><p><code>$A ? 2 ? *</code> returns (8, 6)</p></item>
+                  <item><p><code>$A ?? *</code> returns <code>(3, 5, 8, 6)</code></p></item>
+               </ulist>
+               
+               <p>We will start by giving the rules for the case where a <code>JAxis</code>
+               is included, and then explain what happens when it is omitted.</p>
+               
+               <p>An expression such as <code>$A ? child::<var>KS</var> is evaluated as follows:</code></p>
+               
+               <ulist>
+                  <item><p>If the value of <code>$A</code> is not a singleton, then the expression
+                  is evaluated for each item in <code>$A</code>, and the expression returns
+                  the <termref def="dt-sequence-concatenation"/> of the results.</p></item>
+                  <item><p>If the value of <code>$A</code> is a map or an array, then it
+                  is wrapped in a root <xtermref spec="DM40" ref="dt-JNode"/> by applying
+                  the <function>pin</function> function.</p></item>
+                  <item><p>If the value of <code>$A</code> is a <xtermref spec="DM40" ref="dt-JNode"/>,
+                  then the <code>JAxis</code> is evaluated, as described below, to deliver a sequence
+                  of JNodes.</p></item>
+                  <item><p>This sequence of JNodes is filtered, retaining only those that satisfy
+                  the <code>KeySpecifier</code> <var>KS</var>.</p></item>
+               </ulist>
+               
+               <p>A <code>JAxis</code> is essentially a function that takes a JNode as its input
+               and returns a sequence of JNodes. The rules for each <code>JAxis</code> follow:</p>
+               
+               <ulist>
+                  <item><p>The <code>self</code> <code>JAxis</code>, applied to a JNode <var>N</var>,
+                  returns <var>N</var>.</p></item>
+                  <item><p>The <code>parent</code> <code>JAxis</code>, applied to a JNode <var>N</var>,
+                  returns the <code>¶parent</code> property of <var>N</var>, or an empty sequence
+                     if the property is absent.</p></item>
+                  <item><p>The <code>ancestor</code> <code>JAxis</code>, applied to a JNode <var>N</var>,
+                  returns the transitive closure of the <code>parent</code> <code>JAxis</code>,
+                     that is, it returns the <code>¶parent</code>, then the <code>¶parent</code>
+                     of the <code>¶parent</code>,
+                     and so on until the root JNode (which has no parent) is reached. Note
+                  that the result is in reverse document order.</p></item>
+                  <item><p>The <code>ancestor-or-self</code> <code>JAxis</code>, applied to a JNode <var>N</var>,
+                     returns <var>N</var> followed by the content of the <code>ancestor</code> <code>JAxis</code>.
+                     The result is in reverse document order.</p></item>
+                  <item><p>The <code>child</code> <code>JAxis</code>, applied to a JNode <var>N</var>,
+                  applies the following processing to each item <var>C</var>
+                     in the <code>¶value</code> of <var>N</var>
+                  and returns the <termref def="dt-sequence-concatenation"/> of the result.</p>
+                  <ulist>
+                     <item><p>If <var>C</var> is an array, it constructs a JNode
+                     for each member of the array. The <code>¶parent</code> property of this JNode
+                     is set to <var>N</var>; the <code>¶selector</code> property is set to
+                     the 1-based index of the member within the array; and the <code>¶value</code>
+                     property is set to the member itself.</p></item>
+                     <item><p>If <var>C</var> is a map, it constructs a JNode
+                     for each entry (key-value pair) in the map. The <code>¶parent</code> property of this JNode
+                     is set to <var>N</var>; the <code>¶selector</code> property is set to
+                     the entry's key; and the <code>¶value</code>
+                     property is set to the entry's value.</p></item>
+                     <item><p>If <var>C</var> is of any other type, it returns an empty sequence.</p></item>
+                  </ulist>
+                     <p>The order of the result reflects the order of members in an array or of entries
+                     within a map, and this is in document order by definition.</p>
+                  </item>
+                  <item><p>The <code>descendant</code> <code>JAxis</code>, applied to a JNode <var>N</var>,
+                     returns the transitive closure of the <code>child</code> <code>JAxis</code>. The result
+                     is in document order.</p></item>
+                  <item><p>The <code>descendant-or-self</code> <code>JAxis</code>, applied to a JNode <var>N</var>,
+                     returns <var>N</var> followed by the content of the <code>descendant</code> <code>JAxis</code>.
+                     The result is in document order.</p></item>
+            
+               </ulist>
+               
+               <ednote><edtext>Elimination of duplicates?</edtext></ednote>
+               
+               <p>The <code>KeySpecifier</code> filters the result, as follows:</p>
+               
+               <ulist>
+                  <item><p>If the <code>KeySpecifier</code> is a <code>LookupWildcard</code>, 
+                     then a JNode <var>J</var> satisfies the <code>KeySpecifier</code> unconditionally.</p></item>
+                  
+                  <item><p>If the <code>KeySpecifier</code> is a <code>TypeSpecifier</code>, 
+                     then a JNode <var>J</var> satisfies the <code>KeySpecifier</code> if and only if
+                     the <code>¶value</code> property of <var>J</var> is an instance of
+                     the sequence type defined by the <code>KeySpecifier</code>.</p></item>
+
+                  <item><p>If the <code>KeySpecifier</code> is an NCName, then a 
+                     JNode <var>J</var> satisfies the <code>KeySpecifier</code> if and only if
+                     the <code>¶selector</code> property of <var>J</var> is equal to the NCName
+                     under the rules of the <function>atomic-equal</function> function.</p></item>
+           
+                  <item><p>In all other cases the <code>KeySpecifer</code> is treated as an expression.
+                  It is evaluated in the current context and the result is atomized to deliver
+                  a sequence of atomic items.</p>
+                  <p>A JNode <var>J</var> satisfies the <code>KeySpecifer</code>
+                  if the <code>¶selector</code> property of <var>J</var> is equal to some atomic item
+                  in this sequence, under the rules of the <function>atomic-equal</function>
+                  function.</p></item>
+               </ulist>
+               
+               <p>In the absence of an <code>JAxis</code>, an abbreviated lookup expression
+               is evaluated as follows:</p>
+               
+               <ulist>
+                  <item><p><code>$C ? <var>KS</var></code> is evaluated as 
+                  <code>$C ? child::KS => unpin()</code></p></item>
+                  <item><p><code>$C ?? <var>KS</var></code> is evaluated as 
+                  <code>$C ? descendant::KS =!> unpin()</code></p></item>
+               </ulist>
+               
+               <p>The effect of the <function>unpin</function> call is to extract the 
+               <code>¶value</code> properties of the returned JNodes and deliver their
+               <termref def="dt-sequence-concatenation"/>.</p>
+               
+               <note>
+                  <p>The effect of omitting the explicit axis is to lose information.
+                  This happens in two ways.
+                  Firsly, no information is retained about the parent map or array,
+                  or about the key that was used to make the selection, which means
+                  it is not possible to navigate around the containing tree to obtain
+                  properties of other JNodes. Secondly, the results are flattened
+                  into a single sequence: for example, the result of the lookup
+                  expression <code>[ 1, 2, (), 4 ] ? *</code> is the sequence
+                  <code>( 1, 2, 4 )</code>, losing any information about the third
+                  array member.</p>
+               </note>
+               
+               <p>The following examples use the <code>?</code> operator without a <code>JAxis</code>.
+                  Given <code>$A</code> as an array
                   <code>[ ("a", "b"), ("c", "d"), ("e", "f"), 42 ]</code>, some example Lookup expressions
                   are:</p>
                
                <table width="100%">
-                  <caption>Example Lookup Expressions on an Array</caption>
+                  <caption>Simple Lookup Expressions on an Array</caption>
                   <thead>
                      <tr>
                         <th>Expression</th>
@@ -20302,68 +20518,21 @@ processing with JSON processing.</p>
                   </thead>
                   <tbody>
                      <tr>
-                        <td><code>$A?*</code> (or <code>$A?items::*)</code></td>
+                        <td><code>$A ? *</code></td>
                         <td><eg>("a", "b", "c", "d", "e", "f", 42)</eg></td>
                      </tr>
+                     
                      <tr>
-                        <td><code>$A?pairs::*</code></td>
-                        <td><eg>({ "key": 1, "value": ("a", "b") }, 
- { "key": 2, "value": ("c", "d") }, 
- { "key": 3, "value": ("e", "f") },
- { "key": 4, "value": 42 })</eg></td>
-                    </tr>
-                     <tr>
-                        <td><code>$A?values::*</code></td>
-                        <td><eg>([ "a", "b" ], [ "c", "d" ], [ "e", "f" ], [42])</eg></td>
-                     </tr>
-                     <tr>
-                        <td><code>$A?keys::*</code></td>
-                        <td><eg>(1, 2, 3, 4)</eg></td>
-                     </tr>
-                     <tr>
-                        <td><code>$A?2</code> (or <code>$A?items::2)</code></td>
+                        <td><code>$A ? 2</code></td>
                         <td><eg>("c", "d")</eg></td>
-                     </tr>
+                     </tr>                   
                      <tr>
-                        <td><code>$A?pairs::2</code></td>
-                        <td><eg>({ "key": 2, "value":("c", "d") })</eg></td>
-                     </tr>
+                        <td><code>$A ? (3, 1)</code></td>
+                        <td><eg>("a", "b", "e", "f")</eg></td>
+                     </tr>                    
                      <tr>
-                        <td><code>$A?values::2</code></td>
-                        <td><eg>([ "c", "d" ])</eg></td>
-                     </tr>
-                     <tr>
-                        <td><code>$A?keys::2</code></td>
-                        <td><eg>(2)</eg></td>
-                     </tr>
-                     <tr>
-                        <td><code>$A?(3, 1)</code> (or <code>$A?items::(3, 1))</code></td>
-                        <td><eg>("e", "f", "a", "b")</eg></td>
-                     </tr>
-                     <tr>
-                        <td><code>$A?pairs::(3, 1)</code></td>
-                        <td><eg>({ "key": 3, "value": ("e", "f") }, 
- { "key": 1, "value": ("a", "b") })</eg></td>
-                     </tr>
-                     <tr>
-                        <td><code>$A?values::(3, 1)</code></td>
-                        <td><eg>([ "e", "f" ][ "a", "b" ])</eg></td>
-                     </tr>
-                     <tr>
-                        <td><code>$A?keys::(3, 1)</code></td>
-                        <td><eg>(3, 1)</eg></td>
-                     </tr>
-                     <tr>
-                        <td><code>$A?~[xs:integer]</code></td>
+                        <td><code>$A ? ~[xs:integer]</code></td>
                         <td><eg>42</eg></td>
-                     </tr>
-                     <tr>
-                        <td><code>$A?keys::~[xs:integer]</code></td>
-                        <td><eg>4</eg></td>
-                     </tr>
-                     <tr>
-                        <td><code>$A?keys::~[xs:string+]</code></td>
-                        <td><eg>(1, 2, 3)</eg></td>
                      </tr>
                   </tbody>
                </table>
@@ -20371,9 +20540,9 @@ processing with JSON processing.</p>
                <p>Similarly, given <code>$M</code> as a map
                   <code>{ "X": ("a", "b"), "Y": ("c", "d"), "Z": ("e", "f"), "N": 42 }</code>, 
                   some example lookup expressions are as follows.</p>
-               
+            
                <table width="100%">
-                  <caption>Example Lookup Expressions on a Map</caption>
+                  <caption>Simple Lookup Expressions on a Map</caption>
                   <thead>
                      <tr>
                         <th>Expression</th>
@@ -20382,268 +20551,59 @@ processing with JSON processing.</p>
                   </thead>
                   <tbody>
                      <tr>
-                        <td><code>$M?*</code> (or <code>$M?items::*)</code></td>
+                        <td><code>$M ? *</code></td>
                         <td><eg>("a", "b", "c", "d", "e", "f", 42)</eg></td>
                      </tr>
                      <tr>
-                        <td><code>$M?pairs::*</code></td>
-                        <td><eg>({ "key": "X", "value": ("a", "b") }, 
- { "key": "Y", "value": ("c", "d") }, 
- { "key": "Z", "value": ("e", "f") },
- { "key": "N", "value": 42 })</eg></td>
-                     </tr>
-                     <tr>
-                        <td><code>$M?values::*</code></td>
-                        <td><eg>([ "a", "b" ], [ "c", "d" ], [ "e", "f" ], [42])</eg></td>
-                     </tr>
-                     <tr>
-                        <td><code>$M?keys::*</code></td>
-                        <td><eg>("X", "Y", "Z", "N")</eg></td>
-                     </tr>
-                     <tr>
-                        <td><code>$M?Y</code> (or <code>$M?items::Y)</code></td>
+                        <td><code>$M ? Y</code></td>
                         <td><eg>("c", "d")</eg></td>
                      </tr>
                      <tr>
-                        <td><code>$M?pairs::Y</code></td>
-                        <td><eg>({ "key": "Y", "value":("c", "d") })</eg></td>
+                        <td><code>$M ? ("Z", "X")</code></td>
+                        <td><eg>( "a", "b", "e", "f",)</eg></td>
                      </tr>
                      <tr>
-                        <td><code>$M?values::Y</code></td>
-                        <td><eg>([ "c", "d" ])</eg></td>
-                     </tr>
-                     <tr>
-                        <td><code>$M?keys::Y</code></td>
-                        <td><eg>("Y")</eg></td>
-                     </tr>
-                     <tr>
-                        <td><code>$M?("Z", "X")</code> (or <code>$A?items::("Z", "X"))</code></td>
-                        <td><eg>("e", "f", "a", "b")</eg></td>
-                     </tr>
-                     <tr>
-                        <td><code>$M?pairs::("Z", "X")</code></td>
-                        <td><eg>({ "key": "Z", "value": ("e", "f") }, 
- { "key": "X", "value": ("a", "b") })</eg></td>
-                     </tr>
-                     <tr>
-                        <td><code>$M?values::("Z", "X")</code></td>
-                        <td><eg>([ "e", "f" ][ "a", "b" ])</eg></td>
-                     </tr>
-                     <tr>
-                        <td><code>$M?keys::("Z", "X")</code></td>
-                        <td><eg>("Z", "X")</eg></td>
-                     </tr>
-                     <tr>
-                        <td><code>$M?~[xs:integer]</code></td>
+                        <td><code>$M ? ~[xs:integer]</code></td>
                         <td><eg>42</eg></td>
-                     </tr>
-                     <tr>
-                        <td><code>$M?keys::~[xs:integer]</code></td>
-                        <td><eg>"N"</eg></td>
-                     </tr>
-                     <tr>
-                        <td><code>$M?keys::~[xs:string+]</code></td>
-                        <td><eg>("X", "Y", "Z")</eg></td>
-                     </tr>
+                     </tr>                    
                   </tbody>
                </table>
- 
-               
-               <p>The semantics of a postfix lookup expression <code><var>E</var>?pairs::<var>KS</var></code> are defined as follows.
-               The results with other modifiers can be derived from this result, as explained below.</p>
-               
-               <olist>
-                  <item><p><var>E</var> is evaluated to produce a value <code>$V</code>.</p></item>
-                  <item><p>If <code>$V</code> is not a <termref def="dt-singleton"/> 
-                     (that is if <code>count($V) ne 1</code>),
-                  then the result (by recursive application of these rules) is the value of
-                  <code>for $v in $V return $v?pairs::<var>KS</var></code>.</p></item>
-                  <item><p>If <code>$V</code> is a <termref def="dt-singleton"/> array item (that is, 
-                     if <code>$V instance of array(*)</code>) then:</p>
-                  <olist>
-                     <item><p>If the <nt def="KeySpecifier">KeySpecifier</nt> <var>KS</var> is a <code>ParenthesizedExpr</code>,
-                        then it is evaluated to produce a value <code>$K</code>
-                        and the result is:</p> 
-                        <eg><![CDATA[data($K) ! { "key": ., "value": array:get($V, .) }]]></eg>
-                        <note>
-                           <p>The focus for evaluating the key specifier expression is the 
-                              same as the focus for the <code>Lookup</code> expression itself.</p>
-                        </note>
-                     </item>
-                     <item>
-                        <p>If the <nt def="KeySpecifier">KeySpecifier</nt> <var>KS</var> is a <nt
-                           def="VarRef">VarRef</nt> <code>$<var>X</var></code>, 
-                        the result is the same as <code>$V?pairs::($<var>X</var>)</code>.</p>
-                     </item>
-                     <item>
-                        <p>If the <nt def="KeySpecifier">KeySpecifier</nt> <var>KS</var> is an <nt
-                           def="IntegerLiteral">IntegerLiteral</nt> with value <code>$i</code>, 
-                        the result is the same as <code>$V?pairs::($i)</code>.</p>
-                     </item>
-                     
-                     <item>
-                        <p>If the <nt def="KeySpecifier">KeySpecifier</nt> <var>KS</var> is an <code>NCName</code>
-                           <phrase diff="add" at="A">or <code>StringLiteral</code></phrase>, 
-                           the expression raises a type error <errorref class="TY" code="0004"/>.</p>
-                     </item>
-                     <item>
-                        <p>If the <nt def="KeySpecifier">KeySpecifier</nt> <code>KS</code> is a wildcard
-                           (<code>*</code>), 
-                           the result is the same as <code>$V?pairs::(1 to array:size($V))</code>:</p>
-
-                        <note>
-                           <p>Note that array items are returned in order.</p>
-                        </note>
-                     </item>
-                     <item>
-                        <p>If the <nt def="KeySpecifier">KeySpecifier</nt> <var>KS</var> 
-                           is a <nt def="TypeSpecifier">TypeSpecifier</nt> <code>~[<var>T</var>]</code>,
-                           the result is the same as <code>$V?pairs::*[?value instance of <var>T</var>]</code>.
-                        </p>
-                     </item>
-
-                  </olist>
-                  </item>
-                  <item><p>If <var>$V</var> is a <termref def="dt-singleton"/> 
-                     map item (that is, if <code>$V instance of map(*)</code>)
-                     then:</p>
-                     <olist>
-                        <item><p>If the <nt def="KeySpecifier">KeySpecifier</nt> <var>KS</var> 
-                           is a <code>ParenthesizedExpr</code>,
-                           then it is evaluated to produce a value <code>$K</code>
-                           and the result is:</p>
-                           <eg><![CDATA[data($K) ! { "key": ., "value": map:get($V, .) }]]></eg>
-                           <note>
-                              <p>The focus for evaluating the key specifier expression is the 
-                                 same as the focus for the <code>Lookup</code> expression itself.</p>
-                           </note>
-                        </item>
-                        <item>
-                        <p>If the <nt def="KeySpecifier">KeySpecifier</nt> <var>KS</var> is a <nt
-                           def="VarRef">VarRef</nt> <code>$<var>X</var></code>, 
-                        the result is the same as <code>$V?pairs::($<var>X</var>)</code>.</p>
-                     </item>
-                        <item>
-                           <p>If the <nt def="KeySpecifier">KeySpecifier</nt> 
-                              <var>KS</var> is an <code>NCName</code>
-                              or a <code>StringLiteral</code>, with value <code>$S</code>, 
-                              the result is the same as <code>$V?pairs::($S)</code></p>
-                        </item>
-                        <item>
-                           <p>If the <nt def="KeySpecifier">KeySpecifier</nt> 
-                              <var>KS</var> is an <code>IntegerLiteral</code>
-                              with value <code>$N</code>, 
-                              the result is the same as <code>$V?pairs::($N)</code>.</p>
-                        </item>
-                        <item>
-                           <p>If the <nt def="KeySpecifier">KeySpecifier</nt> 
-                              <var>KS</var> is a wildcard (<code>*</code>), 
-                              the result is the same as <code>$V?pairs::(map:keys($V))</code>.</p>
-                          <note>
-                              <p>The order of entries in the result sequence 
-                                 reflects the <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref>
-                                 of the map.</p>
-                           </note>
-                        </item>
-                        <item>
-                           <p>If the <nt def="KeySpecifier">KeySpecifier</nt> <var>KS</var> 
-                              is a <nt def="TypeSpecifier">TypeSpecifier</nt> <code>~<var>T</var></code>,
-                              the result is the same as <code>$V?pairs::*[?value instance of <var>T</var>]</code>.
-                              Note that <var>T</var> is in general a sequence type: if there is an occurrence
-                              indicator, then it must be written within parentheses, but if it is a plain
-                              item type with no occurrence indicator, then the parentheses may be omitted.
-                           </p>
-                        </item>
-                     </olist>
-                  </item>
-                  <item><p>Otherwise (that is, if <code>$V</code> is neither a map nor an array)
-                     a <termref def="dt-type-error">type error</termref> is raised <errorref class="TY"
-                           code="0004"/>.</p></item>
-               </olist>
-               
-               <p>For modifiers other than <code>pairs</code>, the resulting key-value pair
-               is post-processed as follows:</p>
-               
-               <ulist>
-                  <item><p>If the modifier is <code>items</code> (explicitly or by default), 
-                     and the key specifier is an <code>NCName</code> or <code>StringLiteral</code>, then the result of
-                  <code>$V?items::<var>KS</var></code> is the result of the expression:</p>
-                     <eg>
-for $KVP in $V?pairs::<var>KS</var>
-let $value := map:get($KVP, 'value')
-return if ($value instance of %method function(*))
-       then bind-focus($value, $V)
-       else $value
-                     </eg>
-                     <p>where <code>bind-focus($F, $V)</code> is a function that takes a function
-                     item <code>$F</code> and returns a modified function item whose captured context
-                     has the focus set to <code>$V</code>: for more detail see <specref ref="id-methods"/>.</p>
-                     <note><p>The effect of this is that if any of the selected values is a 
-                     <termref def="dt-singleton"/> <termref def="dt-method"/>, the selected
-                     function item is modified by binding the context value to
-                     the containing map <var>$V</var>. In other cases the result is
-                     the <termref def="dt-sequence-concatenation"/> of the value parts.</p></note>
-                     
-                     
-                  </item>
-                  <item><p>If the modifier is <code>items</code> (explicitly or by default),
-                     and the key specifier is not an <code>NCName</code> nor a <code>StringLiteral</code>,
-                     then the result of <code>$V?items::<var>KS</var></code> is the result of the expression
-                     <code>$V?pairs::KS ! map:get(., "value")</code>. This returns the sequence concatenation
-                     of the selected values.</p></item>
-                     
-                  <item><p>If the modifier is <code>values</code>, the result of
-                  <code>$V?values::KS</code> is the same as the result of 
-                  <code>$V?pairs::KS ! array { map:get(., "value") }</code>.
-                  This returns each value as an array.</p></item>
                   
-                  <item><p>If the modifier is <code>keys</code>, the result of
-                  <code>$V?keys::KS</code> is the same as the result of 
-                  <code>$V?pairs::KS ! map:get(., "key")</code>.
-                  This returns the keys (integer indexes in the case of an array)
-                     without the values.</p></item>
-               </ulist>
-
-
-               <p>Examples:</p>
-
-
-               <ulist>
-                  <item>
-                     <p>
-                        <code>{ "first" : "Jenna", "last" : "Scott" }?first</code> evaluates to <code>"Jenna"</code>
-                     </p>
-                  </item>
-                  <item diff="add" at="A">
-                     <p>
-                        <code>{ "first name" : "Jenna", "last name" : "Scott" }?"first name"</code> evaluates to <code>"Jenna"</code>
-                     </p>
-                  </item>
-                  <item>
-                     <p>
-                        <code>[ 4, 5, 6 ]?2</code> evaluates to <code>5</code>.</p>
-                  </item>
-                  <item>
-                     <p>
-                        <code>({ "first": "Tom" }, { "first": "Dick" }, { "first": "Harry" })?first</code> evaluates to the sequence <code>("Tom", "Dick", "Harry")</code>.</p>
-                  </item>
-                  <item>
-                     <p>
-                        <code>([ 1, 2, 3 ], [ 4, 5, 6 ])?2</code> evaluates to the sequence <code>(2, 5)</code>.</p>
-                  </item>
-                  <item>
-                     <p>
-                        <code>([ 1, [ "a", "b" ], [ 4, 5, [ "c", "d"] ])?value::*[. instance of array(xs:string)]</code> evaluates to 
-                        the sequence <code>([ "a", "b" ], [ "c", "d" ])</code>.</p>
-                  </item>
-                  <item>
-                     <p>
-                        <code>[ "a", "b" ]?3</code> raises a dynamic error <xerrorref spec="FO40"
-                           class="AY" code="0001"/>
-                     </p>
-                  </item>
-               </ulist>
-            </div4>
+               <p>The following examples illustrate lookup expressions on an array of maps, where
+               some of the maps themselves contain arrays. The input array <code>$A</code> is:</p>
+                  
+                  <eg>[ {"a":1, "b":"banana"}, {"a":2, "b":"bread", "c":[10, 20, 30] } ]</eg>
+               
+               <table width="100%">
+                  <caption>Example Lookup Expressions on an Array of Maps</caption>
+                  <thead>
+                     <tr>
+                        <th>Expression</th>
+                        <th>Result</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td><code>$A ? * ? a</code></td>
+                        <td><eg>(1, 2)</eg></td>
+                     </tr>
+                     <tr>
+                        <td><code>$A ? * ? c ? 2</code></td>
+                        <td><eg>20</eg></td>
+                     </tr>
+                     <tr>
+                        <td><code>$A ? descendant::c ? parent::* ? a</code></td>
+                        <td><eg>2</eg></td>
+                     </tr>
+                     
+                  </tbody>
+               </table>
+               
+               
+           
+            </div4>   
+               
+               
             
             <div4 id="id-unary-lookup">
                <head>Unary Lookup</head>
@@ -20657,8 +20617,8 @@ return if ($value instance of %method function(*))
                <p>Unary lookup is most commonly used in predicates (for example, <code>$map[?name = 'Mike']</code>)
                   or with the simple map operator (for example, <code>avg($maps ! (?price - ?discount))</code>).</p>
                
-               <p>The unary lookup expression <code>?modifier::KS</code> is defined to be equivalent to the postfix lookup
-                  expression <code>.?modifier::KS</code> which has the context value (<code>.</code>) as the implicit first operand.
+               <p>The unary lookup expression <code>?axis::KS</code> is defined to be equivalent to the postfix lookup
+                  expression <code>.?axis::KS</code> which has the context value (<code>.</code>) as the implicit first operand.
                   See <specref ref="id-postfix-lookup"/> for the postfix lookup operator.</p>
                
                
@@ -20681,7 +20641,7 @@ return if ($value instance of %method function(*))
   "previous-address": { "street": "12 Seaview Road", "postcode": "EX8 9AA" }
 }</eg>
 
-                     <p>then <code>?*[. instance of record(street, postcode)]?postcode</code>
+                     <p>then <code>?~[record(street, postcode)]?postcode</code>
                         returns <code>("MK12 2EX", "EX8 9AA")</code> (reflecting the 
                         <xtermref spec="DM40" ref="dt-entry-order"/> of the map).</p>
                      <note><p>Writing <code>?*?postcode</code> would raise a type error, because the result of the initial
@@ -20761,13 +20721,17 @@ return if ($value instance of %method function(*))
             <div4 id="id-deep-lookup" diff="add" at="2023-11-15">
                <head>Deep Lookup</head>
                
-               <p>The deep lookup operator <code>??</code> has both unary and postfix forms. The unary form <code>??modifier::KS</code>
-               (where <var>KS</var> is any <code>KeySpecifier</code>) has the same effect as the binary form <code>.??modifier::KS</code>.
-               </p>
+               <p>The deep lookup operator <code>??</code> has both unary and postfix forms.
+                  No explicit JAxis is allowed, because the <code>descendant</code> JAxis
+                  is implicit.</p>
                
-               <p>The semantics are defined as follows.</p>
+               <p>A deep lookup expression
+               is evaluated as follows:</p>
                
-               <p>First we define the <term>recursive content</term> of an item as follows:</p>
+               <p><code>$C ?? <var>KS</var></code> is equivalent to 
+                  <code>$C ? descendant::KS =!> unpin()</code></p>
+               
+               <!--<p>First we define the <term>recursive content</term> of an item as follows:</p>
                
                <eg><![CDATA[declare function immediate-content($item as item()) as record(key, value)* {
   if ($item instance of map(*)) {
@@ -21080,7 +21044,7 @@ declare function recursive-content($item as item()) as record(key, value)* {
                         </tr>
                      </tbody>
                   </table>
-               </example>
+               </example>-->
             </div4>
             
             <div4 id="id-implausible-lookup-expressions" diff="add" at="Issue602">

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -3192,7 +3192,7 @@ in the <code>children</code> property of their parent node.</p>
 
             </olist>
             
-            <p>Similarly, within a an <xtermref spec="DM40" ref="dt-JTree"/>,
+            <p>Similarly, within an <xtermref spec="DM40" ref="dt-JTree"/>,
                (that is, a tree consisting of JNodes), document order satisfies the following constraints:</p>
             
             <olist>
@@ -7571,9 +7571,9 @@ declare record Particle (
                      by applying the coercion rules recursively.</p>
                      
                      <note><p>For example, if <code>$A</code> is an array and the members
-                     of the array are maps, then <code>$A?child::*</code> returns a sequence
+                     of the array are maps, then <code>$A/child::*</code> returns a sequence
                      of JNodes that encapsulate maps, and the average size of these maps can be obtained 
-                     using the expression <code>avg($A?child::* ! map:size(.))</code>. The first
+                     using the expression <code>avg($A/child::* ! map:size(.))</code>. The first
                      argument of <code>map:size</code> does not accept a JNode directly, but
                      it does (in effect) accept a JNode that encapsulates a map.</p></note>
                   </item>
@@ -11623,15 +11623,13 @@ return if (every $r in $R satisfies $r instance of GNode())
 
                      <note>
                         <p>In an XTree, only document nodes and element
-                        nodes have children. If the ori is origin
+                        nodes have children. If the origin is any
                          other kind of XNode, or if the origin is an empty
                          document or element node, then the child
                          axis returns an empty sequence.  The
                          children of a document node or element node may be
                          element, processing instruction, comment, or text
-                         nodes.  Attribute<phrase
-                              role="xpath"
-                              >, namespace,</phrase> and
+                         nodes.  Attribute, namespace, and
                          document nodes can never appear as children.</p>
                      </note>
                      
@@ -11931,7 +11929,7 @@ return if (every $r in $R satisfies $r instance of GNode())
                <p>
                   <termdef id="dt-node-test" term="node test"
                         >A <term>node test</term> is a condition on the properties of a GNode. 
-      A node test determines which GNode contained by an axis are selected by a <termref
+      A node test determines which GNodes returned by an axis are selected by a <termref
                         def="dt-step">step</termref>.</termdef>
                </p>
                
@@ -12121,7 +12119,8 @@ return if (every $r in $R satisfies $r instance of GNode())
                   <item><p><code>child::get("date of birth")</code> selects
                an entry in a map whose key is the string <code>"date of birth"</code></p></item>
                   <item><p><code>child::get(3)</code> selects the third member
-                  of an array</p></item>
+                  of an array</p>
+                  <note><p>The same result can be achieved using the expression <code>child::*[3]</code>.</p></note></item>
                   <item><p><code>child::get(1 to 3)</code> selects the first three members
                   of an array, in document order.</p>
                   <note><p><code>child::get(3, 2, 1)</code> also returns the first three
@@ -12132,7 +12131,6 @@ return if (every $r in $R satisfies $r instance of GNode())
                   <item><p><code>child::get(array:size(.))</code> gets the last
                   member of an array. The same can be achieved using
                   <code>child::*[last()]</code>.</p></item>
-                  <item><p><code></code></p></item>
                   <item><p><code>child::Q{}code</code> selects
                an entry in a map whose key is the no-namespace QName 
                      with local name <code>"code"</code>.</p></item>
@@ -12168,7 +12166,7 @@ return if (every $r in $R satisfies $r instance of GNode())
            <code>node()</code>, <code>text()</code>, <code>array(*)</code>, and <code>record(x, y)</code>
            can be written directly without the enclosing <code>type(...)</code>.</p>
                
-        <p>If the origin is a <code>JNode</code> the type used will normally be a 
+        <p>If the origin is an XNode the type used will normally be a 
            <nt def="NodeKindTest">NodeKindTest</nt> such as <code>node()</code>
            or <code>comment()</code>. Specifying a type that cannot select nodes,
            such as <code>map(*)</code>, is allowed but pointless.</p>
@@ -12337,14 +12335,14 @@ return if (every $r in $R satisfies $r instance of GNode())
 
                   <item>
                      <p><code role="parse-test">array(*)</code> matches any JNode
-                        whose <code>¶value</code> is an array.</p>
-                     <p><code role="parse-test">record(longitude, latitude, *)</code> matches any JNode
-                        whose <code>¶value</code> is a map having entries with keys
-                        <code>"longitude"</code> and <code>"latitude"</code>.</p>
-                     <p><code role="parse-test">type(empty-sequence())</code> matches any JNode
-                        whose <code>¶value</code> is an empty sequence.</p>
-                     <p><code role="parse-test">type(xs:date)</code> matches any JNode
-                        whose <code>¶value</code> is an instance of <code>xs:date</code>.</p>
+                        whose <code>¶value</code> is an array.</p></item>
+                  <item><p><code role="parse-test">record(longitude, latitude, *)</code> matches any JNode
+                     whose <code>¶value</code> is a map having entries with keys
+                     <code>"longitude"</code> and <code>"latitude"</code>.</p></item>
+                  <item><p><code role="parse-test">type(empty-sequence())</code> matches any JNode
+                     whose <code>¶value</code> is an empty sequence.</p></item>
+                  <item><p><code role="parse-test">type(xs:date)</code> matches any JNode
+                     whose <code>¶value</code> is an instance of <code>xs:date</code>.</p>
                   </item>
                </ulist>
                
@@ -12410,7 +12408,7 @@ return if (every $r in $R satisfies $r instance of GNode())
                <prodrecap ref="AxisStep"/>
             </scrap>
             <p id="dt-predicate"
-                  >A predicate within a <nt def="AxisStep"/> has similar syntax and semantics
+                  >A predicate within an <nt def="AxisStep">AxisStep</nt> has similar syntax and semantics
 	 to a predicate within a <termref def="dt-filter-expression"/>.  The
 	 only difference is in the way the context position is set for
 	 evaluation of the predicate.</p>
@@ -12900,8 +12898,10 @@ last <code>chapter</code> or <code>appendix</code> child of the context node.</p
                   entry within this map (presumably an array), then the second member of this array (presumably
                   a map), and finally the <code>part-no</code> entry within this map.</p>
                   <note><p>The same selection could be made using the lookup expression <code>?1?parts?2?part-no</code>.
-                  The difference is that path expressions offer more flexibility in being able to navigate around
-                  the containing JTree.</p></note>
+                  The main difference is that path expressions offer more flexibility in being able to navigate around
+                  the containing JTree. Also, the lookup expression <code>$a?1</code> fails if the
+                  array index is out of bounds; the path expression <code>$a/get(1)</code> 
+                  (or <code>$a/*[1]</code>) instead returns an empty sequence.</p></note>
                   <note diff="add" at="2022-12-13"><p>An abbreviated axis step that omits the axis name must use a
                   <nt def="SimpleNodeTest">SimpleNodeTest</nt> rather than a <nt def="UnionNodeTest">UnionNodeTest</nt>.
                   This means that a construct such as <code>(ul|ol)</code>
@@ -12938,7 +12938,7 @@ for <code
                   
                   <p>Similarly, if <code>$dateOfBirth</code> is a JNode resulting from the expression
                   <code>$map/get("date of birth")</code>, then <code>$dateOfBirth/../gender</code>
-                  will select the entry having key <code>"gender"</code> within $map.</p>
+                  will select the entry having key <code>"gender"</code> within <code>$map</code>.</p>
                   <note>
                      <p>The expression <code>.</code>, known as a <term>context value
    reference</term>, is a <termref
@@ -13153,9 +13153,15 @@ every <code>section</code> element that has a parent that is either a <code>chap
                obtained by parsing the JSON text:</p>
             
             <eg>[
-{ "first": "John", "last": "Baker", "date of birth": "2003-04-19", "occupation": "cook"}, 
-{ "first": "Mary", "last": "Smith", "date of birth": "2006-08-12", "occupation": "teacher"},                 
-            ]</eg>
+  { "first": "John", 
+    "last": "Baker", 
+    "date of birth": "2003-04-19", 
+    "occupation": "cook"}, 
+  { "first": "Mary", 
+    "last": "Smith", 
+    "date of birth": "2006-08-12", 
+    "occupation": "teacher"},                 
+]</eg>
             
             <ulist>
                <item><p><code>get(1)/first</code> returns a JNode whose <code>¶value</code>
@@ -13260,17 +13266,17 @@ every <code>section</code> element that has a parent that is either a <code>chap
                         <tr>
                            <td valign="top">The third book</td>
                            <td valign="top"><code>$..book[2]  </code></td>
-                           <td valign="top"><code>//book/get(3)</code></td>
+                           <td valign="top"><code>//book/*[3]</code></td>
                         </tr>
                         <tr>
                            <td valign="top">The third book's author</td>
                            <td valign="top"><code>$..book[2].author</code></td>
-                           <td valign="top"><code>//book/get(3)/author</code></td>
+                           <td valign="top"><code>//book/*[3]/author</code></td>
                         </tr>
                         <tr>
                            <td valign="top">The third book's publisher (empty result)</td>
                            <td valign="top"><code>$..book[2].publisher</code></td>
-                           <td valign="top"><code>//book/get(3)/publisher</code></td>
+                           <td valign="top"><code>//book/*[3]/publisher</code></td>
                         </tr>
                         <tr>
                            <td valign="top">The last book (in order)</td>
@@ -13280,7 +13286,7 @@ every <code>section</code> element that has a parent that is either a <code>chap
                         <tr>
                            <td valign="top">The first two books</td>
                            <td valign="top"><code>$..book[0,1]</code></td>
-                           <td valign="top"><code>//book/get(1,2)</code></td>
+                           <td valign="top"><code>//book/*[1,2]</code></td>
                         </tr>
                         <tr>
                            <td valign="top">All books with an ISBN</td>
@@ -13593,8 +13599,15 @@ the results are the same.
             with JNodes:</p>
             
             <eg>let $m := JNode($map)
-for $e in $m?child::* except $m?child::xx 
+for $e in $m/child::* except $m/child::xx 
 return ...</eg>
+            
+            <note><p>Because the <function>JNode</function> creates a new JTree root,
+            calling it twice potentially creates two different trees, in which the JNodes have
+            different identity. The expression <code>$map/child::* except $map/child::xx</code>
+            might therefore have the wrong effect, because JNodes in two different trees 
+            are being compared. For more details see the specification of the
+            <function>JNode</function> function.</p></note>
             
             <p>In addition to the sequence operators described here, see <xspecref spec="FO40"
                   ref="sequence-functions"/> for functions defined on sequences.

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -3482,7 +3482,7 @@ its <termref def="dt-typed-value"
                
                <item>
                   <p>If the item is a <xtermref spec="DM40" ref="dt-JNode"/>,
-                  its <code>¶value</code> property is atomized and the result is returned.</p>
+                  its <term>·content·</term> property is atomized and the result is returned.</p>
                </item>
 
                <item>
@@ -6070,7 +6070,7 @@ declare record Particle (
                </scrap>
                
                <p>The form <code>JNode()</code> matches any JNode. The form
-               <code>JNode(<var>T</var>)</code> matches a JNode whose ¶value is an instance
+               <code>JNode(<var>T</var>)</code> matches a JNode whose <term>·content·</term> is an instance
                of the sequence type <var>T</var>.</p>
                
             </div3>
@@ -7567,7 +7567,7 @@ declare record Particle (
                   <item>
                      <p>If <var>J</var> is a <xtermref spec="DM40" ref="dt-JNode"/> and does not
                         match <var>R</var>,
-                     then each item in the ¶value of <var>J</var> is coerced to type <var>R</var>
+                     then each item in the <term>·content·</term> of <var>J</var> is coerced to type <var>R</var>
                      by applying the coercion rules recursively.</p>
                      
                      <note><p>For example, if <code>$A</code> is an array and the members
@@ -11232,12 +11232,29 @@ return $lib?product((1.2, 1.3, 1.4))
             </ulist>
          </note>
          
-         <p><termdef id="dt-GTree" term="GTree">GTree - TBA</termdef></p>
-         <p><termdef id="dt-JTree" term="JTree">JTree - TBA</termdef></p>
-         <p><termdef id="dt-XTree" term="XTree">XTree - TBA</termdef></p>
-         <p><termdef id="dt-GNode" term="GNode">GNode - TBA</termdef></p>
-         <p><termdef id="dt-JNode" term="JNode">JNode - TBA</termdef></p>
-         <!--<p><termdef id="dt-XNode" term="XNode">XNode - TBA</termdef></p>-->
+         <p>The following definitions are copied from the data model specification,
+         for convenience:</p>
+         
+         <ulist>
+         <item><p><termdef id="dt-JTree" term="JTree">A tree that is rooted at a parentless
+    <termref def="dt-JNode"/> is referred to as a <term>JTree</term>.</termdef></p></item>
+         <item><p><termdef id="dt-XTree" term="XTree">A tree that is rooted at a parentless
+    <termref def="dt-XNode"/> is referred to as an <term>XTree</term>.</termdef></p></item>
+         <item><p><termdef id="dt-GNode" term="GNode">The term <term>generic node</term> or <term>GNode</term>
+    is a collective term for <termref def="dt-XNode">XNodes</termref> (more commonly called simply
+      <termref def="dt-node">nodes</termref>) representing
+    the parts of an XML document, and <termref def="dt-JNode">JNodes</termref>, 
+    often used to represent the parts of a JSON document.</termdef></p></item>
+         <item><p><termdef id="dt-JNode" term="JNode">A <term>JNode</term> is a kind of <termref def="dt-item"/>
+      used to represent a value within the context of a tree of <termref def="dt-map">maps</termref>
+      and <termref def="dt-array">arrays</termref>. A root <term>JNode</term> represents
+      a map or array; a non-root <term>JNode</term> represents a <termref def="dt-member"/> of an 
+      array or an <termref def="dt-entry"/> in a map.</termdef></p></item>
+            
+         </ulist>
+         
+         <p><termdef id="dt-GTree" term="GTree">The term <term>GTree</term>
+         means <termref def="dt-JTree"/> or <termref def="dt-XTree"/>.</termdef></p>
          
          <p>Absolute path expressions (those starting with an initial <code>/</code>
             or <code>//</code>), start their selection from the root GNode of a GTree;
@@ -11645,7 +11662,7 @@ return if (every $r in $R satisfies $r instance of GNode())
 			 of the origin (the children, the children of the children, and so on).</p>
                      <p>More formally, <code>$node/descendant::GNode()</code> delivers the result
                      of <code>fn:transitive-closure($node, fn { child::GNode() })</code>.</p>
-                     <ednote><edtext>Assuming we extend fn:transitive-closure to apply to all GNodes</edtext></ednote>
+                     
                   </item>
                   
                   <item>
@@ -11663,7 +11680,7 @@ return if (every $r in $R satisfies $r instance of GNode())
                      <p>If the origin is an XNode, this is the result of the 
 				          <xspecref spec="DM40" ref="dm-parent"/> accessor.</p>
                      <p>If the origin is a JNode, this is the value of the
-                     <code>¶parent</code> property of the origin.</p>
+                     <term>·parent·</term> property of the origin.</p>
                      <p>If the GNode has no parent, the axis returns an empty sequence.</p>
 
                      <note>
@@ -11712,7 +11729,6 @@ return if (every $r in $R satisfies $r instance of GNode())
 			 empty.</p>
                      <p>More formally, <code>$node/following-sibling::GNode()</code> delivers the result
                      of <code>fn:siblings($node)[. >> $node])</code>.</p>
-                     <ednote><edtext>Assuming fn:siblings is extended to handle GNodes.</edtext></ednote>
                   </item>
                   
                   <item>
@@ -12084,22 +12100,22 @@ return if (every $r in $R satisfies $r instance of GNode())
                <head>Selectors for JNodes</head>
                
                <p>When the origin is a JNode, the selector filters the JNodes returned
-               by the axis according to the JNode's <code>¶selector</code> property.
+               by the axis according to the JNode's <term>·selector·</term> property.
                In the case of a JNode that wraps an entry in a map, this can be any
                atomic value; for a JNode that wraps a member of an array, it will
                be a non-negative integer.</p>
                
                <p>If the selector takes the form <code>*</code>, then it matches
-               every JNode (including one whose <code>¶selector</code> property
+               every JNode (including one whose <term>·selector·</term> property
                is absent).</p>
                
                <p>If the selector takes the form of an <code>NCName</code>, then it matches
-               every JNode whose <code>¶selector</code> property is a string (or <code>xs:anyURI</code>
+               every JNode whose <term>·selector·</term> property is a string (or <code>xs:anyURI</code>
                   or <code>xs:untypedAtomic</code> value) that is equal to this <code>NCName</code>
                   under the rules of the <function>fn:atomic-equal</function> function.</p>
                
                <p>If the selector takes the form of any other <code>EQName</code> or wildcard,
-               then it matches every JNode whose <code>¶selector</code> property is a matching 
+               then it matches every JNode whose <term>·selector·</term> property is a matching 
                   <code>xs:QName</code>, using the same rules as for wildcards in XNode steps
                (see <specref ref="id-selectors-for-xnodes"/>).</p>
                
@@ -12107,7 +12123,7 @@ return if (every $r in $R satisfies $r instance of GNode())
                then the contained expression <var>Expr</var> is evaluated with the focus
                of the containing axis step (so its value is independent of the specific
                JNode being tested). A JNode satisfies the selector
-               if its <code>¶selector</code> property is equal to 
+               if its <term>·selector·</term> property is equal to 
                one or more of the values returned by the selector expression,
                under the rules of the <function>fn:atomic-equal</function> function.</p>
                
@@ -12147,7 +12163,7 @@ return if (every $r in $R satisfies $r instance of GNode())
 		  form of a node test called a
 		  <term>type test</term> can select XNodes based
 		  on their type, or in the case of JNodes, the type of their
-                  contained <code>¶value</code></termdef>.</p>
+                  contained <term>·content·</term></termdef>.</p>
                
             <scrap>
                <prodrecap ref="TypeTest"/>
@@ -12158,7 +12174,7 @@ return if (every $r in $R satisfies $r instance of GNode())
                
         <ulist>
            <item><p>XNodes that are instances of the supplied <var>SequenceType</var>;</p></item>
-           <item><p>JNodes whose <code>¶value</code> property is an instance of the 
+           <item><p>JNodes whose <term>·content·</term> property is an instance of the 
               supplied <var>SequenceType</var>.</p></item>
         </ulist>
                
@@ -12335,14 +12351,14 @@ return if (every $r in $R satisfies $r instance of GNode())
 
                   <item>
                      <p><code role="parse-test">array(*)</code> matches any JNode
-                        whose <code>¶value</code> is an array.</p></item>
+                        whose <term>·content·</term> is an array.</p></item>
                   <item><p><code role="parse-test">record(longitude, latitude, *)</code> matches any JNode
-                     whose <code>¶value</code> is a map having entries with keys
+                     whose <term>·content·</term> is a map having entries with keys
                      <code>"longitude"</code> and <code>"latitude"</code>.</p></item>
                   <item><p><code role="parse-test">type(empty-sequence())</code> matches any JNode
-                     whose <code>¶value</code> is an empty sequence.</p></item>
+                     whose <term>·content·</term> is an empty sequence.</p></item>
                   <item><p><code role="parse-test">type(xs:date)</code> matches any JNode
-                     whose <code>¶value</code> is an instance of <code>xs:date</code>.</p>
+                     whose <term>·content·</term> is an instance of <code>xs:date</code>.</p>
                   </item>
                </ulist>
                
@@ -13164,11 +13180,11 @@ every <code>section</code> element that has a parent that is either a <code>chap
 ]</eg>
             
             <ulist>
-               <item><p><code>get(1)/first</code> returns a JNode whose <code>¶value</code>
+               <item><p><code>get(1)/first</code> returns a JNode whose <term>·content·</term>
                is the string <code>"John"</code>.</p></item>
-               <item><p><code>//first[. = "Mary"]/../last</code> returns a JNode whose <code>¶value</code>
+               <item><p><code>//first[. = "Mary"]/../last</code> returns a JNode whose <term>·content·</term>
                is the string <code>"Smith"</code>.</p></item>
-               <item><p><code>//first[. = "Mary"]/../get("date of birth")</code> returns a JNode whose <code>¶value</code>
+               <item><p><code>//first[. = "Mary"]/../get("date of birth")</code> returns a JNode whose <term>·content·</term>
                is the string <code>"2006-08-12"</code>.</p></item>
                <item><p><code>//*[occupation = "cook"]!`{first} {last}`</code> returns the
                string <code>"John Baker"</code>.</p></item>
@@ -20773,207 +20789,14 @@ processing with JSON processing.</p>
                
                <p>The value of the left-hand operand must be a sequence of maps or arrays
                (but if it includes JNodes, these will be coerced to maps or arrays
-               by extracting the <code>¶value</code> property of the JNode). The lookup
+               by extracting the <term>·content·</term> property of the JNode). The lookup
                operation is applied independently to each of these maps or arrays,
                and the final expression result is the <termref def="dt-sequence-concatenation"/>
                of the individual results.</p>
                
-               <!--<p>The above examples do not include a <code>JAxis</code>. For purposes of exposition,
-               however, we will consider cases in the following order:</p>
-               
-               <ulist>
-                  <item><p><specref ref="id-lookup-with-jaxis"/></p></item>
-                  <item><p><specref ref="id-keyspecifiers"/></p></item>
-                  <item><p><specref ref="id-abbreviated-lookup"/></p></item>
-                  <item><p><specref ref="id-lookup-sans-jaxis"/></p></item>
-               </ulist>-->
-               
-               <!--<div5 id="id-lookup-with-jaxis">
-                  <head>Lookup Expressions using a JAxis</head>
-                  
-               
-               <p>We will start by giving the rules for the case where a <code>JAxis</code>
-               is included.</p>
-               
-               <p>An expression such as <code>$A ? child::<var>KS</var></code> (where <code>child</code>
-                  might be replaced by any other <code>JAxis</code>) is evaluated as follows:</p>
-               
-               <ulist>
-                  <item><p>The expression
-                  is expanded to <code>for $a in $A return $a ? child::<var>KS</var></code>
-                     (where <code>$a</code> is some otherwise unused variable name),
-                     which is then evaluated using the rules below.</p></item>
-                  
-                  <item><p>If the value of <code>$a</code> is anything other than a map,
-                  an array, or a <xtermref spec="DM40" ref="dt-JNode"/>, then a type 
-                     error is raised <errorref class="TY" code="0004"/>.</p></item>
-                 
-                  <item><p>If the value of <code>$a</code> is a map or an array, then it
-                  is wrapped in a root <xtermref spec="DM40" ref="dt-JNode"/> by applying
-                  the <function>fn:JNode</function> function, and the expression is then
-                  evaluated using the rules below.</p></item>
-                  
-                  <item><p>If the value of <code>$a</code> is a <xtermref spec="DM40" ref="dt-JNode"/>,
-                  then the <code>JAxis</code> is evaluated, as described below, to deliver a sequence
-                  of JNodes.</p></item>
-                  
-                  <item><p>This sequence of JNodes is filtered and potentially reordered, retaining 
-                     only those JNodes that satisfy the <code>KeySpecifier</code> <var>KS</var>,
-                  as described in <specref ref="id-keyspecifiers"/>.</p></item>
-               </ulist>
-               
-               <p>A <code>JAxis</code> is essentially a function that takes a JNode as its input
-               and returns a sequence of JNodes. The rules for each <code>JAxis</code> follow:</p>
-               
-               <ulist>
-                  <item><p>The <code>self</code> <code>JAxis</code>, applied to a JNode <var>N</var>,
-                  returns <var>N</var>.</p></item>
-                  <item><p>The <code>parent</code> <code>JAxis</code>, applied to a JNode <var>N</var>,
-                  returns the <code>¶parent</code> property of <var>N</var>, or an empty sequence
-                     if the property is absent.</p></item>
-                  <item><p>The <code>ancestor</code> <code>JAxis</code>, applied to a JNode <var>N</var>,
-                  returns the transitive closure of the <code>parent</code> <code>JAxis</code>,
-                     that is, it returns the <code>¶parent</code>, then the <code>¶parent</code>
-                     of the <code>¶parent</code>,
-                     and so on until the root JNode (which has no parent) is reached. 
-                     The result is in reverse <termref def="dt-document-order"/>.</p></item>
-                  <item><p>The <code>ancestor-or-self</code> <code>JAxis</code>, applied to a JNode <var>N</var>,
-                     returns <var>N</var> followed by the content of the <code>ancestor</code> <code>JAxis</code>.
-                     The result is in reverse <termref def="dt-document-order"/>.</p></item>
-                  <item><p>The <code>child</code> <code>JAxis</code>, applied to a JNode <var>N</var>,
-                     returns the result of the <xtermref spec="DM40" ref="dt-j-children"/> accessor
-                     function defined in the data model. The effect of this accessor applied to a JNode <var>$N</var>
-                     is repeated here for convenience, assuming the existence of a function <code>dm:JNode</code>
-                     that returns a JNode with given values for its ¶parent, ¶position, ¶selector, and ¶value
-                     properties:</p> <eg>         
-for $item at $pos in JNode-value($N)
-return
-  if ($item instance of array(*))
-  then for member $member at $index in $item
-       return dm:JNode(parent := $P,
-                       position := $pos,
-                       selector := $index,
-                       value := $member)
-  else if ($item instance of map(*))
-  then for key $key value $value in $item
-       return dm:JNode(parent := $P,
-                       position := $pos,
-                       selector := $key
-                       value := $value)
-  else ()
-</eg> 
-                     <p>The order of the result reflects the order of members in an array or of entries
-                     within a map, and this is in document order by definition.</p>
-                  </item>
-                  <item><p>The <code>descendant</code> <code>JAxis</code>, applied to a JNode <var>N</var>,
-                     returns the transitive closure of the <code>child</code> <code>JAxis</code>. The result
-                     is in document order.</p>
-                     <p>More specifically, the descendant axis returns the result of the recursive XQuery function:</p>
-                     <eg>
-  function descendants($root as JNode()) as JNode()* {
-     for $c in $root ? child::*
-     return ($c, if ($c instance of JNode(array(*)|map(*))) 
-                 then descendants($c)
-                 else ())
-  }
-                     </eg>
-                  </item>
-                  <item><p>The <code>descendant-or-self</code> <code>JAxis</code>, applied to a JNode <var>N</var>,
-                     returns <var>N</var> followed by the content of the <code>descendant</code> <code>JAxis</code>.
-                     The result is in document order.</p></item>
-            
-               </ulist>
-                  
-               </div5>-->
                
                
-               
-               
-               <p>The <code>KeySpecifier</code> determines which values are selected from the
-                  map or array.</p>
-               
-               <p>For an array <var>$A</var>:</p>
-               
-               <ulist>
-                  <item><p>If the <code>KeySpecifier</code> is a <code>LookupWildcard</code>
-                     (that is, <code>*</code>), the result is the <termref def="dt-sequence-concatenation"/>
-                     of the members of <var>$A</var>: that is, <code>array:items($A)</code>.</p></item>
-                  
-                  <item><p>If the <code>KeySpecifier</code> is an NCName, a type error 
-                     <errorref class="TY" code="0004"/> is raised.</p></item>
-                  
-                  <item><p>In all other cases the <code>KeySpecifier</code> is treated
-                     as an expression, which is evaluated in the current context to return a value <var>$K</var>.
-                     The result of the lookup is then equivalent to</p>
-                     
-                     <eg>$K ! array:get($A, .)</eg>
-                        
-                     <note><p>This results in a dynamic error if the array index is out of bounds.</p></note> 
-                     <note><p>The order of the results corresponds to the order of the values
-                        in <code>$K</code>. For example, <code>["a", "b", "c"]?(3, 2, 1)</code>
-                     returns <code>("c", "b", "a")</code>.</p></note> 
-                  </item>
-                  
-               </ulist>
-               
-               <p>For a map <var>$M</var>:</p>
-               
-               <ulist>
-                  <item><p>If the <code>KeySpecifier</code> is a <code>LookupWildcard</code>
-                     (that is, <code>*</code>), the result is the <termref def="dt-sequence-concatenation"/>
-                     of the values in the entries of <var>$M</var>, retaining map order: 
-                     that is, <code>map:items($M)</code>.</p></item>
-                  
-                  <item><p>If the <code>KeySpecifier</code> is an NCName, it is treated as
-                     if the NCName were in quotation marks, for example <code>$M?code</code>
-                     is equivalent to <code>$M?"code"</code>.</p></item>
-                  
-                  <item><p>In all other cases the <code>KeySpecifier</code> is treated
-                     as an expression, which is evaluated in the current context to return a value <var>$K</var>.
-                     The result of the lookup is then equivalent to</p>
-                     
-                     <eg>$K ! map:get($A, .)</eg>
-                        
-                     <note><p>No error occurs in respect of a key that is not present in the map.</p></note> 
-                     <note><p>The order of the results corresponds to the order of the values
-                        in <code>$K</code>. For example, <code>{"a":1, "b":2} ? ("b", "a")</code>
-                     returns <code>(2, 1)</code>.</p></note> 
-                  </item>
-                  
-                  <item>
-                     <p>In addition to the above processing, if the <code>KeySpecifier</code>
-                     is written as an <code>NCName</code> or a string literal, and the
-                     value of the corresponding map entry is a function item annotated
-                     as a <code>%method</code> (see <specref ref="id-methods"/>) then
-                     the returned function item is modified by giving it a captured
-                     context that includes the containing map as the context item.</p>
-                  </item>
-                  
-               
-                  
-                  <!--<item><p>If the <code>KeySpecifier</code> is a <code>TypeSpecifier</code>, 
-                     then the raw result is filtered to retain only those JNodes 
-                     whose <code>¶value</code> property is an instance of
-                     the sequence type defined by the <code>KeySpecifier</code>.</p>
-                     <p>For example, the expression <code>$array?child::~[array(*)]</code>
-                     selects only those members of an array that are themselves arrays.</p>
-                  </item>-->
-
-                  <!--<item><p>If the <code>KeySpecifier</code> is an NCName, then the raw
-                     result is filtered to retain only those JNodes whose <code>¶selector</code> property 
-                     is equal to the NCName
-                     under the rules of the <function>atomic-equal</function> function.</p>
-                     <p>For example, the expression <code>$map?child::status</code> returns a JNode
-                     that wraps the map entry having the key <code>"status"</code>, if such an entry
-                     exists.</p>
-                     <note><p>There may be more than one such JNode in the case of a <code>JAxis</code>
-                     other than <code>child</code>.</p></note>
-                  </item>-->
-           
-                    
-                  
-                  
-               </ulist>
+    
                
                <p>Examples:</p>
 
@@ -21005,30 +20828,9 @@ return
                      </p>
                   </item>
                </ulist>
-               <!--<p>The lookup operator <code>?</code> (unlike the path operator <code>/</code>)
-               does not force the results into document order, nor does it eliminate duplicates.
-               If this is required, it can be achieved by a call on the <function>distinct-ordered-nodes</function>
-               function (or more concisely, with the union operator: <code>$X|()</code> has the same effect
-               as <code>distinct-ordered-nodes($X)</code>).</p>-->
-                  
                
-               <!--<div5 id="id-abbreviated-lookup">
-                  <head>Abbreviated Lookup Expressions</head>
-                  
-                  
                
-                  <p>The expression <code>$A ? ..</code> is an abbreviation for <code>$A ? parent::*</code>.
-                  If <code>$A</code> is a root JNode (a JNode with no parent), or if it is a map or array
-                     (which is implicitly wrapped in a root JNode) then the expression returns an empty sequence;
-                  otherwise it returns the ¶parent property of <code>$A</code>. If <code>$A</code> is a
-                  sequence with multiple items, it returns the sequence concatenation of the results.</p>
-                  
-                  <p>The expression <code>$A ? .</code> is an abbreviation for <code>$A ? self::*</code>.
-                  If <code>$A</code> is a JNode, it returns that JNode unchanged; otherwise, it returns
-                  the result of <code>fn:JNode($A)</code>. If <code>$A</code> is a sequence containing
-                  multiple items, it returns the sequence concatenation of the result.</p>
-                  
-               </div5>-->
+               
             </div4>
                <div4 id="id-unary-lookup">
                <head>Unary Lookup</head>
@@ -21046,11 +20848,7 @@ return
                   expression <code>.?KS</code>, which has the context value (<code>.</code>) as the implicit first operand.
                   See <specref ref="id-postfix-lookup"/> for the postfix lookup operator.</p>
                
-               <!--<p>Similarly, <code>?.</code> is equivalent to <code>.?.</code>, 
-               <code>?..</code> is equivalent to <code>.?..</code>, and <code>?<var>KS</var></code> (where 
-               <var>KS</var> is some <code>KeySpecifier</code>) is equivalent to
-               <code>.?<var>KS</var></code>.</p>
-               -->
+               
                
                <p>Examples:</p>
                
@@ -21063,23 +20861,7 @@ return
                      <p>
                         <code>?2</code> is equivalent to <code>.(2)</code>, an appropriate lookup for an array or an integer-valued map.</p>
                   </item>
-                  <!--<item>
-                     <p>If the context item is the result of parsing the JSON input:</p>
-                     <eg>{
-  "name": "John Smith",
-  "address": { "street": "18 Acacia Avenue", "postcode": "MK12 2EX" },
-  "previous-address": { "street": "12 Seaview Road", "postcode": "EX8 9AA" }
-}</eg>
-
-                     <p>then <code>? ~[record(street, postcode)] ? postcode</code>
-                        returns <code>("MK12 2EX", "EX8 9AA")</code> (reflecting the 
-                        <xtermref spec="DM40" ref="dt-entry-order"/> of the map).</p>
-                     <note><p>Writing <code>? * ? postcode</code> would raise a type error, 
-                        because the result of the initial
-                        step <code>? *</code> includes an item (the string <code>"John Smith"</code>) 
-                        that is neither a map nor an array. Adding the <code>TypeSpecifier</code>
-                        avoids this problem.</p></note>
-                  </item>-->
+                  
                   <item>
                      <p><code>?"first name"</code> is equivalent to <code>.("first name")</code></p>
                   </item>
@@ -21144,7 +20926,7 @@ return
                   The expression <code>$m/code = 3</code> (unless simplified by an optimizer)
                   effectively expands the expression to <code>(JNode($m)/child::get("code") => JNode-value()) = 3</code>:
                   that is, the supplied map is wrapped in a JNode, the child axis returns a sequence of JNodes,
-                  and the <code>¶value</code> properties of these JNodes are compared with the
+                  and the <term>·content·</term> properties of these JNodes are compared with the
                   supplied value <code>3</code>.</p>
                   
                   <p>Whereas simple lookups of specific entries in maps and arrays work well,
@@ -21154,18 +20936,18 @@ return
                   <code>$A?*</code> is the sequence <code>(1, 2, 3, 4, 5)</code> which loses information
                   that might be needed for further processing. By contrast, the path expression
                   <code>$A/*</code> (or <code>$A/child::*</code>) returns a sequence of four
-                  JNodes, whose <code>¶value</code> properties are respectively <code>(1,2)</code>, 
+                  JNodes, whose <term>·content·</term> properties are respectively <code>(1,2)</code>, 
                      <code>(3,4)</code>, <code>()</code>, and <code>5</code>.</p>
                   
                   <p>The result of a lookup expression is a simple value (the value of an entry in a map
                   or a member of an array, or the <termref def="dt-sequence-concatenation"/> of 
                   several such values). By contrast, the result of a path expression applied to maps
                   or arrays is always a sequence of JNodes. These JNodes can be used for further
-                  navigation. If only the <code>¶value</code> properties of the JNodes are 
+                  navigation. If only the <term>·content·</term> properties of the JNodes are 
                   needed, these will usually be extracted automatically by virtue of the
                   <termref def="dt-coercion-rules"/>: for example if the value is used in an
                   arithmetic expression or a value comparison, atomization of the JNode
-                  automatically extracts its <code>¶value</code>. In other cases the value can
+                  automatically extracts its <term>·content·</term>. In other cases the value can
                   be extracted explicitly by a call of the <function>JNode-value</function> function.</p>
                   
                   <p>Method lookup (see <specref ref="id-methods"/>), as in the expression 
@@ -21173,486 +20955,12 @@ return
                      not with path expressions.</p>
                </div4>
                
-               <!--<div5 id="id-lookup-sans-jaxis">
-                  <head>Lookup Expressions with no Explicit JAxis</head>
-               
-               
-               <p>In the absence of an <code>JAxis</code>, a shallow lookup expression
-               <code>$C ? <var>KS</var></code> is evaluated as follows:</p> 
-               
-               <eg>
-for $c in $C
-return if ($c instance of JNode())
-       then $c ? child::KS
-       else JNode($c) ? child::KS =!> JNode-value()
-               </eg>
-               
-               <p>The effect of this is that when the left-hand operand of the expression
-               contains a JNode, the result will be a sequence of JNodes. But when the left-hand
-               operand is a simple map or array, the result will contain
-               simple values, flattened by <termref def="dt-sequence-concatenation"/>.</p>
-                  
-               <p>For example, if <code>$m</code> is the map <code>{ "a":1, "b": 2 }</code>,
-               then <code>$m?b</code> returns the <code>xs:integer</code> value 2. In contrast,
-               <code>JNode($m)?b</code> returns a JNode having <code>¶parent=JNode($m)</code>, <code>¶selector="b"</code>,
-               <code>¶position=1</code>, and <code>¶value=2</code>.</p>   
-               
-               <note>
-                  <p>The effect of returning a simple value as the result is to lose information.
-                  This happens in two ways.
-                  Firsly, no information is retained about the parent map or array,
-                  or about the key that was used to make the selection, which means
-                  it is not possible to navigate around the containing tree to obtain
-                  properties of other related JNodes. Secondly, the results are flattened
-                  into a single sequence: for example, the result of the lookup
-                  expression <code>[ 1, 2, (), 4 ] ? *</code> is the sequence
-                  <code>( 1, 2, 4 )</code>, losing any information about the third
-                  array member.</p>
-                  
-                  <p>This effect can be avoided in a number of ways:</p>
-                  
-                  <ulist>
-                     <item><p>Use of an explicit call on <function>fn:JNode</function>
-                        on the left-hand side, 
-                     for example <code>JNode($A) ? K</code></p></item>
-                     <item><p>Use of an explicit axis, for example
-                     <code>$A ? child::K</code></p></item>
-                     <item><p>Implicit wrapping using the step <code>.</code>,
-                     for example <code>$A ? . ? K</code>. This is equivalent
-                     to <code>$A ? self::* ? K</code>, which (because it uses an
-                        explicit axis) ensures that the left-hand operand of the second <code>?</code>
-                     operator is a JNode, and therefore the result of the final expression
-                     is also a JNode.</p></item>
-                  </ulist>
-                  
-                  <p>The reason for the design choice is primarily for backwards compatibility; but
-                  it also has the benefit of keeping common cases simple.</p>
-               </note>
-               
-               
-               <p>The following examples use the <code>?</code> operator without a <code>JAxis</code>.
-                  Given <code>$A</code> as an array
-                  <code>[ ("a", "b"), ("c", "d"), ("e", "f"), 42 ]</code>, some example Lookup expressions
-                  are:</p>
-               
-               <table width="100%">
-                  <caption>Simple Lookup Expressions on an Array</caption>
-                  <thead>
-                     <tr>
-                        <th>Expression</th>
-                        <th>Result</th>
-                     </tr>
-                  </thead>
-                  <tbody>
-                     <tr>
-                        <td valign="top"><code>$A ? *</code></td>
-                        <td valign="top"><eg>("a", "b", "c", "d", "e", "f", 42)</eg></td>
-                     </tr>
-                     
-                     <tr>
-                        <td valign="top"><code>$A ? 2</code></td>
-                        <td valign="top"><eg>("c", "d")</eg></td>
-                     </tr>                   
-                     <tr>
-                        <td valign="top"><code>$A ? (3, 1)</code></td>
-                        <td valign="top"><eg>("e", "f", "a", "b")</eg></td>
-                     </tr> 
-                     <tr>
-                        <td valign="top"><code>$A ? 82</code></td>
-                        <td valign="top"><eg>()</eg>
-                        <note><p>There is no array bound checking.</p></note></td>
-                     </tr> 
-                     <tr>
-                        <td valign="top"><code>$A ? xyz</code></td>
-                        <td valign="top"><eg>()</eg>
-                        <note><p>No type error is raised.</p></note></td>
-                     </tr>
-                     <tr>
-                        <td valign="top"><code>$A ? ~[xs:integer]</code></td>
-                        <td valign="top"><eg>42</eg></td>
-                     </tr>
-                  </tbody>
-               </table>
-               
-               <p>Similarly, given <code>$M</code> as a map
-                  <code>{ "X": ("a", "b"), "Y": ("c", "d"), "Z": ("e", "f"), "N": 42 }</code>, 
-                  some example lookup expressions are as follows.</p>
-            
-               <table width="100%">
-                  <caption>Simple Lookup Expressions on a Map</caption>
-                  <thead>
-                     <tr>
-                        <th>Expression</th>
-                        <th>Result</th>
-                     </tr>
-                  </thead>
-                  <tbody>
-                     <tr>
-                        <td valign="top"><code>$M ? *</code></td>
-                        <td valign="top"><eg>("a", "b", "c", "d", "e", "f", 42)</eg></td>
-                     </tr>
-                     <tr>
-                        <td valign="top"><code>$M ? Y</code></td>
-                        <td valign="top"><eg>("c", "d")</eg></td>
-                     </tr>
-                     <tr>
-                        <td valign="top"><code>$M ? ("Z", "X")</code></td>
-                        <td valign="top"><eg>("e", "f", "a", "b")</eg></td>
-                     </tr>
-                     <tr>
-                        <td valign="top"><code>$M ? ~[xs:integer]</code></td>
-                        <td valign="top"><eg>42</eg></td>
-                     </tr>                    
-                  </tbody>
-               </table>
-                  
-               <p>The following examples illustrate lookup expressions on an array of maps, where
-               some of the maps themselves contain arrays. The input array <code>$A</code> is:</p>
-                  
-                  <eg>[ {"a":1, "b":"banana"}, {"a":2, "b":"bread", "c":[10, 20, 30] } ]</eg>
-               
-               <table width="100%">
-                  <caption>Example Lookup Expressions on an Array of Maps</caption>
-                  <thead>
-                     <tr>
-                        <th>Expression</th>
-                        <th>Result</th>
-                     </tr>
-                  </thead>
-                  <tbody>
-                     <tr>
-                        <td><code>$A ? * ? a</code></td>
-                        <td><eg>(1, 2)</eg></td>
-                     </tr>
-                     <tr>
-                        <td><code>$A ? * ? c ? 2</code></td>
-                        <td><eg>20</eg></td>
-                     </tr>
-                     <tr>
-                        <td><code>data($A ? descendant::c ? parent::* ? a)</code></td>
-                        <td><eg>2</eg></td>
-                     </tr>
-                     <tr>
-                        <td><code>data($A ? descendant::c ? .. ? a)</code></td>
-                        <td><eg>2</eg></td>
-                     </tr>
-                     <tr>
-                        <td><code>$A ? ~[record(a, b, c)] ? c ? 2</code></td>
-                        <td><eg>20</eg></td>
-                     </tr>
-                  </tbody>
-               </table>
-               
-               </div5>-->
-           
-              
                
                
             
             
             
-            <!--<div4 id="id-deep-lookup" diff="add" at="2023-11-15">
-               <head>Deep Lookup</head>
-               
-               <p>The deep lookup operator <code>??</code> has both unary and postfix forms.
-                  No explicit JAxis is allowed, because the <code>descendant</code> JAxis
-                  is implicit.</p>
-               
-               <scrap>
-                  <prodrecap ref="DeepLookup"/>
-               </scrap>
-               
-               <p>A deep lookup expression
-               is evaluated as follows:</p>
-               
-               <p><code>$C ?? <var>KS</var></code> is equivalent to 
-                  <code>$C ? descendant::KS</code></p>
-               
-               <p>Unlike the shallow lookup operator <code>?</code>, the deep lookup
-               operator always returns a sequence of JNodes.</p>
-               
-               <p>The unary form is also available: the expression <code>?? <var>KS</var></code> is equivalent
-               to <code>. ?? <var>KS</var></code>.</p>
-               
-               <example id="ex-deep-lookup-array">
-                  <head>Deep Lookup Expressions applied to an Array</head>
-               
-
-                  <p>Let <code>$V</code> be the array <code> [ { "first": "John", "last": "Smith" }, { "first": "Mary", "last": "Evans" } ]</code>.</p>
-                  <p>The result of <code>$V ?? * => JNode-value()</code> is a sequence of six values:</p>
-                  <ulist>
-                     <item><p><code>{ "first": "John", "last": "Smith" }</code></p></item>
-                     <item><p><code>"John"</code></p></item>
-                     <item><p><code>"Smith"</code></p></item>
-                     <item><p><code>{ "key": "last", "value": "Smith" }</code></p></item>
-                     <item><p><code>"Mary"</code></p></item>
-                     <item><p><code>"Evans"</code></p></item>
-                  </ulist>
-                  
-                  <p>The associated selectors can be included in the result by forming a sequence
-                     of key-value pair records, using the
-                  expression <code>$V ?? * ! { "key": JNode-selector(.), "value": JNode-value(.) }</code>,
-                  which returns:</p>
-                                      
-                  <olist>
-                     <item><p><code>{ "key": 1, "value": { "first": "John", "last": "Smith" } }</code></p></item>                    
-                     <item><p><code>{ "key": "first", "value": "John" }</code></p></item>
-                     <item><p><code>{ "key": "last", "value": "Smith" }</code></p></item>
-                     <item><p><code>{ "key": 2, "value": { "first": "Mary", "last": "Evans" } }</code></p></item>
-                     <item><p><code>{ "key": "first", "value": "Mary" }</code></p></item>
-                     <item><p><code>{ "key": "last", "value": "Evans" }</code></p></item>
-                  </olist>
-                  
-                  <p>The surnames of all people with first name "John" can be found using the expression:</p>
-               
-                  <eg>$V ?? first [. = "John"] ? .. ? last => string()</eg>
-                  
-                  <p>The call on <code>string()</code> here achieves the same effect as a call on 
-                  <code>JNode-value</code>, because the <function>string</function> function, when
-                  applied to a JNode, extracts the ¶value property and converts it to a string.
-                  Indeed the predicate <code>[. = "John"]</code> is also implicitly extracting
-                  the ¶value property of a JNode: this happens automatically when a JNode is 
-                  atomized, as required by the <code>=</code> operator.</p>
-               
-               </example>
-                  
-                  
-               
-               <!-\-<note>
-
-                  <p>This means that with the example given earlier:</p>
-                  <ulist>
-                     <item><p>The expression <code>$V ?? first</code> 
-                        returns the sequence <code>"John", "Mary"</code>.</p></item>
-                     <item><p>The expression <code>$V ?? last</code> 
-                        returns the sequence <code>"Smith", "Evans"</code>.</p></item>
-                     <item><p>The expression <code>$V ?? 1</code> 
-                        returns the sequence <code>{ "first": "John", "last": "Smith" }</code>.</p></item>
-                     <item><p>The expression <code>$V ?? ~[record(first, last)] ! `{ ?first } { ?last }`</code> 
-                        returns the sequence <code>"John Smith", "Mary Evans"</code>. This expression
-                     selects all values of type <code>record(first, last)</code> at any level in the tree.</p></item>
-                 </ulist>
-               </note>
-               <note>
-                  <p>The effect of evaluating all shallow lookups on maps rather than arrays is that no error arises
-                  if an array subscript is out of bounds. In the above example, <code>$value??3</code> would
-                  return an empty sequence, it would not raise an error.</p>
-                  <p>This also affects the way an <code>xs:untypedAtomic</code> key value is handled. 
-                     Given the shallow lookup
-                     expression <code>$A?$x</code>, if <code>$A</code> is an array and <code>$x</code>
-                     (after atomization) is <code>xs:untypedAtomic</code> then the value of <code>$x</code>
-                     is converted to an integer (by virtue of the coercion rules applying to a call
-                     on <function>array:get</function>). With a deep lookup expression <code>$A??$x</code>, by
-                     contrast, the semantics are defined in terms of a map lookup, in which 
-                     <code>xs:untypedAtomic</code> items are always treated as strings.
-                  </p>
-               </note>-\->
-               <note>
-                  <p>The definition of the <code>recursive-content</code> function is such that items
-                  in the top-level value that are not maps or arrays are ignored, whereas items that
-                  are not themselves maps or arrays, but which appear in the content of a map or array
-                  at the top level, are included. This means that <code>E??X</code> mirrors the
-                  behavior of <code>E//X</code>, in that it includes all items that are one-or-more levels
-                  deep in the tree.</p>
-               </note>
-               <note>
-
-                  <p>An expression involving multiple deep lookup operators may return duplicates.
-                     For example, the result of the expression 
-                     <code>[ [ [ "a" ], [ "b" ] ], [ [ "c" ], [ "d" ] ] ] ?? 1 ?? 1</code>
-                     is <code>([ "a" ], "a", "b", "a", "c")</code>. This is because the first <code>??</code> operator
-                     selects members in position 1 at all three levels, that is it selects the arrays
-                     <code>[ [ "a" ], [ "b" ] ]</code>, <code>[ "a" ]</code>, and <code>[ "c" ]</code> as well
-                     as each of the four string values. The second <code>??</code> operator 
-                  selects members in position 1 within each of these values, which results in the string
-                  <code>"a"</code> being selected twice.</p>
-               </note>
             
- 
-               
-               <example id="ex-deep-lookup-map">
-                  <head>Deep Lookup Expressions applied to a Map</head>
-                  <p>Consider the tree <code>$tree</code> of maps and arrays that results from applying the <function>fn:parse-json</function>
-                  function to the following JSON input:</p>
-                  <eg><![CDATA[
-{
-  "desc"    : "Distances between several cities, in kilometers.",
-  "updated" : "2014-02-04T18:50:45",
-  "uptodate": true,
-  "author"  : null,
-  "cities"  : {
-    "Brussels": [
-      { "to": "London",    "distance": 322 },
-      { "to": "Paris",     "distance": 265 },
-      { "to": "Amsterdam", "distance": 173 }
-    ],
-    "London": [
-      { "to": "Brussels",  "distance": 322 },
-      { "to": "Paris",     "distance": 344 },
-      { "to": "Amsterdam", "distance": 358 }
-    ],
-    "Paris": [
-      { "to": "Brussels",  "distance": 265 },
-      { "to": "London",    "distance": 344 },
-      { "to": "Amsterdam", "distance": 431 }
-     ],
-    "Amsterdam": [
-      { "to": "Brussels",  "distance": 173 },
-      { "to": "London",    "distance": 358 },
-      { "to": "Paris",     "distance": 431 }
-    ]
-  }
-}]]></eg>
-                  
-                  <p>Given two variables <code>$from</code> and <code>$to</code> containing the
-                  names of two cities that are present in this table, the distance between the
-                  two cities can be obtained with the expression:</p> 
-                     
-
-                     <eg>$tree ?? $from ?? ~[record(to, distance)] [?to = $to] ? distance</eg>
-                 
-                  <p>The names of all pairs of cities whose distance is represented in the data
-                  can be obtained with the expression:</p>
-                  
-                  <eg>$tree ?? "to" ! `{JNode-selector(?..?..)} to {.}`</eg>
-                  
-                  <p>The JNodes returned by the initial lookup <code>$tree ?? "to</code>
-                  wrap values such as <code>"London"</code>. The first <code>?..</code> selection
-                  from such a value returns a JNode wrapping a value such as the map
-                  <code>{ "to": "London", "distance": 322 }</code>. The second <code>?..</code>
-                  selection returns the containing array. The selector for this array is a key
-                  in the containing map, such as <code>"Brussels"</code>.</p>
-                  <note><p>The quotation marks around the key <code>"to"</code> are not needed,
-                  but are included here to improve readability.</p></note>
-                  
-                  <p>An alternative way to deliver the same result would be:</p>
-                  
-                  <eg>for key $from value $array in $tree ? cities
-for $to in $array ?? "to"
-return `{$from} to {$to}`</eg>
-
-               </example>
-               <example>
-                  <head>Comparison with JSONPath</head>
-                  <p>This example provides XPath equivalents to some examples given in the
-                  JSONPath specification. [TODO: add a reference].</p>
-                  <p>The examples query the result of parsing the following JSON value, representing
-                     a store whose stock consists of four books and a bicycle:</p>
-                  <eg><![CDATA[{
-  "store": {
-    "book": [
-      {
-        "category": "reference",
-        "author": "Nigel Rees",
-        "title": "Sayings of the Century",
-        "price": 8.95
-      },
-      {
-        "category": "fiction",
-        "author": "Evelyn Waugh",
-        "title": "Sword of Honour",
-        "price": 12.99
-      },
-      {
-        "category": "fiction",
-        "author": "Herman Melville",
-        "title": "Moby Dick",
-        "isbn": "0-553-21311-3",
-        "price": 8.99
-      },
-      {
-        "category": "fiction",
-        "author": "J. R. R. Tolkien",
-        "title": "The Lord of the Rings",
-        "isbn": "0-395-19395-8",
-        "price": 22.99
-      }
-    ],
-    "bicycle": {
-      "color": "red",
-      "price": 399
-    }
-  }
-}]]></eg>
-                  <p>The following table illustrates some queries on this data, expressed
-                  both in JSONPath and in &language;.</p>
-                  <table role="small" width="100%">
-                     <caption>JSONPath vs &language; Comparison</caption>
-                     <col width="40%"/>
-                     <col width="30%"/>
-                     <col width="30%"/>
-                     <thead>
-                        <tr>
-                           <th>Query</th>
-                           <th>JSONPath</th>
-                           <th>&language;</th>
-                        </tr>
-                     </thead>
-                     <tbody>
-                        <tr>
-                           <td valign="top">The authors of all books in the store</td>
-                           <td valign="top"><code>$.store.book[*].author</code></td>
-                           <td valign="top"><code>?store?book??author</code></td>
-                        </tr>
-                        <tr>
-                           <td valign="top">All authors</td>
-                           <td valign="top"><code>$..author</code></td>
-                           <td valign="top"><code>??author</code></td>
-                        </tr>
-                        <tr>
-                           <td valign="top">All things in store (four books and a red bicycle)</td>
-                           <td valign="top"><code>$.store.*  </code></td>
-                           <td valign="top"><code>?store?*</code></td>
-                        </tr>
-                        <tr>
-                           <td valign="top">The prices of everything in the store</td>
-                           <td valign="top"><code>$.store..price</code></td>
-                           <td valign="top"><code>?store??price</code></td>
-                        </tr>
-                        <tr>
-                           <td valign="top">The third book</td>
-                           <td valign="top"><code>$..book[2]  </code></td>
-                           <td valign="top"><code>??book?3</code></td>
-                        </tr>
-                        <tr>
-                           <td valign="top">The third book's author</td>
-                           <td valign="top"><code>$..book[2].author</code></td>
-                           <td valign="top"><code>??book?3?author</code></td>
-                        </tr>
-                        <tr>
-                           <td valign="top">The third book's publisher (empty result)</td>
-                           <td valign="top"><code>$..book[2].publisher</code></td>
-                           <td valign="top"><code>??book?3?publisher</code></td>
-                        </tr>
-                        <tr>
-                           <td valign="top">The last book (in order)</td>
-                           <td valign="top"><code>$..book[-1]</code></td>
-                           <td valign="top"><code>??book?*[last()]</code></td>
-                        </tr>
-                        <tr>
-                           <td valign="top">The first two books</td>
-                           <td valign="top"><code>$..book[0,1]</code></td>
-                           <td valign="top"><code>??book?(1,2)</code></td>
-                        </tr>
-                        <tr>
-                           <td valign="top">All books with an ISBN</td>
-                           <td valign="top"><code>$..book[?@.isbn]</code></td>
-                           <td valign="top"><code>??book[?isbn]</code></td>
-                        </tr>
-                        <tr>
-                           <td valign="top">All books cheaper than 10</td>
-                           <td valign="top"><code>$..book[?@.price&lt;10]</code></td>
-                           <td valign="top"><code>??book[?price lt 10]</code></td>
-                        </tr>
-                        <tr>
-                           <td valign="top">All member values and array elements contained in the input value</td>
-                           <td valign="top"><code>$..*</code></td>
-                           <td valign="top"><code>??*</code></td>
-                        </tr>
-                     </tbody>
-                  </table>
-               </example>
-            </div4>-->
             
             <div4 id="id-implausible-lookup-expressions" diff="add" at="Issue602">
                <head>Implausible Lookup Expressions</head>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -6069,8 +6069,8 @@ declare record Particle (
                   <prodrecap ref="JNodeType"/>
                </scrap>
                
-               <p>The form <code>jnode()</code> matches any JNode. The form
-               <code>jnode(<var>T</var>)</code> matches a JNode whose <term>·content·</term> is an instance
+               <p>The form <code>jnode-type()</code> matches any JNode. The form
+               <code>jnode-type(<var>T</var>)</code> matches a JNode whose <term>·content·</term> is an instance
                of the sequence type <var>T</var>.</p>
                
             </div3>
@@ -6518,11 +6518,11 @@ declare record Particle (
                            <p><var>A</var> is a <nt def="JNodeType">JNodeType</nt> and <var>B</var> is a <nt def="GNodeType">GNodeType</nt>.</p>
                         </item>
                         <item>
-                           <p><var>A</var> is <code>jnode(<var>T</var>)</code> and <var>B</var> is <code>jnode()</code>, for any sequence type 
+                           <p><var>A</var> is <code>jnode-type(<var>T</var>)</code> and <var>B</var> is <code>jnode-type()</code>, for any sequence type 
                               <var>T</var>.</p>
                         </item>
                         <item>
-                           <p><var>A</var> is <code>jnode(<var>T</var>)</code>, <var>B</var> is <code>jnode(<var>U</var>)</code>, 
+                           <p><var>A</var> is <code>jnode-type(<var>T</var>)</code>, <var>B</var> is <code>jnode-type(<var>U</var>)</code>, 
                               and <code>T ⊑ U</code>.</p>
                         </item>
                         <item>
@@ -11274,7 +11274,7 @@ return $lib?product((1.2, 1.3, 1.4))
          
          <p>An expression of the form <code>/<var>PP</var></code> (that is, a path expression
             with a leading <code>/</code>) is treated as an abbreviation for
-	 the expression <code>self::gnode()/(fn:root(.) treat as (document-node()|jnode())/<var>PP</var></code>. 
+	 the expression <code>self::gnode()/(fn:root(.) treat as (document-node()|jnode-type())/<var>PP</var></code>. 
             The effect of this expansion is that for every item <var>J</var> 
             in the context value <var>V</var>:</p>
 	 
@@ -11338,7 +11338,7 @@ return $lib?product((1.2, 1.3, 1.4))
 
          <p>An expression of the form <code>//<var>PP</var></code> (that is, a path expression
             with a leading <code>//</code>) is treated as an abbreviation for
-            the expression <code>self::gnode()/(fn:root(.) treat as (document-node()|jnode())/descendant-or-self::gnode()/<var>PP</var></code>. 
+            the expression <code>self::gnode()/(fn:root(.) treat as (document-node()|jnode-type())/descendant-or-self::gnode()/<var>PP</var></code>. 
             The effect of this expansion is that for every item <var>J</var> 
             in the context value <var>V</var>:</p>
 
@@ -13618,12 +13618,12 @@ the results are the same.
 for $e in $m/child::* except $m/child::xx 
 return ...</eg>
             
-            <note><p>Because the <function>JNode</function> creates a new JTree root,
+            <note><p>Because the <function>jnode</function> creates a new JTree root,
             calling it twice potentially creates two different trees, in which the JNodes have
             different identity. The expression <code>$map/child::* except $map/child::xx</code>
             might therefore have the wrong effect, because JNodes in two different trees 
             are being compared. For more details see the specification of the
-            <function>JNode</function> function.</p></note>
+            <function>jnode</function> function.</p></note>
             
             <p>In addition to the sequence operators described here, see <xspecref spec="FO40"
                   ref="sequence-functions"/> for functions defined on sequences.
@@ -20924,7 +20924,7 @@ processing with JSON processing.</p>
                   <code>$m?code = 3</code> and <code>$m/code = 3</code> have the same effect.
                   Path expressions, however, have more power, and with it, more complexity.
                   The expression <code>$m/code = 3</code> (unless simplified by an optimizer)
-                  effectively expands the expression to <code>(jnode($m)/child::get("code") => JNode-value()) = 3</code>:
+                  effectively expands the expression to <code>(jnode($m)/child::get("code") => jnode-value()) = 3</code>:
                   that is, the supplied map is wrapped in a JNode, the child axis returns a sequence of JNodes,
                   and the <term>·content·</term> properties of these JNodes are compared with the
                   supplied value <code>3</code>.</p>
@@ -20948,7 +20948,7 @@ processing with JSON processing.</p>
                   <termref def="dt-coercion-rules"/>: for example if the value is used in an
                   arithmetic expression or a value comparison, atomization of the JNode
                   automatically extracts its <term>·content·</term>. In other cases the value can
-                  be extracted explicitly by a call of the <function>JNode-value</function> function.</p>
+                  be extracted explicitly by a call of the <function>jnode-value</function> function.</p>
                   
                   <p>Method lookup (see <specref ref="id-methods"/>), as in the expression 
                      <code>$rectangle?area()</code> works only with the lookup operator and

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -13255,7 +13255,7 @@ every <code>section</code> element that has a parent that is either a <code>chap
                         </tr>
                         <tr>
                            <td valign="top">All things in store (four books and a red bicycle)</td>
-                           <td valign="top"><code>$.store.*  </code></td>
+                           <td valign="top"><code>$.store.*</code></td>
                            <td valign="top"><code>/store/*</code></td>
                         </tr>
                         <tr>
@@ -13301,7 +13301,7 @@ every <code>section</code> element that has a parent that is either a <code>chap
                         <tr>
                            <td valign="top">All member values and array elements contained in the input value</td>
                            <td valign="top"><code>$..*</code></td>
-                           <td valign="top"><code>??*</code></td>
+                           <td valign="top"><code>//*</code></td>
                         </tr>
                      </tbody>
                   </table>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -6500,7 +6500,7 @@ declare record Particle (
                   
                      <olist>
                         <item>
-                           <p><var>A</var> is a <nt def="KindTest">KindTest</nt> and <var>B</var> is <code>node()</code>.</p>
+                           <p><var>A</var> is a <nt def="NodeKindTest">NodeKindTest</nt> and <var>B</var> is <code>node()</code>.</p>
                            <example>
                               <head>Example:</head>
                               <p><code>comment() ⊆ node()</code></p>
@@ -9272,10 +9272,10 @@ At evaluation time, the value of a variable reference is the value to which the 
                the result of the primary expression.</p>
             
             <note>
-               <p>Where the expression before the square brackets is a
-                  <nt def="ReverseStep"
-                     >ReverseStep</nt> or <nt def="ForwardStep"
-                        >ForwardStep</nt>, the expression is technically not a
+               <p>Where the expression before the square brackets is an
+                  <nt def="AbbreviatedStep"
+                     >AbbreviatedStep</nt> or <nt def="FullStep"
+                        >FullStep</nt>, the expression is technically not a
                   filter expression but an <nt
                      def="AxisStep"
                      >AxisStep</nt>. There are minor differences
@@ -11202,6 +11202,13 @@ return $lib?product((1.2, 1.3, 1.4))
 
       <div2 id="id-path-expressions">
          <head>Path Expressions</head>
+         
+         <changes>
+            <change issue="2054">
+               Path expressions are extended to handle JNodes (found in trees of maps and arrays)
+               as well as XNodes (found in trees representing parsed XML).
+            </change>
+         </changes>
 
          <scrap>
             <prodrecap ref="PathExpr"/>
@@ -11213,11 +11220,28 @@ return $lib?product((1.2, 1.3, 1.4))
                   >steps</termref>, separated by <code>/</code> or
 	 <code>//</code>, and optionally beginning with
                <code>/</code> or <code>//</code>.  
-               A <term>path expression</term> is typically used to locate nodes
-               within trees. </termdef></p>
+               A <term>path expression</term> is typically used to locate GNodes
+               within GTrees. </termdef></p>
+         
+         <note>
+            <p>Note the terminology:</p>
+            <ulist>
+               <item><p>A <termref def="dt-GNode"/> is a generalized node, either a
+               <termref def="dt-XNode"/> or a <termref def="dt-JNode"/>.</p></item>
+               <item><p>A <termref def="dt-GTree"/> is a generalized tree, either an
+               <termref def="dt-XTree"/> or a <termref def="dt-JTree"/>.</p></item>
+            </ulist>
+         </note>
+         
+         <p><termdef id="dt-GTree" term="GTree">GTree - TBA</termdef></p>
+         <p><termdef id="dt-JTree" term="JTree">JTree - TBA</termdef></p>
+         <p><termdef id="dt-XTree" term="XTree">XTree - TBA</termdef></p>
+         <p><termdef id="dt-GNode" term="GNode">GNode - TBA</termdef></p>
+         <p><termdef id="dt-JNode" term="JNode">JNode - TBA</termdef></p>
+         <!--<p><termdef id="dt-XNode" term="XNode">XNode - TBA</termdef></p>-->
          
          <p>Absolute path expressions (those starting with an initial <code>/</code>
-            or <code>//</code>), start their selection from the root node of a tree;
+            or <code>//</code>), start their selection from the root GNode of a GTree;
             relative path expressions (those without a leading <code>/</code> or
             <code>//</code>) start from the <termref def="dt-context-value"/>.</p>
          
@@ -11234,22 +11258,22 @@ return $lib?product((1.2, 1.3, 1.4))
          
          <p>An expression of the form <code>/<var>PP</var></code> (that is, a path expression
             with a leading <code>/</code>) is treated as an abbreviation for
-	 the expression <code>self::node()/(fn:root(.) treat as document-node())/<var>PP</var></code>. 
+	 the expression <code>self::GNode()/(fn:root(.) treat as (document-node()|JNode())/<var>PP</var></code>. 
             The effect of this expansion is that for every item <var>J</var> 
             in the context value <var>V</var>:</p>
 	 
 	 <olist>
-	    <item><p>A <termref def="dt-type-error"/> occurs if <var>J</var> is not a node
+	    <item><p>A <termref def="dt-type-error"/> occurs if <var>J</var> is not a GNode
 	       <errorref class="TY" code="0020"/>.</p></item>
-	    <item><p>The root node <var>R</var> of the tree containing <var>J</var> is selected.</p></item>
-	    <item><p>A <termref def="dt-dynamic-error"/> occurs if <var>R</var> is not a document node
-	       <errorref class="DY" code="0050"/>.</p></item>
+	    <item><p>The root GNode <var>R</var> of the GTree containing <var>J</var> is selected.</p></item>
+	    <item><p>A <termref def="dt-dynamic-error"/> occurs if <var>R</var> is neither a JNode nor 
+	       a document node <errorref class="DY" code="0050"/>.</p></item>
 	    <item><p>The expression that follows the leading <code>/</code> is evaluated with 
 	       <var>R</var> as the context value.</p></item>
 	 </olist>
          
     <p>The results of these multiple evaluations are then combined into a single sequence;
-       if the result is a set of nodes, the nodes are delivered in document order with
+       if the result is a set of GNodes, the GNodes are delivered in document order with
        duplicates eliminated.</p>
             
             <note>
@@ -11298,40 +11322,40 @@ return $lib?product((1.2, 1.3, 1.4))
 
          <p>An expression of the form <code>//<var>PP</var></code> (that is, a path expression
             with a leading <code>//</code>) is treated as an abbreviation for
-            the expression <code>self::node()/(fn:root(.) treat as document-node())/descendant-or-self:node()/<var>PP</var></code>. 
+            the expression <code>self::GNode()/(fn:root(.) treat as (document-node()|JNode())/descendant-or-self::GNode()/<var>PP</var></code>. 
             The effect of this expansion is that for every item <var>J</var> 
             in the context value <var>V</var>:</p>
 
 
          
          <olist>
-            <item><p>A <termref def="dt-type-error"/> occurs if <var>J</var> is not a node
+            <item><p>A <termref def="dt-type-error"/> occurs if <var>J</var> is not a GNode
                <errorref class="TY" code="0020"/>.</p></item>
-            <item><p>The root node <var>R</var> of the tree containing <var>J</var> is selected.</p></item>
-            <item><p>A <termref def="dt-dynamic-error"/> occurs if <var>R</var> is not a document node
+            <item><p>The root GNode <var>R</var> of the GTree containing <var>J</var> is selected.</p></item>
+            <item><p>A <termref def="dt-dynamic-error"/> occurs if <var>R</var> is neither a JNode nor a document node
                <errorref class="DY" code="0050"/>.</p></item>
             <item><p>The descendants of <var>R</var> are selected, along with <var>R</var> itself.</p></item>
-            <item><p>For every node <var>D</var> in this set of nodes, the expression that 
+            <item><p>For every GNode <var>D</var> in this set of GNodes, the expression that 
                follows the leading <code>//</code> is evaluated with <var>D</var> as the context value.</p></item>
          </olist>
          
          <p>The results of these multiple evaluations are then combined into a single sequence;
-            if the result is a set of nodes, the nodes are delivered in document order with
+            if the result is a set of GNodes, the GNodes are delivered in document order with
             duplicates eliminated.</p>
          
-         <p>If the context value is not a node, a
+         <p>If the context value is not a sequence of GNodes, a
 	 <termref
                def="dt-type-error">type error</termref> is
 	 raised <errorref class="TY" code="0020"
                />. At evaluation time, if the
-	 root node of the context node is not a document node, a
+	 root GNode of any item in the context value is not a document node or a JNode, a
 	 <termref
                def="dt-dynamic-error">dynamic error</termref> is
 	 raised <errorref class="DY"
                code="0050"/>.</p>
 
          <note>
-            <p>The descendants of a node do not include attribute
+            <p>The descendants of an XNode do not include attribute
 	 nodes<phrase role="xpath"
                   > or namespace nodes</phrase>. However, the rules for expanding <code>//</code>
             ensure that <code>.//@*</code> selects all attributes of all descendants<phrase role="xpath">,
@@ -11354,8 +11378,8 @@ return $lib?product((1.2, 1.3, 1.4))
 
             <p>
           A relative path expression is a path expression that selects
-          nodes within a tree by following a series of steps starting
-          at the nodes in the context value (which may be any kind of node,
+          GNodes within a GTree by following a series of steps starting
+          at the GNodes in the context value (which may be any kind of GNode,
           not necessarily the root of the tree).
           </p>
             <p>
@@ -11385,8 +11409,9 @@ return $lib?product((1.2, 1.3, 1.4))
          </p>
             </note>
 
-            <p>The following example illustrates the use of relative path expressions.
-            In each case it is assumed that the context value is a single node,
+            <p>The following example illustrates the use of a relative path expressions
+               to select within an XTree.
+            It is assumed that the context value is a single XNode,
             referred to as the context node.</p>
 
             <example>
@@ -11407,8 +11432,8 @@ return $lib?product((1.2, 1.3, 1.4))
 
 
             <note>
-               <p>Since each step in a path provides context nodes for the following step, 
-                  in effect, only the last step in a path is allowed to return a sequence of non-nodes.</p>
+               <p>Since each step in a path provides context GNodes for the following step, 
+                  in effect, only the last step in a path is allowed to return a sequence of non-GNodes.</p>
             </note>
 
 
@@ -11418,16 +11443,16 @@ return $lib?product((1.2, 1.3, 1.4))
                <head>Path operator (<code>/</code>)</head>
 
                <p>The path operator <code>/</code> is primarily used for 
-                  locating nodes within trees. Its left-hand operand must return 
-                  a sequence of nodes. The result of the operator is either a sequence of nodes
-                  (in document order, with no duplicates), or a sequence of non-nodes.</p>
+                  locating GNodes within GTrees. Its left-hand operand must return 
+                  a sequence of nodes. The result of the operator is either a sequence of GNodes
+                  (in document order, with no duplicates), or a sequence of non-GNodes.</p>
 
                <p>The operation <code><var>E1</var>/<var>E2</var></code> is evaluated as follows: Expression <var>E1</var> 
-                  is evaluated, and if the result is not a (possibly empty) sequence <var>S</var> of nodes, 
+                  is evaluated, and if the result is not a (possibly empty) sequence <var>S</var> of GNodes, 
                   a <termref def="dt-type-error">type error</termref> is raised <errorref class="TY"
                      code="0019"
-                     />. Each node in <var>S</var> then serves in turn to provide an inner focus 
-                  (the node as the context value, its position in <var>S</var> as the context 
+                     />. Each GNode in <var>S</var> then serves in turn to provide an inner focus 
+                  (the GNode as the context value, its position in <var>S</var> as the context 
                   position, the length of <code>S</code> as the context size) for an evaluation 
                   of <var>E2</var>, as described in  <specref
                      ref="eval_context"
@@ -11437,9 +11462,9 @@ return $lib?product((1.2, 1.3, 1.4))
 
                <olist>
                   <item>
-                     <p>If every evaluation of <var>E2</var> returns a (possibly empty) sequence of nodes, 
-                        these sequences are combined, and duplicate nodes are eliminated based on node identity.
-                        The resulting node sequence is returned in <termref
+                     <p>If every evaluation of <var>E2</var> returns a (possibly empty) sequence of GNodes, 
+                        these sequences are combined, and duplicate GNodes are eliminated based on GNode identity.
+                        The resulting GNode sequence is returned in <termref
                               def="dt-document-order">document order</termref>.
                      </p>
                   </item>
@@ -11447,14 +11472,18 @@ return $lib?product((1.2, 1.3, 1.4))
                   <item>
 
                      <p>If every evaluation of <var>E2</var> returns a (possibly empty) 
-                        sequence of non-nodes, these sequences are concatenated, in order, and returned.
+                        sequence of non-GNodes, these sequences are concatenated, in order, and returned.
                         The returned sequence preserves the orderings within and among the subsequences 
                         generated by the evaluations of <var>E2</var>.
                      </p>
+                     <note><p>The use of path expressions to select values other than GNodes is for
+                     backwards compatibility. Generally it is preferable to use the simple mapping
+                     operator <code>!</code> for this purpose. For example, write <code>$nodes!node-name()</code>
+                     in preference to <code>$nodes/node-name()</code>.</p></note>
                   </item>
 
                   <item>
-                     <p>If the multiple evaluations of <var>E2</var> return at least one node and at least one non-node, a <termref
+                     <p>If the multiple evaluations of <var>E2</var> return at least one GNode and at least one non-GNode, a <termref
                            def="dt-type-error">type error</termref> is raised <errorref class="TY"
                            code="0018"/>.</p>
                   </item>
@@ -11466,9 +11495,9 @@ return $lib?product((1.2, 1.3, 1.4))
                      <code>fn:distinct-ordered-nodes($R)</code> has the effect of 
                      eliminating duplicates and sorting nodes into document order):</p>
                   <eg><![CDATA[let $R := E1 ! E2
-return if (every $r in $R satisfies $r instance of node())
+return if (every $r in $R satisfies $r instance of GNode())
        then (fn:distinct-ordered-nodes($R))
-       else if (every $r in $R satisfies not($r instance of node()))
+       else if (every $r in $R satisfies not($r instance of GNode()))
        then $R
        else error()]]></eg>
                   <p>For a table comparing the step operator to the map operator, see <specref ref="id-map-operator"/>.</p>
@@ -11493,58 +11522,56 @@ return if (every $r in $R satisfies $r instance of node())
 		<termref
                      def="dt-predicate"
                      >predicates</termref>. The value of the step
-		consists of those items that satisfy the
+		consists of those items that satisfy each of the
 		predicates, working from left to right. A step may be either an <termref
                      def="dt-axis-step"
                   >axis step</termref> or a postfix expression.</termdef> Postfix expressions are described in <specref
                   ref="id-postfix-expression"/>.</p>
             <p>
                <termdef term="axis step" id="dt-axis-step"
-                     >An <term>axis step</term> returns a sequence of nodes that are 
-                  reachable from a starting node via a specified axis. Such a step has two parts: an
-		<term>axis</term>, which defines the "direction of
-		movement" for the step, and a <termref
+                     >An <term>axis step</term> returns a sequence of GNodes that are 
+                  reachable from a starting GNode via a specified axis. Such a step has two parts: an
+		<term>axis</term>, which defines the direction of
+		movement for the step, and a <termref
                      def="dt-node-test"
                      >node test</termref>,
-		which selects nodes based on their kind, name, and/or
-		<termref def="dt-type-annotation">type annotation</termref> .</termdef></p> 
+		which selects GNodes based on their properties.</termdef></p> 
             
             <p>If the context value is a 
-               sequence of zero or more nodes, an axis
+               sequence of zero or more GNodes, an axis
 		step returns a sequence of zero or more
-		nodes; otherwise, a <termref def="dt-type-error">type error</termref> is
+		GNodes; otherwise, a <termref def="dt-type-error">type error</termref> is
 		raised <errorref class="TY" code="0020"/>.</p>
             
             <p>The step expression <code>S</code> is equivalent to <code>./S</code>.
-               Thus, if the context value is a sequence containing multiple nodes,
+               Thus, if the context value is a sequence containing multiple GNodes,
                the semantics of a step expression are equivalent to a path expression
-               in which the step is always applied to a single node. The following
+               in which the step is always applied to a single GNode. The following
                description therefore explains the semantics for the case where
-               the context value is a single node, called the context node.</p>
+               the context value is a single GNode, called the <term>origin</term>.</p>
             
             
             <note><p>The equivalence of a step <code>S</code> to the
             path expression <code>./S</code> means that 
-            the resulting node sequence is returned in <termref def="dt-document-order">document
+            the resulting GNode sequence is returned in <termref def="dt-document-order">document
 	         order</termref>.</p></note> 
             
-            <p>An axis step may be either a <term>forward
+            <!--<p>An axis step may be either a <term>forward
 		step</term> or a <term>reverse step</term>, followed
-		by zero or more <termref def="dt-predicate">predicates</termref>.</p>
+		by zero or more <termref def="dt-predicate">predicates</termref>.</p>-->
 
             <p>In the <term>abbreviated syntax</term> for a step, the axis can
 		be omitted and other shorthand notations can be used as described in
 		<specref
                   ref="abbrev"/>.</p>
             <p>The unabbreviated syntax for an axis step consists of the axis name
-		and node test separated by a double colon. The result of the step consists of the nodes
-		reachable from the starting node via the specified axis that have the node kind, name,
-		and/or <termref
-                  def="dt-type-annotation"
-                  >type annotation</termref> specified by the node test. For example, the
+		and node test separated by a double colon. The result of the step consists of the GNodes
+		reachable from the origin via the specified axis that match the node test. For example, the
 		step <code
                   role="parse-test"
-                  >child::para</code> selects the <code>para</code> element children of the context node: <code>child</code> is the name of the axis, and <code>para</code> is the name of the element nodes to be selected on this axis. The available axes are described in <specref
+                  >child::para</code> selects the <code>para</code> element children of the origin XNode: 
+               <code>child</code> is the name of the axis, and <code>para</code> is the name of the element nodes 
+               to be selected on this axis. The available axes are described in <specref
                   ref="axes"/>. The
 		available node tests are described in <specref
                   ref="node-tests"/>. Examples of
@@ -11561,21 +11588,20 @@ return if (every $r in $R satisfies $r instance of node())
                </changes>
                
                <scrap>
-                  <prodrecap ref="ForwardAxis"/>
-                  <prodrecap ref="ReverseAxis"/>
+                  <prodrecap ref="Axis"/>
                </scrap>
 
 
+               <p>An axis is essentially a function that takes a GNode (the origin)
+               as input, and delivers a sequence of GNodes (always from within the same
+               GTree as the origin) as its result.</p>
 
-
-               <p role="xpath"
-                     >XPath defines a set of <term>axes</term>
+               <p role="xpath">XPath defines a set of <term>axes</term>
 		  for traversing documents, but a <term>host language</term> may define a subset
 		  of these axes. The following axes are defined:</p>
 
                <p role="xquery"
-                  >XQuery supports the following axes<!-- <phrase diff="del"/>
-		  (subject to limitations as described in <specref ref="id-full-axis-feature"/>)-->:</p>
+                  >XQuery supports the following axes:</p>
 
 
                <ulist>
@@ -11584,40 +11610,29 @@ return if (every $r in $R satisfies $r instance of node())
                   <item>
 
                      <p>The <code>child</code> axis
-				contains the children of the context
-				node, which are the nodes returned by the
-				<xspecref
-                           spec="DM40" ref="dm-children"/>.
+				contains the children of the origin.</p>
+                     
+                     <p>If the origin is an XNode, these are the XNodes returned by the
+				<xspecref spec="DM40" ref="dm-children"/> accessor.
                                 </p>
 
 
                      <note>
-
-                        <p>Only document nodes and element
-                                                  nodes have
-                                                  children. If the
-                                                  context node is any
-                                                  other kind of node,
-                                                  or if the context
-                                                  node is an empty
-                                                  document or element
-                                                  node, then the child
-                                                  axis is an empty
-                                                  sequence.  The
-                                                  children of a
-                                                  document node or
-                                                  element node may be
-                                                  element, processing
-                                                  instruction,
-                                                  comment, or text
-                                                  nodes.  Attribute<phrase
+                        <p>In an XTree, only document nodes and element
+                        nodes have children. If the ori is origin
+                         other kind of XNode, or if the origin is an empty
+                         document or element node, then the child
+                         axis returns an empty sequence.  The
+                         children of a document node or element node may be
+                         element, processing instruction, comment, or text
+                         nodes.  Attribute<phrase
                               role="xpath"
-                              >,
-                                                  namespace,</phrase> and
-                                                  document nodes can
-                                                  never appear as
-                                                  children.</p>
+                              >, namespace,</phrase> and
+                         document nodes can never appear as children.</p>
                      </note>
+                     
+                     <p>If the origin is a JNode, these are the JNodes returned
+                     by the <xspecref spec="DM40" ref="dm-jnode-children"/> accessor.</p>
                                       
                   </item>
 
@@ -11625,94 +11640,84 @@ return if (every $r in $R satisfies $r instance of node())
                      <p>The <code>descendant</code>
 			 axis is defined as the transitive closure of
 			 the child axis; it contains the descendants
-			 of the context node (the children, the children of the children, and so on).</p>
-                     <p>More formally, <code>$node/descendant::node()</code> delivers the result
-                     of <code>fn:transitive-closure($node, fn { child::node() })</code>.</p>
+			 of the origin (the children, the children of the children, and so on).</p>
+                     <p>More formally, <code>$node/descendant::GNode()</code> delivers the result
+                     of <code>fn:transitive-closure($node, fn { child::GNode() })</code>.</p>
+                     <ednote><edtext>Assuming we extend fn:transitive-closure to apply to all GNodes</edtext></ednote>
                   </item>
                   
                   <item>
-                     <p>The <code>descendant-or-self</code> axis contains the context node and the descendants of the context
-				node.</p>
-                     <p>More formally, <code>$node/descendant-or-self::node()</code> delivers the result
-                     of <code>$node/(. | descendant::node())</code>.</p>
+                     <p>The <code>descendant-or-self</code> axis contains the origin and the descendants 
+                        of the origin.</p>
+                     <p>More formally, <code>$node/descendant-or-self::GNode()</code> delivers the result
+                     of <code>$node/(. | descendant::GNode())</code>.</p>
                   </item>
 
 
 
                   <item>
 
-                     <p>The <code>parent</code>
-                                          axis contains the sequence
-                                          returned by the
-				          <xspecref
-                           spec="DM40" ref="dm-parent"
-                        />, 
-                                          which returns
-                                          the parent of the context
-                                          node, or an empty sequence
-                                          if the context node has no
-                                          parent.</p>
+                     <p>The <code>parent</code> axis returns the parent of the origin.</p>
+                     <p>If the origin is an XNode, this is the result of the 
+				          <xspecref spec="DM40" ref="dm-parent"/> accessor.</p>
+                     <p>If the origin is a JNode, this is the value of the
+                     <code>¶parent</code> property of the origin.</p>
+                     <p>If the GNode has no parent, the axis returns an empty sequence.</p>
 
                      <note>
-                        <p>An attribute node may have an element node as its parent, even though the attribute node is not a child of the element node.</p>
+                        <p>An attribute node may have an element node as its parent, 
+                           even though the attribute node is not a child of the element node.</p>
                      </note>
                   </item>
 
 
 
                   <item>
-                     <p>The
-                                        <code>ancestor</code> axis is
-                                        defined as the transitive
-                                        closure of the parent axis; it
-                                        contains the ancestors of the
-                                        context node (the parent, the
-                                        parent of the parent, and so
-                                        on).</p>
+                     <p>The <code>ancestor</code> axis is
+                        defined as the transitive closure of the parent axis; it
+                        contains the ancestors of the origin (the parent, the
+                        parent of the parent, and so on).</p>
                      
-                     <p>More formally, <code>$node/ancestor::node()</code> delivers the result
-                     of <code>fn:transitive-closure($node, fn { parent::node() })</code>.</p>
+                     <p>More formally, <code>$node/ancestor::GNode()</code> delivers the result
+                     of <code>fn:transitive-closure($node, fn { parent::GNode() })</code>.</p>
 
                      <note>
-                        <p>The ancestor axis
-                                        includes the root node of the
-                                        tree in which the context node
-                                        is found, unless the context
-                                        node is the root node.</p>
+                        <p>The ancestor axis includes the root GNode of the
+                           GTree in which the origin is found, unless the origin is 
+                           itself the root GNode.</p>
                      </note>
 
                   </item>
                   
                   <item>
-                     <p>The <code>ancestor-or-self</code> axis contains the context node and the ancestors of the context node;
-				thus, the ancestor-or-self axis will always include the root node.</p>
+                     <p>The <code>ancestor-or-self</code> axis contains the origin and the ancestors of the origin;
+				            thus, the ancestor-or-self axis will always include the root.</p>
                      
-                     <p>More formally, <code>$node/ancestor-or-self::node()</code> delivers the result
-                     of <code>$node/(. | ancestor::node())</code>.</p>
+                     <p>More formally, <code>$node/ancestor-or-self::GNode()</code> delivers the result
+                     of <code>$node/(. | ancestor::GNode())</code>.</p>
                   </item>
 
 
 
                   <item>
                      <p>The <code>following-sibling</code>
-			 axis contains the context node’s following
-			 siblings, that is, those children of the context
-			 node’s parent that occur after the context
-			 node in <termref
+			 axis returns the origin’s following
+			 siblings, that is, those children of the origin’s parent that occur after the origin in <termref
                            def="dt-document-order"
-                           >document order</termref>. If the context node
+                           >document order</termref>. If the origin
 			 is an attribute or namespace node, the
 			 <code>following-sibling</code> axis is
 			 empty.</p>
-                     <p>More formally, <code>$node/following-sibling::node()</code> delivers the result
+                     <p>More formally, <code>$node/following-sibling::GNode()</code> delivers the result
                      of <code>fn:siblings($node)[. >> $node])</code>.</p>
+                     <ednote><edtext>Assuming fn:siblings is extended to handle GNodes.</edtext></ednote>
                   </item>
                   
                   <item>
-                     <p>The <code>following-sibling-or-self</code> axis contains the context node,
+                     <p>The <code>following-sibling-or-self</code> axis contains the origin,
                      together with the contents of the <code>following-sibling</code> axis.</p>
                      
-                     <p>More formally, <code>$node/following-sibling-or-self::node()</code> delivers the result
+                     <p>More formally, <code>$node/following-sibling-or-self::GNode()</code> delivers the result
                      of <code><![CDATA[fn:siblings($node)[not(. << $node)]]]></code></p>
                   </item>
 
@@ -11720,23 +11725,22 @@ return if (every $r in $R satisfies $r instance of node())
 
                   <item>
                      <p>The <code>preceding-sibling</code>
-			 axis contains the context node’s preceding
-			 siblings, that is, those children of the context
-			 node’s parent that occur before the context
+			 axis returns the origin’s preceding
+			 siblings, that is, those children of the origin’s parent that occur before the context
 			 node in <termref
                            def="dt-document-order"
-                           >document order</termref>. If the context node
+                           >document order</termref>. If the origin
 			 is an attribute or namespace node, the
 			 <code>preceding-sibling</code> axis is
 			 empty.</p>
-                     <p>More formally, <code>$node/preceding-sibling::node()</code> delivers the result
+                     <p>More formally, <code>$node/preceding-sibling::GNode()</code> delivers the result
                      of <code><![CDATA[fn:siblings($node)[. << $node]]]></code>.</p>
                   </item>
                   
                   <item>
-                     <p>The <code>preceding-sibling-or-self</code> axis contains the context node,
+                     <p>The <code>preceding-sibling-or-self</code> axis contains the origin,
                      together with the contents of the <code>preceding-sibling</code> axis.</p>
-                     <p>More formally, <code>$node/preceding-sibling-or-self::node()</code> delivers the result
+                     <p>More formally, <code>$node/preceding-sibling-or-self::GNode()</code> delivers the result
                      of <code><![CDATA[fn:siblings($node)[not(. >> $node)]]></code>.</p>
                   </item>
 
@@ -11745,67 +11749,69 @@ return if (every $r in $R satisfies $r instance of node())
                   <item>
 
                      <p>The <code>following</code> axis
-				contains all nodes that are
-				descendants of the root of the tree in
-				which the context node is found, are
-				not descendants of the context node,
-				and occur after the context node in
-				<termref
-                           def="dt-document-order">document order</termref>.
+				contains all 
+				descendants of the root of the GTree in
+				which the origin is found, are
+				not descendants of the origin,
+				and occur after the origin in
+				<termref def="dt-document-order">document order</termref>.
                      </p>
-                     <p>More formally, <code>$node/following::node()</code> delivers the result
-                     of <code>$node/ancestor-or-self::node()/following-sibling::node()/descendant-or-self::node()</code></p>
+                     <p>More formally, <code>$node/following::GNode()</code> delivers the result
+                     of <code>$node/ancestor-or-self::GNode()/following-sibling::GNode()/descendant-or-self::GNode()</code></p>
 
                   </item>
 
                   <item>
-                     <p>The <code>following-or-self</code> axis contains the context node,
+                     <p>The <code>following-or-self</code> axis contains the origin,
                      together with the contents of the <code>following</code> axis.</p>
-                     <p>More formally, <code>$node/following-or-self::node()</code> delivers the result
-                     of <code>$node/(. | following::node())</code>.</p>
+                     <p>More formally, <code>$node/following-or-self::GNode()</code> delivers the result
+                     of <code>$node/(. | following::GNode())</code>.</p>
                   </item>        
 
                   <item>
 
                      <p>The <code>preceding</code> axis
-				contains all nodes that are
-				descendants of the root of the tree in
-				which the context node is found, are
-				not ancestors of the context node, and
-				occur before the context node in
+				returns all 
+				descendants of the root of the GTree in
+				which the origin is found, are
+				not ancestors of the origin, and
+				occur before the origin in
 				<termref
                            def="dt-document-order">document order</termref>.
                      </p>
-                     <p>More formally, <code>$node/preceding::node()</code> delivers the result
-                     of <code>$node/ancestor-or-self::node()/preceding-sibling::node()/descendant-or-self::node()</code>.</p>
+                     <p>More formally, <code>$node/preceding::GNode()</code> delivers the result
+                     of <code>$node/ancestor-or-self::GNode()/preceding-sibling::GNode()/descendant-or-self::GNode()</code>.</p>
 
                   </item>
 
                   <item>
-                     <p>The <code>preceding-or-self</code> axis contains the context node,
+                     <p>The <code>preceding-or-self</code> axis returns the origin,
                      together with the contents of the <code>preceding</code> axis.</p>
-                     <p>More formally, <code>$node/preceding-or-self::node()</code> delivers the result
-                     of <code>$node/(. | preceding::node())</code>.</p>
+                     <p>More formally, <code>$node/preceding-or-self::GNode()</code> delivers the result
+                     of <code>$node/(. | preceding::GNode())</code>.</p>
                   </item>  
 
                   <item>
-                     <p>The <code>attribute</code> axis
-			 contains the attributes of the context node,
+                     <p>The <code>attribute</code> axis is defined only for XNodes.
+			 It returns the attributes of the origin,
 			 which are the nodes returned by the
 			 <phrase diff="chg" at="B">
 			 <xspecref spec="DM40" ref="dm-attributes"/></phrase>; the axis will be
 			 empty unless the context node is an
 			 element.</p>
+                     
+                     <p>If the <code>attribute</code> axis is applied to a JNode,
+                     a type error <errorref class="TY" code="0004"/> is raised.</p>
 
                   </item>
 
 
 
                   <item>
-                     <p>The <code>self</code> axis contains just the context node itself.</p>
-                     <p>The <code>self</code> axis is primarily useful when testing whether the context
-                     node satisfies particular conditions, for example <code>if ($x[self::chapter])</code>.</p>
-                     <p>More formally, <code>$node/self::node()</code> delivers the result
+                     <p>The <code>self</code> axis contains just the origin itself.</p>
+                     <p>The <code>self</code> axis is primarily useful when testing whether the origin
+                     satisfies particular conditions, for example <code>if ($x[self::chapter])</code>.</p>
+                     <p>More formally, <code>$node/self::GNode()</code> delivers the result
                      of <code>$node</code>.</p>
                   </item>
 
@@ -11819,14 +11825,14 @@ return if (every $r in $R satisfies $r instance of node())
 
                   <item role="xpath">
 
-                     <p>The <code>namespace</code> axis
-				contains the namespace nodes of the
-				context node, which are the nodes
+                     <p>The <code>namespace</code> axis is defined only for XNodes.
+				It returns the namespace nodes of the
+				origin, which are the nodes
 				returned by the
                                 <xspecref
                            spec="DM40" ref="dm-namespace-nodes"
                            />; this axis
-				is empty unless the context node is an
+				is empty unless the origin is an
 				element node. The
 				<code>namespace</code> axis is
 				deprecated as of XPath 2.0. If <termref
@@ -11856,11 +11862,14 @@ return if (every $r in $R satisfies $r instance of node())
                            >in-scope namespaces</termref> of an element
 				should use the function <function>fn:in-scope-namespaces</function>.
                                 </p>
+                     
+                   <p>If the <code>namespace</code> axis is applied to a JNode,
+                     a type error <errorref class="TY" code="0004"/> is raised.</p>  
 
                   </item>
                </ulist>
                <p>Axes can be categorized as <term>forward axes</term> and
-		  <term>reverse axes</term>. An axis that only ever contains the context node or
+		  <term>reverse axes</term>. An axis that only ever contains the origin or
 		  nodes that are after the context node in <termref
                      def="dt-document-order"
                      >document order</termref> is a forward axis. An
@@ -11873,11 +11882,11 @@ return if (every $r in $R satisfies $r instance of node())
                   are reverse axes; all other axes are forward axes.</p>
                
                  <p>The <code>ancestor</code>, <code>descendant</code>, 
-                  <code>following</code>, <code>preceding</code> and <code>self</code> axes partition a document (ignoring attribute <phrase
+                  <code>following</code>, <code>preceding</code> and <code>self</code> axes partition a GTree (ignoring attribute <phrase
                      role="xpath"
                   >and namespace</phrase> nodes):
-		  they do not overlap and together they contain all the nodes in the
-		  document.</p>
+		  they do not overlap and together they contain all the GNodes in the
+		  GTree.</p>
 
                <p>
                   <termdef id="dt-principal-node-kind" term="principal node kind"
@@ -11917,11 +11926,8 @@ return if (every $r in $R satisfies $r instance of node())
                </changes>
                <p>
                   <termdef id="dt-node-test" term="node test"
-                        >A <term>node test</term> is a condition on the name, kind (element, attribute, text, document, comment,
-		  or processing instruction), and/or  <termref
-                        def="dt-type-annotation"
-                        >type annotation</termref> of a node. 
-      A node test determines which nodes contained by an axis are selected by a <termref
+                        >A <term>node test</term> is a condition on the properties of a GNode. 
+      A node test determines which GNode contained by an axis are selected by a <termref
                         def="dt-step">step</termref>.</termdef>
                </p>
                
@@ -11929,10 +11935,30 @@ return if (every $r in $R satisfies $r instance of node())
                   <prodrecap id="NodeTest" ref="NodeTest"/>
                </scrap>
                
+               <p>Node tests fall into three categories:</p>
+               
+               <ulist>
+                  <item><p>Type tests, which test the type of the GNode;</p></item>
+                  <item><p>Selectors, which act as keys used to identify the GNode
+                     among its siblings (in the case of XNodes, this is the node name);</p></item>
+                  <item><p>Union node tests, which provide multiple conditions: a GNode satisfies
+                  the union node test if it satisfies any of its operand node tests.</p></item>
+               </ulist>
+               
                <p diff="add" at="2022-12-13">A <nt def="UnionNodeTest">UnionNodeTest</nt> matches a node <var>N</var>
                   if at least one of the constituent <nt def="SimpleNodeTest">SimpleNodeTest</nt>s matches <var>N</var>.</p>
                
                <p diff="add" at="2022-12-13">For example, <code>(div1|div2|div3)</code> matches a node named <code>div1</code>, <code>div2</code>, or <code>div3</code></p>
+
+               <p>The semantics of selectors varies between XNodes and JNodes, so the two
+               cases are described separately.</p>
+               
+            </div4>
+            <div4 id="id-selectors-for-xnodes">
+               <head>Selectors for XNodes</head>
+               
+               <p>This section describes the semantics of a name test in the case
+               where the origin is an XNode.</p>
 
                <p>
                   <termdef id="dt-name-test" term="name test"
@@ -12037,31 +12063,103 @@ return if (every $r in $R satisfies $r instance of node())
              </item>
           </ulist>
                
+               <p>A selector can also take the form <code>get(<var>Expr</var>)</code>.
+               The contained expression <var>Expr</var> is evaluated with the focus
+               of the containing axis step (so its value is independent of the specific
+               XNode being tested). The result of the expression after atomization must be a sequence
+               of zero or more <code>xs:QName</code> values (otherwise a type error
+               <errorref class="TY" code="0004"/> is raised). An XNode satisfies the selector
+               if its node kind is the principal node kind of the axis and its node name
+               is among the values returned by the selector expression.</p>
+               
+               <p>For example, <code>child::get(#body, #x:body)</code> selects
+               an element whose name is one of the QName values <code>body</code>
+               or <code>x:body</code>. Note that the evaluation of QName literals
+               is not sensitive to the default namespace for elements and types.</p>
+            </div4>
+            
+            <div4 id="id-selectors-for-JNodes">
+               <head>Selectors for JNodes</head>
+               
+               <p>When the origin is a JNode, the selector filters the JNodes returned
+               by the axis according to the JNode's <code>¶selector</code> property.
+               In the case of a JNode that wraps an entry in a map, this can be any
+               atomic value; for a JNode that wraps a member of an array, it will
+               be a non-negative integer.</p>
+               
+               <p>If the selector takes the form <code>*</code>, then it matches
+               every JNode (including one whose <code>¶selector</code> property
+               is absent).</p>
+               
+               <p>If the selector takes the form of an <code>NCName</code>, then it matches
+               every JNode whose <code>¶selector</code> property is a string (or <code>xs:anyURI</code>
+                  or <code>xs:untypedAtomic</code> value) that is equal to this <code>NCName</code>
+                  under the rules of the <function>fn:atomic-equal</function> function.</p>
+               
+               <p>If the selector takes the form of any other <code>EQName</code> or wildcard,
+               then it matches every JNode whose <code>¶selector</code> property is a matching 
+                  <code>xs:QName</code>, using the same rules as for wildcards in XNode steps
+               (see <specref ref="id-selectors-for-xnodes"/>).</p>
+               
+               <p>If the selector takes the form <code>get(<var>Expr</var>)</code>,
+               then the contained expression <var>Expr</var> is evaluated with the focus
+               of the containing axis step (so its value is independent of the specific
+               JNode being tested). A JNode satisfies the selector
+               if its <code>¶selector</code> property is equal to 
+               one or more of the values returned by the selector expression,
+               under the rules of the <function>fn:atomic-equal</function> function.</p>
+               
+               <p>For example, <code>child::get("date of birth")</code> selects
+               an entry in a map whose key is the string <code>"date of birth"</code>,
+                  while <code>child::get(3)</code> selects the third member
+                  of an array. The expression <code>child::get(current-date())</code>
+               selects an entry in a map whose key is an <code>xs:date</code> value
+               equal to the current date.</p>
+            </div4>
+            <div4 id="id-type-tests">
+               <head>Type Tests</head>
                <p>
                   <termdef term="kind test" id="dt-kind-test"
                         >An alternative
 		  form of a node test called a
-		  <term>kind test</term> can select nodes based
-		  on their kind, name, and <termref
-                        def="dt-type-annotation"
-                     >type annotation</termref>.</termdef> The syntax
+		  <term>type test</term> can select XNodes based
+		  on their type, or in the case of JNodes, the type of their
+                  contained <code>¶value</code></termdef>.</p>
+               
+            <scrap>
+               <prodrecap ref="TypeTest"/>
+            </scrap>
+               
+        <p>The most general form of type test uses the syntax 
+           <code>type(<var>SequenceType</var>)</code>. This selects:</p>
+               
+        <ulist>
+           <item><p>XNodes that are instances of the supplied <var>SequenceType</var>;</p></item>
+           <item><p>JNodes whose <code>¶value</code> property is an instance of the 
+              supplied <var>SequenceType</var>.</p></item>
+        </ulist>
+               
+        <p>For the most commonly encountered types, this syntax can be abbreviated: for example
+           <code>node()</code>, <code>text()</code>, <code>array(*)</code>, and <code>record(x, y)</code>
+           can be written directly without the enclosing <code>type(...)</code>.</p>
+               
+        <p>If the origin is a <code>JNode</code> the type used will normally be a 
+           <nt def="NodeKindTest">NodeKindTest</nt> such as <code>node()</code>
+           or <code>comment()</code>. Specifying a type that cannot select nodes,
+           such as <code>map(*)</code>, is allowed but pointless.</p>
+               
+        <p>The syntax
 		  and semantics of a kind test are described in
 		  <specref
                      ref="id-sequencetype-syntax"/> and <specref ref="id-sequencetype-matching"
-                     />. When a kind test is used
-		  in a <termref def="dt-node-test"
-                     >node test</termref>, only those nodes on the designated
-		  axis that match the kind test are selected. Shown
-		  below are several examples of kind tests that might
-		  be used in path
-		  expressions:</p>
+                     />.</p>
+        <p>Shown below are several examples of type tests that might
+		  be used in path expressions selecting within an XTree:</p>
                <ulist>
 
                   <item>
                      <p>
-                        <code role="parse-test">node()</code>
-		  matches any
-		  node.</p>
+                        <code role="parse-test">node()</code> matches any XNode.</p>
                   </item>
 
                   <item>
@@ -12207,6 +12305,24 @@ return if (every $r in $R satisfies $r instance of node())
                   for <code>document-node(element(book))</code>.</p></item>
 
                </ulist>
+               
+               <p>The following examples show type type tests that might
+		  be used in path expressions selecting within a JTree:</p>
+               <ulist>
+
+                  <item>
+                     <p><code role="parse-test">array(*)</code> matches any JNode
+                        whose <code>¶value</code> is an array.</p>
+                     <p><code role="parse-test">record(longitude, latitude, *)</code> matches any JNode
+                        whose <code>¶value</code> is a map having entries with keys
+                        <code>"longitude"</code> and <code>"latitude"</code>.</p>
+                     <p><code role="parse-test">type(empty-sequence())</code> matches any JNode
+                        whose <code>¶value</code> is an empty sequence.</p>
+                     <p><code role="parse-test">type(xs:date)</code> matches any JNode
+                        whose <code>¶value</code> is an instance of <code>xs:date</code>.</p>
+                  </item>
+               </ulist>
+               
             </div4>
             <div4 id="implausible-axis-steps" diff="add" at="Issue602">
                <head>Implausible Axis Steps</head>
@@ -12252,6 +12368,8 @@ return if (every $r in $R satisfies $r instance of node())
                   <item><p><code>@code/text()</code>: attributes cannot have text node children.</p></item>
                   <item><p><code>/@code</code>: document nodes cannot have attributes.</p></item>
                   <item><p><code>ancestor::text()</code>: the ancestor axis never returns text nodes.</p></item>
+                  <item><p><code>element(*)/child::map</code>: the child axis starting at an element node
+                     will never select a map.</p></item>
                </ulist>
                
                <note><p>Processors may choose not to classify the expression <code>/..</code>
@@ -12690,8 +12808,7 @@ last <code>chapter</code> or <code>appendix</code> child of the context node.</p
          <div3 id="abbrev">
             <head>Abbreviated Syntax</head>
             <scrap>
-               <prodrecap id="AbbrevForwardStep" ref="AbbrevForwardStep"/>
-               <prodrecap id="AbbrevReverseStep" ref="AbbrevReverseStep"/>
+               <prodrecap id="AbbreviatedStep" ref="AbbreviatedStep"/>
             </scrap>
             <p>The abbreviated syntax permits the following abbreviations:</p>
 

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -21178,7 +21178,7 @@ return $map?[?key ge 2]</eg>
             </note>
          </div3>
          
-         <div3 id="id-pinned-maps-and-arrays">
+         <!--<div3 id="id-pinned-maps-and-arrays">
             <head>Pinned Maps and Arrays</head>
             <p>Unlike navigation within node trees derived from XML, navigation within a tree of maps and
                arrays derived from JSON is normally “downwards only”: there is no equivalent of the parent
@@ -21260,7 +21260,7 @@ return $map?[?key ge 2]</eg>
             
             <ednote><edtext>That note is anticipating a proposal in a separate PR.</edtext></ednote>
             
-         </div3>
+         </div3>-->
       
          
       </div2>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -7516,7 +7516,7 @@ declare record Particle (
                      <note><p>For example, if <code>$A</code> is an array and the members
                      of the array are maps, then <code>$A?child::*</code> returns a sequence
                      of JNodes that encapsulate maps, and the size of these maps can be obtained 
-                     using the expression <code>$A?child::* ! map:size()</code>.</p></note>
+                     using the expression <code>$A?child::* ! map:size(.)</code>.</p></note>
                   </item>
                               
                   <item diff="add" at="A">
@@ -20329,19 +20329,25 @@ processing with JSON processing.</p>
                   A deep lookup operator <code>??</code> is provided for searching
                   trees of maps and arrays.
                </change>
-               <change issue="960 1094" PR="1125" date="2024-04-23">
+               <!--<change issue="960 1094" PR="1125" date="2024-04-23">
                   Lookup expressions can now take a modifier (such as <code>keys</code>,
                   <code>values</code>, or <code>pairs</code>) enabling them to return
-                  structured results rather than a flattened sequence. <!--In addition
+                  structured results rather than a flattened sequence. <!-\-In addition
                   they can be qualified with a type to select only the results that
-                  match that type.-->
-               </change>
+                  match that type.-\->
+               </change>-->
                <change issue="1800 1845" PR="1817 1853" date="2025-03-04">An inline function may be annotated
                as a <code>%method</code>, giving it access to its containing map.</change>
                <change issue="1456 1866" PR="1864 1877">
                   The key specifier can reference an item type or sequence type, to select
                   values of that type only. This is especially useful when processing
                   trees of maps and arrays, as encountered when processing JSON input.
+               </change>
+               <change issue="2025">
+                  The "?" operator can now be followed by an axis step, such as <code>child::*</code>
+                  or <code>descendant::*</code>. This returns a sequence of JNodes, which
+                  allow access to the key used for selection, and to parents and ancestors 
+                  in the selection tree; it also avoids flattening the result sequence.
                </change>
             </changes>
 
@@ -20380,26 +20386,41 @@ processing with JSON processing.</p>
                   <item><p><code>$A ? * ? *</code> returns <code>(3, 5, 8, 6)</code></p></item>
                   <item><p><code>$A ? * ? Peter</code> returns <code>8</code></p></item>
                   <item><p><code>$A ? 2 ? *</code> returns (8, 6)</p></item>
-                  <item><p><code>$A ?? *</code> returns <code>(3, 5, 8, 6)</code></p></item>
+                  <item><p><code>$A ?? *</code> returns <code>({ "John": 3, "Jill": 5}, 3, 5, {"Peter": 8, "Mary": 6}, 8, 6)</code></p></item>
+                  <item><p><code>$A ?? ~[xs:integer]</code> returns <code>(3, 5, 8, 6)</code></p></item>
                </ulist>
                
-               <p>We will start by giving the rules for the case where a <code>JAxis</code>
-               is included, and then explain what happens when it is omitted.</p>
+               <p>The expression <code>$A ? ..</code> is an abbreviation for <code>$A ? parent::*</code>.</p>
                
-               <p>An expression such as <code>$A ? child::<var>KS</var> is evaluated as follows:</code></p>
+               <p>The expression <code>$A ? .</code> is an abbreviation for <code>$A ? self::*</code>.</p>
+               
+               <p>We will start by giving the rules for the case where a <code>JAxis</code>
+               is included (either explicitly, or by use of the abbreviated forms <code>.</code> or <code>..</code>), 
+               and then explain what happens when it is omitted.</p>
+               
+               <p>An expression such as <code>$A ? child::<var>KS</var></code> (where <code>child</code>
+                  might be replaced by any other <code>JAxis</code>) is evaluated as follows:</p>
                
                <ulist>
-                  <item><p>If the value of <code>$A</code> is not a singleton, then the expression
-                  is evaluated for each item in <code>$A</code>, and the expression returns
-                  the <termref def="dt-sequence-concatenation"/> of the results.</p></item>
-                  <item><p>If the value of <code>$A</code> is a map or an array, then it
+                  <item><p>The expression
+                  is expanded to <code>for $a in $A return $a ? child::<var>KS</var></code>
+                     (where <code>$a</code> is some otherwise unused variable name),
+                     which is then evaluated using the rules below.</p></item>
+                  
+                  <item><p>If the value of <code>$a</code> is anything other than a map,
+                  an array, or a JNode, then a type error is raised <errorref class="TY" code="0004"/>.</p></item>
+                 
+                  <item><p>If the value of <code>$a</code> is a map or an array, then it
                   is wrapped in a root <xtermref spec="DM40" ref="dt-JNode"/> by applying
-                  the <function>pin</function> function.</p></item>
-                  <item><p>If the value of <code>$A</code> is a <xtermref spec="DM40" ref="dt-JNode"/>,
+                  the <function>pin</function> function, and the expression is then
+                  evaluated using the rules below.</p></item>
+                  
+                  <item><p>If the value of <code>$a</code> is a <xtermref spec="DM40" ref="dt-JNode"/>,
                   then the <code>JAxis</code> is evaluated, as described below, to deliver a sequence
                   of JNodes.</p></item>
-                  <item><p>This sequence of JNodes is filtered, retaining only those that satisfy
-                  the <code>KeySpecifier</code> <var>KS</var>.</p></item>
+                  
+                  <item><p>This sequence of JNodes is filtered and potentially reordered, retaining 
+                     only those JNodes that satisfy the <code>KeySpecifier</code> <var>KS</var>.</p></item>
                </ulist>
                
                <p>A <code>JAxis</code> is essentially a function that takes a JNode as its input
@@ -20415,8 +20436,8 @@ processing with JSON processing.</p>
                   returns the transitive closure of the <code>parent</code> <code>JAxis</code>,
                      that is, it returns the <code>¶parent</code>, then the <code>¶parent</code>
                      of the <code>¶parent</code>,
-                     and so on until the root JNode (which has no parent) is reached. Note
-                  that the result is in reverse document order.</p></item>
+                     and so on until the root JNode (which has no parent) is reached. 
+                     The result is in reverse document order.</p></item>
                   <item><p>The <code>ancestor-or-self</code> <code>JAxis</code>, applied to a JNode <var>N</var>,
                      returns <var>N</var> followed by the content of the <code>ancestor</code> <code>JAxis</code>.
                      The result is in reverse document order.</p></item>
@@ -20449,49 +20470,74 @@ processing with JSON processing.</p>
             
                </ulist>
                
-               <ednote><edtext>Elimination of duplicates?</edtext></ednote>
                
-               <p>The <code>KeySpecifier</code> filters the result, as follows:</p>
+               <p>The <code>KeySpecifier</code> filters and potentially reorders the result 
+                  (referred to below as the <term>raw result</term>), as follows:</p>
                
                <ulist>
                   <item><p>If the <code>KeySpecifier</code> is a <code>LookupWildcard</code>, 
-                     then a JNode <var>J</var> satisfies the <code>KeySpecifier</code> unconditionally.</p></item>
+                     then the raw result is returned unchanged.</p></item>
                   
                   <item><p>If the <code>KeySpecifier</code> is a <code>TypeSpecifier</code>, 
-                     then a JNode <var>J</var> satisfies the <code>KeySpecifier</code> if and only if
-                     the <code>¶value</code> property of <var>J</var> is an instance of
-                     the sequence type defined by the <code>KeySpecifier</code>.</p></item>
+                     then the raw result is filtered to retain only those JNodes 
+                     whose <code>¶value</code> property is an instance of
+                     the sequence type defined by the <code>KeySpecifier</code>.</p>
+                  </item>
 
-                  <item><p>If the <code>KeySpecifier</code> is an NCName, then a 
-                     JNode <var>J</var> satisfies the <code>KeySpecifier</code> if and only if
-                     the <code>¶selector</code> property of <var>J</var> is equal to the NCName
-                     under the rules of the <function>atomic-equal</function> function.</p></item>
+                  <item><p>If the <code>KeySpecifier</code> is an NCName, then the raw
+                     result if filtered to retain only those JNodes whose <code>¶selector</code> property 
+                     is equal to the NCName
+                     under the rules of the <function>atomic-equal</function> function.</p>
+                     <note><p>There may be more than one such JNode in the case of a <code>JAxis</code>
+                     other than <code>child</code>.</p></note>
+                  </item>
            
                   <item><p>In all other cases the <code>KeySpecifer</code> is treated as an expression.
-                  It is evaluated in the current context and the result is atomized to deliver
-                  a sequence of atomic items.</p>
-                  <p>A JNode <var>J</var> satisfies the <code>KeySpecifer</code>
-                  if the <code>¶selector</code> property of <var>J</var> is equal to some atomic item
-                  in this sequence, under the rules of the <function>atomic-equal</function>
-                  function.</p></item>
+                  It is evaluated in the current context: call the result <code>$K</code>.</p>
+                     <p>The final result is then obtained from the raw result <code>$RR</code>
+                      by evaluating the expression:</p>
+                     <eg>
+for $k in data($K)
+return $RR[atomic-equal($k, selector(.))] 
+                     </eg>
+                     
+                        <note><p>This expression will never raise a type error, nor will it raise
+                        an error if an array index is out of bounds.</p></note>   
+                        
+                           
+                        <p>For example, the expression:</p>
+                           <eg>let $M := {1:10, 2:20, 3:30} return $M?child::(3, 1, 82)</eg>
+                        <p>returns JNodes representing the entries <code>3:30</code>
+                           and <code>1:10</code> in that order; the index <code>82</code>
+                        selects nothing.</p>
+                     </item>   
+                  
+                  
                </ulist>
                
-               <p>In the absence of an <code>JAxis</code>, an abbreviated lookup expression
-               is evaluated as follows:</p>
+               <p>The lookup operator <code>?</code> (unlike the path operator <code>/</code>)
+               does not force the results into document order, nor does it eliminate duplicates.
+               If this is required, it can be achieved by a call on the <code>distinct-ordered-nodes</code>
+               function (or more concisely, with the union operator: <code>$X|()</code> has the same effect
+               as <code>distinct-ordered-nodes($X)</code>).</p>
                
-               <ulist>
-                  <item><p><code>$C ? <var>KS</var></code> is evaluated as 
-                  <code>$C ? child::KS => unpin()</code></p></item>
-                  <item><p><code>$C ?? <var>KS</var></code> is evaluated as 
-                  <code>$C ? descendant::KS =!> unpin()</code></p></item>
-               </ulist>
+               <p>In the absence of an <code>JAxis</code>, a shallow lookup expression
+               <code>$C ? <var>KS</var></code> is evaluated as follows:</p> 
                
-               <p>The effect of the <function>unpin</function> call is to extract the 
-               <code>¶value</code> properties of the returned JNodes and deliver their
-               <termref def="dt-sequence-concatenation"/>.</p>
+               <eg>
+for $c in $C
+return if ($c instance of JNode())
+       then $c ? child::KS
+       else pin($c) ? child::KS =!> unpin()
+               </eg>
+               
+               <p>The effect of this is that when the left-hand operand of the expression
+               contains a JNode, the result will contain a JNode. But when the left-hand
+               operand is a simple (unpinned) map or array, the result will contain
+               simple values, flattened by <termref def="dt-sequence-concatenation"/>.</p>
                
                <note>
-                  <p>The effect of omitting the explicit axis is to lose information.
+                  <p>The effect of unpinning the result is to lose information.
                   This happens in two ways.
                   Firsly, no information is retained about the parent map or array,
                   or about the key that was used to make the selection, which means
@@ -20501,7 +20547,22 @@ processing with JSON processing.</p>
                   expression <code>[ 1, 2, (), 4 ] ? *</code> is the sequence
                   <code>( 1, 2, 4 )</code>, losing any information about the third
                   array member.</p>
+                  
+                  <p>This effect can be avoided in a number of ways:</p>
+                  
+                  <ulist>
+                     <item><p>Use of an explicit call on <function>pin</function>, 
+                     for example <code>pin($A)?K</code></p></item>
+                     <item><p>Use of an explicit axis, for example
+                     <code>$A?child::K</code></p></item>
+                     <item><p>Implicit pinning using the step <code>.</code>,
+                     for example <code>$A?.?K</code>. This is equivalent
+                     to <code>$A?self::*?K</code>, which (because it uses an
+                        explicit axis) ensures that the left-hand operand of the second <code>?</code>
+                     operator is a JNode.</p></item>
+                  </ulist>
                </note>
+               
                
                <p>The following examples use the <code>?</code> operator without a <code>JAxis</code>.
                   Given <code>$A</code> as an array
@@ -20528,8 +20589,18 @@ processing with JSON processing.</p>
                      </tr>                   
                      <tr>
                         <td><code>$A ? (3, 1)</code></td>
-                        <td><eg>("a", "b", "e", "f")</eg></td>
-                     </tr>                    
+                        <td><eg>("e", "f", "a", "b")</eg></td>
+                     </tr> 
+                     <tr>
+                        <td><code>$A ? 82</code></td>
+                        <td><eg>()</eg>
+                        <note><p>There is no array bound checking.</p></note></td>
+                     </tr> 
+                     <tr>
+                        <td><code>$A ? xyz</code></td>
+                        <td><eg>()</eg>
+                        <note><p>No type error is raised.</p></note></td>
+                     </tr>
                      <tr>
                         <td><code>$A ? ~[xs:integer]</code></td>
                         <td><eg>42</eg></td>
@@ -20560,7 +20631,7 @@ processing with JSON processing.</p>
                      </tr>
                      <tr>
                         <td><code>$M ? ("Z", "X")</code></td>
-                        <td><eg>( "a", "b", "e", "f",)</eg></td>
+                        <td><eg>("e", "f", "a", "b")</eg></td>
                      </tr>
                      <tr>
                         <td><code>$M ? ~[xs:integer]</code></td>
@@ -20592,10 +20663,17 @@ processing with JSON processing.</p>
                         <td><eg>20</eg></td>
                      </tr>
                      <tr>
-                        <td><code>$A ? descendant::c ? parent::* ? a</code></td>
+                        <td><code>data($A ? descendant::c ? parent::* ? a)</code></td>
                         <td><eg>2</eg></td>
                      </tr>
-                     
+                     <tr>
+                        <td><code>data($A ? descendant::c ? .. ? a)</code></td>
+                        <td><eg>2</eg></td>
+                     </tr>
+                     <tr>
+                        <td><code>$A ? ~[record(a, b, c)] ? c ? 2</code></td>
+                        <td><eg>20</eg></td>
+                     </tr>
                   </tbody>
                </table>
                
@@ -20641,21 +20719,17 @@ processing with JSON processing.</p>
   "previous-address": { "street": "12 Seaview Road", "postcode": "EX8 9AA" }
 }</eg>
 
-                     <p>then <code>?~[record(street, postcode)]?postcode</code>
+                     <p>then <code>? ~[record(street, postcode)] ? postcode</code>
                         returns <code>("MK12 2EX", "EX8 9AA")</code> (reflecting the 
                         <xtermref spec="DM40" ref="dt-entry-order"/> of the map).</p>
-                     <note><p>Writing <code>?*?postcode</code> would raise a type error, because the result of the initial
-                        step <code>?*</code> includes an item (the string <code>"John Smith"</code>) that is neither
-                        a map nor an array.</p></note>
+                     <note><p>Writing <code>? * ? postcode</code> would raise a type error, 
+                        because the result of the initial
+                        step <code>? *</code> includes an item (the string <code>"John Smith"</code>) 
+                        that is neither a map nor an array. Writing <code>?? postcode</code>
+                        avoids this problem.</p></note>
                   </item>
-                  <item diff="add" at="A">
+                  <item>
                      <p><code>?"first name"</code> is equivalent to <code>.("first name")</code></p>
-                  </item>
-                  
-                  <item role="xquery">
-                     <p>
-                        <code>?("$funky / &lt;looking @string")</code> is equivalent to
-                        <code>.("$funky / &lt;looking @string")</code>, an appropriate lookup for a map with rather odd conventions for keys.</p>
                   </item>
                   <item>
                      <p>
@@ -20668,7 +20742,9 @@ processing with JSON processing.</p>
                   </item>
                   <item>
                      <p>
-                        <code>?(3.5)</code> raises a type error if the context value is an array because the parameter must be an integer.</p>
+                        <code>?(3.0e0)</code> returns the same result as <code>?3</code>, because <code>xs:double(3.0e0)</code>
+                        and <code>xs:integer(3)</code> compare equal under the rules of the <function>atomic-equal</function>
+                        function.</p>
                   </item>
                   
                   <item role="xquery">
@@ -20725,11 +20801,18 @@ processing with JSON processing.</p>
                   No explicit JAxis is allowed, because the <code>descendant</code> JAxis
                   is implicit.</p>
                
+               <scrap>
+                  <prodrecap ref="DeepLookup"/>
+               </scrap>
+               
                <p>A deep lookup expression
                is evaluated as follows:</p>
                
                <p><code>$C ?? <var>KS</var></code> is equivalent to 
                   <code>$C ? descendant::KS =!> unpin()</code></p>
+               
+               <ednote><edtext>Should we drop the <code>unpin()</code>? The result is much more
+               useful if we can use it as a basis for further navigation.</edtext></ednote>
                
                <!--<p>First we define the <term>recursive content</term> of an item as follows:</p>
                

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -6069,8 +6069,8 @@ declare record Particle (
                   <prodrecap ref="JNodeType"/>
                </scrap>
                
-               <p>The form <code>JNode()</code> matches any JNode. The form
-               <code>JNode(<var>T</var>)</code> matches a JNode whose <term>·content·</term> is an instance
+               <p>The form <code>jnode()</code> matches any JNode. The form
+               <code>jnode(<var>T</var>)</code> matches a JNode whose <term>·content·</term> is an instance
                of the sequence type <var>T</var>.</p>
                
             </div3>
@@ -6518,11 +6518,11 @@ declare record Particle (
                            <p><var>A</var> is a <nt def="JNodeType">JNodeType</nt> and <var>B</var> is a <nt def="GNodeType">GNodeType</nt>.</p>
                         </item>
                         <item>
-                           <p><var>A</var> is <code>JNode(<var>T</var>)</code> and <var>B</var> is <code>JNode()</code>, for any sequence type 
+                           <p><var>A</var> is <code>jnode(<var>T</var>)</code> and <var>B</var> is <code>jnode()</code>, for any sequence type 
                               <var>T</var>.</p>
                         </item>
                         <item>
-                           <p><var>A</var> is <code>JNode(<var>T</var>)</code>, <var>B</var> is <code>JNode(<var>U</var>)</code>, 
+                           <p><var>A</var> is <code>jnode(<var>T</var>)</code>, <var>B</var> is <code>jnode(<var>U</var>)</code>, 
                               and <code>T ⊑ U</code>.</p>
                         </item>
                         <item>
@@ -11274,7 +11274,7 @@ return $lib?product((1.2, 1.3, 1.4))
          
          <p>An expression of the form <code>/<var>PP</var></code> (that is, a path expression
             with a leading <code>/</code>) is treated as an abbreviation for
-	 the expression <code>self::GNode()/(fn:root(.) treat as (document-node()|JNode())/<var>PP</var></code>. 
+	 the expression <code>self::gnode()/(fn:root(.) treat as (document-node()|jnode())/<var>PP</var></code>. 
             The effect of this expansion is that for every item <var>J</var> 
             in the context value <var>V</var>:</p>
 	 
@@ -11338,7 +11338,7 @@ return $lib?product((1.2, 1.3, 1.4))
 
          <p>An expression of the form <code>//<var>PP</var></code> (that is, a path expression
             with a leading <code>//</code>) is treated as an abbreviation for
-            the expression <code>self::GNode()/(fn:root(.) treat as (document-node()|JNode())/descendant-or-self::GNode()/<var>PP</var></code>. 
+            the expression <code>self::gnode()/(fn:root(.) treat as (document-node()|jnode())/descendant-or-self::gnode()/<var>PP</var></code>. 
             The effect of this expansion is that for every item <var>J</var> 
             in the context value <var>V</var>:</p>
 
@@ -11516,9 +11516,9 @@ return $lib?product((1.2, 1.3, 1.4))
                      <code>fn:distinct-ordered-nodes($R)</code> has the effect of 
                      eliminating duplicates and sorting nodes into document order):</p>
                   <eg><![CDATA[let $R := E1 ! E2
-return if (every $r in $R satisfies $r instance of GNode())
+return if (every $r in $R satisfies $r instance of gnode())
        then (fn:distinct-ordered-nodes($R))
-       else if (every $r in $R satisfies not($r instance of GNode()))
+       else if (every $r in $R satisfies not($r instance of gnode()))
        then $R
        else error()]]></eg>
                   <p>For a table comparing the step operator to the map operator, see <specref ref="id-map-operator"/>.</p>
@@ -11660,16 +11660,16 @@ return if (every $r in $R satisfies $r instance of GNode())
 			 axis is defined as the transitive closure of
 			 the child axis; it contains the descendants
 			 of the origin (the children, the children of the children, and so on).</p>
-                     <p>More formally, <code>$node/descendant::GNode()</code> delivers the result
-                     of <code>fn:transitive-closure($node, fn { child::GNode() })</code>.</p>
+                     <p>More formally, <code>$node/descendant::gnode()</code> delivers the result
+                     of <code>fn:transitive-closure($node, fn { child::gnode() })</code>.</p>
                      
                   </item>
                   
                   <item>
                      <p>The <code>descendant-or-self</code> axis contains the origin and the descendants 
                         of the origin.</p>
-                     <p>More formally, <code>$node/descendant-or-self::GNode()</code> delivers the result
-                     of <code>$node/(. | descendant::GNode())</code>.</p>
+                     <p>More formally, <code>$node/descendant-or-self::gnode()</code> delivers the result
+                     of <code>$node/(. | descendant::gnode())</code>.</p>
                   </item>
 
 
@@ -11697,8 +11697,8 @@ return if (every $r in $R satisfies $r instance of GNode())
                         contains the ancestors of the origin (the parent, the
                         parent of the parent, and so on).</p>
                      
-                     <p>More formally, <code>$node/ancestor::GNode()</code> delivers the result
-                     of <code>fn:transitive-closure($node, fn { parent::GNode() })</code>.</p>
+                     <p>More formally, <code>$node/ancestor::gnode()</code> delivers the result
+                     of <code>fn:transitive-closure($node, fn { parent::gnode() })</code>.</p>
 
                      <note>
                         <p>The ancestor axis includes the root GNode of the
@@ -11712,8 +11712,8 @@ return if (every $r in $R satisfies $r instance of GNode())
                      <p>The <code>ancestor-or-self</code> axis contains the origin and the ancestors of the origin;
 				            thus, the ancestor-or-self axis will always include the root.</p>
                      
-                     <p>More formally, <code>$node/ancestor-or-self::GNode()</code> delivers the result
-                     of <code>$node/(. | ancestor::GNode())</code>.</p>
+                     <p>More formally, <code>$node/ancestor-or-self::gnode()</code> delivers the result
+                     of <code>$node/(. | ancestor::gnode())</code>.</p>
                   </item>
 
 
@@ -11727,7 +11727,7 @@ return if (every $r in $R satisfies $r instance of GNode())
 			 is an attribute or namespace node, the
 			 <code>following-sibling</code> axis is
 			 empty.</p>
-                     <p>More formally, <code>$node/following-sibling::GNode()</code> delivers the result
+                     <p>More formally, <code>$node/following-sibling::gnode()</code> delivers the result
                      of <code>fn:siblings($node)[. >> $node])</code>.</p>
                   </item>
                   
@@ -11735,7 +11735,7 @@ return if (every $r in $R satisfies $r instance of GNode())
                      <p>The <code>following-sibling-or-self</code> axis contains the origin,
                      together with the contents of the <code>following-sibling</code> axis.</p>
                      
-                     <p>More formally, <code>$node/following-sibling-or-self::GNode()</code> delivers the result
+                     <p>More formally, <code>$node/following-sibling-or-self::gnode()</code> delivers the result
                      of <code><![CDATA[fn:siblings($node)[not(. << $node)]]]></code></p>
                   </item>
 
@@ -11751,14 +11751,14 @@ return if (every $r in $R satisfies $r instance of GNode())
 			 is an attribute or namespace node, the
 			 <code>preceding-sibling</code> axis is
 			 empty.</p>
-                     <p>More formally, <code>$node/preceding-sibling::GNode()</code> delivers the result
+                     <p>More formally, <code>$node/preceding-sibling::gnode()</code> delivers the result
                      of <code><![CDATA[fn:siblings($node)[. << $node]]]></code>.</p>
                   </item>
                   
                   <item>
                      <p>The <code>preceding-sibling-or-self</code> axis contains the origin,
                      together with the contents of the <code>preceding-sibling</code> axis.</p>
-                     <p>More formally, <code>$node/preceding-sibling-or-self::GNode()</code> delivers the result
+                     <p>More formally, <code>$node/preceding-sibling-or-self::gnode()</code> delivers the result
                      of <code><![CDATA[fn:siblings($node)[not(. >> $node)]]></code>.</p>
                   </item>
 
@@ -11774,16 +11774,16 @@ return if (every $r in $R satisfies $r instance of GNode())
 				and occur after the origin in
 				<termref def="dt-document-order">document order</termref>.
                      </p>
-                     <p>More formally, <code>$node/following::GNode()</code> delivers the result
-                     of <code>$node/ancestor-or-self::GNode()/following-sibling::GNode()/descendant-or-self::GNode()</code></p>
+                     <p>More formally, <code>$node/following::gnode()</code> delivers the result
+                     of <code>$node/ancestor-or-self::gnode()/following-sibling::gnode()/descendant-or-self::gnode()</code></p>
 
                   </item>
 
                   <item>
                      <p>The <code>following-or-self</code> axis contains the origin,
                      together with the contents of the <code>following</code> axis.</p>
-                     <p>More formally, <code>$node/following-or-self::GNode()</code> delivers the result
-                     of <code>$node/(. | following::GNode())</code>.</p>
+                     <p>More formally, <code>$node/following-or-self::gnode()</code> delivers the result
+                     of <code>$node/(. | following::gnode())</code>.</p>
                   </item>        
 
                   <item>
@@ -11797,16 +11797,16 @@ return if (every $r in $R satisfies $r instance of GNode())
 				<termref
                            def="dt-document-order">document order</termref>.
                      </p>
-                     <p>More formally, <code>$node/preceding::GNode()</code> delivers the result
-                     of <code>$node/ancestor-or-self::GNode()/preceding-sibling::GNode()/descendant-or-self::GNode()</code>.</p>
+                     <p>More formally, <code>$node/preceding::gnode()</code> delivers the result
+                     of <code>$node/ancestor-or-self::gnode()/preceding-sibling::gnode()/descendant-or-self::gnode()</code>.</p>
 
                   </item>
 
                   <item>
                      <p>The <code>preceding-or-self</code> axis returns the origin,
                      together with the contents of the <code>preceding</code> axis.</p>
-                     <p>More formally, <code>$node/preceding-or-self::GNode()</code> delivers the result
-                     of <code>$node/(. | preceding::GNode())</code>.</p>
+                     <p>More formally, <code>$node/preceding-or-self::gnode()</code> delivers the result
+                     of <code>$node/(. | preceding::gnode())</code>.</p>
                   </item>  
 
                   <item>
@@ -11829,7 +11829,7 @@ return if (every $r in $R satisfies $r instance of GNode())
                      <p>The <code>self</code> axis contains just the origin itself.</p>
                      <p>The <code>self</code> axis is primarily useful when testing whether the origin
                      satisfies particular conditions, for example <code>if ($x[self::chapter])</code>.</p>
-                     <p>More formally, <code>$node/self::GNode()</code> delivers the result
+                     <p>More formally, <code>$node/self::gnode()</code> delivers the result
                      of <code>$node</code>.</p>
                   </item>
 
@@ -12946,10 +12946,10 @@ selects all descendant <code>para</code> elements that are the first <code>para<
                   <p>A step consisting
 of <code role="parse-test">..</code> is short
 for <code
-                        role="parse-test">parent::GNode()</code>. For example (assuming the context
+                        role="parse-test">parent::gnode()</code>. For example (assuming the context
                      item is an XNode), <code
                         role="parse-test">../title</code> is short for <code role="parse-test"
-                        >parent::GNode()/child::title</code> and so will select the 
+                        >parent::gnode()/child::title</code> and so will select the 
                      <code>title</code> children of the parent of the context node.</p>
                   
                   <p>Similarly, if <code>$dateOfBirth</code> is a JNode resulting from the expression
@@ -13614,7 +13614,7 @@ the results are the same.
             <p>The following example demonstrates the use of the <code>except</code> operator
             with JNodes:</p>
             
-            <eg>let $m := JNode($map)
+            <eg>let $m := jnode($map)
 for $e in $m/child::* except $m/child::xx 
 return ...</eg>
             
@@ -20924,7 +20924,7 @@ processing with JSON processing.</p>
                   <code>$m?code = 3</code> and <code>$m/code = 3</code> have the same effect.
                   Path expressions, however, have more power, and with it, more complexity.
                   The expression <code>$m/code = 3</code> (unless simplified by an optimizer)
-                  effectively expands the expression to <code>(JNode($m)/child::get("code") => JNode-value()) = 3</code>:
+                  effectively expands the expression to <code>(jnode($m)/child::get("code") => JNode-value()) = 3</code>:
                   that is, the supplied map is wrapped in a JNode, the child axis returns a sequence of JNodes,
                   and the <term>·content·</term> properties of these JNodes are compared with the
                   supplied value <code>3</code>.</p>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -10994,13 +10994,12 @@ let $rectangle := {
                
                <p>The dynamic function call <code>$rectangle?area()</code> returns <code>12</code>.</p>
                
-               <p>The detailed rule is as follows: When the lookup operator <code>?</code> or <code>??</code>
+               <p>The detailed rule is as follows: When the lookup operator <code>?</code>
                   is applied to a map <var>M</var> (see <specref ref="id-lookup"/>), 
-                     and all the following conditions apply:</p>
+                     and both the following conditions apply:</p>
                
                <ulist>
-                  <item><p>The <code>Modifier</code> in the lookup expression is <code>items</code>,
-                  explicitly or by default;</p></item>
+         
                   <item><p>The <code>KeySpecifier</code> in the lookup expression is an
                   <code>NCName</code> or <code>StringLiteral</code>;</p></item>
                   <item><p>The lookup expression selects a <termref def="dt-singleton"/> value that
@@ -11342,8 +11341,11 @@ return $lib?product((1.2, 1.3, 1.4))
          <p>The results of these multiple evaluations are then combined into a single sequence;
             if the result is a set of GNodes, the GNodes are delivered in document order with
             duplicates eliminated.</p>
+            
+            <p>Any map or array that is present in the context value is first
+            coerced to a JNode by applying the <function>JNode</function> function.</p>
          
-         <p>If the context value is not a sequence of GNodes, a
+         <p>If (after this coercion) the context value is not a sequence of GNodes, a
 	 <termref
                def="dt-type-error">type error</termref> is
 	 raised <errorref class="TY" code="0020"
@@ -11448,7 +11450,9 @@ return $lib?product((1.2, 1.3, 1.4))
                   (in document order, with no duplicates), or a sequence of non-GNodes.</p>
 
                <p>The operation <code><var>E1</var>/<var>E2</var></code> is evaluated as follows: Expression <var>E1</var> 
-                  is evaluated, and if the result is not a (possibly empty) sequence <var>S</var> of GNodes, 
+                  is evaluated. Any maps or arrays in the result are converted to JNodes
+                  by applying the <function>JNode</function> function. If the result is not a 
+                  (possibly empty) sequence <var>S</var> of GNodes, 
                   a <termref def="dt-type-error">type error</termref> is raised <errorref class="TY"
                      code="0019"
                      />. Each GNode in <var>S</var> then serves in turn to provide an inner focus 
@@ -20690,10 +20694,10 @@ processing with JSON processing.</p>
                      map keys are strings other than NCNames. It can also be followed by a variable
                      reference.
                </change>
-               <change issue="297" PR="837" date="2023-11-23">
+               <!--<change issue="297" PR="837" date="2023-11-23">
                   A deep lookup operator <code>??</code> is provided for searching
                   trees of maps and arrays.
-               </change>
+               </change>-->
                <!--<change issue="960 1094" PR="1125" date="2024-04-23">
                   Lookup expressions can now take a modifier (such as <code>keys</code>,
                   <code>values</code>, or <code>pairs</code>) enabling them to return
@@ -20703,27 +20707,27 @@ processing with JSON processing.</p>
                </change>-->
                <change issue="1800 1845" PR="1817 1853" date="2025-03-04">An inline function may be annotated
                as a <code>%method</code>, giving it access to its containing map.</change>
-               <change issue="1456 1866" PR="1864 1877">
+               <!--<change issue="1456 1866" PR="1864 1877">
                   The key specifier can reference an item type or sequence type, to select
                   values of that type only. This is especially useful when processing
                   trees of maps and arrays, as encountered when processing JSON input.
-               </change>
-               <change issue="2025" PR="2031" date="2025-06-13">
+               </change>-->
+               <!--<change issue="2025" PR="2031" date="2025-06-13">
                   The "?" operator can now be followed by an axis step, such as <code>child::*</code>
                   or <code>descendant::*</code>. This returns a sequence of JNodes, which
                   allow access to the key used for selection, and to parents and ancestors 
                   in the selection tree; it also avoids flattening the result sequence.
-               </change>
+               </change>-->
             </changes>
 
-            <p>&language; provides two lookup operators <code>?</code> and <code>??</code>
+            <!--<p>&language; provides two lookup operators <code>?</code> and <code>??</code>
                for maps and arrays. These provide a terse syntax
                for accessing the entries in a map or the members of an array.</p>
-            
-            <p diff="add" at="2023-11-15">The operator "?", known as the shallow lookup operator,
-               returns values found immediately in the operand map or array. The operator "??",
+            -->
+            <p diff="add" at="2023-11-15">The operator "?", known as the lookup operator,
+               returns values found in the operand map or array.<!-- The operator "??",
             known as the deep lookup operator, also searches nested maps and arrays. The effect of the
-            deep lookup operator "??" is explained in <specref ref="id-deep-lookup"/>.</p>
+            deep lookup operator "??" is explained in <specref ref="id-deep-lookup"/>.--></p>
             
          
 
@@ -20736,12 +20740,11 @@ processing with JSON processing.</p>
                   <prodrecap ref="LookupExpr"/>
                </scrap>
                
-               <p>A postfix <code>Lookup</code> has three parts: the left hand operand
-                  selects maps or arrays to be searched. The <code>JAxis</code>
-                  defines the scope of a search for the required data, and
+               <p>A postfix <code>Lookup</code> has two parts: the left hand operand
+                  selects maps or arrays to be searched, and
                   the <code>KeySelector</code> defines the search criteria.</p>
                
-               <p>First a very simple example: given an array <code>$A</code> of maps:</p>
+               <p>First a simple example: given an array <code>$A</code> of maps:</p>
                
                <eg>[ { "John": 3, "Jill": 5}, {"Peter": 8, "Mary": 6} ]</eg>
                
@@ -20755,7 +20758,14 @@ processing with JSON processing.</p>
                   <item><p><code>$A ?? ~[xs:integer]</code> returns <code>(3, 5, 8, 6)</code></p></item>-->
                </ulist>
                
-               <p>The above examples do not include a <code>JAxis</code>. For purposes of exposition,
+               <p>The value of the left-hand operand must be a sequence of maps or arrays
+               (but if it includes JNodes, these will be coerced to maps or arrays
+               by extracting the <code>¶value</code> property of the JNode). The lookup
+               operation is applied independently to each of these maps or arrays,
+               and the final expression result is the <termref def="dt-sequence-concatenation"/>
+               of the individual results.</p>
+               
+               <!--<p>The above examples do not include a <code>JAxis</code>. For purposes of exposition,
                however, we will consider cases in the following order:</p>
                
                <ulist>
@@ -20763,9 +20773,9 @@ processing with JSON processing.</p>
                   <item><p><specref ref="id-keyspecifiers"/></p></item>
                   <item><p><specref ref="id-abbreviated-lookup"/></p></item>
                   <item><p><specref ref="id-lookup-sans-jaxis"/></p></item>
-               </ulist>
+               </ulist>-->
                
-               <div5 id="id-lookup-with-jaxis">
+               <!--<div5 id="id-lookup-with-jaxis">
                   <head>Lookup Expressions using a JAxis</head>
                   
                
@@ -20861,31 +20871,82 @@ return
             
                </ulist>
                   
-               </div5>
-               
-               <div5 id="id-keyspecifiers">
-                  <head>Key Specifiers</head>
+               </div5>-->
                
                
                
-               <p>The <code>KeySpecifier</code> filters and potentially reorders the sequence
-                  of JNodes selected by the axis (referred to below as the <term>raw result</term>), 
-                  as follows:</p>
+               
+               <p>The <code>KeySpecifier</code> determines which values are selected from the
+                  map or array.</p>
+               
+               <p>For an array <var>$A</var>:</p>
                
                <ulist>
                   <item><p>If the <code>KeySpecifier</code> is a <code>LookupWildcard</code>
-                     (that is, <code>*</code>)
-                     then the raw result is returned unchanged.</p></item>
+                     (that is, <code>*</code>), the result is the <termref def="dt-sequence-concatenation"/>
+                     of the members of <var>$A</var>: that is, <code>array:items($A)</code>.</p></item>
                   
-                  <item><p>If the <code>KeySpecifier</code> is a <code>TypeSpecifier</code>, 
+                  <item><p>If the <code>KeySpecifier</code> is an NCName, a type error 
+                     <errorref class="TY" code="0004"/> is raised.</p></item>
+                  
+                  <item><p>In all other cases the <code>KeySpecifier</code> is treated
+                     as an expression, which is evaluated in the current context to return a value <var>$K</var>.
+                     The result of the lookup is then equivalent to</p>
+                     
+                     <eg>$K ! array:get($A, .)</eg>
+                        
+                     <note><p>This results in a dynamic error if the array index is out of bounds.</p></note> 
+                     <note><p>The order of the results corresponds to the order of the values
+                        in <code>$K</code>. For example, <code>["a", "b", "c"]?(3, 2, 1)</code>
+                     returns <code>("c", "b", "a")</code>.</p></note> 
+                  </item>
+                  
+               </ulist>
+               
+               <p>For a map <var>$M</var>:</p>
+               
+               <ulist>
+                  <item><p>If the <code>KeySpecifier</code> is a <code>LookupWildcard</code>
+                     (that is, <code>*</code>), the result is the <termref def="dt-sequence-concatenation"/>
+                     of the values in the entries of <var>$M</var>, retaining map order: 
+                     that is, <code>map:items($M)</code>.</p></item>
+                  
+                  <item><p>If the <code>KeySpecifier</code> is an NCName, it is treated as
+                     if the NCName were in quotation marks, for example <code>$M?code</code>
+                     is equivalent to <code>$M?"code"</code>.</p></item>
+                  
+                  <item><p>In all other cases the <code>KeySpecifier</code> is treated
+                     as an expression, which is evaluated in the current context to return a value <var>$K</var>.
+                     The result of the lookup is then equivalent to</p>
+                     
+                     <eg>$K ! map:get($A, .)</eg>
+                        
+                     <note><p>No error occurs in respect of a key that is not present in the map.</p></note> 
+                     <note><p>The order of the results corresponds to the order of the values
+                        in <code>$K</code>. For example, <code>{"a":1, "b":2} ? ("b", "a")</code>
+                     returns <code>(2, 1)</code>.</p></note> 
+                  </item>
+                  
+                  <item>
+                     <p>In addition to the above processing, if the <code>KeySpecifier</code>
+                     is written as an <code>NCName</code> or a string literal, and the
+                     value of the corresponding map entry is a function item annotated
+                     as a <code>%method</code> (see <specref ref="id-methods"/>) then
+                     the returned function item is modified by giving it a captured
+                     context that includes the containing map as the context item.</p>
+                  </item>
+                  
+               
+                  
+                  <!--<item><p>If the <code>KeySpecifier</code> is a <code>TypeSpecifier</code>, 
                      then the raw result is filtered to retain only those JNodes 
                      whose <code>¶value</code> property is an instance of
                      the sequence type defined by the <code>KeySpecifier</code>.</p>
                      <p>For example, the expression <code>$array?child::~[array(*)]</code>
                      selects only those members of an array that are themselves arrays.</p>
-                  </item>
+                  </item>-->
 
-                  <item><p>If the <code>KeySpecifier</code> is an NCName, then the raw
+                  <!--<item><p>If the <code>KeySpecifier</code> is an NCName, then the raw
                      result is filtered to retain only those JNodes whose <code>¶selector</code> property 
                      is equal to the NCName
                      under the rules of the <function>atomic-equal</function> function.</p>
@@ -20894,44 +20955,51 @@ return
                      exists.</p>
                      <note><p>There may be more than one such JNode in the case of a <code>JAxis</code>
                      other than <code>child</code>.</p></note>
-                  </item>
+                  </item>-->
            
-                  <item><p>In all other cases the <code>KeySpecifer</code> is treated as an expression.
-                  It is evaluated in the current context: call the result <code>$K</code>.</p>
-                     <p>The final result is then obtained from the raw result <code>$RR</code>
-                      by evaluating the expression:</p>
-                     <eg>
-for $k in data($K)
-return $RR[atomic-equal($k, JNode-selector(.))] 
-                     </eg>
-                     
-                        <note><p>This expression will never raise a type error, nor will it raise
-                        an error if an array index is out of bounds.</p></note>   
-                        
-                           
-                        <p>For example, the expression:</p>
-                           <eg>let $M := {1:10, 2:20, 3:30} return $M?child::(3, 1, 82)</eg>
-                        <p>returns JNodes representing the entries <code>3:30</code>
-                           and <code>1:10</code> in that order; the index <code>82</code>
-                        selects nothing.</p>
-                     
-                        <note><p>In a practical implementation one might reasonably expect
-                        that the entry for a particular key in a map can be accessed without
-                        a sequential search of all entries, as this pseudo-code would suggest.</p></note>
-                     </item>   
+                    
                   
                   
                </ulist>
                
-               <p>The lookup operator <code>?</code> (unlike the path operator <code>/</code>)
+               <p>Examples:</p>
+
+               <ulist>
+                  <item>
+                     <p>
+                        <code>[ 1, 2, 5, 7 ]?*</code> evaluates to <code>(1, 2, 5, 7)</code>.</p>
+                  </item>
+                  <item>
+                     <p>
+                        <code>[ [ 1, 2, 3 ], [ 4, 5, 6 ] ]?*</code> evaluates to <code>([ 1, 2, 3 ], [ 4, 5, 6 ])</code>
+                     </p>
+                  </item>
+                  <item>
+                     <p>
+
+                        <code>[ [ 1, 2, 3 ], 4, 5 ]?*[. instance of array(xs:integer)]</code> evaluates to <code>([ 1, 2, 3 ])</code>
+                        </p>
+                  </item>
+                  <item>
+                     <p>
+                        <code>[ [ 1, 2, 3 ], [ 4, 5, 6 ], 7 ]?*[. instance of array(*)]?2</code> evaluates to <code>(2, 5)</code>
+                     </p>
+                  </item>
+                  <item>
+                     <p>
+                        <code>[ [ 1, 2, 3 ], 4, 5 ]?*[. instance of xs:integer]</code> 
+                        evaluates to <code>(4, 5)</code>.
+                     </p>
+                  </item>
+               </ulist>
+               <!--<p>The lookup operator <code>?</code> (unlike the path operator <code>/</code>)
                does not force the results into document order, nor does it eliminate duplicates.
                If this is required, it can be achieved by a call on the <function>distinct-ordered-nodes</function>
                function (or more concisely, with the union operator: <code>$X|()</code> has the same effect
-               as <code>distinct-ordered-nodes($X)</code>).</p>
+               as <code>distinct-ordered-nodes($X)</code>).</p>-->
                   
-               </div5>
                
-               <div5 id="id-abbreviated-lookup">
+               <!--<div5 id="id-abbreviated-lookup">
                   <head>Abbreviated Lookup Expressions</head>
                   
                   
@@ -20947,9 +21015,152 @@ return $RR[atomic-equal($k, JNode-selector(.))]
                   the result of <code>fn:JNode($A)</code>. If <code>$A</code> is a sequence containing
                   multiple items, it returns the sequence concatenation of the result.</p>
                   
-               </div5>
+               </div5>-->
+            </div4>
+               <div4 id="id-unary-lookup">
+               <head>Unary Lookup</head>
                
-               <div5 id="id-lookup-sans-jaxis">
+               <scrap>
+                  <prodrecap ref="UnaryLookup"/>
+               </scrap>
+               
+               
+               
+               <p>Unary lookup is most commonly used in predicates (for example, <code>$map[?name = 'Mike']</code>)
+                  or with the simple map operator (for example, <code>avg($maps ! (?price - ?discount))</code>).</p>
+               
+               <p>The unary lookup expression <code>?KS</code> is defined to be equivalent to the postfix lookup
+                  expression <code>.?KS</code>, which has the context value (<code>.</code>) as the implicit first operand.
+                  See <specref ref="id-postfix-lookup"/> for the postfix lookup operator.</p>
+               
+               <!--<p>Similarly, <code>?.</code> is equivalent to <code>.?.</code>, 
+               <code>?..</code> is equivalent to <code>.?..</code>, and <code>?<var>KS</var></code> (where 
+               <var>KS</var> is some <code>KeySpecifier</code>) is equivalent to
+               <code>.?<var>KS</var></code>.</p>
+               -->
+               
+               <p>Examples:</p>
+               
+               <ulist>
+                  <item>
+                     <p>
+                        <code>?name</code> is equivalent to <code>.("name")</code>, an appropriate lookup for a map.</p>
+                  </item>
+                  <item>
+                     <p>
+                        <code>?2</code> is equivalent to <code>.(2)</code>, an appropriate lookup for an array or an integer-valued map.</p>
+                  </item>
+                  <!--<item>
+                     <p>If the context item is the result of parsing the JSON input:</p>
+                     <eg>{
+  "name": "John Smith",
+  "address": { "street": "18 Acacia Avenue", "postcode": "MK12 2EX" },
+  "previous-address": { "street": "12 Seaview Road", "postcode": "EX8 9AA" }
+}</eg>
+
+                     <p>then <code>? ~[record(street, postcode)] ? postcode</code>
+                        returns <code>("MK12 2EX", "EX8 9AA")</code> (reflecting the 
+                        <xtermref spec="DM40" ref="dt-entry-order"/> of the map).</p>
+                     <note><p>Writing <code>? * ? postcode</code> would raise a type error, 
+                        because the result of the initial
+                        step <code>? *</code> includes an item (the string <code>"John Smith"</code>) 
+                        that is neither a map nor an array. Adding the <code>TypeSpecifier</code>
+                        avoids this problem.</p></note>
+                  </item>-->
+                  <item>
+                     <p><code>?"first name"</code> is equivalent to <code>.("first name")</code></p>
+                  </item>
+                  <item>
+                     <p>
+                        <code>?($a)</code> and <code>?$a</code> are 
+                        equivalent to <code>for $k in $a return .($k)</code>, 
+                        allowing keys for an array or map to be passed using a variable.</p>
+                  </item>
+                  <item>
+                     <p>
+                        <code>?(2 to 4)</code> is equivalent to <code>for $k in (2, 3, 4) return .($k)</code>, 
+                        a convenient way to return a range of values from an array.</p>
+                  </item>
+                  <item>
+                     <p>
+                        <code>?(3.0e0)</code> returns the same result as <code>?3</code>, because <code>xs:double(3.0e0)</code>
+                        and <code>xs:integer(3)</code> compare equal under the rules of the <function>atomic-equal</function>
+                        function.</p>
+                  </item>
+                  
+                  <item role="xquery">
+                     <p>If the context value is an array, <code>let $x:= &lt;node i="3"/&gt; return ?($x/@i)</code> 
+                        does not raise a type error, because the attribute is untyped.</p>
+                     <p>But <code>let $x:= &lt;node i="3"/&gt; return ?($x/@i+1)</code> does raise a type error
+                        because the <code>+</code> operator with an untyped operand returns a double.</p>
+                  </item>
+                  <item>
+                     <p>
+                        <code>([ 1, 2, 3 ], [ 1, 2, 5 ], [ 1, 2 ])[?3 = 5]</code> raises an error,
+                        because <code>?3</code> applied to one of the
+                        items in the sequence fails.</p>
+                  </item>
+                  <item>
+                     <p>If <code>$m</code> is bound to the weekdays map described in <specref
+                        ref="id-maps"
+                     />, then <code>$m?*</code> returns the values <code>("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday")</code>, in <termref
+                        def="dt-implementation-dependent"
+                        >implementation-dependent</termref> order.</p>
+                  </item>
+                  
+               </ulist>
+               
+            </div4>
+               
+               <div4 id="id-lookup-vs-path-expressions">
+                  <head>Comparing Lookup and Path Expressions</head>
+                  
+                  <p>Lookup expressions are retained in this specification with only
+                  minor changes from the previous version 3.1. They remain a convenient
+                  solution for simple lookups of entries in maps and arrays.</p>
+                  
+                  <p>For more complex queries into trees of maps and arrays, &language;
+                  introduces a generalization of path expressions (see <specref ref="id-path-expressions"/>)
+                  which can now handle <termref def="dt-JTree">JTrees</termref> 
+                     as well as <termref def="dt-XTree">XTrees</termref>.</p>
+                  
+                  <p>For simple expressions, the capabilities of the two constructs overlap.
+                  For example, if <code>$m</code> is a map, then the expressions
+                  <code>$m?code = 3</code> and <code>$m/code = 3</code> have the same effect.
+                  Path expressions, however, have more power, and with it, more complexity.
+                  The expression <code>$m/code = 3</code> (unless simplified by an optimizer)
+                  effectively expands the expression to <code>(JNode($m)/child::get("code") => JNode-value()) = 3</code>:
+                  that is, the supplied map is wrapped in a JNode, the child axis returns a sequence of JNodes,
+                  and the <code>¶value</code> properties of these JNodes are compared with the
+                  supplied value <code>3</code>.</p>
+                  
+                  <p>Whereas simple lookups of specific entries in maps and arrays work well,
+                  experience has shown that the <code>?*</code> wildcard lookup can be problematic.
+                  This is because of the flattening effect: for example, given the array
+                  <code>let $A := [(1,2), (3,4), (), 5]</code> the result of the expression
+                  <code>$A?*</code> is the sequence <code>(1, 2, 3, 4, 5)</code> which loses information
+                  that might be needed for further processing. By contrast, the path expression
+                  <code>$A/*</code> (or <code>$A/child::*</code>) returns a sequence of four
+                  JNodes, whose <code>¶value</code> properties are respectively <code>(1,2)</code>, 
+                     <code>(3,4)</code>, <code>()</code>, and <code>5</code>.</p>
+                  
+                  <p>The result of a lookup expression is a simple value (the value of an entry in a map
+                  or a member of an array, or the <termref def="dt-sequence-concatenation"/> of 
+                  several such values). By contrast, the result of a path expression applied to maps
+                  or arrays is always a sequence of JNodes. These JNodes can be used for further
+                  navigation. If only the <code>¶value</code> properties of the JNodes are 
+                  needed, these will usually be extracted automatically by virtue of the
+                  <termref def="dt-coercion-rules"/>: for example if the value is used in an
+                  arithmetic expression or a value comparison, atomization of the JNode
+                  automatically extracts its <code>¶value</code>. In other cases the value can
+                  be extracted explicitly by a call of the <function>JNode-value</function> function.</p>
+                  
+                  <p>Method lookup (see <specref ref="id-methods"/>), as in the expression 
+                     <code>$rectangle?area()</code> works only with the lookup operator and
+                     not with path expressions.</p>
+               </div4>
+               
+               <!--<div5 id="id-lookup-sans-jaxis">
                   <head>Lookup Expressions with no Explicit JAxis</head>
                
                
@@ -21119,129 +21330,15 @@ return if ($c instance of JNode())
                   </tbody>
                </table>
                
-               </div5>
+               </div5>-->
            
-            </div4>   
+              
                
                
             
-            <div4 id="id-unary-lookup">
-               <head>Unary Lookup</head>
-               
-               <scrap>
-                  <prodrecap ref="UnaryLookup"/>
-               </scrap>
-               
-               
-               
-               <p>Unary lookup is most commonly used in predicates (for example, <code>$map[?name = 'Mike']</code>)
-                  or with the simple map operator (for example, <code>avg($maps ! (?price - ?discount))</code>).</p>
-               
-               <p>The unary lookup expression <code>?axis::KS</code> is defined to be equivalent to the postfix lookup
-                  expression <code>.?axis::KS</code> which has the context value (<code>.</code>) as the implicit first operand.
-                  See <specref ref="id-postfix-lookup"/> for the postfix lookup operator.</p>
-               
-               <p>Similarly, <code>?.</code> is equivalent to <code>.?.</code>, 
-               <code>?..</code> is equivalent to <code>.?..</code>, and <code>?<var>KS</var></code> (where 
-               <var>KS</var> is some <code>KeySpecifier</code>) is equivalent to
-               <code>.?<var>KS</var></code>.</p>
-               
-               
-               <p>Examples:</p>
-               
-               <ulist>
-                  <item>
-                     <p>
-                        <code>?name</code> is equivalent to <code>.("name")</code>, an appropriate lookup for a map.</p>
-                  </item>
-                  <item>
-                     <p>
-                        <code>?2</code> is equivalent to <code>.(2)</code>, an appropriate lookup for an array or an integer-valued map.</p>
-                  </item>
-                  <item>
-                     <p>If the context item is the result of parsing the JSON input:</p>
-                     <eg>{
-  "name": "John Smith",
-  "address": { "street": "18 Acacia Avenue", "postcode": "MK12 2EX" },
-  "previous-address": { "street": "12 Seaview Road", "postcode": "EX8 9AA" }
-}</eg>
-
-                     <p>then <code>? ~[record(street, postcode)] ? postcode</code>
-                        returns <code>("MK12 2EX", "EX8 9AA")</code> (reflecting the 
-                        <xtermref spec="DM40" ref="dt-entry-order"/> of the map).</p>
-                     <note><p>Writing <code>? * ? postcode</code> would raise a type error, 
-                        because the result of the initial
-                        step <code>? *</code> includes an item (the string <code>"John Smith"</code>) 
-                        that is neither a map nor an array. Adding the <code>TypeSpecifier</code>
-                        avoids this problem.</p></note>
-                  </item>
-                  <item>
-                     <p><code>?"first name"</code> is equivalent to <code>.("first name")</code></p>
-                  </item>
-                  <item>
-                     <p>
-                        <code>?($a)</code> <phrase diff="add" at="A">and <code>?$a</code> are</phrase> 
-                        equivalent to <code>for $k in $a return .($k)</code>, allowing keys for an array or map to be passed using a variable.</p>
-                  </item>
-                  <item>
-                     <p>
-                        <code>?(2 to 4)</code> is equivalent to <code>for $k in (2, 3, 4) return .($k)</code>, a convenient way to return a range of values from an array.</p>
-                  </item>
-                  <item>
-                     <p>
-                        <code>?(3.0e0)</code> returns the same result as <code>?3</code>, because <code>xs:double(3.0e0)</code>
-                        and <code>xs:integer(3)</code> compare equal under the rules of the <function>atomic-equal</function>
-                        function.</p>
-                  </item>
-                  
-                  <item role="xquery">
-                     <p>If the context value is an array, <code>let $x:= &lt;node i="3"/&gt; return ?($x/@i)</code> does not raise a type error because the attribute is untyped.</p>
-                     <p>But <code>let $x:= &lt;node i="3"/&gt; return ?($x/@i+1)</code> does raise a type error
-                        because the <code>+</code> operator with an untyped operand returns a double.</p>
-                  </item>
-                  <item>
-                     <p>
-                        <code>([ 1, 2, 3 ], [ 1, 2, 5 ], [ 1, 2 ])[?3 = 5]</code> raises an error because <code>?3</code> on one of the
-                        items in the sequence fails.</p>
-                  </item>
-                  <item>
-                     <p>If <code>$m</code> is bound to the weekdays map described in <specref
-                        ref="id-maps"
-                     />, then <code>$m?*</code> returns the values <code>("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday")</code>, in <termref
-                        def="dt-implementation-dependent"
-                        >implementation-dependent</termref> order.</p>
-                  </item>
-                  <item>
-                     <p>
-                        <code>[ 1, 2, 5, 7 ]?*</code> evaluates to <code>(1, 2, 5, 7)</code>.</p>
-                  </item>
-                  <item>
-                     <p>
-                        <code>[ [ 1, 2, 3 ], [ 4, 5, 6 ] ]?*</code> evaluates to <code>([ 1, 2, 3 ], [ 4, 5, 6 ])</code>
-                     </p>
-                  </item>
-                  <item>
-                     <p>
-
-                        <code>[ [ 1, 2, 3 ], 4, 5 ]?*[. instance of array(xs:integer)]</code> evaluates to <code>([ 1, 2, 3 ])</code>
-                        </p>
-                  </item>
-                  <item>
-                     <p>
-                        <code>[ [ 1, 2, 3 ], [ 4, 5, 6 ], 7 ]?*[. instance of array(*)]?2</code> evaluates to <code>(2, 5)</code>
-                     </p>
-                  </item>
-                  <item>
-                     <p>
-                        <code>[ [ 1, 2, 3 ], 4, 5 ]?*[. instance of xs:integer]</code> 
-                        evaluates to <code>(4, 5)</code>.
-                     </p>
-                  </item>
-               </ulist>
-               
-            </div4>
             
-            <div4 id="id-deep-lookup" diff="add" at="2023-11-15">
+            
+            <!--<div4 id="id-deep-lookup" diff="add" at="2023-11-15">
                <head>Deep Lookup</head>
                
                <p>The deep lookup operator <code>??</code> has both unary and postfix forms.
@@ -21308,7 +21405,7 @@ return if ($c instance of JNode())
                   
                   
                
-               <!--<note>
+               <!-\-<note>
 
                   <p>This means that with the example given earlier:</p>
                   <ulist>
@@ -21336,7 +21433,7 @@ return if ($c instance of JNode())
                      contrast, the semantics are defined in terms of a map lookup, in which 
                      <code>xs:untypedAtomic</code> items are always treated as strings.
                   </p>
-               </note>-->
+               </note>-\->
                <note>
                   <p>The definition of the <code>recursive-content</code> function is such that items
                   in the top-level value that are not maps or arrays are ignored, whereas items that
@@ -21542,7 +21639,7 @@ return `{$from} to {$to}`</eg>
                      </tbody>
                   </table>
                </example>
-            </div4>
+            </div4>-->
             
             <div4 id="id-implausible-lookup-expressions" diff="add" at="Issue602">
                <head>Implausible Lookup Expressions</head>

--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -3772,6 +3772,7 @@ according to the <bibref ref="JSON-LINES"/> format, as described in <specref ref
     </change>
     <change issue="2059" PR="TODO" date="2025-06-23">
       The output of QNames reflects the new syntax for QName literals.
+    </change>
     <change issue="2025" PR="2031" date="2025-05-29">
       A JNode is replaced by its <code>¶value</code> property.
     </change>

--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -488,49 +488,53 @@ The steps in computing the normalized sequence are:
 </p>
       <!--End of text replaced by erratum E6-->
 <olist>
-<item><p>Create a new sequence <var>S1</var> from <var>S0</var> as follows. For
-each item in <var>S0</var>, if the item is an array, copy the results of
-passing the item into the function <code>array:flatten()</code>; otherwise, copy the item
-itself. If <var>S0</var> is empty, let <var>S1</var> consist
-of a zero-length string. </p></item>
+  <item><p>Create a new sequence <var>S1</var> from <var>S0</var> as follows. For
+each item in <var>S0</var>, if the item is a JNode, copy the <code>¶value</code>
+    property of the item; otherwise, copy the item itself.</p></item>
+  
 <item><p>Create a new sequence <var>S2</var> from <var>S1</var> as follows. For
-each item in <var>S1</var>, if the item is atomic, copy to <var>S2</var> only the lexical
+each item in <var>S1</var>, if the item is an array, copy the results of
+passing the item into the function <code>array:flatten()</code>; otherwise, copy the item
+itself. If <var>S1</var> is empty, let <var>S2</var> consist
+of a zero-length string. </p></item>
+<item><p>Create a new sequence <var>S3</var> from <var>S2</var> as follows. For
+each item in <var>S3</var>, if the item is atomic, copy to <var>S3</var> only the lexical
 representation resulting from casting the item to an <code role="SCHEMATYPE">xs:string</code>, otherwise, 
-copy the item to <var>S2</var>.</p></item>
+copy the item to <var>S3</var>.</p></item>
 <item>
-<p>Create a new sequence <var>S3</var> from <var>S2</var> as follows. If the
+<p>Create a new sequence <var>S4</var> from <var>S3</var> as follows. If the
 <code>item-separator</code> serialization parameter is present, then copy each item in
-<var>S2</var> to <var>S3</var>, inserting between each pair of items
+<var>S3</var> to <var>S4</var>, inserting between each pair of items
 a string whose value is equal to the value of the item-separator parameter. If the
 <code>item-separator</code> serialization parameter is not present, then first maximally 
-group the items in <var>S2</var> into subsequences of <code role="SCHEMATYPE">xs:string</code> items 
+group the items in <var>S3</var> into subsequences of <code role="SCHEMATYPE">xs:string</code> items 
 and non-<code role="SCHEMATYPE">xs:string</code> items. For each group of items, if the group is a subsequence of
 non-<code role="SCHEMATYPE">xs:string</code> items, copy the subsequence to
-<var>S3</var>; if the group is a subsequence of <code role="SCHEMATYPE">xs:string</code> 
-items, copy to <var>S3</var> the results of passing to
+<var>S4</var>; if the group is a subsequence of <code role="SCHEMATYPE">xs:string</code> 
+items, copy to <var>S4</var> the results of passing to
 <code>fn:string-join()</code> the subsequence and the value of
 <code>item-separator</code> as the function’s two parameters. </p></item>
-<item><p>Create a new sequence <var>S4</var> from <var>S3</var> as follows.
-For each item in <var>S3</var>, if the item is a string,
-copy to <var>S4</var> a text node whose <termref def="dt-string-value">string value</termref> is equal to
-the string; otherwise, copy the item to <var>S4</var>.</p></item>
+<item><p>Create a new sequence <var>S5</var> from <var>S4</var> as follows.
+For each item in <var>S4</var>, if the item is a string,
+copy to <var>S5</var> a text node whose <termref def="dt-string-value">string value</termref> is equal to
+the string; otherwise, copy the item to <var>S5</var>.</p></item>
 <item><p>
-Create a new sequence <var>S5</var> from <var>S4</var> as follows.
-For each item in <var>S4</var>, if the item is a document node,
-copy its children to <var>S5</var>; otherwise, copy the item to <var>S5</var>.</p></item>
-<item><p>Create a new sequence <var>S6</var> from <var>S5</var> as follows. First,
-remove any text nodes with values of zero length from <var>S5</var>, then
+Create a new sequence <var>S6</var> from <var>S5</var> as follows.
+For each item in <var>S5</var>, if the item is a document node,
+copy its children to <var>S6</var>; otherwise, copy the item to <var>S6</var>.</p></item>
+<item><p>Create a new sequence <var>S7</var> from <var>S6</var> as follows. First,
+remove any text nodes with values of zero length from <var>S6</var>, then
 maximally group the results into groups of text nodes and non-text nodes. For each group
 of items, if the group is a subsequence of text nodes, copy to
-<var>S6</var> a single text node whose value is equal to the concatenated
+<var>S7</var> a single text node whose value is equal to the concatenated
 values of the subsequence; if the group is a subsequence of non-text nodes, copy the
-subsequence of items to <var>S6</var>. It is a <termref def="serial-err">serialization error</termref>
-<errorref code="0001" class="NR"/> if any item in <var>S6</var> is an
+subsequence of items to <var>S7</var>. It is a <termref def="serial-err">serialization error</termref>
+<errorref code="0001" class="NR"/> if any item in <var>S7</var> is an
 attribute node, a namespace node, or a <termref def="dt-function-item">function</termref>. </p></item>
-<item><p>Create a new sequence <var>S7</var> from <var>S6</var> as follows.
-Let <var>S7</var> be a single document node. 
-Copy sequence <var>S6</var> to the document node as its children.
-</p></item></olist><p><var>S7</var> is the normalized sequence.</p>
+<item><p>Create a new sequence <var>S8</var> from <var>S7</var> as follows.
+Let <var>S8</var> be a single document node. 
+Copy sequence <var>S7</var> to the document node as its children.
+</p></item></olist><p><var>S8</var> is the normalized sequence.</p>
 <p>The <termref def="result-tree">result tree</termref> rooted at the document node that is
 created by the final step of this sequence
 normalization process is the
@@ -3400,6 +3404,9 @@ is described in <specref ref="serdm"/>.</p>
     <change issue="1651" PR="1703" date="2025-01-14">
       The serialization of maps retains the order of entries.
     </change>
+    <change issue="2025" PR="2031" date="2025-05-29">
+      A JNode is replaced by its <code>¶value</code> property.
+    </change>
   </changes>
 
   <p>The JSON output method serializes the <termref diff="chg" at="2023-11-01" def="dt-input-tree"/>
@@ -3425,6 +3432,7 @@ is described in <specref ref="serdm"/>.</p>
   <p>An individual item is serialized as follows:</p>
 
 <ulist>
+  <item><p>A JNode is serialized by serializing its <code>¶value</code> property.</p></item>
 <item><p>An <termref def="dt-array-item">array item</termref> in the
   <termref diff="chg" at="2023-11-01" def="dt-input-tree"/> is
 serialized to a JSON array by outputting the serialized JSON value of
@@ -3764,6 +3772,8 @@ according to the <bibref ref="JSON-LINES"/> format, as described in <specref ref
     </change>
     <change issue="2059" PR="TODO" date="2025-06-23">
       The output of QNames reflects the new syntax for QName literals.
+    <change issue="2025" PR="2031" date="2025-05-29">
+      A JNode is replaced by its <code>¶value</code> property.
     </change>
   </changes>
 
@@ -3780,6 +3790,8 @@ follows, with an occurrence of the chosen <code>item-separator</code>
 between successive items.</p>
 
 <ulist>
+  
+  <item><p>A JNode is serialized by serializing its <code>¶value</code> property.</p></item>
 
 <item><p>A document, element, text, comment, or processing instruction
 node is serialized using the XML


### PR DESCRIPTION
This proposal (which has the JNodes proposal as its baseline) is a first cut at defining generalised steps and path expressions that handle both XNodes and JNodes in a uniform way.

The proposal adds functionality to path expressions (using "/") but does not yet remove the corresponding functionality from lookup expressions (using "?") - that will follow in a subsequent draft.

The changes are largely confined to XPath section §4.6. 

Obviously there is much scope to add notes and examples. There is also a need to reorganise sections so concepts are introduced before they are referenced.