### PR TITLE
2143 Redesign of method calls

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1903,6 +1903,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
       <g:ref name="FilterExpr"/>
       <g:ref name="DynamicFunctionCall"/>     
       <g:ref name="LookupExpr"/>
+      <g:ref name="MethodCall"/>
       <g:ref name="FilterExprAM"/>
     </g:choice> 
   </g:production>
@@ -1911,6 +1912,14 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:ref name="PostfixExpr"/>
     <g:ref name="PositionalArgumentList"/>
   </g:production>
+  
+  <g:production name="MethodCall" if="xpath40 xquery40  xslt40-patterns">
+    <g:ref name="PostfixExpr"/>
+    <g:string>?></g:string>
+    <g:ref name="NCName"/>
+    <g:ref name="PositionalArgumentList"/>
+  </g:production>
+
 
 
   <g:production name="ArgumentList" if="xpath40 xquery40  xslt40-patterns">

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -10296,31 +10296,7 @@ return $vat(doc('wares.xml')/shop/article)
 ]]></eg>
                                  </example>
             
-            <example>
-               <head>Chaining method calls</head>
-               
-               <p>Methods are described in <specref ref="id-methods"/>, and are commonly used in 
-                  dynamic function calls such as <code>$rectangle?area()</code>. In this example <code>$rectangle</code>
-               is typically a map, and <code>area</code> is the key of one of the entries in the map, the value
-               of the entry being a <termref def="dt-method"/>. The lookup expression
-                  <code>$rectangle?area</code> returns a function item whose captured context includes the containing
-               map, and the dynamic function call then evaluates the body of this method, which is
-               able to access the containing map as the context item.</p>
-               
-               <p>Such calls can be chained. For example if <code>$rectangle?resize(2)</code> returns a rectangle that
-               is twice the size of the original, then <code>$rectangle?resize(2)?area()</code> returns the area of the
-               enlarged rectangle.</p>
-               
-               <p>This kind of chaining extends to the case where a method returns zero or more maps. For example, suppose
-               that rectangles are nested, and that <code>$rectangle?contents()</code> delivers a sequence of zero or more 
-               rectangles. Then the expression <code>$rectangle?area() - sum($rectangle?contents()?area())</code> returns
-               the difference between the area of the containing rectangle and the total area of the contained
-               rectangles. This works because the dynamic function call <code>$rectangle?contents()?area()</code>
-               applies the function <code>area</code> to each of the function items in the sequence returned
-               by the expression <code>$rectangle?contents()</code>.</p>
-               
-               
-            </example>
+            
             
                <note diff="add" at="A"><p>Keyword arguments are not allowed in a dynamic function call.</p></note>
             </div4>
@@ -10865,8 +10841,8 @@ return $a("A")]]></eg>
                      for simple inline functions taking a single argument. 
                      An example is <code>fn { ../@code }</code>
                </change>
-               <change issue="1800 1845" PR="1817 1853" date="2025-03-04">An inline function may be annotated
-               as a <code>%method</code>, giving it access to its containing map.</change>
+               <!--<change issue="1800 1845" PR="1817 1853" date="2025-03-04">An inline function may be annotated
+               as a <code>%method</code>, giving it access to its containing map.</change>-->
             </changes>
 
             <scrap>
@@ -10933,10 +10909,9 @@ return $a("A")]]></eg>
                <p role="xquery"
                      >An inline function
 	  expression may have
-	  annotations. The only annotation defined in &language; 
+	  annotations; however, no annotations are defined in &language; 
 	  for inline function
-	  expressions is the annotation <code>%method</code>, described in 
-                  <specref ref="id-methods"/>.
+	  expressions.
                   It is a <termref
                      def="dt-static-error">static error</termref>
                   <errorref class="ST" code="0125"
@@ -10946,8 +10921,8 @@ return $a("A")]]></eg>
 	  to support functionality beyond the scope of this
 	  specification.</p>
             
-            <p role="xpath">The annotation keyword <code>%method</code> is described
-            in <specref ref="id-methods"/>.</p>
+            <!--<p role="xpath">The annotation keyword <code>%method</code> is described
+            in <specref ref="id-methods"/>.</p>-->
 
                <p>
           The static context for the function body is inherited from the location of the inline function expression.
@@ -10997,10 +10972,10 @@ return $a("A")]]></eg>
                      <item>
                            <p><term>annotations</term>: <phrase role="xquery">The annotations explicitly
                            included in the inline function expression.</phrase>
-                              <phrase role="xpath">If the keyword <code>%method</code> is present, then a list containing
+                              <!--<phrase role="xpath">If the keyword <code>%method</code> is present, then a list containing
                                  a single annotation whose name is a QName with local name <code>"method"</code>
                                  and namespace <code>"http://www.w3.org/2012/xquery"</code> and whose
