### PR TITLE
Allow implicit whitespace in StringInterpolation

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -2501,7 +2501,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     </g:zeroOrMore>
   </g:production>
 
-  <g:production name="StringInterpolation" if="xquery40" whitespace-spec="explicit">
+  <g:production name="StringInterpolation" if="xquery40">
     <g:string>`{</g:string>
     <g:optional>
       <g:ref name="Expr"/>


### PR DESCRIPTION
Production `StringInterpolation` currently does not allow implicit whitespace:

```
StringInterpolation ::= "`{"  Expr?  "}`"
                                                                         /* ws: explicit */
```

But this is likely not intended - all examples in the spec do have whitespace adjacent to the braces.

This change thus removes ` /* ws: explicit */` in order to allow implicit whitespace.