### PR TITLE
Proposed new operator keywords: precedes, follows

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1653,6 +1653,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   <g:production name="NodeComp" if="xpath40 xquery40  xslt40-patterns" is-binary="yes" node-type="void">
     <g:choice break="false" name="NodeCompOps">
       <g:string>is</g:string>
+      <g:string>is-not</g:string>
       <g:ref name="NodePrecedes"/>
       <g:ref name="NodeFollows"/>
     </g:choice>

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1668,7 +1668,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
 
   <g:production name="NodeFollows" if="xpath40 xquery40  xslt40-patterns" is-binary="yes" node-type="void">
     <g:choice break="false" name="NodeFollowsOps">
-      <g:string>&lt;&lt;</g:string>
+      <g:string>&gt;&gt;</g:string>
       <g:string>follows</g:string>
     </g:choice>
   </g:production>

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1666,7 +1666,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   </g:production>
 
   <g:production name="NodeFollows" if="xpath40 xquery40  xslt40-patterns" is-binary="yes" node-type="void">
-    <g:choice break="false" name="NodePrecedesOps">
+    <g:choice break="false" name="NodeFollowsOps">
       <g:string>&lt;&lt;</g:string>
       <g:string>follows</g:string>
     </g:choice>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -23751,6 +23751,7 @@ return $f(xs:date('2025-03-01'))</eg></fos:expression>
             <code>"&gt;"</code>, <code>">="</code>, <code>"!="</code>, <code>"eq"</code>,
             <code>"lt"</code>, <code>"le"</code>, <code>"gt"</code>, <code>"ge"</code>,
             <code>"ne"</code>, <code>"&lt;&lt;"</code>, <code>"&gt;&gt;"</code>,
+            <code>precedes</code>, <code>follows</code>,
             <code>"is"</code>, <code>"||"</code>, <code>"|"</code>, <code>"union"</code>,
             <code>"except"</code>, <code>"intersect"</code>, <code>"to"</code>,
             <code>"otherwise"</code></p>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -23752,7 +23752,7 @@ return $f(xs:date('2025-03-01'))</eg></fos:expression>
             <code>"lt"</code>, <code>"le"</code>, <code>"gt"</code>, <code>"ge"</code>,
             <code>"ne"</code>, <code>"&lt;&lt;"</code>, <code>"&gt;&gt;"</code>,
             <code>"precedes"</code>, <code>"follows"</code>,
-            <code>"is"</code>, <code>"||"</code>, <code>"|"</code>, <code>"union"</code>,
+            <code>"is"</code>, <code>"is-not"</code>, <code>"||"</code>, <code>"|"</code>, <code>"union"</code>,
             <code>"except"</code>, <code>"intersect"</code>, <code>"to"</code>,
             <code>"otherwise"</code></p>
          <p>The result of calling <code>fn:op("⊙")</code>, where <code>⊙</code> is one of the above operators, is

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -297,7 +297,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
                in the <bibref ref="xpath-40"/> language; indeed, in the interests of avoiding duplication, the majority of
                operators (including all higher-order operators such as <code>x/y</code>, <code>x!y</code>, and <code>x[y]</code>,
                as well simple operators such as <code>x,y</code>, <code>x and y</code>, <code>x or y</code>,            
-            <code>x&lt;&lt;y</code>, <code>x>>y</code>, <code>x is y</code>, <code>x||y</code>, <code>x|y</code>,
+            <code>x&lt;&lt;y</code>, <code>x>>y</code>, <code>x precedes y</code>, <code>x follows y</code>, <code>x is y</code>, <code>x||y</code>, <code>x|y</code>,
             <code>x union y</code>, <code>x except y</code>, <code>x intersect y</code>, <code>x to y</code>
             and <code>x otherwise y</code>) are now defined entirely within <bibref ref="xpath-40"/>.</p>
             

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -297,7 +297,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
                in the <bibref ref="xpath-40"/> language; indeed, in the interests of avoiding duplication, the majority of
                operators (including all higher-order operators such as <code>x/y</code>, <code>x!y</code>, and <code>x[y]</code>,
                as well simple operators such as <code>x,y</code>, <code>x and y</code>, <code>x or y</code>,            
-            <code>x&lt;&lt;y</code>, <code>x>>y</code>, <code>x precedes y</code>, <code>x follows y</code>, <code>x is y</code>, <code>x||y</code>, <code>x|y</code>,
+            <code>x&lt;&lt;y</code>, <code>x>>y</code>, <code>x precedes y</code>, <code>x follows y</code>, <code>x is y</code>, <code>x is-not y</code>, <code>x||y</code>, <code>x|y</code>,
             <code>x union y</code>, <code>x except y</code>, <code>x intersect y</code>, <code>x to y</code>
             and <code>x otherwise y</code>) are now defined entirely within <bibref ref="xpath-40"/>.</p>
             

