### PR TITLE
2139 Make hexBinary and base64Binary fully comparable

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -13036,6 +13036,10 @@ else QName("", $value)</eg>
             are of the same length, measured in binary octets, and contain the same octets in the
             same order. Otherwise, it returns <code>false</code>. </p>
       </fos:rules>
+      <fos:changes>
+         <fos:change issue="911 2139" PR="980" date="2024-01-30"><p>Atomic items of types <code>xs:hexBinary</code> 
+            and <code>xs:base64Binary</code> are now mutually comparable.</p></fos:change>
+      </fos:changes>
    </fos:function>
    <fos:function name="binary-less-than" prefix="op">
       <fos:signatures>
@@ -13078,6 +13082,10 @@ else QName("", $value)</eg>
             </item>
          </olist>
       </fos:rules>
+      <fos:changes>
+         <fos:change issue="911 2139" PR="980" date="2024-01-30"><p>Atomic items of types <code>xs:hexBinary</code> 
+            and <code>xs:base64Binary</code> are now mutually comparable.</p></fos:change>
+      </fos:changes>
    </fos:function>
 
   
@@ -14708,6 +14716,11 @@ filter($values,
          </fos:change>
          <fos:change issue="628" PR="987"><p>The order of results is now prescribed; 
             it was previously implementation-dependent.</p></fos:change>
+         <fos:change issue="2139" date="2025-08-14"><p>Atomic items of types <code>xs:hexBinary</code> 
+            and <code>xs:base64Binary</code> are now mutually comparable. In rare cases, where an
+            application uses both types and assumes they are distinct, this can represent a backwards
+            incompatibility.</p>
+         </fos:change>
       </fos:changes>
    </fos:function>
 
@@ -16685,11 +16698,7 @@ declare function equal-strings(
                            <code>$i1 eq $i2</code>
                            returns <code>true</code>.
                         </p></item>
-                        <item><p>If both <code>$i1</code> and <code>$i2</code> are instances of
-                           <code>xs:hexBinary</code> or <code>xs:base64Binary</code>,
-                           <code>$i1 eq $i2</code>
-                           returns <code>true</code>.
-                        </p></item>
+
                         <item><p>Otherwise, <code>fn:atomic-equal($i1, $i2)</code>
                            returns <code>true</code>.
                         </p></item>
@@ -17296,6 +17305,11 @@ declare function equal-strings(
          </fos:change>
          <fos:change issue="99 1142" PR="1120 1150" date="2024-04-09">
             <p>A callback function can be supplied for comparing individual items.</p>
+         </fos:change>
+         <fos:change issue="2139" date="2025-08-14"><p>Atomic items of types <code>xs:hexBinary</code> 
+            and <code>xs:base64Binary</code> are now mutually comparable. In rare cases, where an
+            application uses both types and assumes they are distinct, this can represent a backwards
+            incompatibility.</p>
          </fos:change>
       </fos:changes>
    </fos:function>
@@ -23988,7 +24002,7 @@ return ($type ? name,
       </fos:changes>
    </fos:function>
    
-   <fos:function name="atomic-equal" prefix="fn" diff="chg" at="2023-01-25">
+   <fos:function name="atomic-equal" prefix="fn">
       <fos:signatures>
          <fos:proto name="atomic-equal" return-type="xs:boolean">
             <fos:arg name="value1" type="xs:anyAtomicType"/>
@@ -24129,14 +24143,26 @@ return ($type ? name,
                <p>All of the following conditions are true:</p>
                <olist>
                   <item>
+                     <p><code>$value1</code> is an instance of <code>xs:hexBinary</code> or <code>xs:base64Binary</code></p>
+                  </item>
+                  <item>
+                     <p><code>$value2</code> is an instance of <code>xs:hexBinary</code> or <code>xs:base64Binary</code></p>
+                  </item>
+                  <item>
+                     <p><code>op:binary-equal($value1, $value2)</code></p>
+                  </item>
+               </olist>
+            </item>
+            <item>
+               <p>All of the following conditions are true:</p>
+               <olist>
+                  <item>
                      <p>One of the following conditions is true:</p>
                      <olist>
                         <item><p><code>$value1</code> and <code>$value2</code> are both instances of <code>xs:boolean</code>.</p></item>
                         <item><p><code>$value1</code> and <code>$value2</code> are both instances of <code>xs:QName</code>.</p></item>
                         <item><p><code>$value1</code> and <code>$value2</code> are both instances of <code>xs:NOTATION</code>.</p></item>
                         <item><p><code>$value1</code> and <code>$value2</code> are both instances of <code>xs:duration</code>.</p></item>
-                        <item><p><code>$value1</code> and <code>$value2</code> are both instances of <code>xs:hexBinary</code>.</p></item>
-                        <item><p><code>$value1</code> and <code>$value2</code> are both instances of <code>xs:base64Binary</code>.</p></item>
                      </olist>
                   </item>
 
@@ -24234,8 +24260,14 @@ return ($type ? name,
          </fos:example>
       </fos:examples>
       <fos:changes>
-         <fos:change><p>New in 4.0. The function is identical to the internal <code>op:same-key</code>
+         <fos:change><p>New in 4.0. The function replaces the internal <code>op:same-key</code>
          function in 3.1</p></fos:change>
+
+         <fos:change issue="2139" date="2025-08-14"><p>Atomic items of types <code>xs:hexBinary</code> 
+            and <code>xs:base64Binary</code> are now mutually comparable. In rare cases, where an
+            application uses both types and assumes they are distinct, this can represent a backwards
+            incompatibility.</p>
+         </fos:change>
       </fos:changes>
    </fos:function>
    <fos:function name="merge" prefix="map">

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -14739,6 +14739,15 @@ ISBN 0 521 77752 6.</bibl>
                  and <code><![CDATA[<a>abcde<!--note2-->f</code>]]></code> were considered non-equal. In version 4.0, 
                  the text nodes are now merged prior to comparison, so these two elements compare equal.</p>
            </item>
+           <item>
+              <p>In version 3.1, the atomic types <code>xs:hexBinary</code> and <code>xs:base64Binary</code>
+              were not mutually comparable under the <code>eq</code> operator, and always compared not equal
+              as map keys or under operations such as <code>fn:distinct-values</code> and <code>fn:deep-equal</code>.
+              In version 4.0, instances of <code>xs:hexBinary</code> and <code>xs:base64Binary</code> are
+              equal if they represent the same octet sequence. This means, for example, that the zero-length
+              values <code>xs:hexBinary("")</code> and <code>xs:base64Binary("")</code> can no longer co-exist
+              as keys in the same map.</p>
+           </item>
            <item diff="add" at="2024-10-01">
               <p>The format of numeric values in the output of <function>fn:xml-to-json</function> may be different. 
                  In version 3.1, the supplied value was parsed as an <code>xs:double</code> and then serialized


### PR DESCRIPTION
Fix #2139

hexBinary and base64Binary become mutually comparable under all comparison operators: which may affect backward compatibility.