### PR TITLE
Fix type of `fn:schema-type-record` field `constructor`

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -170,7 +170,7 @@
                is an instance of this type. In all other cases, absent.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="constructor" type="fn(xs:anyAtomicType?) as xs:anyAtomicType?" required="false">
+      <fos:field name="constructor" type="fn(xs:anyAtomicType?) as xs:anyAtomicType*" required="false">
          <fos:meaning>
             <p>For a simple type, a function item that can be used to construct instances of this type. In the case of a named
              type that is present in the dynamic context, the result is the same function as returned by 


### PR DESCRIPTION
The `constructor` of `fn:schema-type-record` [is currently shown](https://qt4cg.org/specifications/xpath-functions-40/Overview.html#schema-type-record) with a type of

```xquery
fn(xs:anyAtomicType?) as xs:anyAtomicType?
```

However this does not cover list type constructors, returning multiple occurrences. It should thus be

```xquery
fn(xs:anyAtomicType?) as xs:anyAtomicType*
```

A test exists that requires this: [`schema-type-005`](https://github.com/qt4cg/qt4tests/blob/79fd5cec8a8b15f9cad3f3d09045946f5bcab931/fn/schema-type.xml#L99-L116)