--- a/specifications/xquery-40/src/ebnf.xml
+++ b/specifications/xquery-40/src/ebnf.xml
@@ -988,7 +988,7 @@
           <td>5</td>
           <td>
             <nt def="ValueComp">eq, ne, lt, le, gt, ge</nt>, <nt def="GeneralComp">=, !=, &lt;,
-              &lt;=, &gt;, &gt;=</nt>, <nt def="NodeComp">is, &lt;&lt;, &gt;&gt;, precedes, follows</nt>
+              &lt;=, &gt;, &gt;=</nt>, <nt def="NodeComp">is, is-not, &lt;&lt;, &gt;&gt;, precedes, follows</nt>
           </td>
           <td>NA</td>
         </tr>

--- a/specifications/xquery-40/src/ebnf.xml
+++ b/specifications/xquery-40/src/ebnf.xml
@@ -988,7 +988,7 @@
           <td>5</td>
           <td>
             <nt def="ValueComp">eq, ne, lt, le, gt, ge</nt>, <nt def="GeneralComp">=, !=, &lt;,
-              &lt;=, &gt;, &gt;=</nt>, <nt def="NodeComp">is, &lt;&lt;, &gt;&gt;</nt>
+              &lt;=, &gt;, &gt;=</nt>, <nt def="NodeComp">is, &lt;&lt;, &gt;&gt;, precedes, follows</nt>
           </td>
           <td>NA</td>
         </tr>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -14788,6 +14788,13 @@ is <code>false</code>. See <bibref
                         ref="xpath-datamodel-40"/> for  the definition of GNode identity.</p>
                </item>
 
+               <item>
+                  <p>A comparison with the <code>is-not</code> operator is <code>false</code> if 
+                     the values of two operands are the same GNode; otherwise it
+is <code>true</code>. See <bibref
+                        ref="xpath-datamodel-40"/> for  the definition of GNode identity.</p>
+               </item>
+
 
                <item>
                   <p>A comparison with the <code>&lt;&lt;</code> or <code>precedes</code> operator returns <code>true</code> 

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -14748,6 +14748,15 @@ of this value comparison is <code>true</code>.</p>
          </div3>
          <div3 id="id-node-comparisons">
             <head>GNode Comparisons</head>
+            <changes>
+               <change date="2025-07-28">
+                  Operator <code>is-not</code> is introduced, as a complement to the operator <code>is</code>.
+               </change>
+               <change date="2025-07-28">
+                  Operators <code>precedes</code> and <code>follows</code> are introduced as synonyms
+                  for operators <code>&lt;&lt;</code> and <code>&gt;&gt;</code>.
+               </change>
+            </changes>
             <p>GNode comparisons are used to compare two <xtermref spec="DM40" ref="dt-GNode">GNodes</xtermref>
                (that is, <termref def="dt-XNode">XNodes</termref> or
                <xtermref spec="DM40" ref="dt-JNode">JNodes</xtermref>), by their identity or by their <termref


### PR DESCRIPTION
The operators `<<` and `>>`, in my opinion, are poorly known, and challenging for developers working in XSLT. Many punctuation-based operators have aliases in ordinary-language quasi-equivalents, but `<<` and `>>` lack any ordinary verbal equivalents, and break this principle.

The attached proposal offers to make `precedes` a keyword equivalent to `<<` and `follows` a keyword equivalent to `>>`. This means that `//title[. &lt;&lt; following-sibling::isbn[1]]` can now be expressed as `//title[. precedes following-sibling::isbn[1]]`