-                                 value is an empty sequence; otherwise an empty set.</phrase>.</p>
+                                 value is an empty sequence; otherwise an empty set.</phrase>.--></p>
                         
                         </item>
                      <item>
@@ -11054,134 +11029,7 @@ return $incrementors[2](4)]]></eg>
          
 
             
-            <div4 id="id-methods">
-               <head>Methods</head>
-               
-               <changes>
-                  <change issue="1800 1845" PR="1817 1853" date="2025-03-04">An inline function may be annotated
-               as a <code>%method</code>, giving it access to its containing map.</change>
-               </changes>
-               
-               <p><termdef id="dt-method" term="method">A <term>method</term> is a
-               function item that has the annotation <code>%method</code>.</termdef></p>
             
-               <p>A method appearing as a value within a map can refer to the containing map as
-                  the <termref def="dt-context-value"/>. For example, given the variable:</p>
-               
-               <eg>
-let $rectangle := {
-  'height': 3,
-  'width': 4,
-  'area': %method fn() { ?height × ?width }
-}
-               </eg>
-               
-               <p>The dynamic function call <code>$rectangle?area()</code> returns <code>12</code>.</p>
-               
-               <p>The detailed rule is as follows: When the lookup operator <code>?</code>
-                  is applied to a map <var>M</var> (see <specref ref="id-lookup"/>), 
-                     and both the following conditions apply:</p>
-               
-               <ulist>
-         
-                  <item><p>The <code>KeySpecifier</code> in the lookup expression is an
-                  <code>NCName</code> or <code>StringLiteral</code>;</p></item>
-                  <item><p>The lookup expression selects a <termref def="dt-singleton"/> value that
-                  is a function item <var>F</var> declared as a <termref def="dt-method"/></p></item>
-               </ulist>
-               
-               <p>then the function item <var>F'</var> that is returned by the lookup expression is
-                  derived from <var>F</var> as follows:</p>
-               
-                  <ulist>
-                     <item><p><var>F'</var> has a <term>captured context</term> in which 
-                        the <termref def="dt-focus"/> is a <termref def="dt-singleton-focus"/> 
-                        based on the map <var>M</var>.
-                     </p></item>
-                     <item><p><var>F'</var>
-                     has no <code>%method</code> annotation and is therefore not a <termref def="dt-method"/>.
-                     </p></item>
-                     <item><p><var>F'</var>
-                     has a separate function identity from <var>F</var>. It is <termref def="dt-implementation-dependent"/>
-                     whether repeated evaluations of lookup expressions with the same map and the same
-                     key produce functions having the same function identity.
-                     </p></item>
-                     <item><p>In all other respects <var>F'</var> has the same properties as <var>F</var>.</p></item>
-                  
-               </ulist>
-               
-               <note>
-                  <p>Methods are typically invoked using a dynamic function call such as the call
-                  <code>$rectangle?area()</code> in the example above. However, a method selected
-                     using a lookup expression such as <code>$rectangle?area</code> can
-                     be used in the same way as any other function item. For example,
-                  it can be passed as an argument to a higher-order function, or it can be partially
-                  applied.</p>
-                  <p>Although methods mimic some of the capability of object-oriented
-                  languages, the functionality is more limited:</p>
-                  <ulist>
-                     <item><p>There is no encapsulation: the entries in a map are all publicly
-                     exposed.</p></item>
-                     <item><p>There is no class hierarchy, and no inheritance or overriding.</p></item>
-                     <item><p>Methods within a map can be removed or replaced in the same way as
-                     any other entries in the map.</p></item>
-                  </ulist>
-                  <p>The context value in the body of a method is bound to the containing
-                  map by any lookup expression (using the <code>?</code> or <code>??</code> operators)
-                  that selects the method as a singleton item within a key/value pair. It is not
-                  bound by other operations that deliver the value, for example a call on
-                  <function>map:get</function> or <function>map:for-each</function>.
-                  The result of the lookup expression is not itself a method.
-                  The means, for example that the expression:</p>
-                  <eg>
-
-let $rectangle1 := { 'x':3, 'y':4, 'area': %method fn() { ?x × ?y } }
-let $rectangle2 := { 'x':5, 'y':5, 'area': $rectangle1?area }
-return $rectangle2?area()
-                  </eg>
-                  <p>returns 12, because the function item bound to the key <code>"area"</code> in 
-                  <code>$rectangle2</code> is an ordinary function item, not a method.</p>
-                  <p>If the same method is to be used in both variables, this can be written:
-                  </p>
-                  <eg>
-let $area := %method fn() { ?x × ?y }
-let $rectangle1 := { 'x':3, 'y':4, 'area': $area }
-let $rectangle2 := { 'x':5, 'y':5, 'area': $area }
-return $rectangle2?area()
-                  </eg>
-                  <p>which returns 25.</p>
-
-                  <p>An attempt to evaluate a method without binding a context item
-                     will typically result in a dynamic error indicating that the context
-                     item is not bound. Given the declaration above, the expression
-                     <code>$area()</code> raises a type error <errorref class="DY" code="0002"/>
-                     because a unary lookup expression (<code>?x</code> or <code>?y</code>)
-                     requires the context value to be bound.</p>
-
-               </note>
-               <note>
-                  <p>Methods can be useful when there is a need to write inline recursive
-                  functions. For example:</p>
-                  <eg>
-let $lib := {
-  'product': %method fn($in as xs:double*) {
-    if (empty( $in ))
-    then 1
-    else head($in) × ?product(tail($in))
-  }
-}
-return $lib?product((1.2, 1.3, 1.4))
-                  </eg>
-                  <p>In an environment that supports XPath but not XQuery, this mechanism can be used 
-                  to define all the functions that a particular XPath expression needs to invoke,
-                  and these functions can be mutually recursive.</p>
-               </note>
-               <note role="xquery">
-                  <p>Methods are often useful in conjunction with named record types:
-                  see <specref ref="id-functions-as-fields"/>.</p>
-               </note>
-
-            </div4>
 
             <div4 id="id-focus-functions">
                <head>Focus Functions</head>
