### PR TITLE
2112 Refine/revise the rules for get() in node tests

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1870,7 +1870,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
       <g:sequence>
         <g:string>get</g:string>
         <g:string>(</g:string>
-        <g:ref name="Expr"/>
+        <g:ref name="ExprSingle"/>
         <g:string>)</g:string>
       </g:sequence>
     </g:choice>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -20411,11 +20411,11 @@ processing with JSON processing.</p>
                   function.</p>
     
                   <p><termdef id="dt-same-key" term="same key"
-                        >Two atomic items <code>K1</code> and
-    <code>K2</code> have the <term>same key value</term> if
+                        >Two atomic items <var>K1</var> and
+    <var>K2</var> have the <term>same key value</term> if
     
     
-      <code>fn:atomic-equal(K1, K2)</code> returns <code>true</code>, as specified in <xspecref
+      <code>fn:atomic-equal(<var>K1</var>, <var>K2</var>)</code> returns <code>true</code>, as specified in <xspecref
          spec="FO40" ref="func-atomic-equal"  diff="chg" at="2023-01-25"/>
                   </termdef>
 

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -12082,14 +12082,18 @@ return if (every $r in $R satisfies $r instance of gnode())
                   present in the atomized value of the selector expression.</p>
                
                <p>That is, if the context item is an XNode, then 
-                  <code><var>axis</var>::get(<var>EXPR</var>)</code> returns the result
+                  <code><var>Axis</var>::get(<var>Expr</var>)</code> returns the result
                of the expression:</p>
                
-               <eg><![CDATA[let $selector := fn(){ data(<var>EXPR</var>) }()
-return <var>axis</var>::*[some($selector, atomic-equal(?, node-name()))]
-]]></eg>
+               <eg>let $selector := fn(){ data(<var>Expr</var>) }()
+return <var>Axis</var>::*[some($selector, atomic-equal(?, node-name()))]</eg>
                
-               <note><p>It is not an error if the atomized value of <var>EXPR</var>
+               <note>
+                  <p>The purpose of evaluating <var>Expr</var> within the body of
+                  an anonymous inline function is to ensure that it is evaluated
+                  with an absent focus.</p>
+                  
+                  <p>It is not an error if the atomized value of <var>Expr</var>
                includes atomic items that are not <code>xs:QName</code> values:
                such values are effectively ignored.</p></note>
                
@@ -12122,7 +12126,7 @@ return <var>axis</var>::*[some($selector, atomic-equal(?, node-name()))]
                is absent).</p>
                
                <p>If the selector takes the form of an <code>NCName</code>, then it matches
-               every JNode whose <term>·selector·</term> property is a atomic item
+               every JNode whose <term>·selector·</term> property is an atomic item
                   (necessarily an <code>xs:string</code>, <code>xs:anyURI</code>
                   or <code>xs:untypedAtomic</code> value) that is equal to this <code>NCName</code>
                   under the rules of the <function>fn:atomic-equal</function> function.</p>
@@ -12132,7 +12136,7 @@ return <var>axis</var>::*[some($selector, atomic-equal(?, node-name()))]
                   <code>xs:QName</code>, using the same rules as for wildcards in XNode steps
                (see <specref ref="id-selectors-for-xnodes"/>).</p>
                
-               <p>If the selector takes the form <code>get(<var>Expr</var>)</code>.
+               <p>If the selector takes the form <code>get(<var>Expr</var>)</code>,
                the contained expression <var>Expr</var> is evaluated with an
                   <xtermref ref="dt-absent" spec="DM40"/> <termref def="dt-focus"/>. 
                   A JNode satisfies the selector if the value of its 
@@ -12142,14 +12146,18 @@ return <var>axis</var>::*[some($selector, atomic-equal(?, node-name()))]
                
                
                <p>That is, if the context item is a JNode, then 
-                  <code><var>axis</var>::get(<var>EXPR</var>)</code> returns the result
+                  <code><var>Axis</var>::get(<var>Expr</var>)</code> returns the result
                of the expression:</p>
                
