### PR TITLE
Fix markup errors in the EXPath file: specification

### DIFF
--- a/specifications/EXPath/file/src/function-catalog.xml
+++ b/specifications/EXPath/file/src/function-catalog.xml
@@ -174,11 +174,13 @@
       <fos:example>
         <fos:test>
           <fos:expression>file:last-modified('.')</fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>Returns the last modification time of the
           <termref def="current-working-dir"/>.</fos:postamble>
         </fos:test>
         <fos:test>
           <fos:expression>file:last-modified(file:base-dir())</fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>Returns the last modification time of the
             <termref def="base-dir"/>.</fos:postamble>
         </fos:test>
@@ -274,11 +276,13 @@
       <fos:example>
         <fos:test spec="XQuery">
           <fos:expression><![CDATA[file:append('fragments.xml', <fragment/>)]]></fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>Appends a serialized element node to the file
             <code>fragments.xml</code>. The file is created if it does not already exist.</fos:postamble>
         </fos:test>
         <fos:test>
           <fos:expression>file:append('snippets.json', { 'one': 1 }, { 'method': 'json' })</fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>Serializes a map as JSON and appends the resulting string to the file
             <code>snippets.json</code>.</fos:postamble>
         </fos:test>
@@ -326,6 +330,7 @@
       <fos:example>
         <fos:test>
           <fos:expression>file:append-binary('data.bin', xs:hexBinary('414243'))</fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>Appends the bytes <code>0x44</code>, <code>0x43</code> and <code>0x41</code>
             to the file <code>data.bin</code>.
             The file is created if it does not already exist.</fos:postamble>
@@ -374,6 +379,7 @@
       <fos:example>
         <fos:test>
           <fos:expression>file:append-text('todos.txt', 'clean up')</fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>Appends a string to the file <code>todos.txt</code>.
             The file is created if it does not already exist.</fos:postamble>
         </fos:test>
@@ -422,6 +428,7 @@
       <fos:example>
         <fos:test>
           <fos:expression>file:append-text-lines('numbers.txt', (1 to 5) ! string())</fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>Appends the string representation of the integers 1 to 5 to the file
             <code>numbers.txt</code>. The file is created if it does not already exist.</fos:postamble>
         </fos:test>
@@ -500,16 +507,19 @@
       <fos:example>
         <fos:test>
           <fos:expression>file:copy('a.txt', 'b.txt')</fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>Creates a copy of the file <code>a.txt</code> in the
             same directory, named <code>b.txt</code>.</fos:postamble>
         </fos:test>
         <fos:test>
           <fos:expression>file:copy('a.txt', '../')</fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>Creates a copy of the file <code>a.txt</code> with the same name
             in the parent directory.</fos:postamble>
         </fos:test>
         <fos:test>
           <fos:expression>file:copy('dir/', 'dir2/')</fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>Creates a recursive copy of the directory <code>dir</code>
             in the <termref def="current-working-dir"/>, named <code>dir2</code>. If
             <code>dir2</code> already exists, the contents of <code>dir</code> will be copied
@@ -549,11 +559,13 @@
       <fos:example>
         <fos:test>
           <fos:expression>file:create-dir('examples')</fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>Creates a directory named <code>examples</code> in the
             <termref def="current-working-dir"/>.</fos:postamble>
         </fos:test>
         <fos:test>
           <fos:expression>file:create-dir('/')</fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>Will do nothing, as the root directory already exists.</fos:postamble>
         </fos:test>
       </fos:example>
@@ -586,6 +598,13 @@
         <p>The created directory will not be deleted automatically after query execution.</p>
       </note>
     </fos:rules>
+    <fos:errors>
+      <p>
+        <errorref spec="FILE40" code="no-dir"/> is raised if the specified directory does not
+        exist or points to a file.</p>
+      <p>
+        <errorref spec="FILE40" code="io-error"/> is raised if any other error occurs.</p>
+    </fos:errors>
     <fos:examples>
       <fos:example>
         <fos:test>