@@ -11220,10 +11068,10 @@ return $lib?product((1.2, 1.3, 1.4))
                
                <p>For example, the expression <code>every(1 to 10, fn { . gt 0 })</code> returns <code>true</code>.</p>
                
-               <p>A focus function cannot be annotated as a <termref def="dt-method"/> 
+               <!--<p>A focus function cannot be annotated as a <termref def="dt-method"/> 
                   (<errorref spec="XP" class="ST" code="0107"/>). (This is because the context value
                in a method is bound to the containing map, and is therefore not available to be bound to the function’s argument).</p>
-               
+               -->
             </div4>
 
          </div3>
@@ -20934,8 +20782,8 @@ processing with JSON processing.</p>
                   they can be qualified with a type to select only the results that
                   match that type.-\->
                </change>-->
-               <change issue="1800 1845" PR="1817 1853" date="2025-03-04">An inline function may be annotated
-               as a <code>%method</code>, giving it access to its containing map.</change>
+               <!--<change issue="1800 1845" PR="1817 1853" date="2025-03-04">An inline function may be annotated
+               as a <code>%method</code>, giving it access to its containing map.</change>-->
                <!--<change issue="1456 1866" PR="1864 1877">
                   The key specifier can reference an item type or sequence type, to select
                   values of that type only. This is especially useful when processing
@@ -21207,6 +21055,138 @@ processing with JSON processing.</p>
                </ulist>
             </div4>
          </div3>
