### PR TITLE
2173 Drop method annotations from XPath grammar

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -623,10 +623,6 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
       </g:sequence>
     </g:choice>
   </g:production>
-  
-  <g:production name="MethodAnnotation" if="xpath40 xslt40-patterns">
-    <g:string>%method</g:string>
-  </g:production>
 
   <g:production name="VarDecl" if="xquery40">
     <g:string>declare</g:string>
@@ -2408,9 +2404,6 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   <g:production name="InlineFunctionExpr" if="xpath40 xquery40  xslt40-patterns">
     <g:zeroOrMore if="xquery40">
       <g:ref name="Annotation"/>
-    </g:zeroOrMore>
-    <g:zeroOrMore if="xpath40 xslt40-patterns">
-      <g:ref name="MethodAnnotation"/>
     </g:zeroOrMore>
     <g:choice>
       <g:string>function</g:string>

--- a/specifications/xquery-40/src/errors.xml
+++ b/specifications/xquery-40/src/errors.xml
@@ -889,11 +889,7 @@ if the value bound to a grouping  variable consists of a sequence of more than o
       </error>
 
 
-      <error spec="XP" code="0107" class="ST" type="static">
-         <p diff="add"> It is a <termref def="dt-static-error">static error</termref> if the annotation 
-            <code>%method</code> is used on a <termref def="dt-focus-function"/><phrase role="xquery"> or on
-            a function declaration in the query prolog</phrase>.</p>
-      </error>
+      
 
       <error spec="XQ" role="xquery" code="0108" class="ST" type="static">
          <p> It is a <termref def="dt-static-error">static error</termref> if an <termref

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -10997,10 +10997,11 @@ return $a("A")]]></eg>
             </p>
                      </item>
                      <item>
-                           <p><term>annotations</term>: <phrase role="xquery">The annotations explicitly
-                           included in the inline function expression.</phrase></p>
-                           
-                        
+                           <p><term>annotations</term>: 
+                              <phrase role="xquery">The annotations explicitly
+                                 included in the inline function expression.</phrase>
+                              <phrase role="xpath">None.</phrase>
+                           </p> 
                         </item>
                      <item>
                         <p>


### PR DESCRIPTION
The MethodAnnotation construct should have been dropped from the XPath grammar when we changed the mechanism for methods.

Fix #2173