@@ -594,6 +613,7 @@
         </fos:test>
         <fos:test>
           <fos:expression><eg>file:create-temp-dir(dir := file:base-dir())</eg></fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>Creates a temporary directory in the <termref def="base-dir"/> or,
             if it is undefined, in the default temporary-file directory.</fos:postamble>
         </fos:test>
@@ -606,18 +626,12 @@ return try {
   file:delete($dir, true())
 }
           </eg></fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>Creates a temporary directory, writes a file into that directory, and
             deletes it again.</fos:postamble>
         </fos:test>
       </fos:example>
     </fos:examples>
-    <fos:errors>
-      <p>
-        <errorref spec="FILE40" code="no-dir"/> is raised if the specified directory does not
-        exist or points to a file.</p>
-      <p>
-        <errorref spec="FILE40" code="io-error"/> is raised if any other error occurs.</p>
-    </fos:errors>
     <fos:changes>
       <fos:change issue="2016" PR="2077" date="2025-07-07">
         <p>All parameters are optional now.</p>
@@ -651,15 +665,6 @@ return try {
         <p>The created file will not be deleted automatically after query execution.</p>
       </note>
     </fos:rules>
-    <fos:examples>
-      <fos:example>
-        <fos:test>
-          <fos:expression>file:create-temp-file(suffix := '.txt')</fos:expression>
-          <fos:postamble>Creates a file with the suffix <code>.txt</code> in the
-            temporary-file directory.</fos:postamble>
-        </fos:test>
-      </fos:example>
-    </fos:examples>
     <fos:errors>
       <p>
         <errorref spec="FILE40" code="no-dir"/> is raised if the specified does not exist or
@@ -667,6 +672,16 @@ return try {
       <p>
         <errorref spec="FILE40" code="io-error"/> is raised if any other error occurs.</p>
     </fos:errors>
+    <fos:examples>
+      <fos:example>
+        <fos:test>
+          <fos:expression>file:create-temp-file(suffix := '.txt')</fos:expression>
+          <fos:result>���</fos:result>
+          <fos:postamble>Creates a file with the suffix <code>.txt</code> in the
+            temporary-file directory.</fos:postamble>
+        </fos:test>
+      </fos:example>
+    </fos:examples>
     <fos:changes>
       <fos:change issue="2016" PR="2077" date="2025-07-07">
         <p>All parameters are optional now.</p>
@@ -694,20 +709,6 @@ return try {
         If <code>$recursive</code> is <code>true</code>, subdirectories will be deleted as well.</p>
       <p>The function returns the empty sequence if the operation is successful.</p>
     </fos:rules>
-    <fos:examples>
-      <fos:example>
-        <fos:test>
-          <fos:expression>file:delete('list.txt')</fos:expression>
-          <fos:postamble>Deletes the file <code>list.txt</code> from the
-            <termref def="current-working-dir"/>.</fos:postamble>
-        </fos:test>
-        <fos:test>
-          <fos:expression>file:delete('examples', true())</fos:expression>
-          <fos:postamble>Deletes the file or directory <code>example</code> and (if available)
-            all subdirectories.</fos:postamble>
-        </fos:test>
-      </fos:example>
-    </fos:examples>
     <fos:errors>
       <p>
         <errorref spec="FILE40" code="not-found"/> is raised if the specified path does not exist.</p>
@@ -717,6 +718,22 @@ return try {
       <p>
         <errorref spec="FILE40" code="io-error"/> is raised if any other error occurs.</p>
     </fos:errors>
+    <fos:examples>
+      <fos:example>
+        <fos:test>
+          <fos:expression>file:delete('list.txt')</fos:expression>
+          <fos:result>���</fos:result>
+          <fos:postamble>Deletes the file <code>list.txt</code> from the
+            <termref def="current-working-dir"/>.</fos:postamble>
+        </fos:test>
+        <fos:test>
+          <fos:expression>file:delete('examples', true())</fos:expression>
+          <fos:result>���</fos:result>
+          <fos:postamble>Deletes the file or directory <code>example</code> and (if available)
+            all subdirectories.</fos:postamble>
+        </fos:test>
+      </fos:example>
+    </fos:examples>
   </fos:function>
 
   <fos:function name="list" prefix="file">
@@ -774,6 +791,7 @@ return try {
       <fos:example>
         <fos:test>
           <fos:expression>file:list('.')</fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>Returns the names of all files in the
             <termref def="current-working-dir"/>.</fos:postamble>
         </fos:test>
@@ -781,6 +799,7 @@ return try {
       <fos:example>
         <fos:test>
           <fos:expression>file:list('.', pattern := '*.zip')</fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>Returns the names of archive files in the
             <termref def="current-working-dir"/>.</fos:postamble>
         </fos:test>
@@ -794,6 +813,7 @@ let $path := file:resolve-path($file, $root)
 where file:size($path) > 1000000
 return file:read-text($path)
           </eg></fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>Returns the contents of large text files found in a specific
             directory and its subdirectories.</fos:postamble>
         </fos:test>
@@ -838,6 +858,7 @@ return file:read-text($path)
       <fos:example>
         <fos:test>
           <fos:expression>file:list-roots('/')</fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>A single slash as result indicates a UNIX-based system.</fos:postamble>
         </fos:test>
       </fos:example>
@@ -916,14 +937,17 @@ return file:read-text($path)
       <fos:example>
         <fos:test>
           <fos:expression>file:move('a.txt', 'b.txt')</fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>Renames <code>a.txt</code> to <code>b.txt</code>.</fos:postamble>
         </fos:test>
         <fos:test>
           <fos:expression>file:move('a.txt', '../')</fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>Moves the file <code>a.txt</code> to the parent directory.</fos:postamble>
         </fos:test>
         <fos:test>
           <fos:expression>file:move('dir/', 'dir2/')</fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>Renames <code>dir</code> to <code>dir2</code>. If <code>dir2</code>
           already exists, moves the source directory into that directory.</fos:postamble>
         </fos:test>
@@ -970,11 +994,13 @@ return file:read-text($path)
       <fos:example>
         <fos:test>
           <fos:expression>file:read-binary('data.bin') eq xs:hexBinary('41')</fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>Returns <code>true</code> if the file <code>data.bin</code>
             contains the single byte <code>0x41</code>.</fos:postamble>
         </fos:test>
         <fos:test>
           <fos:expression>file:read-binary('data.bin', file:size($path) - 1, 1)</fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>Returns the last byte of the file <code>data.bin</code>.</fos:postamble>
         </fos:test>
       </fos:example>
@@ -1027,6 +1053,7 @@ return file:read-text($path)
       <fos:example>
         <fos:test>
           <fos:expression>contains(file:read-text('todos.txt'), 'push forward')</fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>Returns <code>true</code> if the file <code>todos.txt</code>
             contains the specified string.</fos:postamble>
         </fos:test>
@@ -1155,6 +1182,7 @@ return (
       <fos:example>
         <fos:test>
           <fos:expression>file:write('numbers.txt', 1 to 10)</fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>Writes 10 numbers to the file <code>numbers.txt</code>.</fos:postamble>
         </fos:test>
         <fos:test spec="XQuery">
@@ -1165,6 +1193,7 @@ file:write(
   { 'encoding': 'us-ascii', 'indent': true() }
 )
           ]]></eg></fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>Serializes an indented element node as <code>US-ASCII</code> and
             writes it to the file <code>result.xml</code>.</fos:postamble>
         </fos:test>
@@ -1176,6 +1205,7 @@ file:write(
   { 'method': 'json' }
 )
           </eg></fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>Writes a map, serialized as JSON, to a specified file.</fos:postamble>
         </fos:test>
       </fos:example>
@@ -1232,11 +1262,13 @@ file:write(
       <fos:example>
         <fos:test>
           <fos:expression>file:write-binary('data.bin', xs:hexBinary('414243'))</fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>Writes the bytes <code>0x44</code>, <code>0x43</code> and <code>0x41</code>
             to the file <code>data.bin</code>.</fos:postamble>
         </fos:test>
         <fos:test>
           <fos:expression>file:write-binary('data.bin', xs:hexBinary('44', 2))</fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>If this expression is called after the previous one, overwrites the last
             byte with <code>0x44</code>.</fos:postamble>
         </fos:test>
@@ -1283,6 +1315,7 @@ file:write(
       <fos:example>
         <fos:test>
           <fos:expression>file:write-text('todos.txt', 'get organized')</fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>Writes a string to the file <code>todos.txt</code>.
             The file is created if it does not already exist.</fos:postamble>
         </fos:test>
@@ -1330,6 +1363,7 @@ file:write(
       <fos:example>
         <fos:test>
           <fos:expression>file:write-text-lines('numbers.txt', (1 to 5) ! string())</fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>Writes the string representation of the integers 1 to 5 to the file
             <code>numbers.txt</code>.</fos:postamble>
         </fos:test>
@@ -1468,6 +1502,7 @@ file:write(
       <fos:example>
         <fos:test>
           <fos:expression>count(file:children('.'))</fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>
             Counts the files and directories in the <termref def="current-working-dir"/>.
           </fos:postamble>
@@ -1476,6 +1511,7 @@ file:write(
           <fos:expression>
             file:children('path/to/media/')[matches(., '\.(avi|mpg|mp4)$', 'i')]
           </fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>
             Returns the paths to large videos found in a specific directory.
           </fos:postamble>
@@ -1519,6 +1555,7 @@ file:write(
       <fos:example>
         <fos:test>
           <fos:expression>count(file:descendants('.')[file:is-directory(.)])</fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>
             Counts the subdirectories in the <termref def="current-working-dir"/>.
           </fos:postamble>
@@ -1529,6 +1566,7 @@ for $file in file:descendants('.')
 where file:last-modified($file) > current-dateTime() - xs:dayTimeDuration('PT1H')
 return $file
           </eg></fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>
             Returns the paths to all files that have been modified in the last hour.
           </fos:postamble>
@@ -1572,6 +1610,7 @@ return $file
       <fos:example>
         <fos:test>
           <fos:expression>file:path-to-native('/')</fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>Returns <code>/</code> on a UNIX-based system.</fos:postamble>
         </fos:test>
       </fos:example>
@@ -1602,6 +1641,7 @@ return $file
       <fos:example>
         <fos:test>
           <fos:expression>file:path-to-uri('/temp')</fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>Returns <code>file:///temp</code> on a UNIX-based system</fos:postamble>
         </fos:test>
         <fos:test>
@@ -1777,6 +1817,7 @@ return $file
       <fos:example>
         <fos:test>
           <fos:expression>file:write-text(file:temp-dir() || 'todos.txt', 'get on going')</fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>Write a text string to a file in the temporary-file directory.</fos:postamble>
         </fos:test>
       </fos:example>
@@ -1807,6 +1848,7 @@ return $file
 let $dir := file:base-dir() otherwise file:create-temp-dir()
 return file:write-text($dir || 'todos.txt', 'get up')
           </eg></fos:expression>
+          <fos:result>���</fos:result>
           <fos:postamble>Writes <code>todos.txt</code> to the <termref def="base-dir"/> or,
 if it is not defined, to a temporary directory.</fos:postamble>
         </fos:test>


### PR DESCRIPTION
The FOS schema does not allow an fos:example containing an fos:test to omit the fos:result element. I’ve inserted

```
<fos:result>���</fos:result>
```

as a placeholder to mark the problem. I also had to move some of the fos:errors sections to a different location.

@ChristianGruen apologies for just pushing these in. I wanted to get the specs building again.