+         
+         <div3 id="id-methods">
+               <head>Method Calls</head>
+               
+               <changes>
+                  <change issue="2143" date="2025-08-04">A method call invokes a function
+                     held as the value of an entry in a map, supplying the map implicitly
+                     as the value of the first argument.</change>
+               </changes>
+            
+            <scrap>
+               <prodrecap ref="MethodCall"/>
+            </scrap>
+               
+               <p>A method call combines looking up an entry
+               in a map whose value is a function item, and calling that function item
+               with that map as the implicit value of the first argument.</p>
+            
+               <p>For example, given the variable:</p>
+               
+               <eg>
+let $rectangle := {
+  'height': 3,
+  'width': 4,
+  'area': fn ($rect) { $rect?height × $rect?width }
+}
+               </eg>
+               
+               <p>The dynamic function call <code>$rectangle ?> area()</code> returns <code>12</code>.</p>
+            
+               <p>The function can also be written as a <termref def="dt-focus-function"/>:</p>
+            
+            <eg>
+let $rectangle := {
+  'height': 3,
+  'width': 4,
+  'area': fn { ?height × ?width }
+}
+               </eg>
+               
+               <p>The expression <code><var>M</var> ?> <var>N</var>(<var>X</var>, <var>Y</var>, ...)</code>
+                  is by definition equivalent to:</p>
+              <eg>for $map as map(*) in <var>M</var> 
+return ($map?<var>N</var> treat as function(*))
+           ($map, <var>X</var>, <var>Y</var>, ...)</eg> 
+            <p>(where <code>$map</code>
+                  is some otherwise unused variable name).</p>
+            
+               <p>The argument list in a method call must not include an argument placeholder; that is,
+               the call must not be a partial function application.</p>
+                  
+               <note>
+                  <p>Implicit in this definition are the following rules:</p>
+                  <ulist>
+                     <item><p>The value of <var>M</var> must be
+                     a sequence of zero or more maps;</p></item>
+                     <item><p>Each of those maps must have an entry with the
+                        key <var>N</var> (as an instance of <code>xs:string</code>,
+                        <code>xs:untypedAtomic</code>, or <code>xs:anyURI</code>);</p></item>
+                     <item><p>The value of that entry must be
+                     a single function item;</p></item>
+                     <item><p>That function item must have an arity equal to one plus the number
+                        of supplied arguments, and the signature of the function
+                        must allow a map to be supplied as the first argument.</p></item>
+                  </ulist>
+                  <p>The error codes raised if these conditions are not satisfied are
+                  exactly the same as if the expanded code were used directly.</p>
+               </note>
+               
+               
+               
+               <note>
+                  
+                  <p>Although methods mimic some of the capability of object-oriented
+                  languages, the functionality is more limited:</p>
+                  <ulist>
+                     <item><p>There is no encapsulation: the entries in a map are all publicly
+                     exposed.</p></item>
+                     <item><p>There is no class hierarchy, and no inheritance or overriding.</p></item>
+                     <item><p>Methods within a map can be removed or replaced in the same way as
+                     any other entries in the map.</p></item>
+                  </ulist>
+               </note>   
+               <note>
+                  <p>Methods can be useful when there is a need to write inline recursive
+                  functions. For example:</p>
+                  <eg>
+let $lib := {
+  'product': fn($map as map(*), $in as xs:double*) {
+    if (empty( $in ))
+    then 1
+    else head($in) × $map ?> product(tail($in))
+  }
+}
+return $lib ?> product((1.2, 1.3, 1.4))
+                  </eg>
+                  <p>In an environment that supports XPath but not XQuery, this mechanism can be used 
+                  to define all the functions that a particular XPath expression needs to invoke,
+                  and these functions can be mutually recursive.</p>
+               </note>
+               <note role="xquery">
+                  <p>Methods are often useful in conjunction with named record types:
+                  see <specref ref="id-functions-as-fields"/>.</p>
+               </note>
+            
+            <example>
+               <head>Chaining method calls</head>
+               
+               <p>In the example above, <code>$rectangle ?> area()</code>, <code>$rectangle</code>
+               is typically a single map, and <code>area</code> is the key of one of the entries in the map, the value
+               of the entry being a function item that takes the map as its implicit first argument. 
+               The method call
+                  <code>$rectangle ?> area()</code> first performs a map lookup (<code>$rectangle?area</code>)
+                  to select the function item, and calls the function item, supplying the containing
+                  map as the first (and in this case only) argument.</p>
+               
+               <p>Such calls can be chained. For example if <code>$rectangle ?> resize(2)</code> returns a rectangle that
+               is twice the size of the original, then <code>$rectangle ?> resize(2) ?> area()</code> returns the area of the
+               enlarged rectangle.</p>
+               
+               <p>This kind of chaining extends to the case where a method returns zero or more maps. For example, suppose
+               that rectangles are nested, and that <code>$rectangle ?> contents()</code> delivers a sequence of zero or more 
+               rectangles. Then the expression <code>$rectangle ?> area() - sum($rectangle ?> contents() ?> area())</code> returns
+               the difference between the area of the containing rectangle and the total area of the contained
+               rectangles. This works because the dynamic function call <code>$rectangle ?> contents() ?> area()</code>
+               applies the <code>area</code> function in each of the maps the sequence returned
+               by the expression <code>$rectangle ?> contents()</code>.</p>
+               
+               
+            </example>
+
+            </div3>
          
          <div3 id="id-filter-maps-and-arrays">
             <head>Filter Expressions for Maps and Arrays</head>

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -1855,8 +1855,8 @@ local:summary(doc("acme_corp.xml")//employee[location = "Denver"])</eg>
       <errorref spec="XQ" class="ST" code="0150"/>.
       For an overview of the behavior of variadic functions, see <specref ref="id-variadic-functions-overview"/>. </p>-->
       
-      <p>The annotation <code>%method</code> is reserved for use with inline function declarations: see
-      <specref ref="id-methods"/> <errorref spec="XP" class="ST" code="0107"/>.</p>
+      <!--<p>The annotation <code>%method</code> is reserved for use with inline function declarations: see
+      <specref ref="id-methods"/> <errorref spec="XP" class="ST" code="0107"/>.</p>-->
       
       <p>An implementation can define annotations, in its own namespace, to support functionality
         beyond the scope of this specification. For instance, an implementation that supports external
@@ -2280,34 +2280,34 @@ local:depth(doc("partlist.xml"))
     <div3 id="id-functions-as-fields">
       <head>Using Methods in Records</head>
        
-       <p>Named record declarations are useful in conjunction with <termref def="dt-method">methods</termref>, 
+       <p>Named record declarations are useful in conjunction with method calls, 
          described in <specref ref="id-methods"/>. For example, given the declaration:</p>
        
        <eg>declare record geom:rectangle(
   width as xs:double,
   height as xs:double,
-  area as fn() as xs:double := %method fn() { 
-    ?width × ?height
+  area as fn($rect as map(*)) as xs:double := fn($rect) { 
+    $rect -> ?width × ?height
   },
-  perimeter as fn() as xs:double := %method fn() {
-    2 × (?width + ?height)
+  perimeter as fn($rect as map(*)) as xs:double := fn($rect) {
+    $rect -> 2 × (?width + ?height)
   },
-  expand as fn($factor as xs:double) as geom:rectangle := %method fn() {
-    geom:rectangle(?width × $factor, ?height × $factor)
+  expand as fn($rect as map(*), $factor as xs:double) as geom:rectangle := fn() {
+    $rect -> geom:rectangle(?width × $factor, ?height × $factor)
   }   
 );</eg>
        
        <p>The following expression constructs a rectangle and calculates its area:</p>
        
        <eg>let $box := geom:rectangle(3, 2)
-return $box?area()</eg>
+return $box ?> area()</eg>
       
       <p>The following expands the dimensions of the rectangle and 
         calculates the perimeter of the result:</p>
       <eg>let $box := geom:rectangle(3, 2)
-return $box?expand(2)?perimeter()</eg>
+return $box ?> expand(2) ?> perimeter()</eg>
      <note><p>There is nothing to stop a user constructing an instance of <code>geom:rectangle</code>
-     in which the <code>area</code> field holds some different function: while the syntax imitates
+     in which the <code>area</code> entry holds some different function: while the syntax imitates
      that of object-oriented languages, there is no encapsulation.</p></note>
     </div3>
     
@@ -2333,12 +2333,12 @@ return $box?expand(2)?perimeter()</eg>
                   
                   <item><p>
                      <eg><![CDATA[declare variable $odds as set:atomic-set
-    := set:build((1 to 100)) ? except($evens)]]></eg>
+    := set:build((1 to 100)) ?> except($evens)]]></eg>
                   </p></item>
                   
                   <item><p>
                      <eg><![CDATA[declare function my:is-even ($n as xs:integer) as xs:boolean {
-    $evens ? contains($n)
+    $evens ?> contains($n)
 };]]></eg>
                   </p></item>
                   
@@ -2363,29 +2363,29 @@ module namespace set = "http://qt4cg.org/atomic-set";
       If $A and $B are instances of set:atomic-set, then they
       can be manipulated using methods including:
       
-      $A?size() - returns the number of items in the set
-      $A?empty() - returns true if the set is empty
-      $A?contains($k) - determines whether $k is a member of the set
-      $A?contains-all($B) - returns true if $B is a subset of $A
-      $A?values() - returns the items in $A, as a sequence
-      $A?add($k) - returns a new atomic set containing an additional item
-      $A?remove($k) - returns a new atomic set in which the given item is absent
-      $A?union($B) - returns a new atomic set holding the union of $A and $B
-      $A?intersect($B) - returns a new atomic set holding the intersection of $A and $B
-      $A?except($B) - returns a new atomic set holding the difference of $A and $B
+      $A?>size() - returns the number of items in the set
+      $A?>empty() - returns true if the set is empty
+      $A?>contains($k) - determines whether $k is a member of the set
+      $A?>contains-all($B) - returns true if $B is a subset of $A
+      $A?>values() - returns the items in $A, as a sequence
+      $A?>add($k) - returns a new atomic set containing an additional item
+      $A?>remove($k) - returns a new atomic set in which the given item is absent
+      $A?>union($B) - returns a new atomic set holding the union of $A and $B
+      $A?>intersect($B) - returns a new atomic set holding the intersection of $A and $B
+      $A?>except($B) - returns a new atomic set holding the difference of $A and $B
    :)
    
    declare %public record set:atomic-set (
        _data        as map(xs:anyAtomicType, xs:boolean),
-       size         as %method fn() as xs:integer,
-       empty        as %method fn() as xs:boolean,
-       contains     as %method fn($value as xs:anyAtomicType) as xs:boolean,
-       contains-all as %method fn($value as set:atomic-set) as xs:boolean,
-       add          as %method fn($item as xs:anyAtomicType) as set:atomic-set,
-       remove       as %method fn($item as xs:anyAtomicType) as set:atomic-set,
-       union        as fn($value as set:atomic-set) as set:atomic-set,
-       intersect    as fn($value as set:atomic-set) as set:atomic-set,
-       except       as fn($value as set:atomic-set) as set:atomic-set,
+       size         as fn($set as set:atomic-set) as xs:integer,
+       empty        as fn($set as set:atomic-set) as xs:boolean,
+       contains     as fn($set as set:atomic-set, $value as xs:anyAtomicType) as xs:boolean,
+       contains-all as fn($set as set:atomic-set, $value as set:atomic-set) as xs:boolean,
+       add          as fn($set as set:atomic-set, $item as xs:anyAtomicType) as set:atomic-set,
+       remove       as fn($set as set:atomic-set, $item as xs:anyAtomicType) as set:atomic-set,
+       union        as fn($set as set:atomic-set, $value as set:atomic-set) as set:atomic-set,
+       intersect    as fn($set as set:atomic-set, $value as set:atomic-set) as set:atomic-set,
+       except       as fn($set as set:atomic-set, $value as set:atomic-set) as set:atomic-set,
        * );
 
    declare %private variable DATA := "'_data'"; 
@@ -2409,38 +2409,28 @@ module namespace set = "http://qt4cg.org/atomic-set";
        {
          _data:
              map:build($values, values:=true#0, {'duplicates': 'use-first'}),
-         size:
-             %method fn() as xs:integer 
-                     { map:size(?$DATA) },
-         empty:
-             %method fn() as xs:boolean 
-                     { map:empty(?$DATA) },
-         contains:
-             %method fn($value as xs:anyAtomicType) as xs:boolean 
-                     { map:contains(?$DATA, $value) },
-         contains-all:
-             %method fn($other as set:atomic-set) as xs:boolean 
-                     { every($value, map:contains(?$DATA, ?)) },
-         values:
-            "%method fn() as xs:anyAtomicType* 
-                     { keys(?$DATA) }"
-         add:
-             %method fn($value as xs:anyAtomicType) as xs:anyAtomicType*
-                     { set:replaceData(., map:put(?, $value, true())) },
-         remove:
-             %method fn($value as xs:anyAtomicType) as xs:anyAtomicType* 
-                     { set:replaceData(., map:remove(?, $value)) },
-         union:
-             %method fn($other as set:atomic-set) as set:atomic-set 
-                     { set:replaceData(., fn($this) {map:merge(($this, $other?$DATA),
+         size: fn($set as set:atomic-set) as xs:integer 
+                     { map:size($set?$DATA) },
+         empty: fn($set as set:atomic-set) as xs:boolean 
+                     { map:empty($set?$DATA) },
+         contains: fn($set as set:atomic-set, $value as xs:anyAtomicType) as xs:boolean 
+                     { map:contains($set?$DATA, $value) },
+         contains-all: fn($set as set:atomic-set, $other as set:atomic-set) as xs:boolean 
+                     { every($other, map:contains($set?$DATA, ?)) },
+         values: fn($set as set:atomic-set) as xs:anyAtomicType* 
+                     { keys($set?$DATA) }"
+         add: fn($set as set:atomic-set, $value as xs:anyAtomicType) as xs:anyAtomicType*
+                     { set:replaceData($set, map:put(?, $value, true())) },
+         remove: fn($set as set:atomic-set, $value as xs:anyAtomicType) as xs:anyAtomicType* 
+                     { set:replaceData($set, map:remove(?, $value)) },
+         union: fn($set as set:atomic-set, $other as set:atomic-set) as set:atomic-set 
+                     { set:replaceData($set, fn($this) {map:merge(($this, $other?$DATA),
                                                     {'duplicates': 'use-first'})})
                      },
-         intersect:
-             %method fn($other as set:atomic-set) as set:atomic-set 
-                     { set:replaceData(., map:filter(?, $other?contains)) },
-         except=
-             %method fn($other as set:atomic-set) as set:atomic-set 
-                     { set:replaceData(., map:remove(?, $other?values())) }
+         intersect: fn($set as set:atomic-set, $other as set:atomic-set) as set:atomic-set 
+                     { set:replaceData($set, map:filter(?, $other?contains)) },
+         except: fn($set as set:atomic-set, $other as set:atomic-set) as set:atomic-set 
+                     { set:replaceData($set, map:remove(?, $other?values())) }
       }
    };]]></eg>
                

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -11917,15 +11917,15 @@ and <code>version="1.0"</code> otherwise.</p>
    <xsl:field name="left" as="my:binary-tree?"/>
    <xsl:field name="payload" as="item()*"/>
    <xsl:field name="right" as="my:binary-tree?"/>
-   <xsl:field name="depth" as="%method fn(my:binary-tree) as xs:integer"
-      default="%method fn() {1 + max((?left ? depth(), ?right ? depth())) otherwise 0)}"/>
+   <xsl:field name="depth" as="fn(my:binary-tree) as xs:integer"
+      default="fn {1 + max((?left ?> depth(), ?right ?> depth())) otherwise 0)}"/>
 </xsl:record-type>]]></eg>
                   
-                  <p>The <code>%method</code> annotation is described in
-                     <xspecref spec="XP40" ref="id-methods"/>. Its effect is to
+                  <p>Method calls (using the operator <code>?></code>) are described in
+                     <xspecref spec="XP40" ref="id-methods"/>. The effect is to
                      give a function item contained in a map access to the containing
                      map.
-                  It thus mimics method invocation in object-oriented languages, though
+                  They thus mimic method invocation in object-oriented languages, though
                   there is no inheritance or encapsulation.</p>
                   
                   <p>The following code builds a simple tree and calculates its depth:</p>
@@ -11936,7 +11936,7 @@ let $tree := my:binary-tree(
                18,
                my:binary-tree((), 19, 
                  my:binary-tree((), 20, ())))
-return $tree =?> depth()]]></eg>
+return $tree ?> depth()]]></eg>
                
                
                   <p>Returning the result 3.</p>
