### PR TITLE
2104 Point out places where jnode-content is called implicitly

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -35496,10 +35496,40 @@ return $input / child::b / *
          ensures that the actual value being passed to the first argument of <function>matches</function>
             is the atomized value of the 
           <term>·content·</term> property.</p>
-         <p>One case where the function call may be needed is when computing the effective boolean
+         <p>Other examples where the <term>·content·</term> of a JNode is extracted automatically
+         include:</p>
+         
+         <ulist>
+            <item><p>Any context where the required type is an atomic value, for example
+            arithmetic operations, value comparisons and general comparisons, and calls
+            on functions that expect an atomic value.</p></item>
+            <item><p>Any context where the required type is a map or array, for example
+            the first argument of functions such as <function>map:size</function>
+               or <code>array:size</code>, a free-standing expression within a map
+               constructor such as <code>map{ $jnode }</code>, the constructs
+            <code>for member</code> and <code>for key/value</code>, the left-hand
+            operand of the lookup operator <code>?</code> (or the context value
+            in the case of a unary lookup operator), and the operand of a map/array
+            filter expression <code>$jnode?[predicate]</code>.</p></item>
+         </ulist>
+         <p>Notable places where the <term>·content·</term> is <emph>not</emph>
+         automatically extracted include:</p>
+         <ulist>
+            <item><p>When computing the effective boolean
          value. As with XNodes, writing <code>if ($array/child::*[1]) ...</code> tests for the existence
          of a child, it does not test its value. To test its value, write <code>if (jnode-content($array/child::*[1])) ...</code>,
-         or equivalently <code>if (xs:boolean($array/child::*[1])) ...</code>.</p>
+         or equivalently <code>if (xs:boolean($array/child::*[1])) ...</code>.</p></item>
+            <item><p>When calling functions that accept arbitrary sequences, such as
+            <function>count</function> or <function>deep-equal</function>.</p></item>
+         </ulist>
+         <p>It is possible (though probably unwise) to construct a JNode whose <term>·content·</term>
+         property itself contains another JNode. For example, the expression 
+         <code>jnode([jnode([]), jnode([])])</code> creates a JNode whose <term>·content·</term>
+         is an array of JNodes, and applying the <code>child</code> axis to this JNode will
+         return a sequence of two JNodes that themselves have further JNodes as their content.
+         The <function>jnode-content</function> returns these contained JNodes, it does not
+         recursively extract their content.</p>
+         
       </fos:notes>
       <fos:examples>
          <fos:example>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -8549,6 +8549,11 @@ return <table>
             <p>There is no operation to atomize a map or convert it to a string. The function <function>fn:serialize</function> can in some cases
             be used to produce a JSON representation of a map.</p>
             
+            <p>Note that when the required type of an argument to a function such as <function>map:build</function>
+            is a map type, then the coercion rules ensure that a JNode can be supplied in the function call:
+            if the <term>·content·</term> property of the JNode is a map, then the map is automatically
+            extracted as if by the <function>jnode-content</function> function.</p>
+            
             
             
             <?local-function-index?>
@@ -10303,7 +10308,10 @@ map( xs:string,
             chosen for a value record is <code>record(value as item()*)</code>, that is, a map containing a single
             entry whose key is the string <code>"value"</code> and whose value is the encapsulated sequence.</p>
  
-            
+            <p>Note that when the required type of an argument to a function such as <function>array:build</function>
+            is an array type, then the coercion rules ensure that a JNode can be supplied in the function call:
+            if the <term>·content·</term> property of the JNode is an array, then the array is automatically
+            extracted as if by the <function>jnode-content</function> function.</p>
      
             
             <?local-function-index?>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -17588,7 +17588,8 @@ let $z := g($x, $y)]]></eg>
                the range variable is bound in turn to each member of the array.</p>
                   <p>In this case the corresponding <code>ExprSingle</code>
                   must evaluate to a single array, otherwise a type error is raised <errorref
