### PR TITLE
Require at least one character in StringTemplateFixedPart

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -2467,17 +2467,17 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   </g:production>
   
   <g:production name="StringTemplateFixedPart" if="xpath40 xquery40 xslt40-patterns" whitespace-spec="explicit">
-    <g:zeroOrMore>
+    <g:oneOrMore>
       <g:choice>
         <g:ref name="Char" subtract-reg-expr="('{' | '}' | '`')"/>
         <g:string>{{</g:string>
         <g:string>}}</g:string>
         <g:string>``</g:string>
       </g:choice>
-    </g:zeroOrMore>
+    </g:oneOrMore>
   </g:production>
   
-  <g:production name="StringTemplateVariablePart" if="xpath40 xquery40 xslt40-patterns" whitespace-spec="explicit">
+  <g:production name="StringTemplateVariablePart" if="xpath40 xquery40 xslt40-patterns">
     <g:ref name="EnclosedExpr"/>
   </g:production>
 


### PR DESCRIPTION
The grammar rules for `StringTemplate` are as follows:

``` 
StringTemplate              ::=  "`" (StringTemplateFixedPart | StringTemplateVariablePart)* "`"
                                                                                      /* ws: explicit */
StringTemplateFixedPart     ::=  ((Char - ('{' | '}' | '`')) | "{{" | "}}" | "``")*
                                                                                      /* ws: explicit */
StringTemplateVariablePart  ::=  EnclosedExpr
                                                                                      /* ws: explicit */
``` 

But `StringTemplateFixedPart` should not be allowed as a zero-length token, because this is causing an ambiguity: the input ` `` ` currently can be parsed as any of

```xml
<StringTemplate>`<StringTemplateFixedPart/>`</StringTemplate>
``` 
```xml
<StringTemplate>`<StringTemplateFixedPart/><StringTemplateFixedPart/>`</StringTemplate>
``` 
```xml
<StringTemplate>`<StringTemplateFixedPart/><StringTemplateFixedPart/><StringTemplateFixedPart/>`</StringTemplate>
``` 
and so on.

In order to ensure an unambiguous result, `StringTemplateFixedPart` should be required to consist of at least one character. Also the `/* ws: explicit */` on `StringTemplateVariablePart` is superfluous. The grammar rules thus should be changed to:

```xml
StringTemplate              ::=  "`" (StringTemplateFixedPart | StringTemplateVariablePart)* "`"
                                                                                      /* ws: explicit */
StringTemplateFixedPart     ::=  ((Char - ('{' | '}' | '`')) | "{{" | "}}" | "``")+
                                                                                      /* ws: explicit */
StringTemplateVariablePart  ::=  EnclosedExpr
``` 