@@ -11982,10 +11982,7 @@ return $tree =?> depth()]]></eg>
                   
                </ulist>
                
-               <p>Here is the implementation of the package. It relies heavily
-               on the use of the function annotation <code>%method</code>, which
-               gives a function item contained in a map access to the containing
-               map: methods are described in <xspecref spec="XP40" ref="id-methods"/>.</p>
+               <p>Here is the implementation of the package.</p>
                
                <eg><![CDATA[
 <xsl:package name="http://qt4cg.org/atomic-set"
@@ -12005,16 +12002,16 @@ return $tree =?> depth()]]></eg>
       If $A and $B are instances of set:atomic-set, then they
       can be manipulated using methods including:
       
-      $A?size() - returns the number of items in the set
-      $A?empty() - returns true if the set is empty
-      $A?contains($k) - determines whether $k is a member of the set
-      $A?contains-all($B) - returns true if $B is a subset of $A
-      $A?values() - returns the items in $A, as a sequence
-      $A?add($k) - returns a new atomic set containing an additional item
-      $A?remove($k) - returns a new atomic set in which the given item is absent
-      $A?union($B) - returns a new atomic set holding the union of $A and $B
-      $A?intersect($B) - returns a new atomic set holding the intersection of $A and $B
-      $A?except($B) - returns a new atomic set holding the difference of $A and $B
+      $A ?> size() - returns the number of items in the set
+      $A ?> empty() - returns true if the set is empty
+      $A ?> contains($k) - determines whether $k is a member of the set
+      $A ?> contains-all($B) - returns true if $B is a subset of $A
+      $A ?> values() - returns the items in $A, as a sequence
+      $A ?> add($k) - returns a new atomic set containing an additional item
+      $A ?> remove($k) - returns a new atomic set in which the given item is absent
+      $A ?> union($B) - returns a new atomic set holding the union of $A and $B
+      $A ?> intersect($B) - returns a new atomic set holding the intersection of $A and $B
+      $A ?> except($B) - returns a new atomic set holding the difference of $A and $B
    </xsl:note>
    
    <xsl:record-type name="set:atomic-set" 
