### PR TITLE
Add note on the impossibility of cyclic instances

### DIFF
--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -5837,6 +5837,16 @@ name.</p>
                with its definition would make the assessment of the subtype relationship non-terminating.
                For details see <specref ref="id-itemtype-subtype"/>.</p>
                
+               <note><p>While record types may be recursive, it is not possible to construct
+               instances containing cyclic references. Specifically, if an instance <var>A</var> contains a reference
+               to <var>B</var> then it is not possible for <var>B</var> to contain a reference to <var>A</var>.
+               This is because <var>A</var> cannot contain a reference to <var>B</var>
+               unless <var>B</var> exists at the time <var>A</var> is created, and since all values
+               are immutable, <var>B</var> cannot subsequently be updated to refer to <code>A</code>.</p>
+               
+               <p>The simplest workaround for this is to make the references indirect, via some kind of index
+               based on application-allocated unique identifiers.</p></note>
+               
                <example id="e-binary-tree">
                   <head>A Binary Tree</head>
                   <p>A record used to represent a node in a binary tree might be represented (using XQuery syntax) as:</p>


### PR DESCRIPTION
Responding to an action at today's meeting, this adds a note to the effect that although types can contain cyclic references, instances can not.