-                  class="TY" code="0141"/>.</p></item>
+                  class="TY" code="0141"/>. However, the coercion rules also allow a JNode
+                  whose <term>·content·</term> is an array to be supplied.</p></item>
                <item><p>When a <nt def="ForItemBinding">ForEntryBinding</nt> is used (that is, when either
                   or both of the keywords <code>key</code> and <code>value</code> are used), 
                   the <code>key</code> range variable (if present) is bound in turn to each key in the map 
@@ -17596,7 +17597,8 @@ let $z := g($x, $y)]]></eg>
                   range variable (if present) is bound to the corresponding value.</p>
                   <p>In this case the corresponding <code>ExprSingle</code>
                   must evaluate to a single map, otherwise a type error is raised <errorref
-                  class="TY" code="0141"/>.</p>
+                  class="TY" code="0141"/>. However, the coercion rules also allow a JNode
+                  whose <term>·content·</term> is a map to be supplied.</p>
                <p>If both the <code>key</code> and <code>value</code> variables are declared,
                their <termref def="dt-expanded-qname">expanded
 			        QNames</termref> must be distinct <errorref
@@ -19775,6 +19777,7 @@ return ($i, $j)]]></eg>
                   <olist>
                      <item><p>The value of the <termref def="dt-binding-collection-xp"/> must be a single array.
                         Otherwise, a <termref def="dt-type-error">type error</termref> is raised: <errorref class="TY" code="0141"/>.
+                        However, the coercion rules also allow a JNode whose <term>·content·</term> is an array to be supplied.
                      </p></item>
                      <item><p>If a <nt def="TypeDeclaration">TypeDeclaration</nt>
                         is present then each member of the <termref def="dt-binding-collection-xp"/> array
@@ -19803,7 +19806,9 @@ return ($i, $j)]]></eg>
                   <olist>
                      <item><p>The value of the <termref def="dt-binding-collection-xp"/> must be a single map.
                         Otherwise, a <termref def="dt-type-error">type error</termref> is raised: 
-                        <errorref class="TY" code="0141"/>. The map is treated as a sequence of key/value
+                        <errorref class="TY" code="0141"/>. However, the coercion rules also allow a JNode
+                        whose <term>·content·</term> is a map to be supplied.
+                        The map is treated as a sequence of key/value
                         pairs, in <termref def="dt-implementation-dependent"/> order.
                      </p></item>
                      <item><p>If the <code>key</code> keyword is present, then the corresponding
@@ -20345,7 +20350,9 @@ processing with JSON processing.</p>
                
                <p>When the <nt def="MapConstructorEntry">MapConstructorEntry</nt> is written as a
                single instance of <nt def="ExprSingle">ExprSingle</nt> with no colon, it must evaluate
-               to a sequence of zero or more map items (<errorref class="TY" code="0004"/>). 
+               to a sequence of zero or more map items (<errorref class="TY" code="0004"/>).
+                  However, the coercion rules also allow a JNode
+                  whose <term>·content·</term> is a map (or a sequence of maps) to be supplied.
                   These map items will be merged into the constructed map, as described below.</p>
                
                <p>Each contained <nt def="MapConstructorEntry">MapConstructorEntry</nt> thus
@@ -21091,7 +21098,10 @@ processing with JSON processing.</p>
             
             <p>The required type of the left-hand operand <code><var>INPUT</var></code> is
                <code>(map(*)|array(*))?</code>: that is, it must be either an empty sequence, a single
-            map, or a single array <errorref class="TY" code="0004"/>. If it is an empty sequence, 
+            map, or a single array <errorref class="TY" code="0004"/>. 
+               However, the coercion rules also allow a JNode
+                  whose <term>·content·</term> is a map or array to be supplied.
+               If the value is an empty sequence, 
                the result of the expression is an empty sequence.</p>
             
            


### PR DESCRIPTION
Fix #2095

This PR is purely editorial: it adds notes and examples showing where jnode-content() is (or is not) called implicitly.