### PR TITLE
2099 Rename fn:jnode and jnode-type

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -2561,7 +2561,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   </g:production>
   
   <g:production name="JNodeType" >
-    <g:string process-value="yes">jnode-type</g:string>
+    <g:string process-value="yes">jnode</g:string>
     <g:string>(</g:string>
     <g:optional>
       <g:ref name="SequenceType"/>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -623,7 +623,7 @@
             </slist></p>
             </item>
             <item><p>If <var>J</var> is a <xtermref spec="DM40" ref="dt-JNode"/>, the result is in
-            the form <code>jnode-type(<var>T</var>)</code>, where <var>T</var> is the result of
+            the form <code>jnode(<var>T</var>)</code>, where <var>T</var> is the result of
             applying the <function>type-of</function> function to the <term>·content·</term> property of <var>J</var>.</p>
             </item>
             <item>
@@ -734,8 +734,8 @@
                <fos:result>"function(*)"</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>type-of(jnode-type([]))</fos:expression>
-               <fos:result>"jnode-type(array(*))"</fos:result>
+               <fos:expression>type-of(jnode([]))</fos:expression>
+               <fos:result>"jnode(array(*))"</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -35220,9 +35220,9 @@ return $result
       </fos:changes>
    </fos:function>
    
-   <fos:function name="jnode" prefix="fn">
+   <fos:function name="jtree" prefix="fn">
       <fos:signatures>
-         <fos:proto name="jnode" return-type="jnode-type(map(*)|array(*))">
+         <fos:proto name="jtree" return-type="jnode(map(*)|array(*))">
             <fos:arg name="input" type="(map(*)|array(*))"/>
          </fos:proto>
       </fos:signatures>
@@ -35249,7 +35249,7 @@ return $result
          <p>A JNode has unique identity. If two maps or arrays <var>M1</var> and
             <var>M2</var> have the same function identity, as determined by the
             <function>function-identity</function> function, then
-            <code>jnode(<var>M1</var>) is jnode(<var>M2</var>)</code> <rfc2119>must</rfc2119>
+            <code>jtree(<var>M1</var>) is jtree(<var>M2</var>)</code> <rfc2119>must</rfc2119>
             return true: that is, the same JNode must be
             delivered for both.</p>
          
@@ -35260,7 +35260,7 @@ return $result
          whether two maps or arrays have the same function identity. Processors
          <rfc2119>should</rfc2119> ensure as a minimum that when 
             a variable <code>$m</code> is bound to a map or array,
-         calling <code>jnode($m)</code> more than once (with the same variable reference)
+         calling <code>jtree($m)</code> more than once (with the same variable reference)
          will deliver the same JNode each time.</p>
          
          <p>The effect of the coercion rules is technically that if an existing JNode is supplied as <code>$input</code>,
@@ -35293,7 +35293,7 @@ return $result
   
          </ulist>
          
-         <p>An alternative way of wrapping a map or array, rather than calling <code>jnode($X)</code>,
+         <p>An alternative way of wrapping a map or array, rather than calling <code>jtree($X)</code>,
          is to use the path expression <code>$X/.</code>.</p>
          
          <p>There are two situations where a map or array is implicitly wrapped in a JNode:</p>
@@ -35310,14 +35310,14 @@ return $result
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>jnode([ "a", "b", "c" ])/*[1]/../*[last()] => string()</fos:expression>
+               <fos:expression>jtree([ "a", "b", "c" ])/*[1]/../*[last()] => string()</fos:expression>
                <fos:result>"c"</fos:result>
                <fos:postamble>The call on <code>fn:jnode</code> would happen automatically</fos:postamble>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>jnode([ "a", "b", "c", "d" ])/* => jnode-selector()</fos:expression>
+               <fos:expression>jtree([ "a", "b", "c", "d" ])/* => jnode-selector()</fos:expression>
                <fos:result>1, 2, 3, 4</fos:result>
             </fos:test>
          </fos:example>
@@ -35327,7 +35327,7 @@ return $result
   "fr": { "capital": "Paris", "languages": [ "French" ] }, 
   "de": { "capital": "Berlin", "languages": [ "German" ] }
 }
-return jnode($data)//languages[. = 'German']/../capital) => string()</eg></fos:expression>
+return jtree($data)//languages[. = 'German']/../capital) => string()</eg></fos:expression>
                <fos:result>"Berlin"</fos:result>
             </fos:test>
          </fos:example>
@@ -35341,7 +35341,7 @@ return jnode($data)//languages[. = 'German']/../capital) => string()</eg></fos:e
    <fos:function name="jnode-selector" prefix="fn">
       <fos:signatures>
          <fos:proto name="jnode-selector" return-type="xs:anyAtomicType?">
-            <fos:arg name="input" type="jnode-type()?" default="."/>
+            <fos:arg name="input" type="jnode()?" default="."/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -35372,7 +35372,7 @@ return jnode($data)//languages[. = 'German']/../capital) => string()</eg></fos:e
                      class="DY" code="0002" type="type"/>.</p>
             </item>
             <item>
-               <p>If the context value is not an instance of the sequence type <code>jnode-type()?</code>, 
+               <p>If the context value is not an instance of the sequence type <code>jnode()?</code>, 
                   type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
             </item>
@@ -35407,7 +35407,7 @@ return $array / descendant::*[. gt 25][1] / ancestor::* =!> jnode-selector() => 
    <fos:function name="jnode-position" prefix="fn">
       <fos:signatures>
          <fos:proto name="jnode-position" return-type="xs:anyAtomicType?">
-            <fos:arg name="input" type="jnode-type()?" default="."/>
+            <fos:arg name="input" type="jnode()?" default="."/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -35439,7 +35439,7 @@ return $array / descendant::*[. gt 25][1] / ancestor::* =!> jnode-selector() => 
                      class="DY" code="0002" type="type"/>.</p>
             </item>
             <item>
-               <p>If the context value is not an instance of the sequence type <code>jnode-type()?</code>, 
+               <p>If the context value is not an instance of the sequence type <code>jnode()?</code>, 
                   type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
             </item>
@@ -35514,7 +35514,7 @@ return $input / child::b / *
    <fos:function name="jnode-content" prefix="fn">
       <fos:signatures>
          <fos:proto name="jnode-content" return-type="item()*">
-            <fos:arg name="input" type="jnode-type()?" default="."/>
+            <fos:arg name="input" type="jnode()?" default="."/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -35540,7 +35540,7 @@ return $input / child::b / *
                      class="DY" code="0002" type="type"/>.</p>
             </item>
             <item>
-               <p>If the context value is not an instance of the sequence type <code>jnode-type()?</code>, 
+               <p>If the context value is not an instance of the sequence type <code>jnode()?</code>, 
                   type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
             </item>
@@ -35582,7 +35582,7 @@ return $input / child::b / *
          </ulist>
          <p>It is possible (though probably unwise) to construct a JNode whose <term>·content·</term>
          property itself contains another JNode. For example, the expression 
-         <code>jnode([jnode([]), jnode([])])</code> creates a JNode whose <term>·content·</term>
+         <code>jtree([jtree([]), jtree([])])</code> creates a JNode whose <term>·content·</term>
          is an array of JNodes, and applying the <code>child</code> axis to this JNode will
          return a sequence of two JNodes that themselves have further JNodes as their content.
          The <function>jnode-content</function> returns these contained JNodes, it does not

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -10478,8 +10478,8 @@ map( xs:string,
          </slist>
          <div2 id="functions-on-jnodes">
             <head>Functions on JNodes</head>
-            <div3 id="func-jnode">
-               <head><?function fn:jnode?></head>
+            <div3 id="func-jtree">
+               <head><?function fn:jtree?></head>
             </div3>
             <div3 id="func-jnode-content">
                <head><?function fn:jnode-content?></head>

--- a/specifications/xquery-40/src/ebnf.xml
+++ b/specifications/xquery-40/src/ebnf.xml
@@ -912,7 +912,7 @@
       <sitem>get</sitem>
       <sitem>if</sitem>
       <sitem>item</sitem>
-      <sitem>jnode-type</sitem>
+      <sitem>jnode</sitem>
       <sitem>map</sitem>
       <sitem>record</sitem>
       <sitem>switch</sitem>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -6100,8 +6100,8 @@ declare record Particle (
                   <prodrecap ref="JNodeType"/>
                </scrap>
                
-               <p>The form <code>jnode-type()</code> matches any JNode. The form
-               <code>jnode-type(<var>T</var>)</code> matches a JNode whose <term>·content·</term> is an instance
+               <p>The form <code>jnode()</code> matches any JNode. The form
+               <code>jnode(<var>T</var>)</code> matches a JNode whose <term>·content·</term> is an instance
                of the sequence type <var>T</var>.</p>
                
             </div3>
@@ -6549,11 +6549,11 @@ declare record Particle (
                            <p><var>A</var> is a <nt def="JNodeType">JNodeType</nt> and <var>B</var> is a <nt def="GNodeType">GNodeType</nt>.</p>
                         </item>
                         <item>
-                           <p><var>A</var> is <code>jnode-type(<var>T</var>)</code> and <var>B</var> is <code>jnode-type()</code>, for any sequence type 
+                           <p><var>A</var> is <code>jnode(<var>T</var>)</code> and <var>B</var> is <code>jnode()</code>, for any sequence type 
                               <var>T</var>.</p>
                         </item>
                         <item>
-                           <p><var>A</var> is <code>jnode-type(<var>T</var>)</code>, <var>B</var> is <code>jnode-type(<var>U</var>)</code>, 
+                           <p><var>A</var> is <code>jnode(<var>T</var>)</code>, <var>B</var> is <code>jnode(<var>U</var>)</code>, 
                               and <code>T ⊑ U</code>.</p>
                         </item>
                         <item>
@@ -11305,7 +11305,7 @@ return $lib?product((1.2, 1.3, 1.4))
          
          <p>An expression of the form <code>/<var>PP</var></code> (that is, a path expression
             with a leading <code>/</code>) is treated as an abbreviation for
-	 the expression <code>self::gnode()/(fn:root(.) treat as (document-node()|jnode-type())/<var>PP</var></code>. 
+	 the expression <code>self::gnode()/(fn:root(.) treat as (document-node()|jnode())/<var>PP</var></code>. 
             The effect of this expansion is that for every item <var>J</var> 
             in the context value <var>V</var>:</p>
 	 
@@ -11372,7 +11372,7 @@ return $lib?product((1.2, 1.3, 1.4))
 
          <p>An expression of the form <code>//<var>PP</var></code> (that is, a path expression
             with a leading <code>//</code>) is treated as an abbreviation for
-            the expression <code>self::gnode()/(fn:root(.) treat as (document-node()|jnode-type())/descendant-or-self::gnode()/<var>PP</var></code>. 
+            the expression <code>self::gnode()/(fn:root(.) treat as (document-node()|jnode())/descendant-or-self::gnode()/<var>PP</var></code>. 
             The effect of this expansion is that for every item <var>J</var> 
             in the context value <var>V</var>:</p>
 
@@ -13652,7 +13652,7 @@ the results are the same.
             <p>The following example demonstrates the use of the <code>except</code> operator
             with JNodes:</p>
             
-            <eg>let $m := jnode($map)
+            <eg>let $m := jtree($map)
 for $e in $m/child::* except $m/child::xx 
 return ...</eg>
             
@@ -21030,7 +21030,7 @@ processing with JSON processing.</p>
                   <code>$m?code = 3</code> and <code>$m/code = 3</code> have the same effect.
                   Path expressions, however, have more power, and with it, more complexity.
                   The expression <code>$m/code = 3</code> (unless simplified by an optimizer)
-                  effectively expands the expression to <code>(jnode($m)/child::get("code") => jnode-value()) = 3</code>:
+                  effectively expands the expression to <code>(jtree($m)/child::get("code") => jnode-value()) = 3</code>:
                   that is, the supplied map is wrapped in a JNode, the child axis returns a sequence of JNodes,
                   and the <term>·content·</term> properties of these JNodes are compared with the
                   supplied value <code>3</code>.</p>


### PR DESCRIPTION
Renames the function `fn:jnode` as `fn:jtree`, and the item type `jnode-type()` as `jnode()`

Fix #2099