-               <eg><![CDATA[let $selector := fn(){ data(<var>EXPR</var>) }()
-return <var>axis</var>::*[some($selector, atomic-equal(?, jnode-selector()))]
+               <eg><![CDATA[let $selector := fn(){ data(<var>Expr</var>) }()
+return <var>Axis</var>::*[some($selector, atomic-equal(?, jnode-selector()))]
 ]]></eg>
                
-               <note><p>It is not an error if the atomized value of <var>EXPR</var>
+               <note>
+                  <p>The purpose of evaluating <var>Expr</var> within the body of
+                  an anonymous inline function is to ensure that it is evaluated
+                  with an absent focus.</p>
+                  <p>It is not an error if the atomized value of <var>Expr</var>
                includes atomic items that select nothing: such values are effectively ignored.
                This is true both for maps and arrays.</p></note>
                

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -11209,7 +11209,7 @@ return $incrementors[2](4)]]></eg>
          <note>
             <p>Note the terminology:</p>
             <ulist>
-               <item><p>A <termref def="dt-GNode"/> is a generalized node, either a
+               <item><p>A <termref def="dt-GNode"/> is a generalized node, either an
                <termref def="dt-XNode"/> or a <termref def="dt-JNode"/>.</p></item>
                <item><p>A <termref def="dt-GTree"/> is a generalized tree, either an
                <termref def="dt-XTree"/> or a <termref def="dt-JTree"/>.</p></item>
@@ -12073,8 +12073,9 @@ return if (every $r in $R satisfies $r instance of gnode())
              </item>
           </ulist>
                
-               <p>A selector can also take the form <code>get(<var>Expr</var>)</code>.
-               The contained expression <var>Expr</var> is evaluated with an
+               <p>A selector can also take the form <code>get(<var>E</var>)</code>
+                  where <var>E</var> is an <nt def="ExprSingle">ExprSingle</nt>.
+               The contained expression <var>E</var> is evaluated with an
                   <xtermref ref="dt-absent" spec="DM40"/> <termref def="dt-focus"/>. 
                   An XNode satisfies the selector if its node kind is the principal
                   node kind of the axis and its node name
@@ -12082,18 +12083,18 @@ return if (every $r in $R satisfies $r instance of gnode())
                   present in the atomized value of the selector expression.</p>
                
                <p>That is, if the context item is an XNode, then 
-                  <code><var>Axis</var>::get(<var>Expr</var>)</code> returns the result
+                  <code><var>Axis</var>::get(<var>E</var>)</code> returns the result
                of the expression:</p>
                
-               <eg>let $selector := fn(){ data(<var>Expr</var>) }()
+               <eg>let $selector := fn(){ data(<var>E</var>) }()
 return <var>Axis</var>::*[some($selector, atomic-equal(?, node-name()))]</eg>
                
                <note>
-                  <p>The purpose of evaluating <var>Expr</var> within the body of
+                  <p>The purpose of evaluating <var>E</var> within the body of
                   an anonymous inline function is to ensure that it is evaluated
                   with an absent focus.</p>
                   
-                  <p>It is not an error if the atomized value of <var>Expr</var>
+                  <p>It is not an error if the atomized value of <var>E</var>
                includes atomic items that are not <code>xs:QName</code> values:
                such values are effectively ignored.</p></note>
                
@@ -12136,28 +12137,29 @@ return <var>Axis</var>::*[some($selector, atomic-equal(?, node-name()))]</eg>
                   <code>xs:QName</code>, using the same rules as for wildcards in XNode steps
                (see <specref ref="id-selectors-for-xnodes"/>).</p>
                
-               <p>If the selector takes the form <code>get(<var>Expr</var>)</code>,
-               the contained expression <var>Expr</var> is evaluated with an
+               <p>If the selector takes the form <code>get(<var>E</var>)</code>,
+                  where <var>E</var> is an <nt def="ExprSingle">ExprSingle</nt>,
+               the contained expression <var>E</var> is evaluated with an
                   <xtermref ref="dt-absent" spec="DM40"/> <termref def="dt-focus"/>. 
                   A JNode satisfies the selector if the value of its 
                   <term>·selector·</term> property is equal to one of the values
-                  present in the atomized value of the selector expression, under the rules
+                  present in the atomized value of the selector expression <var>E</var>, under the rules
                   of the <function>atomic-equal</function> function.</p>
                
                
                <p>That is, if the context item is a JNode, then 
-                  <code><var>Axis</var>::get(<var>Expr</var>)</code> returns the result
+                  <code><var>Axis</var>::get(<var>E</var>)</code> returns the result
                of the expression:</p>
                
