### PR TITLE
Fix return type in `fn:parse-csv` signature

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -27816,7 +27816,7 @@ element-to-map-plan((<a><b/><b/></a>, <a><b/><c/></a>))
 
    <fos:function name="parse-csv" prefix="fn">
       <fos:signatures>
-         <fos:proto name="parse-csv" return-type-ref="parsed-csv-structure-record">
+         <fos:proto name="parse-csv" return-type-ref="parsed-csv-structure-record?">
             <fos:arg name="value" type="(xs:string | xs:hexBinary | xs:base64Binary)?" example="'&lt;a/&gt;'"/>
             <fos:arg name="options" type="map(*)?" usage="inspection" default="{}"/>
          </fos:proto>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -27816,7 +27816,7 @@ element-to-map-plan((<a><b/><b/></a>, <a><b/><c/></a>))
 
    <fos:function name="parse-csv" prefix="fn">
       <fos:signatures>
-         <fos:proto name="parse-csv" return-type-ref="parsed-csv-structure-record?">
+         <fos:proto name="parse-csv" return-type-ref="parsed-csv-structure-record" return-type-ref-occurs="?">
             <fos:arg name="value" type="(xs:string | xs:hexBinary | xs:base64Binary)?" example="'&lt;a/&gt;'"/>
             <fos:arg name="options" type="map(*)?" usage="inspection" default="{}"/>
          </fos:proto>


### PR DESCRIPTION
In f2e1f48, `fn:parse-csv` was changed to return an empty sequence, when its first argument is an empty sequence. This is however not reflected in the function's return type, which is here changed to `parsed-csv-structure-record?`.