@@ -12023,23 +12020,23 @@ return $tree =?> depth()]]></eg>
       <xsl:field name="_data" 
                  as="map(xs:anyAtomicType, xs:boolean)"/>
       <xsl:field name="size" 
-                 as="%method fn() as xs:integer"/>
+                 as="fn(set:atomic-set) as xs:integer"/>
       <xsl:field name="empty" 
-                 as="%method fn() as xs:boolean"/>
+                 as="fn(set:atomic-set) as xs:boolean"/>
       <xsl:field name="contains" 
-                 as="%method fn($value as xs:anyAtomicType) as xs:boolean"/> 
+                 as="fn(set:atomic-set, xs:anyAtomicType) as xs:boolean"/> 
       <xsl:field name="contains-all" 
-                 as="%method fn($value as set:atomic-set) as xs:boolean"/> 
+                 as="fn(set:atomic-set, set:atomic-set) as xs:boolean"/> 
       <xsl:field name="add" 
-                 as="%method fn($item as xs:anyAtomicType) as set:atomic-set"/> 
+                 as="fn(set:atomic-set, xs:anyAtomicType) as set:atomic-set"/> 
       <xsl:field name="remove" 
-                 as="%method fn($item as xs:anyAtomicType) as set:atomic-set"/>
+                 as="fn(set:atomic-set, xs:anyAtomicType) as set:atomic-set"/>
       <xsl:field name="union" 
