### PR TITLE
2082 parse-html options

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -21147,14 +21147,14 @@ serialize(
                   <p>The character encoding to use to decode a sequence of octets that
                   represents an HTML document.</p>
                </fos:meaning>
-               <fos:type>xs:string?</fos:type>
+               <fos:type>xs:string</fos:type>
             </fos:option>
             <fos:option key="fail-on-error">
                <fos:meaning>
                   <p>Indicates whether the function should fail with a dynamic error if the input
                      is not syntactically valid.</p>
                </fos:meaning>
-               <fos:type>xs:boolean?</fos:type>
+               <fos:type>xs:boolean</fos:type>
                <fos:default>false()</fos:default>
                <fos:values>
                   <fos:value value="false">
@@ -21193,7 +21193,7 @@ serialize(
                      </olist>
                   </note>
                </fos:meaning>
-               <fos:type>xs:boolean?</fos:type>
+               <fos:type>xs:boolean</fos:type>
             </fos:option>
          </fos:options>
          
@@ -21264,10 +21264,6 @@ serialize(
       <fos:errors>
          <p>A dynamic error is raised <errorref class="DC" code="0011"/> if the content of
             <code>$value</code> is not a well-formed HTML document.</p>
-         <p>A dynamic error is raised <errorref class="DC" code="0012"/> if the <code>method</code>
-            key of <code>$options</code> is not supported by the implementation.</p>
-         <p>A dynamic error is raised <errorref class="DC" code="0012"/> if a key passed to
-            <code>$options</code>, or the value of that key, is not supported by the implementation.</p>
       </fos:errors>
       <fos:notes>
          <p>If the HTML parser accepts a string as the input then that may be used directly when

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -13985,11 +13985,6 @@ ISBN 0 521 77752 6.</bibl>
                    type="dynamic">
                <p>Raised by <function>fn:parse-html</function> if the supplied string is not a well-formed HTML document.</p>
             </error>
-            <error class="DC" code="0012" label="Unsupported HTML parser option."
-                   type="dynamic">
-               <p>Raised by <function>fn:parse-html</function> if a key passed to <code>$options</code>, or its value,
-                  is not supported by the implementation.</p>
-            </error>
             <error class="DC" code="0013" label="No validating XML parser available."
                type="dynamic">
                <p>Raised when the <code>dtd-validation</code> option to <function>fn:parse-xml</function> is set,


### PR DESCRIPTION
1. Use non-optional types such as xs:boolean for options parameters
2. Use regular error codes for bad options
3. Drop error code relating to the discontinued method option.

Fix #2082