### PR TITLE
2021 Move the section on Patterns to a more logical place in the spec

### DIFF
--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -10698,798 +10698,6 @@ and <code>version="1.0"</code> otherwise.</p>
 
          
 
-         <div2 id="patterns">
-            <head>Patterns</head>
-
-            <p>In XSLT 4.0, patterns can match any kind of item: atomic items and
-               function items as well as nodes.</p>
-
-            <p>A <termref def="dt-template-rule">template rule</termref> identifies the items to which it applies by means of a pattern. As
-               well as being used in template rules, patterns are used for numbering (see <specref ref="number"/>), for grouping (see <specref ref="grouping"/>), and for declaring
-                  <termref def="dt-key">keys</termref> (see <specref ref="key"/>).</p>
-            <p><termdef id="dt-pattern" term="pattern">A <term>pattern</term> specifies a set of
-                  conditions on an item. An item that satisfies the conditions matches the pattern; an
-                     item that does not satisfy the conditions
-                  does not match the pattern.</termdef></p>
-
-            <p diff="chg" at="2022-01-01">There are three kinds of pattern: <termref def="dt-predicate-pattern">predicate patterns</termref>, 
-               <termref def="dt-type-pattern">type patterns</termref>,
-               and <termref def="dt-node-pattern">node patterns</termref>:</p>
-
-            <ulist diff="chg" at="2022-01-01">
-               <item>
-                  <p><termdef id="dt-predicate-pattern" term="predicate pattern">A <term>predicate pattern</term> is written as
-                           <code>.</code> (dot) followed by zero or more predicates in square
-                        brackets, and it matches any item for which each of the predicates evaluates
-                        to <code>true</code>.</termdef></p>
-                  <p>A predicate pattern <code>.[P1][P2]...</code> can be regarded as an abbreviation
-                     for the type pattern <code>type(item())[P1][P2]...</code>.</p>
-                  <p>The detailed semantics are given in <specref ref="predicate-patterns"/>. This construct can be used to match items of any
-                     kind (nodes, atomic items, and function items). For example, the pattern
-                     <code>.[starts-with(., '$')]</code> matches any string that starts with the
-                     character <code>$</code>, or a node whose atomized value starts with 
-                     <code>$</code>. This example shows a predicate pattern with a single
-                     predicate, but the grammar allows any number of predicates (zero or more).</p>
-               </item>
-               <item>
-                  <p><termdef id="dt-type-pattern" term="type pattern">A <term>type pattern</term> can be written as
-                     <code>type(T)</code> (where <var>T</var> is an <xnt spec="XP40" ref="prod-xpath40-ItemType">ItemType</xnt>
-                     followed by zero or more predicates in square
-                     brackets, and it matches any item of type <var>T</var> which each of the predicates evaluates
-                     to <code>true</code>.</termdef></p>
-                  <p>The parameter <var>T</var> can also be a list of item types, separated by <code>"|"</code>.
-                  For example, <code>type(array(*) | map(*))</code> matches arrays and maps, while 
-                  <code>type(text() | comment())</code> matches text nodes and comment nodes.</p>
-                  <p>The most commonly used type patterns can be abbreviated. For example, <code>match="type(record(F1, F2, *))"</code> 
-                     can be abbrevated to <code>match="record(F1, F2, *)"</code>, and <code>match="type(array(xs:string))"</code>
-                     can be abbreviated to <code>match="array(xs:string)"</code>. The main case where such abbreviation is
-                  not possible is with atomic items: <code>match="type(xs:date)"</code> cannot be abbreviated because
-                  a bare QName is interpreted as a node pattern, matching elements named <code>xs:date</code>.
-                  The pattern <code>match="type(text() | comment())"</code> has almost the same effect as
-                  <code>match="text() | comment()"</code>, except that the rules for calculating a default priority
-                  are different.</p>
-                  
-               </item>
-               <item>
-                  <p><termdef id="dt-node-pattern" term="node pattern">A <term>node pattern</term> uses a subset of
-                        the syntax for path expressions, and is defined to match a node if the
-                        corresponding path expression would select the node. Node patterns may
-                        also be formed by combining other patterns using union, intersection, and
-                        difference operators.</termdef></p>
-                  <p>The syntax for node patterns
-                        (<code>UnionExprP</code> in the grammar:
-                        see <specref ref="pattern-syntax"/>) is a subset of the syntax for
-                        <termref def="dt-expression">expressions</termref>. Node patterns are
-                        used only for matching nodes; an item other than a node will never match a
-                           node pattern.
-                     As explained in detail below, a node matches a node pattern if the node can be selected by
-                     deriving an equivalent expression, and evaluating this expression with respect
-                     to some possible context.</p>
-               </item>
-            </ulist>
-
-
-
-
-
-            
-
-
-
-
-            <note>
-               <p>The specification uses the phrases <emph>an item matches a pattern</emph> and
-                     <emph>a pattern matches an item</emph> interchangeably. They are equivalent: an
-                  item matches a pattern if and only if the pattern matches the item.</p>
-            </note>
-            <div3 id="pattern-examples">
-               <head>Examples of Patterns</head>
-               <example id="pattern-examples-1">
-                  <head>Patterns</head>
-                  <p>Here are some examples of patterns:</p>
-                  <ulist>
-                     <item>
-                        <p><emph>Predicate Patterns:</emph></p>
-                        <olist>
-                           <item>
-                              <p><code>.</code> matches any item.</p>
-                           </item>
-                           <item>
-                              <p><code>.[. castable as xs:date]</code> matches any item
-                                 that can be successfully cast to <code>xs:date</code>: for example,
-                              an <code>xs:date</code> or <code>xs:dateTime</code> value, or a string
-                              in the lexical form of a date, or a node whose typed value is an <code>xs:date</code>
-                              or a string in the form of a date.</p>
-                           </item>
-                           <item>
-                              <p><code>.[string() => matches('^[0-9]$')]</code> matches any
-                                 item whose string value is a sequence of digits.</p>
-                           </item>
-                           <item>
-                              <p><code>.[. castable as xs:date][xs:date(.) le current-date()]</code> matches any
-                                 item that is castable to <code>xs:date</code> provided that the result of casting
-                                 the value to <code>xs:date</code> is a date in the past.</p>
-                           </item>
-                        </olist>
-                     </item>
-                     <item diff="add" at="2022-01-01">
-                        <p><emph>Type Patterns</emph></p>
-                        <olist>
-                           <item>
-                              <p><code>type(item())</code> matches any item.</p>
-                           </item>
-                           <item>
-                              <p><code>type(node())</code> matches any node.
-                                 (Note the distinction from the pattern <code>node()</code>.)</p>
-                           </item>
-                           <item>
-                              <p><code>type(xs:date)</code> matches any
-                                 atomic item of type <code>xs:date</code> (or a type derived by
-                                 restriction from <code>xs:date</code>).</p>
-                           </item>
-                           <item>
-                              <p><code>type(xs:date)[. gt current-date()]</code> matches any date in
-                                 the future.</p>
-                           </item>
-                           <item>
-                              <p><code>type(xs:string)[starts-with(., 'e')]</code> matches any <code>xs:string</code>
-                                 value that starts with the letter <code>e</code>. Note there is no type conversion; the pattern
-                              will not match an <code>xs:untypedAtomic</code> or <code>xs:anyURI</code> value,
-                              nor will it match any node.</p>
-                           </item>
-                           <item>
-                              <p><code>type(fn(*))</code> matches any
-                                 function item.</p>
-                           </item>
-                           <item>
-                              <p><code>type(fn($x as xs:integer) as xs:boolean)[.(42)]</code> matches any function that
-                                 accepts an <code>xs:integer</code> argument and returns a boolean result, provided
-                                 that the result of calling the function with the argument value <code>42</code> is <code>true</code>.</p>
-                           </item>
-                           <item>
-                              <p><code>type(xs:date | xs:dateTime | xs:time)</code> matches any atomic item
-                                 that is an instance of <code>xs:date</code>, <code>xs:dateTime</code>, or <code>xs:time</code>.</p>
-                           </item>
-                           <item>
-                              <p><code>type(array(xs:date) | array(xs:dateTime) | array(xs:time))</code> matches any array whose
-                                 members are all of type <code>xs:date</code>, any array whose
-                                 members are all of type <code>xs:dateTime</code>, or any array whose
-                                 members are all of type <code>xs:time</code>.</p>
-                           </item>
-                           <item>
-                              <p><code>type(map((xs:string|xs:untypedAtomic), *)</code> matches any map
-                                 whose keys are all instances of <code>xs:string</code> or <code>xs:untypedAtomic</code>.</p>
-                           </item>
-                           <item>
-                              <p><code>enum("red", "green", "blue")</code> matches any one of the three strings
-                                 <code>"red"</code>, <code>"green"</code>, or <code>"blue"</code>.</p>
-                           </item>
-                           <item>
-                              <p><code>record(first, last, *)[?location = 'UK']</code> matches any map whose keys include the strings <code>"first"</code>
-                                 and <code>"last"</code>, and that also has an entry with key <code>"location"</code> whose
-                              value is <code>"UK"</code>.</p>
-                           </item>
-                           <item>
-                              <p><code>record(longitude, latitude)</code> matches any map with two entries whose keys are the strings <code>"longitude"</code>
-                                 and <code>"latitude"</code>.</p>
-                           </item>
-                           <item>
-                              <p><code>array(xs:integer)[array:size(.) eq 4]</code> matches any array of four integers.</p>
-                           </item>
-                           <item>
-                              <p><code>array(record(first, last, *))</code> matches any array of maps where each map
-                                 contains entries with keys <code>"first"</code> and <code>"last"</code>. (Note that
-                              this includes the empty array).</p>
-                           </item>
-                           <item>
-                              <p><code>array(record(first, last, *))[array:size(.) gt 0]</code> matches any non-empty array of maps where each map
-                                 contains entries with keys <code>"first"</code> and <code>"last"</code>. </p>
-                           </item>
-                           <item>
-                              <p><code>type(complex)</code> matches any value that is an instance of the item type 
-                                 declared in an <elcode>xsl:item-type</elcode> or <elcode>xsl:record-type</elcode>
-                                 declaration with name <code>"complex"</code></p>
-                           </item>
-                           <item>
-                              <p><code>type(complex)[?i eq 0]</code> matches any value that is an instance of the 
-                                 item type declared in an <elcode>xsl:item-type</elcode> or <elcode>xsl:record-type</elcode>
-                                 declaration with name <code>"complex"</code> and that is a map with an entry having key <code>i</code> and value zero.</p>
-                           </item>
-                        </olist>
-                     </item>
-                     <item>
-                        <p><emph>Node Patterns</emph></p>
-                        <olist><item>
-                           <p><code>*</code> matches any element.</p>
-                        </item>
-                        <item>
-                           <p><code>para</code> matches any <code>para</code> element.</p>
-                        </item>
-                        <item>
-                           <p><code>chapter|appendix</code> matches any <code>chapter</code> element
-                              and any <code>appendix</code> element.</p>
-                        </item>
-                           <item diff="add" at="2022-12-13">
-                              <p><code>child::(chapter|appendix)</code> matches any <code>chapter</code> element
-                                 and any <code>appendix</code> element. Note that although the <code>child</code> axis
-                              is explicitly written, an element can match even though it has no parent.</p>
-                           </item>
-                        <item>
-                           <p><code>olist/entry</code> matches any <code>entry</code> element with an
-                              <code>olist</code> parent.</p>
-                        </item>
-                        <item>
-                           <p><code>appendix//para</code> matches any <code>para</code> element with an
-                              <code>appendix</code> ancestor element.</p>
-                        </item>
-                           <item diff="add" at="2022-12-13">
-                              <p><code>appendix/descendant::(para|table)</code> matches any <code>para</code> 
-                                 or <code>table</code>element with an
-                                 <code>appendix</code> ancestor element.</p>
-                           </item>
-                        <item>
-                           <p><code>schema-element(us:address)</code> matches any element that is
-                              annotated as an instance of the type defined by the schema element
-                              declaration <code>us:address</code>, and whose name is either
-                              <code>us:address</code> or the name of another element in its
-                              substitution group. </p>
-                        </item>
-                        <item>
-                           <p><code>attribute(*, xs:date)</code> matches any attribute annotated as
-                              being of type <code>xs:date</code>.</p>
-                        </item>
-                        <item>
-                           <p><code>/</code> matches a document node.</p>
-                        </item>
-                        <item>
-                           <p><code>document-node()</code> matches a document node.</p>
-                        </item>
-                        <item>
-                           <p><code>document-node(schema-element(my:invoice))</code> matches the
-                              document node of a document whose document element is named
-                              <code>my:invoice</code> and matches the type defined by the global
-                              element declaration <code>my:invoice</code>.</p>
-                        </item>
-                        <item>
-                           <p><code>text()</code> matches any text node.</p>
-                        </item>
-                        <item>
-                           <p><code>namespace-node()</code> matches any namespace
-                              node.</p>
-                        </item>
-                        <item>
-                           <p><code>node()</code> matches any node other than an attribute node,
-                              namespace node, or document node.</p>
-                        </item>
-                        <item>
-                           <p><code>id("W33")</code> matches the element with unique ID
-                              <code>W33</code>. </p>
-                        </item>
-                        <item>
-                           <p><code>para[1]</code> matches any <code>para</code> element that is the
-                              first <code>para</code> child element of its parent. It also matches a
-                              parentless <code>para</code> element.</p>
-                        </item>
-                        <item>
-                           <p><code>//para</code> matches any <code>para</code> element in a tree that is rooted at a document node.</p>
-                        </item>
-                        <item>
-                           <p><code>bullet[position() mod 2 = 0]</code> matches any <code>bullet</code>
-                              element that is an even-numbered <code>bullet</code> child of its
-                              parent.</p>
-                        </item>
-                           
-                        <item>
-                           <p><code>div[@class="appendix"]//p</code> matches any <code>p</code> element
-                              with a <code>div</code> ancestor element that has a <code>class</code>
-                              attribute with value <code>appendix</code>. </p>
-                        </item>
-                        <item>
-                           <p><code>@class</code> matches any <code>class</code> attribute
-                              (<emph>not</emph> any element that has a <code>class</code>
-                              attribute).</p>
-                        </item>
-                           <item diff="add" at="2022-12-13">
-                              <p><code>@(class|type|kind)</code> matches any attribute named <code>class</code> 
-                                 or <code>type</code> or <code>kind</code>.</p>
-                           </item>
-                        <item>
-                           <p><code>@*</code> matches any attribute node.</p>
-                        </item>
-                        <item>
-                           <p><code>$xyz</code> matches any node that is present in
-                              the value of the variable <code>$xyz</code>.</p>
-                        </item>
-                        <item>
-                           <p><code>$xyz//*</code> matches any element that is a
-                              descendant of a node that is present in the value of the variable
-                              <code>$xyz</code>.</p>
-                        </item>
-                        <item>
-                           <p><code>doc('product.xml')//*</code> matches any element
-                              within the document whose document URI is <code>product.xml</code>.</p>
-                        </item>
-                    </olist>
-                 </item>
-                  </ulist>       
-                  
-               </example>
-            </div3>
-            <div3 id="pattern-syntax">
-               <head>Syntax of Patterns</head>
-               <p>
-                  <error spec="XT" type="static" class="SE" code="0340">
-                     <p>Where an attribute is defined to contain a <termref def="dt-pattern">pattern</termref>, it is a <termref def="dt-static-error">static
-                           error</termref> if the pattern does not match the production <nt def="Pattern40">Pattern40</nt>.</p>
-                  </error></p>
-               <p>The complete grammar for patterns is listed in <specref ref="pattern-syntax-summary"/>. 
-                  It uses the notation defined in <xspecref spec="XP40" ref="EBNFNotation">Notation</xspecref>. </p>
-               <p>The lexical rules for patterns are the same as the lexical rules
-                  for XPath expressions, as defined in <xspecref spec="XP40" ref="lexical-structure">Lexical structure</xspecref>. Comments are permitted between tokens, using the
-                  syntax <code>(: ... :)</code>. All other provisions of the XPath grammar apply
-                  where relevant, for example the rules for whitespace handling and
-                  extra-grammatical constraints.</p>
-               
-               <scrap headstyle="show" id="Patterns-scrap" >
-                  <prodrecap ref="Pattern40"/>
-               </scrap>
-               
-               <p diff="add" at="2022-01-01">Patterns fall into three groups:</p>
-               
-               <ulist diff="add" at="2022-01-01">
-                  <item><p>A <code>PredicatePattern</code> matches items according to conditions that the item must
-                  satisfy: for example <code>.[. castable as xs:integer]</code> matches any value (it might
-                  be an atomic item, a node, or an array) that is castable as an integer.</p></item>
-                  <item><p>A <code>TypePattern</code> matches items according to their type. For example
-                  <code>type(xs:integer)</code> matches an atomic item that is an instance of <code>xs:integer</code>,
-                  while <code>record(longitude, latitude)</code> matches a map that has exactly two entries, with
-                  keys <code>"longitude"</code> and <code>"latitude"</code></p></item>
-                  <item><p>A <code>NodePattern</code> matches nodes in a tree, typically by specifying a path that
-                  can be used to locate the nodes: for example <code>order</code> matches an element node
-                  named <code>order</code>, while <code>billing-address/city</code> matches an element named <code>city</code>
-                  whose parent node is an element named <code>billing-address</code>.</p></item>
-               </ulist>
-               
-               <p diff="add" at="2022-01-01">The following sections define the rules for each of these groups.</p>
-               
-               <div4 id="predicate-patterns">
-                  <head>Predicate Patterns</head>
-                  
-                  <scrap headstyle="show" id="PredicatePatterns-scrap">
-                     <prodrecap ref="PredicatePattern"/>
-                  </scrap>
-                  
-                  <p>A <nt def="PredicatePattern">PredicatePattern</nt>
-                     <var>PP</var> matches an item <var>J</var> if and only if the XPath expression taking
-                     the same form as <var>PP</var> returns a non-empty sequence when evaluated with a
-                     <termref def="dt-singleton-focus"/> based on <var>J</var>.</p>
-                  
-                  
-                  
-                  <note>
-                     <p>The pattern <code>.</code>, which is a <code>PredicatePattern</code> with no predicates,
-                        matches every item.</p>
-                     <p>A predicate with the numeric value 1 (one) always matches, and a predicate with
-                        any other numeric value never matches. Numeric predicates in a
-                        <code>PredicatePattern</code> are therefore not useful, but are defined this
-                        way in the interests of consistency with XPath.</p>
-                  </note>
-                  
-                  <p diff="add" at="2022-01-01">For example, the pattern <code>.[contains(., "XSLT")]</code>
-                  matches any item whose atomized value contains <code>"XSLT"</code> as a substring. 
-                  It matches values such as the string <code>"XSLT Transformations"</code>, the
-                     <code>xs:anyURI</code> value
-                     <code>http://www.w3.org/TR/XSLT</code>, the attribute node 
-                     <code>class="XSD XSLT XPath"</code>, and the singleton array <code>[ "XSLT 4.0" ]</code>.</p>
-                  
-                  <note diff="add" at="2023-10-10"><p>
-                     Evaluation of this example pattern may fail with a dynamic error if the item in question
-                     has an atomized value that is not a string, or that is a sequence of strings: an example might
-                     be the array <code>[ "XSLT", 1999 ]</code>. It will also fail if the item cannot be atomized,
-                     for example if it is a map. The rules in <specref ref="pattern-errors"/> cause these errors
-                     to be masked: they simply result in the pattern being treated as non-matching.
-                  </p></note>
-                  
-               </div4>
-               
-               <div4 id="type-patterns" diff="add" at="2022-01-01">
-                  <head>Type Patterns</head>
-                  
-                  <changes>
-                     <change issue="400" PR="401" date="2023-03-21">
-                        Patterns (especially those used in template rules) can now be defined
-                        by reference to item types, so any item type can be used as a match
-                        pattern. For example <code>match="record(longitude, latitude, *)"</code>
-                        matches any map that includes the key values <code>"longitude"</code>
-                        and <code>"latitude"</code>.
-                     </change>
-                  </changes>
-                  
-                  <scrap headstyle="show" id="TypePatterns-scrap">
-                     <prodrecap ref="TypePattern"/>
-                  </scrap>
-                  
-      
-                  
-                  <p>A type pattern tests whether an item matches a given item type, optionally qualified
-                  with one or more predicates that the value must also satisfy.</p>
-                  
-                  <p>The general-purpose construct <code>type(ItemType)</code> allows any <code>ItemType</code>
-                  to be used in a pattern. Where syntactic constraints permit, many <code>ItemTypes</code> can 
-                     also be used directly: for example
-                  <code>type(item())</code> can be abbreviated as <code>item()</code>.</p>
-                  <p>For example:</p>
-                  <ulist>
-                     <item><p><code>type(xs:integer)</code> matches any instance of
-                        <code>xs:integer</code></p></item>
-                     <item><p><code>type(xs:integer)[. gt 0]</code> matches
-                        any positive integer.</p></item>
-                     <item><p><code>type(xs:string | xs:untypedAtomic)[matches(., '[0-9]+')]</code> matches
-                        any instance of <code>xs:string</code> or <code>xs:untypedAtomic</code> that
-                        contains a sequence of decimal digits.</p></item>
-                     <item><p><code>type(node())</code> matches any node. (This is not the same as the pattern
-                        <code>node()</code>, which for historical reasons only matches  element, text, comment, 
-                        and processing instruction nodes).</p></item>
-                  </ulist>
-                  
-                  
-                  <p>More formally, an item <var>$J</var> matches a pattern <code>type(<var>T</var>)[<var>P1</var>][<var>P2</var>][<var>P3</var>]</code> if
-                  the XPath expression <code>$J instance of <var>T</var> and exists($J[<var>P1</var>][<var>P2</var>][<var>P3</var>])</code> is true.</p>
-                  
-                  <note><p>As with predicate patterns, numeric predicates are allowed, but serve no useful purpose.</p></note>
-                  
-                  
-                  
-                  <p>A pattern written as <code>record(<var>A</var>, <var>B</var>, <var>C</var>)</code> 
-                     is an abbreviation for <code>type(record(<var>A</var>, <var>B</var>, <var>C</var>))</code>
-                     (retaining any predicates). For example, the pattern <code>record(first, last, *)[?first eq "Sharon"]</code>
-                  matches any map having entries with the string-valued keys <code>"first"</code> and <code>"last"</code>,
-                     where the entry for the key <code>"first"</code> is equal to the string <code>"Sharon"</code>.</p>
-                  
-                  <note>
-                     <p>The item type in a pattern can be any <code>ItemType</code>, but patterns that match
-                        nodes can usually be expressed more economically
-                        as a <code>NodeTest</code>: for example <code>match="type(element(PERSON))"</code> has the same meaning as
-                        <code>match="element(PERSON)"</code>, which in turn is usually abbreviated to <code>match="PERSON"</code>.</p>
-                     <p>Although <code>match="type(element(PERSON))"</code> matches exactly the same items as
-                     <code>match="PERSON"</code>, the priority relative to other template rules (in the absence of an explicit
-                     <code>priority</code> attribute) may be different.</p>
-                  </note>
-                  
-               </div4>
-               
-               <div4 id="node-patterns">
-                  <head>Node Patterns</head>
-                  
-                  <changes>
-                     <change issue="1375 1522" PR="1378" date="2024-10-15">
-                        A function call at the outermost level can now be named using any valid <code>EQName</code>
-                        (for example <xfunction>fn:doc</xfunction>) provided it binds to one of the permitted functions
-                        <xfunction>fn:doc</xfunction>, <xfunction>fn:id</xfunction>, <xfunction>fn:element-with-id</xfunction>, 
-                        <function>fn:key</function>, or <xfunction>fn:root</xfunction>. 
-                        If two functions are called, for example <code>doc('a.xml')/id('abc')</code>,
-                        it is no longer necessary to put the second call in parentheses.
-                     </change>
-                     <change issue="402">
-                        The semantics of patterns using the <code>intersect</code> and <code>except</code>
-                        operators have been changed to reflect the intuitive meaning: for example
-                        a node now matches <code>A except B</code> if it matches <code>A</code>
-                        and does not match <code>B</code>.
-                     </change>
-                  </changes>
-               
-
-               <scrap id="NodePatterns-scrap">
-                  <prodrecap ref="NodePattern"/>
-               </scrap>
-               
-               <p>Node Patterns are used to match XDM nodes.</p>
-
-               <p>The names of these constructs are chosen to align with the XPath 3.0 grammar.
-                  Constructs whose names are suffixed with <code>P</code> are restricted forms of
-                  the corresponding XPath 3.0 construct without the suffix. Constructs labeled with
-                  the suffix “XP40” are defined in <bibref ref="xpath-40"/>.</p>
-
-              
-
-
-               <p>In a <nt def="FunctionCallP">FunctionCallP</nt>, the
-                     <code>EQName</code> used for the function name must bind to
-                  one of the functions <xfunction>fn:doc#1</xfunction>, <xfunction>fn:id#1</xfunction>, 
-                  <xfunction>fn:id#2</xfunction>, <xfunction>fn:element-with-id#1</xfunction>,
-                  <xfunction>fn:element-with-id#2</xfunction>
-                  <function>fn:key#2</function>, <function>fn:key#3</function>
-                  or <xfunction>fn:root#0</xfunction>.</p>
-                  
-                 
-               <note><p>In the case of a call to the
-                     <xfunction>fn:root</xfunction> function, the argument list must be empty: that is,
-                  only the zero-arity form of the function is allowed.</p></note>
-
-               <note>
-                  <p>As with XPath expressions, the pattern <code>/ union /*</code> can be parsed in
-                     two different ways, and the chosen interpretation is to treat
-                        <code>union</code> as an element name rather than as an operator. The other
-                     interpretation can be achieved by writing <code>(/) union (/*)</code></p>
-               </note>
-                  
-            </div4>
-               
-               
-            <div4 id="pattern-semantics">
-               <head>The Meaning of a Node Pattern</head>
-               <p>The meaning of a node pattern is defined formally as follows, where “if” is to be read
-                  as “if and only if”.</p>
-
-               
-  
-
-               
-               <olist>
-                  
-                  <item><p>A node matches a <code>UnionExprP</code> 
-                     <code><var>A</var> union <var>B</var></code> (or equivalently,
-                     <code><var>A</var> | <var>B</var></code>) if it matches either
-                     <var>A</var> or <var>B</var> or both.</p></item>
-                  
-                  <item><p>A node matches an <code>IntersectExceptExprP</code> 
-                     <code><var>A</var> intersect <var>B</var></code>
-                     if it matches both <var>A</var> and <var>B</var>.</p></item>
-                  
-                  <item><p>A node matches an <code>IntersectExceptExprP</code> 
-                     <code><var>A</var> except <var>B</var></code>
-                     if it matches <var>A</var> and does not match <var>B</var>.</p></item>
-                  
-                  <item>
-                     <p>A node matches a <code>PathExprP</code> under the following conditions:</p>
-                     
-                     <olist>
-                        <item><p>If the <code>PathExprP</code> consists in its entirety
-                        of a <code>ParenthesizedExprP</code>, then the node matches
-                        the <code>ParenthesizedExprP</code> if it matches the <code>UnionExprP</code>
-                        enclosed within the parentheses.</p></item>
-                        
-                        <item><p>Otherwise, the <code>PathExprP</code> pattern is converted to an 
-                           <termref def="dt-expression">expression</termref>, 
-                           called the <term>equivalent expression</term>. The
-                           equivalent expression to a <nt def="PathExprP">PathExprP</nt> is the XPath
-                           expression that takes the same lexical form as the <code>PathExprP</code> as
-                           written, with the following adjustment:</p>
-                     <p>If any <code>PathExprP</code> in the
-                              <code>Pattern</code> is a <code>RelativePathExprP</code>, then the
-                           first <code>StepExprP</code>
-                           <var>PS</var> of this <code>RelativePathExprP</code> is adjusted
-                        to allow it to match a parentless element, attribute, or namespace node. The
-                        adjustment depends on the axis used in this step, whether it appears
-                        explicitly or implicitly (according to the rules of <xspecref spec="XP40" ref="abbrev"/>), 
-                        and is made as follows:</p>
-                     <olist>
-                        <item>
-                           <p>If the <code>NodeTest</code> in <var>PS</var> is
-                                 <code>document-node()</code> (optionally with arguments), and if no
-                              explicit axis is specified, then the axis in step <var>PS</var> is
-                              taken as <code>self</code> rather than <code>child</code>.</p>
-                        </item>
-                        <item>
-                           <p>If <var>PS</var> uses the child axis (explicitly or implicitly), and
-                              if the <code>NodeTest</code> in <var>PS</var> is not
-                                 <code>document-node()</code> (optionally with arguments), then the
-                              axis in step <var>PS</var> is replaced by <code>child-or-top</code>,
-                              which is defined as follows. If the context node is a parentless
-                              element, comment, processing-instruction, or text node then the
-                                 <code>child-or-top</code> axis selects the context node; otherwise
-                              it selects the children of the context node. It is a forwards axis
-                              whose principal node kind is element.</p>
-                        </item>
-                        <item>
-                           <p>If <var>PS</var> uses the attribute axis (explicitly or implicitly),
-                              then the axis in step <var>PS</var> is replaced by
-                                 <code>attribute-or-top</code>, which is defined as follows. If the
-                              context node is an attribute node with no parent, then the
-                                 <code>attribute-or-top</code> axis selects the context node;
-                              otherwise it selects the attributes of the context node. It is a
-                              forwards axis whose principal node kind is attribute.</p>
-                        </item>
-                        <item>
-                           <p>If <var>PS</var> uses the namespace axis (explicitly or implicitly), then the axis in step
-                                 <var>PS</var> is replaced by <code>namespace-or-top</code>, which
-                              is defined as follows. If the context node is a namespace node with no
-                              parent, then the <code>namespace-or-top</code> axis selects the
-                              context node; otherwise it selects the namespace nodes of the context
-                              node. It is a forwards axis whose principal node kind is
-                              namespace.</p>
-
-                        </item>
-                     </olist>
-                     <p>The axes <code>child-or-top</code>, <code>attribute-or-top</code>, and
-                           <code>namespace-or-top</code> are introduced only for definitional
-                        purposes. They cannot be used explicitly in a user-written pattern or
-                        expression.</p>
-                     <note>
-                        <p>The purpose of this adjustment is to ensure that a pattern such as
-                              <code>person</code> matches any element named <code>person</code>,
-                           even if it has no parent; and similarly, that the pattern
-                              <code>@width</code> matches any attribute named <code>width</code>,
-                           even a parentless attribute. The rule also ensures that a pattern using a
-                              <code>NodeTest</code> of the form <code>document-node(...)</code>
-                           matches a document node. The pattern <code>node()</code> will match any
-                           element, text node, comment, or processing instruction, whether or not it
-                           has a parent. For backwards compatibility reasons, the pattern
-                              <code>node()</code>, when used without an explicit axis, does not
-                           match document nodes, attribute nodes, or namespace nodes. The rules are
-                           also phrased to ensure that positional patterns of the form
-                              <code>para[1]</code> continue to count nodes relative to their parent,
-                           if they have one. To match any node at all,
-                              XSLT 4.0 allows the pattern <code>.[. instance of node()]</code> to be
-                              used.</p>
-                     </note>
-
-                  </item>
-               </olist>
-
-               <p>The meaning of the pattern is then defined in terms of the semantics of the
-                  equivalent expression, denoted below as <code>EE</code>.</p>
-
-               <p>Specifically, an item <var>N</var> matches a <code>PathExprP</code>
-                  pattern <var>P</var> if  the following applies, where
-                     <code>EE</code> is the <term>equivalent expression</term> to <var>P</var>:</p>
-               <ulist>
-
-                  <item>
-                     <p><var>N</var> is a node, and the result of evaluating the expression
-                           <code>root(.)//(EE)</code> with a <termref def="dt-singleton-focus">singleton focus</termref> based on <var>N</var> is a sequence that
-                        includes the node <var>N</var>.
-                     </p>
-                  </item>
-                  
-               </ulist>
-               </item>
-            </olist>
-               
-
-               <p>If a pattern appears in an attribute of an element that
-                     is processed with <termref def="dt-xslt-10-behavior">XSLT 1.0
-                        behavior</termref> (see <specref ref="backwards"/>), then the
-                  semantics of the pattern are defined on the basis that the equivalent XPath
-                  expression is evaluated with <termref def="dt-xpath-compat-mode">XPath 1.0
-                     compatibility mode</termref> set to <code>true</code>.</p>
-               
-               <note>
-                  <p>This version of the specification includes an incompatible change
-                  to the semantics of patterns using the <code>intersect</code> and
-                  <code>except</code> operators. This change is made to eliminate 
-                  cases where the behavior defined in XSLT 3.0 was counter-intuitive.</p>
-                  
-                  <p>Consider the pattern <code>para except appendix//para</code>.
-                  In XSLT 4.0 this matches any <code>para</code> element that is not
-                  the descendant of an <code>appendix</code> element. In XSLT 3.0 it
-                  would match the <code>para</code> element in the XML tree shown below:</p>
-                  
-                  <eg><![CDATA[<appendix>
-  <section>
-     <para/>
-  </section>
-</appendix>]]>  
-</eg> 
-                  <p>because there is an element <code>$S</code> (specifically, 
-                     the <code>section</code> element), such that the expression
-                     <code>$S//(para except appendix//para)</code> selects this
-                     <code>para</code> element.</p>
-                  
-                  <p>It is <rfc2119>recommended</rfc2119> that processors should report
-                  a compatibility warning when such constructs are encountered. The problem
-                  arises with patterns using <code>intersect</code> or <code>except</code>
-                  where one of the branches uses the descendant axis: it does not arise
-                  in simple cases like <code>* except A</code>, or <code>@* except @code</code>,
-                  where the branches only use the child or attribute axis.</p>
-                  
-                  <p>The change does not affect the meaning of patterns that use the <code>intersect</code>
-                  or <code>except</code> operators nested within a path expression, for example
-                  a pattern such as <code>A[.//C except B//C]</code>.</p>
-               </note>
-
-
-               <example>
-                  <head>The Semantics of Node Patterns</head>
-                  <p>The <termref def="dt-node-pattern"/>
-                     <code>p</code> matches any <code>p</code> element, because a <code>p</code>
-                     element will always be present in the result of evaluating the <termref def="dt-expression">expression</termref>
-                     <code>root(.)//(child-or-top::p)</code>. Similarly, <code>/</code> matches a
-                     document node, and only a document node, because the result of the <termref def="dt-expression">expression</termref>
-                     <code>root(.)//(/)</code> returns the root node of the tree containing the
-                     context node if and only if it is a document node.</p>
-                  <p>The <termref def="dt-node-pattern"/>
-                     <code>node()</code> matches all nodes selected by the expression
-                        <code>root(.)//(child-or-top::node())</code>, that is, all element, text,
-                     comment, and processing instruction nodes, whether or not they have a parent.
-                     It does not match attribute or namespace nodes because the expression does not
-                     select nodes using the attribute or namespace axes. It does not match document
-                     nodes because for backwards compatibility reasons the <code>child-or-top</code>
-                     axis does not match a document node.</p>
-                  <note diff="add" at="2022-01-01">
-                     <p>The pattern <code>type(node())</code> matches all nodes.</p>
-                  </note>
-                  <p>The <termref def="dt-node-pattern"/>
-                     <code>$V</code> matches all nodes selected by the expression
-                        <code>root(.)//($V)</code>, that is, all nodes in the value of $V (which
-                     will typically be a global variable, though when the pattern is used in
-                     contexts such as the <elcode>xsl:number</elcode> or
-                        <elcode>xsl:for-each-group</elcode> instructions, it can also be a local
-                     variable).</p>
-                  <p>The <termref def="dt-node-pattern"/>
-                     <code>doc('product.xml')//product</code> matches all nodes selected by the
-                     expression <code>root(.)//(doc('product.xml')//product)</code>, that is, all
-                        <code>product</code> elements in the document whose URI is
-                        <code>product.xml</code>.</p>
-                  <p>The <termref def="dt-node-pattern"/>
-                     <code>root(.)/self::E</code> matches an <code>E</code> element that is the root
-                     of a tree (that is, an <code>E</code> element with no parent node).</p>
-               </example>
-               <p>Although the semantics of <termref def="dt-node-pattern">node patterns</termref> are
-                  specified formally in terms of expression evaluation, it is possible to understand
-                  pattern matching using a different model. A <termref def="dt-node-pattern"/> such as
-                     <code>book/chapter/section</code> can be examined from right to left. A node
-                  will only match this pattern if it is a <code>section</code> element; and then,
-                  only if its parent is a <code>chapter</code>; and then, only if the parent of that
-                     <code>chapter</code> is a <code>book</code>. When the pattern uses the
-                     <code>//</code> operator, one can still read it from right to left, but this
-                  time testing the ancestors of a node rather than its parent. For example
-                     <code>appendix//section</code> matches every <code>section</code> element that
-                  has an ancestor <code>appendix</code> element.</p>
-               <p>The formal definition, however, is useful for understanding the meaning of a
-                  pattern such as <code>para[1]</code>. This matches any node selected by the
-                  expression <code>root(.)//(child-or-top::para[1])</code>: that is, any
-                     <code>para</code> element that is the first <code>para</code> child of its
-                  parent, or a <code>para</code> element that has no parent.</p>
-               <note>
-                  <p>An implementation, of course, may use any algorithm it wishes for evaluating
-                     patterns, so long as the result corresponds with the formal definition above.
-                     An implementation that followed the formal definition by evaluating the
-                     equivalent expression and then testing the membership of a specific node in the
-                     result would probably be very inefficient.</p>
-               </note>
-               <note diff="chg" at="A2022-03-04">
-                  <p>Patterns using the <code>intersect</code> and <code>except</code> operators
-                  do not always have the intuitive meaning: in particular, it is not always the case
-                  that a node matches <code>A except B</code> if it matches <code>A</code> but does
-                  not match <code>B</code>.</p>
-                  <p>For example, consider the pattern <code>para except appendix//para</code>.
-                  This expands to <code>root(.)/descendant-or-self::node()/(child::para except child::appendix//para)</code>.
-                  Since for a given parent node, the results of <code>child::para</code> and <code>child::appendix</code>
-                  are disjoint, the right-hand operand of <code>except</code> has no effect.</p>
-                  <p>The effect of matching all paragraphs except those within an appendix can be achieved 
-                     using the pattern <code>para except //appendix//para</code>; alternatively, use
-                   <code>para[not(ancestor::appendix)]</code>.</p>
-                  <p>Simpler patterns such as <code>@* except @code</code> generally have the expected effect;
-                  the complications arise mainly when non-trivial relative paths are used.</p>
-               </note>
-            </div4>
-            </div3>
-            <div3 id="pattern-errors">
-               <head>Errors in Patterns</head>
-               <p>A <termref def="dt-dynamic-error">dynamic error</termref> or <termref def="dt-type-error">type error</termref> that occurs during the evaluation of a
-                     <termref def="dt-pattern">pattern</termref> against a particular item has the effect that the item being tested is
-                  treated as not matching the pattern. The error does not cause the transformation
-                  to fail, and cannot be caught by a try/catch expression surrounding the
-                  instruction that causes the pattern to be evaluated.</p>
-               <note>
-                  <p>The reason for this provision is that it is difficult for the stylesheet author
-                     to predict which predicates in a pattern will actually be evaluated. In the
-                     case of match patterns in template rules, it is not even possible to predict
-                     which patterns will be evaluated against a particular node.</p>
-                  <p>There is a risk that ignoring errors in this way may make programming mistakes
-                     harder to debug. Implementations may mitigate this by providing warnings or
-                     other diagnostics when evaluation of a pattern triggers an error condition.</p>
-                  <p>Static errors in patterns, including dynamic and type errors that are raised
-                     statically as permitted by the specification, are raised in the normal way
-                     and cause the transformation to fail.</p>
-               </note>
-               <p>The requirement to detect and raise a <termref def="dt-circularity"/> as a dynamic error overrides this rule.</p>
-
-
-            </div3>
-            
-         </div2>
          <div2 id="named-types">
             <head>Named Types</head>
             
@@ -13392,6 +12600,799 @@ return $tree =?> depth()]]></eg>
                attribute. The <elcode>xsl:apply-templates</elcode> instruction is described in the
                next section. If several template rules match a selected item, only one of them is evaluated, as described in <specref ref="conflict"/>.</p>
          </div2>
+         <div2 id="patterns">
+            <head>Patterns</head>
+
+            <p>In XSLT 4.0, patterns can match any kind of item: atomic items and
+               function items as well as nodes.</p>
+
+            <p>A <termref def="dt-template-rule">template rule</termref> identifies the items to which it applies by means of a pattern. As
+               well as being used in template rules, patterns are used for numbering (see <specref ref="number"/>), for grouping (see <specref ref="grouping"/>), and for declaring
+                  <termref def="dt-key">keys</termref> (see <specref ref="key"/>).</p>
+            <p><termdef id="dt-pattern" term="pattern">A <term>pattern</term> specifies a set of
+                  conditions on an item. An item that satisfies the conditions matches the pattern; an
+                     item that does not satisfy the conditions
+                  does not match the pattern.</termdef></p>
+
+            <p diff="chg" at="2022-01-01">There are three kinds of pattern: <termref def="dt-predicate-pattern">predicate patterns</termref>, 
+               <termref def="dt-type-pattern">type patterns</termref>,
+               and <termref def="dt-node-pattern">node patterns</termref>:</p>
+
+            <ulist diff="chg" at="2022-01-01">
+               <item>
+                  <p><termdef id="dt-predicate-pattern" term="predicate pattern">A <term>predicate pattern</term> is written as
+                           <code>.</code> (dot) followed by zero or more predicates in square
+                        brackets, and it matches any item for which each of the predicates evaluates
+                        to <code>true</code>.</termdef></p>
+                  <p>A predicate pattern <code>.[P1][P2]...</code> can be regarded as an abbreviation
+                     for the type pattern <code>type(item())[P1][P2]...</code>.</p>
+                  <p>The detailed semantics are given in <specref ref="predicate-patterns"/>. This construct can be used to match items of any
+                     kind (nodes, atomic items, and function items). For example, the pattern
+                     <code>.[starts-with(., '$')]</code> matches any string that starts with the
+                     character <code>$</code>, or a node whose atomized value starts with 
+                     <code>$</code>. This example shows a predicate pattern with a single
+                     predicate, but the grammar allows any number of predicates (zero or more).</p>
+               </item>
+               <item>
+                  <p><termdef id="dt-type-pattern" term="type pattern">A <term>type pattern</term> can be written as
+                     <code>type(T)</code> (where <var>T</var> is an <xnt spec="XP40" ref="prod-xpath40-ItemType">ItemType</xnt>
+                     followed by zero or more predicates in square
+                     brackets, and it matches any item of type <var>T</var> which each of the predicates evaluates
+                     to <code>true</code>.</termdef></p>
+                  <p>The parameter <var>T</var> can also be a list of item types, separated by <code>"|"</code>.
+                  For example, <code>type(array(*) | map(*))</code> matches arrays and maps, while 
+                  <code>type(text() | comment())</code> matches text nodes and comment nodes.</p>
+                  <p>The most commonly used type patterns can be abbreviated. For example, <code>match="type(record(F1, F2, *))"</code> 
+                     can be abbrevated to <code>match="record(F1, F2, *)"</code>, and <code>match="type(array(xs:string))"</code>
+                     can be abbreviated to <code>match="array(xs:string)"</code>. The main case where such abbreviation is
+                  not possible is with atomic items: <code>match="type(xs:date)"</code> cannot be abbreviated because
+                  a bare QName is interpreted as a node pattern, matching elements named <code>xs:date</code>.
+                  The pattern <code>match="type(text() | comment())"</code> has almost the same effect as
+                  <code>match="text() | comment()"</code>, except that the rules for calculating a default priority
+                  are different.</p>
+                  
+               </item>
+               <item>
+                  <p><termdef id="dt-node-pattern" term="node pattern">A <term>node pattern</term> uses a subset of
+                        the syntax for path expressions, and is defined to match a node if the
+                        corresponding path expression would select the node. Node patterns may
+                        also be formed by combining other patterns using union, intersection, and
+                        difference operators.</termdef></p>
+                  <p>The syntax for node patterns
+                        (<code>UnionExprP</code> in the grammar:
+                        see <specref ref="pattern-syntax"/>) is a subset of the syntax for
+                        <termref def="dt-expression">expressions</termref>. Node patterns are
+                        used only for matching nodes; an item other than a node will never match a
+                           node pattern.
+                     As explained in detail below, a node matches a node pattern if the node can be selected by
+                     deriving an equivalent expression, and evaluating this expression with respect
+                     to some possible context.</p>
+               </item>
+            </ulist>
+
+
+
+
+
+            
+
+
+
+
+            <note>
+               <p>The specification uses the phrases <emph>an item matches a pattern</emph> and
+                     <emph>a pattern matches an item</emph> interchangeably. They are equivalent: an
+                  item matches a pattern if and only if the pattern matches the item.</p>
+            </note>
+            <div3 id="pattern-examples">
+               <head>Examples of Patterns</head>
+               <example id="pattern-examples-1">
+                  <head>Patterns</head>
+                  <p>Here are some examples of patterns:</p>
+                  <ulist>
+                     <item>
+                        <p><emph>Predicate Patterns:</emph></p>
+                        <olist>
+                           <item>
+                              <p><code>.</code> matches any item.</p>
+                           </item>
+                           <item>
+                              <p><code>.[. castable as xs:date]</code> matches any item
+                                 that can be successfully cast to <code>xs:date</code>: for example,
+                              an <code>xs:date</code> or <code>xs:dateTime</code> value, or a string
+                              in the lexical form of a date, or a node whose typed value is an <code>xs:date</code>
+                              or a string in the form of a date.</p>
+                           </item>
+                           <item>
+                              <p><code>.[string() => matches('^[0-9]$')]</code> matches any
+                                 item whose string value is a sequence of digits.</p>
+                           </item>
+                           <item>
+                              <p><code>.[. castable as xs:date][xs:date(.) le current-date()]</code> matches any
+                                 item that is castable to <code>xs:date</code> provided that the result of casting
+                                 the value to <code>xs:date</code> is a date in the past.</p>
+                           </item>
+                        </olist>
+                     </item>
+                     <item diff="add" at="2022-01-01">
+                        <p><emph>Type Patterns</emph></p>
+                        <olist>
+                           <item>
+                              <p><code>type(item())</code> matches any item.</p>
+                           </item>
+                           <item>
+                              <p><code>type(node())</code> matches any node.
+                                 (Note the distinction from the pattern <code>node()</code>.)</p>
+                           </item>
+                           <item>
+                              <p><code>type(xs:date)</code> matches any
+                                 atomic item of type <code>xs:date</code> (or a type derived by
+                                 restriction from <code>xs:date</code>).</p>
+                           </item>
+                           <item>
+                              <p><code>type(xs:date)[. gt current-date()]</code> matches any date in
+                                 the future.</p>
+                           </item>
+                           <item>
+                              <p><code>type(xs:string)[starts-with(., 'e')]</code> matches any <code>xs:string</code>
+                                 value that starts with the letter <code>e</code>. Note there is no type conversion; the pattern
+                              will not match an <code>xs:untypedAtomic</code> or <code>xs:anyURI</code> value,
+                              nor will it match any node.</p>
+                           </item>
+                           <item>
+                              <p><code>type(fn(*))</code> matches any
+                                 function item.</p>
+                           </item>
+                           <item>
+                              <p><code>type(fn($x as xs:integer) as xs:boolean)[.(42)]</code> matches any function that
+                                 accepts an <code>xs:integer</code> argument and returns a boolean result, provided
+                                 that the result of calling the function with the argument value <code>42</code> is <code>true</code>.</p>
+                           </item>
+                           <item>
+                              <p><code>type(xs:date | xs:dateTime | xs:time)</code> matches any atomic item
+                                 that is an instance of <code>xs:date</code>, <code>xs:dateTime</code>, or <code>xs:time</code>.</p>
+                           </item>
+                           <item>
+                              <p><code>type(array(xs:date) | array(xs:dateTime) | array(xs:time))</code> matches any array whose
+                                 members are all of type <code>xs:date</code>, any array whose
+                                 members are all of type <code>xs:dateTime</code>, or any array whose
+                                 members are all of type <code>xs:time</code>.</p>
+                           </item>
+                           <item>
+                              <p><code>type(map((xs:string|xs:untypedAtomic), *)</code> matches any map
+                                 whose keys are all instances of <code>xs:string</code> or <code>xs:untypedAtomic</code>.</p>
+                           </item>
+                           <item>
+                              <p><code>enum("red", "green", "blue")</code> matches any one of the three strings
+                                 <code>"red"</code>, <code>"green"</code>, or <code>"blue"</code>.</p>
+                           </item>
+                           <item>
+                              <p><code>record(first, last, *)[?location = 'UK']</code> matches any map whose keys include the strings <code>"first"</code>
+                                 and <code>"last"</code>, and that also has an entry with key <code>"location"</code> whose
+                              value is <code>"UK"</code>.</p>
+                           </item>
+                           <item>
+                              <p><code>record(longitude, latitude)</code> matches any map with two entries whose keys are the strings <code>"longitude"</code>
+                                 and <code>"latitude"</code>.</p>
+                           </item>
+                           <item>
+                              <p><code>array(xs:integer)[array:size(.) eq 4]</code> matches any array of four integers.</p>
+                           </item>
+                           <item>
+                              <p><code>array(record(first, last, *))</code> matches any array of maps where each map
+                                 contains entries with keys <code>"first"</code> and <code>"last"</code>. (Note that
+                              this includes the empty array).</p>
+                           </item>
+                           <item>
+                              <p><code>array(record(first, last, *))[array:size(.) gt 0]</code> matches any non-empty array of maps where each map
+                                 contains entries with keys <code>"first"</code> and <code>"last"</code>. </p>
+                           </item>
+                           <item>
+                              <p><code>type(complex)</code> matches any value that is an instance of the item type 
+                                 declared in an <elcode>xsl:item-type</elcode> or <elcode>xsl:record-type</elcode>
+                                 declaration with name <code>"complex"</code></p>
+                           </item>
+                           <item>
+                              <p><code>type(complex)[?i eq 0]</code> matches any value that is an instance of the 
+                                 item type declared in an <elcode>xsl:item-type</elcode> or <elcode>xsl:record-type</elcode>
+                                 declaration with name <code>"complex"</code> and that is a map with an entry having key <code>i</code> and value zero.</p>
+                           </item>
+                        </olist>
+                     </item>
+                     <item>
+                        <p><emph>Node Patterns</emph></p>
+                        <olist><item>
+                           <p><code>*</code> matches any element.</p>
+                        </item>
+                        <item>
+                           <p><code>para</code> matches any <code>para</code> element.</p>
+                        </item>
+                        <item>
+                           <p><code>chapter|appendix</code> matches any <code>chapter</code> element
+                              and any <code>appendix</code> element.</p>
+                        </item>
+                           <item diff="add" at="2022-12-13">
+                              <p><code>child::(chapter|appendix)</code> matches any <code>chapter</code> element
+                                 and any <code>appendix</code> element. Note that although the <code>child</code> axis
+                              is explicitly written, an element can match even though it has no parent.</p>
+                           </item>
+                        <item>
+                           <p><code>olist/entry</code> matches any <code>entry</code> element with an
+                              <code>olist</code> parent.</p>
+                        </item>
+                        <item>
+                           <p><code>appendix//para</code> matches any <code>para</code> element with an
+                              <code>appendix</code> ancestor element.</p>
+                        </item>
+                           <item diff="add" at="2022-12-13">
+                              <p><code>appendix/descendant::(para|table)</code> matches any <code>para</code> 
+                                 or <code>table</code>element with an
+                                 <code>appendix</code> ancestor element.</p>
+                           </item>
+                        <item>
+                           <p><code>schema-element(us:address)</code> matches any element that is
+                              annotated as an instance of the type defined by the schema element
+                              declaration <code>us:address</code>, and whose name is either
+                              <code>us:address</code> or the name of another element in its
+                              substitution group. </p>
+                        </item>
+                        <item>
+                           <p><code>attribute(*, xs:date)</code> matches any attribute annotated as
+                              being of type <code>xs:date</code>.</p>
+                        </item>
+                        <item>
+                           <p><code>/</code> matches a document node.</p>
+                        </item>
+                        <item>
+                           <p><code>document-node()</code> matches a document node.</p>
+                        </item>
+                        <item>
+                           <p><code>document-node(schema-element(my:invoice))</code> matches the
+                              document node of a document whose document element is named
+                              <code>my:invoice</code> and matches the type defined by the global
+                              element declaration <code>my:invoice</code>.</p>
+                        </item>
+                        <item>
+                           <p><code>text()</code> matches any text node.</p>
+                        </item>
+                        <item>
+                           <p><code>namespace-node()</code> matches any namespace
+                              node.</p>
+                        </item>
+                        <item>
+                           <p><code>node()</code> matches any node other than an attribute node,
+                              namespace node, or document node.</p>
+                        </item>
+                        <item>
+                           <p><code>id("W33")</code> matches the element with unique ID
+                              <code>W33</code>. </p>
+                        </item>
+                        <item>
+                           <p><code>para[1]</code> matches any <code>para</code> element that is the
+                              first <code>para</code> child element of its parent. It also matches a
+                              parentless <code>para</code> element.</p>
+                        </item>
+                        <item>
+                           <p><code>//para</code> matches any <code>para</code> element in a tree that is rooted at a document node.</p>
+                        </item>
+                        <item>
+                           <p><code>bullet[position() mod 2 = 0]</code> matches any <code>bullet</code>
+                              element that is an even-numbered <code>bullet</code> child of its
+                              parent.</p>
+                        </item>
+                           
+                        <item>
+                           <p><code>div[@class="appendix"]//p</code> matches any <code>p</code> element
+                              with a <code>div</code> ancestor element that has a <code>class</code>
+                              attribute with value <code>appendix</code>. </p>
+                        </item>
+                        <item>
+                           <p><code>@class</code> matches any <code>class</code> attribute
+                              (<emph>not</emph> any element that has a <code>class</code>
+                              attribute).</p>
+                        </item>
+                           <item diff="add" at="2022-12-13">
+                              <p><code>@(class|type|kind)</code> matches any attribute named <code>class</code> 
+                                 or <code>type</code> or <code>kind</code>.</p>
+                           </item>
+                        <item>
+                           <p><code>@*</code> matches any attribute node.</p>
+                        </item>
+                        <item>
+                           <p><code>$xyz</code> matches any node that is present in
+                              the value of the variable <code>$xyz</code>.</p>
+                        </item>
+                        <item>
+                           <p><code>$xyz//*</code> matches any element that is a
+                              descendant of a node that is present in the value of the variable
+                              <code>$xyz</code>.</p>
+                        </item>
+                        <item>
+                           <p><code>doc('product.xml')//*</code> matches any element
+                              within the document whose document URI is <code>product.xml</code>.</p>
+                        </item>
+                    </olist>
+                 </item>
+                  </ulist>       
+                  
+               </example>
+            </div3>
+            <div3 id="pattern-syntax">
+               <head>Syntax of Patterns</head>
+               <p>
+                  <error spec="XT" type="static" class="SE" code="0340">
+                     <p>Where an attribute is defined to contain a <termref def="dt-pattern">pattern</termref>, it is a <termref def="dt-static-error">static
+                           error</termref> if the pattern does not match the production <nt def="Pattern40">Pattern40</nt>.</p>
+                  </error></p>
+               <p>The complete grammar for patterns is listed in <specref ref="pattern-syntax-summary"/>. 
+                  It uses the notation defined in <xspecref spec="XP40" ref="EBNFNotation">Notation</xspecref>. </p>
+               <p>The lexical rules for patterns are the same as the lexical rules
+                  for XPath expressions, as defined in <xspecref spec="XP40" ref="lexical-structure">Lexical structure</xspecref>. Comments are permitted between tokens, using the
+                  syntax <code>(: ... :)</code>. All other provisions of the XPath grammar apply
+                  where relevant, for example the rules for whitespace handling and
+                  extra-grammatical constraints.</p>
+               
+               <scrap headstyle="show" id="Patterns-scrap" >
+                  <prodrecap ref="Pattern40"/>
+               </scrap>
+               
+               <p diff="add" at="2022-01-01">Patterns fall into three groups:</p>
+               
+               <ulist diff="add" at="2022-01-01">
+                  <item><p>A <code>PredicatePattern</code> matches items according to conditions that the item must
+                  satisfy: for example <code>.[. castable as xs:integer]</code> matches any value (it might
+                  be an atomic item, a node, or an array) that is castable as an integer.</p></item>
+                  <item><p>A <code>TypePattern</code> matches items according to their type. For example
+                  <code>type(xs:integer)</code> matches an atomic item that is an instance of <code>xs:integer</code>,
+                  while <code>record(longitude, latitude)</code> matches a map that has exactly two entries, with
+                  keys <code>"longitude"</code> and <code>"latitude"</code></p></item>
+                  <item><p>A <code>NodePattern</code> matches nodes in a tree, typically by specifying a path that
+                  can be used to locate the nodes: for example <code>order</code> matches an element node
+                  named <code>order</code>, while <code>billing-address/city</code> matches an element named <code>city</code>
+                  whose parent node is an element named <code>billing-address</code>.</p></item>
+               </ulist>
+               
+               <p diff="add" at="2022-01-01">The following sections define the rules for each of these groups.</p>
+               
+               <div4 id="predicate-patterns">
+                  <head>Predicate Patterns</head>
+                  
+                  <scrap headstyle="show" id="PredicatePatterns-scrap">
+                     <prodrecap ref="PredicatePattern"/>
+                  </scrap>
+                  
+                  <p>A <nt def="PredicatePattern">PredicatePattern</nt>
+                     <var>PP</var> matches an item <var>J</var> if and only if the XPath expression taking
+                     the same form as <var>PP</var> returns a non-empty sequence when evaluated with a
+                     <termref def="dt-singleton-focus"/> based on <var>J</var>.</p>
+                  
+                  
+                  
+                  <note>
+                     <p>The pattern <code>.</code>, which is a <code>PredicatePattern</code> with no predicates,
+                        matches every item.</p>
+                     <p>A predicate with the numeric value 1 (one) always matches, and a predicate with
+                        any other numeric value never matches. Numeric predicates in a
+                        <code>PredicatePattern</code> are therefore not useful, but are defined this
+                        way in the interests of consistency with XPath.</p>
+                  </note>
+                  
+                  <p diff="add" at="2022-01-01">For example, the pattern <code>.[contains(., "XSLT")]</code>
+                  matches any item whose atomized value contains <code>"XSLT"</code> as a substring. 
+                  It matches values such as the string <code>"XSLT Transformations"</code>, the
+                     <code>xs:anyURI</code> value
+                     <code>http://www.w3.org/TR/XSLT</code>, the attribute node 
+                     <code>class="XSD XSLT XPath"</code>, and the singleton array <code>[ "XSLT 4.0" ]</code>.</p>
+                  
+                  <note diff="add" at="2023-10-10"><p>
+                     Evaluation of this example pattern may fail with a dynamic error if the item in question
+                     has an atomized value that is not a string, or that is a sequence of strings: an example might
+                     be the array <code>[ "XSLT", 1999 ]</code>. It will also fail if the item cannot be atomized,
+                     for example if it is a map. The rules in <specref ref="pattern-errors"/> cause these errors
+                     to be masked: they simply result in the pattern being treated as non-matching.
+                  </p></note>
+                  
+               </div4>
+               
+               <div4 id="type-patterns" diff="add" at="2022-01-01">
+                  <head>Type Patterns</head>
+                  
+                  <changes>
+                     <change issue="400" PR="401" date="2023-03-21">
+                        Patterns (especially those used in template rules) can now be defined
+                        by reference to item types, so any item type can be used as a match
+                        pattern. For example <code>match="record(longitude, latitude, *)"</code>
+                        matches any map that includes the key values <code>"longitude"</code>
+                        and <code>"latitude"</code>.
+                     </change>
+                  </changes>
+                  
+                  <scrap headstyle="show" id="TypePatterns-scrap">
+                     <prodrecap ref="TypePattern"/>
+                  </scrap>
+                  
+      
+                  
+                  <p>A type pattern tests whether an item matches a given item type, optionally qualified
+                  with one or more predicates that the value must also satisfy.</p>
+                  
+                  <p>The general-purpose construct <code>type(ItemType)</code> allows any <code>ItemType</code>
+                  to be used in a pattern. Where syntactic constraints permit, many <code>ItemTypes</code> can 
+                     also be used directly: for example
+                  <code>type(item())</code> can be abbreviated as <code>item()</code>.</p>
+                  <p>For example:</p>
+                  <ulist>
+                     <item><p><code>type(xs:integer)</code> matches any instance of
+                        <code>xs:integer</code></p></item>
+                     <item><p><code>type(xs:integer)[. gt 0]</code> matches
+                        any positive integer.</p></item>
+                     <item><p><code>type(xs:string | xs:untypedAtomic)[matches(., '[0-9]+')]</code> matches
+                        any instance of <code>xs:string</code> or <code>xs:untypedAtomic</code> that
+                        contains a sequence of decimal digits.</p></item>
+                     <item><p><code>type(node())</code> matches any node. (This is not the same as the pattern
+                        <code>node()</code>, which for historical reasons only matches  element, text, comment, 
+                        and processing instruction nodes).</p></item>
+                  </ulist>
+                  
+                  
+                  <p>More formally, an item <var>$J</var> matches a pattern <code>type(<var>T</var>)[<var>P1</var>][<var>P2</var>][<var>P3</var>]</code> if
+                  the XPath expression <code>$J instance of <var>T</var> and exists($J[<var>P1</var>][<var>P2</var>][<var>P3</var>])</code> is true.</p>
+                  
+                  <note><p>As with predicate patterns, numeric predicates are allowed, but serve no useful purpose.</p></note>
+                  
+                  
+                  
+                  <p>A pattern written as <code>record(<var>A</var>, <var>B</var>, <var>C</var>)</code> 
+                     is an abbreviation for <code>type(record(<var>A</var>, <var>B</var>, <var>C</var>))</code>
+                     (retaining any predicates). For example, the pattern <code>record(first, last, *)[?first eq "Sharon"]</code>
+                  matches any map having entries with the string-valued keys <code>"first"</code> and <code>"last"</code>,
+                     where the entry for the key <code>"first"</code> is equal to the string <code>"Sharon"</code>.</p>
+                  
+                  <note>
+                     <p>The item type in a pattern can be any <code>ItemType</code>, but patterns that match
+                        nodes can usually be expressed more economically
+                        as a <code>NodeTest</code>: for example <code>match="type(element(PERSON))"</code> has the same meaning as
+                        <code>match="element(PERSON)"</code>, which in turn is usually abbreviated to <code>match="PERSON"</code>.</p>
+                     <p>Although <code>match="type(element(PERSON))"</code> matches exactly the same items as
+                     <code>match="PERSON"</code>, the priority relative to other template rules (in the absence of an explicit
+                     <code>priority</code> attribute) may be different.</p>
+                  </note>
+                  
+               </div4>
+               
+               <div4 id="node-patterns">
+                  <head>Node Patterns</head>
+                  
+                  <changes>
+                     <change issue="1375 1522" PR="1378" date="2024-10-15">
+                        A function call at the outermost level can now be named using any valid <code>EQName</code>
+                        (for example <xfunction>fn:doc</xfunction>) provided it binds to one of the permitted functions
+                        <xfunction>fn:doc</xfunction>, <xfunction>fn:id</xfunction>, <xfunction>fn:element-with-id</xfunction>, 
+                        <function>fn:key</function>, or <xfunction>fn:root</xfunction>. 
+                        If two functions are called, for example <code>doc('a.xml')/id('abc')</code>,
+                        it is no longer necessary to put the second call in parentheses.
+                     </change>
+                     <change issue="402">
+                        The semantics of patterns using the <code>intersect</code> and <code>except</code>
+                        operators have been changed to reflect the intuitive meaning: for example
+                        a node now matches <code>A except B</code> if it matches <code>A</code>
+                        and does not match <code>B</code>.
+                     </change>
+                  </changes>
+               
+
+               <scrap id="NodePatterns-scrap">
+                  <prodrecap ref="NodePattern"/>
+               </scrap>
+               
+               <p>Node Patterns are used to match XDM nodes.</p>
+
+               <p>The names of these constructs are chosen to align with the XPath 3.0 grammar.
+                  Constructs whose names are suffixed with <code>P</code> are restricted forms of
+                  the corresponding XPath 3.0 construct without the suffix. Constructs labeled with
+                  the suffix “XP40” are defined in <bibref ref="xpath-40"/>.</p>
+
+              
+
+
+               <p>In a <nt def="FunctionCallP">FunctionCallP</nt>, the
+                     <code>EQName</code> used for the function name must bind to
+                  one of the functions <xfunction>fn:doc#1</xfunction>, <xfunction>fn:id#1</xfunction>, 
+                  <xfunction>fn:id#2</xfunction>, <xfunction>fn:element-with-id#1</xfunction>,
+                  <xfunction>fn:element-with-id#2</xfunction>
+                  <function>fn:key#2</function>, <function>fn:key#3</function>
+                  or <xfunction>fn:root#0</xfunction>.</p>
+                  
+                 
+               <note><p>In the case of a call to the
+                     <xfunction>fn:root</xfunction> function, the argument list must be empty: that is,
+                  only the zero-arity form of the function is allowed.</p></note>
+
+               <note>
+                  <p>As with XPath expressions, the pattern <code>/ union /*</code> can be parsed in
+                     two different ways, and the chosen interpretation is to treat
+                        <code>union</code> as an element name rather than as an operator. The other
+                     interpretation can be achieved by writing <code>(/) union (/*)</code></p>
+               </note>
+                  
+            </div4>
+               
+               
+            <div4 id="pattern-semantics">
+               <head>The Meaning of a Node Pattern</head>
+               <p>The meaning of a node pattern is defined formally as follows, where “if” is to be read
+                  as “if and only if”.</p>
+
+               
+  
+
+               
+               <olist>
+                  
+                  <item><p>A node matches a <code>UnionExprP</code> 
+                     <code><var>A</var> union <var>B</var></code> (or equivalently,
+                     <code><var>A</var> | <var>B</var></code>) if it matches either
+                     <var>A</var> or <var>B</var> or both.</p></item>
+                  
+                  <item><p>A node matches an <code>IntersectExceptExprP</code> 
+                     <code><var>A</var> intersect <var>B</var></code>
+                     if it matches both <var>A</var> and <var>B</var>.</p></item>
+                  
+                  <item><p>A node matches an <code>IntersectExceptExprP</code> 
+                     <code><var>A</var> except <var>B</var></code>
+                     if it matches <var>A</var> and does not match <var>B</var>.</p></item>
+                  
+                  <item>
+                     <p>A node matches a <code>PathExprP</code> under the following conditions:</p>
+                     
+                     <olist>
+                        <item><p>If the <code>PathExprP</code> consists in its entirety
+                        of a <code>ParenthesizedExprP</code>, then the node matches
+                        the <code>ParenthesizedExprP</code> if it matches the <code>UnionExprP</code>
+                        enclosed within the parentheses.</p></item>
+                        
+                        <item><p>Otherwise, the <code>PathExprP</code> pattern is converted to an 
+                           <termref def="dt-expression">expression</termref>, 
+                           called the <term>equivalent expression</term>. The
+                           equivalent expression to a <nt def="PathExprP">PathExprP</nt> is the XPath
+                           expression that takes the same lexical form as the <code>PathExprP</code> as
+                           written, with the following adjustment:</p>
+                     <p>If any <code>PathExprP</code> in the
+                              <code>Pattern</code> is a <code>RelativePathExprP</code>, then the
+                           first <code>StepExprP</code>
+                           <var>PS</var> of this <code>RelativePathExprP</code> is adjusted
+                        to allow it to match a parentless element, attribute, or namespace node. The
+                        adjustment depends on the axis used in this step, whether it appears
+                        explicitly or implicitly (according to the rules of <xspecref spec="XP40" ref="abbrev"/>), 
+                        and is made as follows:</p>
+                     <olist>
+                        <item>
+                           <p>If the <code>NodeTest</code> in <var>PS</var> is
+                                 <code>document-node()</code> (optionally with arguments), and if no
+                              explicit axis is specified, then the axis in step <var>PS</var> is
+                              taken as <code>self</code> rather than <code>child</code>.</p>
+                        </item>
+                        <item>
+                           <p>If <var>PS</var> uses the child axis (explicitly or implicitly), and
+                              if the <code>NodeTest</code> in <var>PS</var> is not
+                                 <code>document-node()</code> (optionally with arguments), then the
+                              axis in step <var>PS</var> is replaced by <code>child-or-top</code>,
+                              which is defined as follows. If the context node is a parentless
+                              element, comment, processing-instruction, or text node then the
+                                 <code>child-or-top</code> axis selects the context node; otherwise
+                              it selects the children of the context node. It is a forwards axis
+                              whose principal node kind is element.</p>
+                        </item>
+                        <item>
+                           <p>If <var>PS</var> uses the attribute axis (explicitly or implicitly),
+                              then the axis in step <var>PS</var> is replaced by
+                                 <code>attribute-or-top</code>, which is defined as follows. If the
+                              context node is an attribute node with no parent, then the
+                                 <code>attribute-or-top</code> axis selects the context node;
+                              otherwise it selects the attributes of the context node. It is a
+                              forwards axis whose principal node kind is attribute.</p>
+                        </item>
+                        <item>
+                           <p>If <var>PS</var> uses the namespace axis (explicitly or implicitly), then the axis in step
+                                 <var>PS</var> is replaced by <code>namespace-or-top</code>, which
+                              is defined as follows. If the context node is a namespace node with no
+                              parent, then the <code>namespace-or-top</code> axis selects the
+                              context node; otherwise it selects the namespace nodes of the context
+                              node. It is a forwards axis whose principal node kind is
+                              namespace.</p>
+
+                        </item>
+                     </olist>
+                     <p>The axes <code>child-or-top</code>, <code>attribute-or-top</code>, and
+                           <code>namespace-or-top</code> are introduced only for definitional
+                        purposes. They cannot be used explicitly in a user-written pattern or
+                        expression.</p>
+                     <note>
+                        <p>The purpose of this adjustment is to ensure that a pattern such as
+                              <code>person</code> matches any element named <code>person</code>,
+                           even if it has no parent; and similarly, that the pattern
+                              <code>@width</code> matches any attribute named <code>width</code>,
+                           even a parentless attribute. The rule also ensures that a pattern using a
+                              <code>NodeTest</code> of the form <code>document-node(...)</code>
+                           matches a document node. The pattern <code>node()</code> will match any
+                           element, text node, comment, or processing instruction, whether or not it
+                           has a parent. For backwards compatibility reasons, the pattern
+                              <code>node()</code>, when used without an explicit axis, does not
+                           match document nodes, attribute nodes, or namespace nodes. The rules are
+                           also phrased to ensure that positional patterns of the form
+                              <code>para[1]</code> continue to count nodes relative to their parent,
+                           if they have one. To match any node at all,
+                              XSLT 4.0 allows the pattern <code>.[. instance of node()]</code> to be
+                              used.</p>
+                     </note>
+
+                  </item>
+               </olist>
+
+               <p>The meaning of the pattern is then defined in terms of the semantics of the
+                  equivalent expression, denoted below as <code>EE</code>.</p>
+
+               <p>Specifically, an item <var>N</var> matches a <code>PathExprP</code>
+                  pattern <var>P</var> if  the following applies, where
+                     <code>EE</code> is the <term>equivalent expression</term> to <var>P</var>:</p>
+               <ulist>
+
+                  <item>
+                     <p><var>N</var> is a node, and the result of evaluating the expression
+                           <code>root(.)//(EE)</code> with a <termref def="dt-singleton-focus">singleton focus</termref> based on <var>N</var> is a sequence that
+                        includes the node <var>N</var>.
+                     </p>
+                  </item>
+                  
+               </ulist>
+               </item>
+            </olist>
+               
+
+               <p>If a pattern appears in an attribute of an element that
+                     is processed with <termref def="dt-xslt-10-behavior">XSLT 1.0
+                        behavior</termref> (see <specref ref="backwards"/>), then the
+                  semantics of the pattern are defined on the basis that the equivalent XPath
+                  expression is evaluated with <termref def="dt-xpath-compat-mode">XPath 1.0
+                     compatibility mode</termref> set to <code>true</code>.</p>
+               
+               <note>
+                  <p>This version of the specification includes an incompatible change
+                  to the semantics of patterns using the <code>intersect</code> and
+                  <code>except</code> operators. This change is made to eliminate 
+                  cases where the behavior defined in XSLT 3.0 was counter-intuitive.</p>
+                  
+                  <p>Consider the pattern <code>para except appendix//para</code>.
+                  In XSLT 4.0 this matches any <code>para</code> element that is not
+                  the descendant of an <code>appendix</code> element. In XSLT 3.0 it
+                  would match the <code>para</code> element in the XML tree shown below:</p>
+                  
+                  <eg><![CDATA[<appendix>
+  <section>
+     <para/>
+  </section>
+</appendix>]]>  
+</eg> 
+                  <p>because there is an element <code>$S</code> (specifically, 
+                     the <code>section</code> element), such that the expression
+                     <code>$S//(para except appendix//para)</code> selects this
+                     <code>para</code> element.</p>
+                  
+                  <p>It is <rfc2119>recommended</rfc2119> that processors should report
+                  a compatibility warning when such constructs are encountered. The problem
+                  arises with patterns using <code>intersect</code> or <code>except</code>
+                  where one of the branches uses the descendant axis: it does not arise
+                  in simple cases like <code>* except A</code>, or <code>@* except @code</code>,
+                  where the branches only use the child or attribute axis.</p>
+                  
+                  <p>The change does not affect the meaning of patterns that use the <code>intersect</code>
+                  or <code>except</code> operators nested within a path expression, for example
+                  a pattern such as <code>A[.//C except B//C]</code>.</p>
+               </note>
+
+
+               <example>
+                  <head>The Semantics of Node Patterns</head>
+                  <p>The <termref def="dt-node-pattern"/>
+                     <code>p</code> matches any <code>p</code> element, because a <code>p</code>
+                     element will always be present in the result of evaluating the <termref def="dt-expression">expression</termref>
+                     <code>root(.)//(child-or-top::p)</code>. Similarly, <code>/</code> matches a
+                     document node, and only a document node, because the result of the <termref def="dt-expression">expression</termref>
+                     <code>root(.)//(/)</code> returns the root node of the tree containing the
+                     context node if and only if it is a document node.</p>
+                  <p>The <termref def="dt-node-pattern"/>
+                     <code>node()</code> matches all nodes selected by the expression
+                        <code>root(.)//(child-or-top::node())</code>, that is, all element, text,
+                     comment, and processing instruction nodes, whether or not they have a parent.
+                     It does not match attribute or namespace nodes because the expression does not
+                     select nodes using the attribute or namespace axes. It does not match document
+                     nodes because for backwards compatibility reasons the <code>child-or-top</code>
+                     axis does not match a document node.</p>
+                  <note diff="add" at="2022-01-01">
+                     <p>The pattern <code>type(node())</code> matches all nodes.</p>
+                  </note>
+                  <p>The <termref def="dt-node-pattern"/>
+                     <code>$V</code> matches all nodes selected by the expression
+                        <code>root(.)//($V)</code>, that is, all nodes in the value of $V (which
+                     will typically be a global variable, though when the pattern is used in
+                     contexts such as the <elcode>xsl:number</elcode> or
+                        <elcode>xsl:for-each-group</elcode> instructions, it can also be a local
+                     variable).</p>
+                  <p>The <termref def="dt-node-pattern"/>
+                     <code>doc('product.xml')//product</code> matches all nodes selected by the
+                     expression <code>root(.)//(doc('product.xml')//product)</code>, that is, all
+                        <code>product</code> elements in the document whose URI is
+                        <code>product.xml</code>.</p>
+                  <p>The <termref def="dt-node-pattern"/>
+                     <code>root(.)/self::E</code> matches an <code>E</code> element that is the root
+                     of a tree (that is, an <code>E</code> element with no parent node).</p>
+               </example>
+               <p>Although the semantics of <termref def="dt-node-pattern">node patterns</termref> are
+                  specified formally in terms of expression evaluation, it is possible to understand
+                  pattern matching using a different model. A <termref def="dt-node-pattern"/> such as
+                     <code>book/chapter/section</code> can be examined from right to left. A node
+                  will only match this pattern if it is a <code>section</code> element; and then,
+                  only if its parent is a <code>chapter</code>; and then, only if the parent of that
+                     <code>chapter</code> is a <code>book</code>. When the pattern uses the
+                     <code>//</code> operator, one can still read it from right to left, but this
+                  time testing the ancestors of a node rather than its parent. For example
+                     <code>appendix//section</code> matches every <code>section</code> element that
+                  has an ancestor <code>appendix</code> element.</p>
+               <p>The formal definition, however, is useful for understanding the meaning of a
+                  pattern such as <code>para[1]</code>. This matches any node selected by the
+                  expression <code>root(.)//(child-or-top::para[1])</code>: that is, any
+                     <code>para</code> element that is the first <code>para</code> child of its
+                  parent, or a <code>para</code> element that has no parent.</p>
+               <note>
+                  <p>An implementation, of course, may use any algorithm it wishes for evaluating
+                     patterns, so long as the result corresponds with the formal definition above.
+                     An implementation that followed the formal definition by evaluating the
+                     equivalent expression and then testing the membership of a specific node in the
+                     result would probably be very inefficient.</p>
+               </note>
+               <note diff="chg" at="A2022-03-04">
+                  <p>Patterns using the <code>intersect</code> and <code>except</code> operators
+                  do not always have the intuitive meaning: in particular, it is not always the case
+                  that a node matches <code>A except B</code> if it matches <code>A</code> but does
+                  not match <code>B</code>.</p>
+                  <p>For example, consider the pattern <code>para except appendix//para</code>.
+                  This expands to <code>root(.)/descendant-or-self::node()/(child::para except child::appendix//para)</code>.
+                  Since for a given parent node, the results of <code>child::para</code> and <code>child::appendix</code>
+                  are disjoint, the right-hand operand of <code>except</code> has no effect.</p>
+                  <p>The effect of matching all paragraphs except those within an appendix can be achieved 
+                     using the pattern <code>para except //appendix//para</code>; alternatively, use
+                   <code>para[not(ancestor::appendix)]</code>.</p>
+                  <p>Simpler patterns such as <code>@* except @code</code> generally have the expected effect;
+                  the complications arise mainly when non-trivial relative paths are used.</p>
+               </note>
+            </div4>
+            </div3>
+            <div3 id="pattern-errors">
+               <head>Errors in Patterns</head>
+               <p>A <termref def="dt-dynamic-error">dynamic error</termref> or <termref def="dt-type-error">type error</termref> that occurs during the evaluation of a
+                     <termref def="dt-pattern">pattern</termref> against a particular item has the effect that the item being tested is
+                  treated as not matching the pattern. The error does not cause the transformation
+                  to fail, and cannot be caught by a try/catch expression surrounding the
+                  instruction that causes the pattern to be evaluated.</p>
+               <note>
+                  <p>The reason for this provision is that it is difficult for the stylesheet author
+                     to predict which predicates in a pattern will actually be evaluated. In the
+                     case of match patterns in template rules, it is not even possible to predict
+                     which patterns will be evaluated against a particular node.</p>
+                  <p>There is a risk that ignoring errors in this way may make programming mistakes
+                     harder to debug. Implementations may mitigate this by providing warnings or
+                     other diagnostics when evaluation of a pattern triggers an error condition.</p>
+                  <p>Static errors in patterns, including dynamic and type errors that are raised
+                     statically as permitted by the specification, are raised in the normal way
+                     and cause the transformation to fail.</p>
+               </note>
+               <p>The requirement to detect and raise a <termref def="dt-circularity"/> as a dynamic error overrides this rule.</p>
+
+
+            </div3>
+            
+         </div2>
+         
          <div2 id="applying-templates">
             <head>Applying Template Rules</head>
             


### PR DESCRIPTION
This PR simply moves the section on Patterns to a more logical place in the XSLT specification. Unless anyone objects, I will merge the PR without waiting for group approval, so that I can use the result as a baseline for further work on patterns and templates, hopefully giving a better diff baseline.