-                 as="%method fn($value as set:atomic-set) as set:atomic-set"/>
+                 as="fn(set:atomic-set, set:atomic-set) as set:atomic-set"/>
       <xsl:field name="intersect" 
-                 as="%method fn($value as set:atomic-set) as set:atomic-set"/> 
+                 as="fn(set:atomic-set, set:atomic-set) as set:atomic-set"/> 
       <xsl:field name="except" 
-                 as="%method fn($value as set:atomic-set) as set:atomic-set"/> 
+                 as="fn(set:atomic-set, set:atomic-set) as set:atomic-set"/> 
    </xsl:record-type>
    
    <xsl:variable name="DATA" select="'_data'" visibility="private"/>
@@ -12064,37 +12061,37 @@ return $tree =?> depth()]]></eg>
          _data=
             "map:build($values, values:=true#0, {'duplicates': 'use-first'})"
          size=
-            "%method fn() as xs:integer 
-                     { map:size(?$DATA) }"
+            "fn($this as set:atomic-set) as xs:integer 
+                     { map:size($this?$DATA) }"
          empty=
-            "%method fn() as xs:boolean 
-                     { map:empty(?$DATA) }"
+            "fn($this as set:atomic-set) as xs:boolean 
+                     { map:empty($this?$DATA) }"
          contains=
