### PR TITLE
2102 Make type labels in diagram consistent

### DIFF
--- a/specifications/image-sources/item-types.xml
+++ b/specifications/image-sources/item-types.xml
@@ -70,7 +70,7 @@
         </ulist>
       </item>
       <item role="abstract function">
-        <p><phrase>function(*)</phrase><phrase role="kind"> (function item)</phrase></p>
+        <p><phrase>function</phrase><phrase role="kind"> (function item)</phrase></p>
         <ulist>
           <item role="function user-defined">
              <p>
@@ -80,7 +80,7 @@
           </item>
    
           <item role="abstract function">
-            <p><phrase>array(*)</phrase><phrase role="kind"> (function item)</phrase></p>
+            <p><phrase>array</phrase><phrase role="kind"> (function item)</phrase></p>
             <ulist>
               <item role="function user-defined">
                  <p>
@@ -91,7 +91,7 @@
             </ulist>
           </item>
           <item role="abstract function">
-            <p><phrase>map(*)</phrase><phrase role="kind"> (function item)</phrase></p>
+            <p><phrase>map</phrase><phrase role="kind"> (function item)</phrase></p>
             <ulist>
               <item role="function user-defined">
                  <p>


### PR DESCRIPTION
Fix #2102 

Drops the parentheses in map(*), array(*), function(*)