### PR TITLE
2152 Revise rules for enumeration types

### DIFF
--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -4481,7 +4481,7 @@ types</term> (such as <code>xs:integer</code>) and function types
                <head>Enumeration Types</head>
 
                <changes>
-                  <change issue="688 2152" PR="691" date="2023-10-10">Enumeration types are added as a new kind of <code>ItemType</code>, constraining
+                  <change issue="688 2152" PR="691 2154" date="2023-10-10">Enumeration types are added as a new kind of <code>ItemType</code>, constraining
                      the value space of strings.</change>
                </changes>
                
@@ -4515,8 +4515,7 @@ types</term> (such as <code>xs:integer</code>) and function types
                      <code>xs:string</code>, the type annotation of <var>S</var> is immaterial.</p></note>
                   </item>                     
                   <item><p>A <termref def="dt-singleton-enumeration-type"/> whose enumerated value
-                  is <var>E</var> is a subtype of <code>xs:string</code> and of every subtype of 
-                  <code>xs:string</code> that has <var>E</var> in its value space.</p></item>
+                  is <var>E</var> is a subtype of <code>xs:string</code>.</p></item>
                   <item><p>Two <termref def="dt-singleton-enumeration-type">singleton enumeration types</termref> 
                      are the same type if and only
                   if they have the same (single) enumerated value, as determined using the Unicode
@@ -6557,27 +6556,22 @@ declare record Particle (
                   
                   <p>If <var>A</var> is a <termref def="dt-singleton-enumeration-type"/>
                      permitting the string value <var>V</var>, then <code><var>A</var> ⊆ <var>B</var></code> 
-                     is true if any of the following apply:</p>
+                     is true if <var>B</var> is <code>xs:string</code>.</p>
   
-                     <olist>
-                        <item>
-                           <p><var>B</var> is <code>xs:string</code>.</p>
-                        </item>
-                        <item>
-                           <p><var>B</var> is any subtype of <code>xs:string</code> whose value
-                              space includes the <xspecref spec="DM40" ref="dt-datum"/> of 
-                              <var>V</var> (regardless of the <xspecref spec="DM40" ref="dt-type-annotation"/> 
-                              of <var>V</var>).</p>
-                        </item>
-                     </olist>
+                     
                   
-                  <p>For example, <code>enum("Z")</code> is a subtype of each of the types
-                  <code>xs:string</code>, <code>xs:token</code>, and <code>xs:NCName</code>.</p>
                   
                   <note><p>Because a non-singleton enumeration type is defined as a choice type,
                   <code><var>A</var> ⊆ <var>B</var></code> also holds if <var>A</var> is
                   <code>enum("red")</code> and <var>B</var> is <code>enum("red", "green")</code>.
                   See <specref ref="id-item-subtype-choice"/>.</p></note>
+                  
+                  <note><p>The type <code>enum("red", "green")</code> is not a subtype
+                  of <code>xs:NCName</code>, despite the fact that all the enumerated values
+                  are valid <code>NCName</code>s. This is because instances of <code>xs:NCName</code>
+                  must have a type annotation of <code>xs:NCName</code> or a subtype thereof,
+                  whereas instances of <code>enum("red", "green")</code> are not subject to this
+                  constraint.</p></note>
                   
                   <note><p>A type <var>T</var> derived by restriction from <code>xs:string</code>,
                   for example a type with the facet <code>length="0"</code> (which permits


### PR DESCRIPTION
Fix #2152

Revises the rules for enumeration types: they are now structural subtypes of `xs:string` rather than nominative subtypes. The main effect is that `"x" instance of enum("x")` is now true. The change is motivated by use cases involving XSLT pattern matching, where strict "instance of" matching is required, with no coercion.