-            "%method fn($value as xs:anyAtomicType) as xs:boolean 
-                     { map:contains(?$DATA, $value) }"
+            "fn($this as set:atomic-set, $value as xs:anyAtomicType) as xs:boolean 
+                     { map:contains($this?$DATA, $value) }"
          contains-all=
-            "%method fn($other as set:atomic-set) as xs:boolean 
-                     { every($value, map:contains(?$DATA, ?)) }"
+            "fn($this as set:atomic-set, $other as set:atomic-set) as xs:boolean 
+                     { every($other, map:contains($this?$DATA, ?)) }"
          values=
-            "%method fn() as xs:anyAtomicType* 
-                     { keys(?$DATA) }"
+            "fn($this as set:atomic-set) as xs:anyAtomicType* 
+                     { keys($this?$DATA) }"
          add=
-            "%method fn($value as xs:anyAtomicType) as xs:anyAtomicType*
-                     { set:replaceData(., map:put(?, $value, true())) }"
+            "fn($this as set:atomic-set, $value as xs:anyAtomicType) as xs:anyAtomicType*
+                     { set:replaceData($this, map:put(?, $value, true())) }"
          remove=
-            "%method fn($value as xs:anyAtomicType) as xs:anyAtomicType* 
-                     { set:replaceData(., map:remove(?, $value)) }"
+            "fn($this as set:atomic-set, $value as xs:anyAtomicType) as xs:anyAtomicType* 
+                     { set:replaceData($this, map:remove(?, $value)) }"
          union=
-            "%method fn($other as set:atomic-set) as set:atomic-set 
-                     { set:replaceData(., fn($this) {map:merge(($this, $other?$DATA),
+            "fn($this as set:atomic-set, $other as set:atomic-set) as set:atomic-set 
+                     { set:replaceData($this, fn($m) {map:merge(($m, $other?$DATA),
                                                     {'duplicates': 'use-first'})})
                      }"
          intersect=
-            "%method fn($other as set:atomic-set) as set:atomic-set 
-                     { set:replaceData(., map:filter(?, $other?contains)) }"
+            "fn($this as set:atomic-set, $other as set:atomic-set) as set:atomic-set 
+                     { set:replaceData($this, map:filter(?, $other?contains)) }"
          except=
-            "%method fn($other as set:atomic-set) as set:atomic-set 
-                     { set:replaceData(., map:remove(?, $other?values())) }"/>
+            "fn($this as set:atomic-set, $other as set:atomic-set) as set:atomic-set 
+                     { set:replaceData($this, map:remove(?, $other?values())) }"/>
       
    </xsl:function>
    
@@ -12102,8 +12099,7 @@ return $tree =?> depth()]]></eg>
 </xsl:package>                  
                   ]]></eg>
                
-               <ednote><edtext><p>The example is not yet tested. It could also be written
-               using the new xsl:record instruction, which might be more concise.</p></edtext></ednote>
+               <ednote><edtext><p>The example is not yet tested. </p></edtext></ednote>
             </div3>
          </div2>
          <div2 id="defining-decimal-format">


### PR DESCRIPTION
Although issue #2143 envisaged redefining method calls in terms of JNodes, this PR takes a different approach.

The "magic" performed by the lookup operator when the entry in a map is annotated %method is dropped. Instead we have a new operator `?>` which is essentially defined as a macro: in simple cases `$map ?> method (X)` is defined to be essentially an abbreviation for `($map ? method)($map, X)`.

I have used the operator `?>` suggested by Christian, but in some ways I prefer the operator we had originally, `=?>`, because (a) there is a stronger analogy with `=>`, and (b) `?>` brings up images of XML syntax for processing instructions.