-               <eg><![CDATA[let $selector := fn(){ data(<var>Expr</var>) }()
+               <eg><![CDATA[let $selector := fn(){ data(<var>E</var>) }()
 return <var>Axis</var>::*[some($selector, atomic-equal(?, jnode-selector()))]
 ]]></eg>
                
                <note>
-                  <p>The purpose of evaluating <var>Expr</var> within the body of
+                  <p>The purpose of evaluating <var>E</var> within the body of
                   an anonymous inline function is to ensure that it is evaluated
                   with an absent focus.</p>
-                  <p>It is not an error if the atomized value of <var>Expr</var>
+                  <p>It is not an error if the atomized value of <var>E</var>
                includes atomic items that select nothing: such values are effectively ignored.
                This is true both for maps and arrays.</p></note>
                

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -3152,7 +3152,7 @@ would raise an error because it has an <code>id</code> child whose value is not 
                corresponding to nodes in an XML document, and generally referred to simply as <term>nodes</term>),
                and also to <xtermref spec="DM40" ref="dt-JNode">JNodes</xtermref>, often corresponding to the contents
                of a JSON source text. These are known collectively as 
-               <xtermref spec="DM40" ref="dt-GNode">GNodes</xtermref> (for "generalized node").</p>
+               <termref def="dt-GNode">GNodes</termref> (for "generalized node").</p>
 
             <p>Document order is defined in <xspecref
                   spec="DM40" ref="document-order"
@@ -3599,7 +3599,7 @@ defined in <xspecref
 
                <item>
                   <p>If its operand is a sequence whose first item is a 
-                     <xtermref spec="DM40" ref="dt-GNode"/>, <function>fn:boolean</function> returns 
+                     <termref def="dt-GNode"/>, <function>fn:boolean</function> returns 
                      <code>true</code>.</p>
                </item>
 
@@ -6123,7 +6123,7 @@ declare record Particle (
                   </change>
                </changes>
                
-               <p>A <nt def="GNodeType">GNodeType</nt> matches a generalized node (GNode):
+               <p>A <nt def="GNodeType">GNodeType</nt> matches a generalized node (<termref def="dt-GNode"/>):
                   that is, it matches any <termref def="dt-XNode"/>
                   or <xtermref spec="DM40" ref="dt-JNode"/>.</p>
                
@@ -11172,6 +11172,7 @@ return $incrementors[2](4)]]></eg>
          <scrap>
             <prodrecap ref="PathExpr"/>
          </scrap>
+
          <p><termdef id="dt-path-expression" term="path expression">A <term>path expression</term>
             is either an <termref def="dt-absolute-path-expression"/> or a
             <termref def="dt-relative-path-expression"/></termdef></p>
@@ -11203,6 +11204,7 @@ return $incrementors[2](4)]]></eg>
             
          <p>A path expression is typically used to locate <termref def="dt-GNode">GNodes</termref> 
             within <termref def="dt-GTree">GTrees</termref>. </p>
+
          
          <note>
             <p>Note the terminology:</p>
@@ -11933,7 +11935,8 @@ return if (every $r in $R satisfies $r instance of gnode())
                </changes>
                <p>
                   <termdef id="dt-node-test" term="node test"
-                        >A <term>node test</term> is a condition on the properties of a GNode. 
+                        >A <term>node test</term> is a condition 
+                     on the properties of a <termref def="dt-GNode"/>. 
       A node test determines which GNodes returned by an axis are selected by a <termref
                         def="dt-step">step</termref>.</termdef>
                </p>
@@ -11972,7 +11975,7 @@ return if (every $r in $R satisfies $r instance of gnode())
                         >A node test that consists only of an EQName or a
 		  Wildcard is called a <term>name test</term>.</termdef></p>
                
-               <p>A node test written as an EQName is expanded as follows:</p>
+               <p>A node test written as an NCName is expanded as follows:</p>
                <ulist>
                   <item><p>If the principal node kind of the axis step is <code>element</code>, 
                   using the <termref def="dt-element-name-matching-rule"/>.</p>
@@ -12071,13 +12074,23 @@ return if (every $r in $R satisfies $r instance of gnode())
           </ulist>
                
                <p>A selector can also take the form <code>get(<var>Expr</var>)</code>.
-               The contained expression <var>Expr</var> is evaluated with the focus
-               of the containing axis step (so its value is independent of the specific
-               XNode being tested). The result of the expression after atomization must be a sequence
-               of zero or more <code>xs:QName</code> values (otherwise a type error
-               <errorref class="TY" code="0004"/> is raised). An XNode satisfies the selector
-               if its node kind is the principal node kind of the axis and its node name
-               is among the values returned by the selector expression.</p>
+               The contained expression <var>Expr</var> is evaluated with an
+                  <xtermref ref="dt-absent" spec="DM40"/> <termref def="dt-focus"/>. 
+                  An XNode satisfies the selector if its node kind is the principal
+                  node kind of the axis and its node name
+                  is equal to one of the values (necessarily an <code>xs:QName</code>)
+                  present in the atomized value of the selector expression.</p>
+               
+               <p>That is, if <code>$N</code> is an XNode, then 
+                  <code>$N/<var>axis</var>::get(<var>EXPR</var>)</code> returns the result
+               of <code>$N/<var>axis</var>::*[some(data(<var>EXPR</var>), atomic-equal(?, node-name()))]</code>,
+               with the qualification that <var>EXPR</var> must not depend on the focus.</p>
+               
+               <note><p>It is not an error if the atomized value of <var>EXPR</var>
+               includes atomic values that are not <code>xs:QName</code> values:
+               such values are effectively ignored.</p></note>
+               
+     
                
                <p>For example, <code>child::get(#body, #x:body)</code> selects
                an element whose name is one of the QName values <code>body</code>
@@ -12108,13 +12121,20 @@ return if (every $r in $R satisfies $r instance of gnode())
                   <code>xs:QName</code>, using the same rules as for wildcards in XNode steps
                (see <specref ref="id-selectors-for-xnodes"/>).</p>
                
-               <p>If the selector takes the form <code>get(<var>Expr</var>)</code>,
-               then the contained expression <var>Expr</var> is evaluated with the focus
-               of the containing axis step (so its value is independent of the specific
-               JNode being tested). A JNode satisfies the selector
-               if its <term>·selector·</term> property is equal to 
-               one or more of the values returned by the selector expression,
-               under the rules of the <function>fn:atomic-equal</function> function.</p>
+               <p>If the selector takes the form <code>get(<var>Expr</var>)</code>.
+               the contained expression <var>Expr</var> is evaluated with an
+                  <xtermref ref="dt-absent" spec="DM40"/> <termref def="dt-focus"/>. 
+                  A JNode satisfies the selector if the value of its 
+                  <term>·selector·</term> property is equal to one of the values
+                  present in the atomized value of the selector expression, under the rules
+                  of the <function>atomic-equal</function> function.</p>
+               
+               <p>That is, if <code>$J</code> is a JNode, then 
+                  <code>$J/<var>axis</var>::get(<var>EXPR</var>)</code> returns the result
+               of <code>$J/<var>axis</var>::*[some(data(<var>EXPR</var>), atomic-equal(?, jnode-selector()))]</code>,
+               with the qualification that <var>EXPR</var> must not depend on the focus.</p>
+
+               
                
                <p>For example:</p>
                
@@ -12133,12 +12153,8 @@ return if (every $r in $R satisfies $r instance of gnode())
                   <item><p><code>child::get(current-date())</code>
                selects an entry in a map whose key is an <code>xs:date</code> value
                equal to the current date.</p></item>
-                  <item><p><code>child::get(array:size(.))</code> gets the last
-                  member of an array. The same can be achieved using
-                  <code>child::*[last()]</code>.</p></item>
-                  <item><p><code>child::Q{}code</code> selects
-               an entry in a map whose key is the no-namespace QName 
-                     with local name <code>"code"</code>.</p></item>
+                  
+                 
                </ulist>
                
                <p>All the above expressions return a sequence of JNodes. If the containing
@@ -12541,11 +12557,13 @@ fact that the final result of the step is always in document order.</p>
                a union expression, so nodes are counted in document order.</p>
             </note>
             
+
             <p>When the context value for evaluation of a step includes multiple GNodes, the step is evaluated
             separately for each of those GNodes, and the results are combined, eliminating duplicates
             and sorting into document order.</p>
             
             <note><p>To avoid reordering and elimination of duplicates, replace the step <code>S</code> by <code>.!S</code>.</p></note>
+
          </div3>
          <div3 id="unabbrev">
             <head>Unabbreviated Syntax</head>
@@ -13458,7 +13476,7 @@ every integer between the two operands, in increasing order. </p>
                <prodrecap ref="UnionExpr"/>
             </scrap>
             <p>&language; provides the following operators for combining sequences of
-GNodes:</p>
+<termref def="dt-GNode">GNodes</termref>:</p>
             <ulist>
 
                <item>
@@ -13478,12 +13496,12 @@ containing all the GNodes that occur in the first operand but not in the second
 operand.</p>
                </item>
             </ulist>
-            <p>All these operators eliminate duplicate GNodes from their result sequences based on GNodes identity. 
+            <p>All these operators eliminate duplicate GNodes from their result sequences based on GNode identity. 
                The resulting sequence is returned in <termref
                      def="dt-document-order">document order</termref>.
             </p>
             <p>If an operand
-of <code>union</code>, <code>intersect</code>, or <code>except</code> contains an item that is not a GNode, a <termref
+of <code>union</code>, <code>intersect</code>, or <code>except</code> contains an item that is not a <termref def="dt-GNode"/>, a <termref
                   def="dt-type-error">type error</termref> is raised <errorref class="TY"
                   code="0004"/>.</p>
 
@@ -14660,16 +14678,19 @@ of this value comparison is <code>true</code>.</p>
          </div3>
          <div3 id="id-node-comparisons">
             <head>GNode Comparisons</head>
+
             <changes>
-               <change date="2025-07-28">
+               <change date="2025-07-28" PR="2130">
                   Operator <code>is-not</code> is introduced, as a complement to the operator <code>is</code>.
                </change>
-               <change date="2025-07-28">
+               <change date="2025-07-28" PR="2130">
                   Operators <code>precedes</code> and <code>follows</code> are introduced as synonyms
                   for operators <code>&lt;&lt;</code> and <code>&gt;&gt;</code>.
                </change>
             </changes>
-            <p>GNode comparisons are used to compare two <xtermref spec="DM40" ref="dt-GNode">GNodes</xtermref>
+            
+            <p>GNode comparisons are used to compare two <termref def="dt-GNode">GNodes</termref>
+
                (that is, <termref def="dt-XNode">XNodes</termref> or
                <xtermref spec="DM40" ref="dt-JNode">JNodes</xtermref>), by their identity or by their <termref
                   def="dt-document-order"
@@ -14680,7 +14701,7 @@ of this value comparison is <code>true</code>.</p>
 
 
                <item>
-                  <p>The operands of a GNode comparison are evaluated in <termref
+                  <p>The operands of a <termref def="dt-GNode"/> comparison are evaluated in <termref
                         def="dt-implementation-dependent"
                      >implementation-dependent</termref> order.</p>
                </item>
@@ -14696,7 +14717,7 @@ of this value comparison is <code>true</code>.</p>
 
 
                <item>
-                  <p> Each operand must be either a single GNode or an empty sequence; otherwise
+                  <p> Each operand must be either a single <termref def="dt-GNode"/> or an empty sequence; otherwise
 a <termref
                         def="dt-type-error">type error</termref> is raised <errorref class="TY"
                         code="0004"/>.</p>
@@ -14718,8 +14739,10 @@ is <code>true</code>. See <bibref
 
 
                <item>
+
                   <p>A comparison with the <code>&lt;&lt;</code> or <code>precedes</code> operator returns <code>true</code> 
-                     if the left operand GNode precedes the right operand GNode in
+                     if the left operand <termref def="dt-GNode"/> precedes the right operand GNode in
+
 <termref
                         def="dt-document-order"
                         >document order</termref>; otherwise it returns <code>false</code>.</p>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -12081,21 +12081,31 @@ return if (every $r in $R satisfies $r instance of gnode())
                   is equal to one of the values (necessarily an <code>xs:QName</code>)
                   present in the atomized value of the selector expression.</p>
                
-               <p>That is, if <code>$N</code> is an XNode, then 
-                  <code>$N/<var>axis</var>::get(<var>EXPR</var>)</code> returns the result
-               of <code>$N/<var>axis</var>::*[some(data(<var>EXPR</var>), atomic-equal(?, node-name()))]</code>,
-               with the qualification that <var>EXPR</var> must not depend on the focus.</p>
+               <p>That is, if the context item is an XNode, then 
+                  <code><var>axis</var>::get(<var>EXPR</var>)</code> returns the result
+               of the expression:</p>
+               
+               <eg><![CDATA[let $selector := fn(){ data(<var>EXPR</var>) }()
+return <var>axis</var>::*[some($selector, atomic-equal(?, node-name()))]
+]]></eg>
                
                <note><p>It is not an error if the atomized value of <var>EXPR</var>
-               includes atomic values that are not <code>xs:QName</code> values:
+               includes atomic items that are not <code>xs:QName</code> values:
                such values are effectively ignored.</p></note>
                
-     
+               <note><p>Unnamed nodes (such as text nodes) will never be selected</p></note>
                
-               <p>For example, <code>child::get(#body, #x:body)</code> selects
-               an element whose name is one of the QName values <code>body</code>
+               <note><p>The result is in document order. The order of items in
+               the result of the selector expression is immaterial.</p></note>
+                         
+               <p>For example, <code>child::get((#body, #x:body))</code> selects
+               all child elements whose name is one of the QName values <code>body</code>
                or <code>x:body</code>. Note that the evaluation of QName literals
                is not sensitive to the default namespace for elements and types.</p>
+               
+               <p>A further example: <code>descendant::(get(#para) | text())</code> returns
+               all descendants of the context node that are either elements named
+               <code>para</code> (in no namespace) or text nodes; the results are in document order.</p>
             </div4>
             
             <div4 id="id-selectors-for-JNodes">
@@ -12112,7 +12122,8 @@ return if (every $r in $R satisfies $r instance of gnode())
                is absent).</p>
                
                <p>If the selector takes the form of an <code>NCName</code>, then it matches
-               every JNode whose <term>·selector·</term> property is a string (or <code>xs:anyURI</code>
+               every JNode whose <term>·selector·</term> property is a atomic item
+                  (necessarily an <code>xs:string</code>, <code>xs:anyURI</code>
                   or <code>xs:untypedAtomic</code> value) that is equal to this <code>NCName</code>
                   under the rules of the <function>fn:atomic-equal</function> function.</p>
                
@@ -12129,12 +12140,26 @@ return if (every $r in $R satisfies $r instance of gnode())
                   present in the atomized value of the selector expression, under the rules
                   of the <function>atomic-equal</function> function.</p>
                
-               <p>That is, if <code>$J</code> is a JNode, then 
-                  <code>$J/<var>axis</var>::get(<var>EXPR</var>)</code> returns the result
-               of <code>$J/<var>axis</var>::*[some(data(<var>EXPR</var>), atomic-equal(?, jnode-selector()))]</code>,
-               with the qualification that <var>EXPR</var> must not depend on the focus.</p>
-
                
+               <p>That is, if the context item is a JNode, then 
+                  <code><var>axis</var>::get(<var>EXPR</var>)</code> returns the result
+               of the expression:</p>
+               
+               <eg><![CDATA[let $selector := fn(){ data(<var>EXPR</var>) }()
+return <var>axis</var>::*[some($selector, atomic-equal(?, jnode-selector()))]
+]]></eg>
+               
+               <note><p>It is not an error if the atomized value of <var>EXPR</var>
+               includes atomic items that select nothing: such values are effectively ignored.
+               This is true both for maps and arrays.</p></note>
+               
+               <note><p>The result is in document order. The order of items in
+               the result of the selector expression is immaterial.</p></note>
+                           
+               <note><p>A performant implementation might reasonably be expected,
+               at least in the case where the value of the selector is a single
+               atomic item, to select an entry in a map or a member in an array
+               in constant time.</p></note>
                
                <p>For example:</p>
                
@@ -12148,7 +12173,7 @@ return if (every $r in $R satisfies $r instance of gnode())
                   <note><p>The same result can be achieved using the expression <code>child::*[3]</code>.</p></note></item>
                   <item><p><code>child::get(1 to 3)</code> selects the first three members
                   of an array, in document order.</p>
-                  <note><p><code>child::get(3, 2, 1)</code> also returns the first three
+                  <note><p><code>child::get((3, 2, 1))</code> also returns the first three
                   members in document order.</p></note></item>
                   <item><p><code>child::get(current-date())</code>
                selects an entry in a map whose key is an <code>xs:date</code> value
@@ -17987,52 +18012,30 @@ return $a + $b + $local:c</eg>
                   </example>
                   <example>
                      <head>Example:</head>
-                     <p>Consider the element <var>$E</var> := <code>&lt;e A="p q r" B="x y z"/></code>.</p>
+                     <p>Consider the element <var>$E</var> := <code>&lt;e A="p q r" B="x y z"/></code>, where
+                     <var>$E</var> has been validated against a schema that defines both attributes
+                     <code>A</code> and <code>B</code> as being lists of strings.</p>
                      <p>Then the expression:</p>
                      <eg>let $( $a, $b ) := $E/(@A, @B)</eg>
-                     <p>binds <code>$a</code> to the attribute node <code>A="p q r"</code>, and
-                        <code>$b</code> to the attribute node <code>B="x y z"</code>.</p>
-                     <p>If type declarations are added to the individual variables, thus:</p>
-                     <eg>let $( $a as xs:string, $b as xs:string ) := $E/(@A, @B)</eg>
-                     <p>then the attributes are atomized, so that <code>$a</code> is bound
-                        to the string <code>"p q r"</code>, and
-                        <code>$b</code> to the string <code>"x y z"</code>.</p>
-                     <p>The same result is achieved if a type declaration is added for the sequence
-                        as a whole:</p>
-                        <eg>let $( $a, $b ) as xs:string* := $E/(@A, @B)</eg>
-                     <p>Now consider the case where the same element <code>$E</code> is validated
-                        against a schema that defines both attributes as lists of strings.</p>
-                      <p>Then the raw expression, without type declarations:</p>
-                     <eg>let $( $a, $b ) := $E/(@A, @B)</eg>
-                        <p>still binds <code>$a</code> and <code>$b</code> to the two attribute
-                           nodes (the only difference being that the typed value of each
-                           attribute is now a sequence of three strings).</p>
-                        <p>If type declarations are added to the individual variables, thus:</p>
-                        <eg>let $( $a as xs:string*, $b as xs:string* ) := $E/(@A, @B)</eg>
-                        <p>then <code>$a</code> is bound to the result of atomizing the first
-                           attribute (that is, to the sequence of three strings <code>("p", "q", "r")</code>),
-                           while <code>$b</code> is bound to the result of atomizing the second
-                           attribute (that is, to the sequence of three strings <code>("x", "y", "z")</code>).</p>
-                        <p>If however, a type declaration is added for the sequence as a whole, namely:</p>
-                        <eg>let $( $a, $b ) as xs:string* := $E/(@A, @B)</eg>
-                        <p>then the binding sequence is a sequence of six strings, <code>("p", "q", "r", "x", "y", "z")</code>.
-                           The variable <code>$a</code> is bound to the first string, <code>"p"</code>, while
-                           <code>$b</code> is bound to the remaining five strings, <code>("q", "r", "x", "y", "z")</code>.</p>
-                     
-                     
+                     <p>binds <code>$a</code> to the sequence <code>("p", "q", "r")</code>
+                     and <code>$b</code> to the sequence <code>("x", "y", "z")</code>.
+                     The evaluation of the expression <code>$E/(@A, @B)</code>
+                        returns a sequence of two attribute nodes;
+                     the value of <code>$a</code> is formed by atomizing the first of these
+                     nodes, while <code>$b</code> is formed by atomizing the second.</p>
                      
                   </example>
                <example>
                      <head>Example:</head>
                      <p>Consider transforming the string <code>"Nf3 Nf6 c4 g6 Nc3 Bg7 d4 O-O Bf4 d5"</code>
                      (notation for the start of a chess game) to the form 
-                     <code>(["Nf3", "Nf6"], ["c4", "g6"], ["Nc3", "Bg7"], ["d4", "O-O"], ["Bf4", "d5"])</code>.
+                     <code>(["Nf3", "Nf6",] ["c4", "g6"], [ "Nc3", "Bg7"], [ "d4", "O-O"], ["Bf4", "d5"])</code>.
                      This can be achieved as follows:</p>
                      <eg>declare function local:grouped-moves($moves) {
    if (exists($moves)) {
-      let $($m1, $m2, $rest) := $moves
-      return [$m1, $m2], local:grouped-moves($rest)
-   }
+     let $($m1, $m2, $rest) := $moves
+     return [$m1, $m2], local:grouped-moves($rest)
+  }
 };
 local:grouped-moves(tokenize("Nf3 Nf6 c4 g6 Nc3 Bg7 d4 O-O Bf4 d5"))</eg>
 


### PR DESCRIPTION
Proposed revision of the rules for get() in node tests.

Mainly editorial clarification; but also changes the rules for the focus - the expression is now evaluated with absent focus to ensure an error in preference to unexpected results.

Fix #2112