### PR TITLE
2130 encore: precedes-or-is, follows-or-is

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1656,6 +1656,8 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
       <g:string>is-not</g:string>
       <g:ref name="NodePrecedes"/>
       <g:ref name="NodeFollows"/>
+      <g:string>precedes-or-is</g:string>
+      <g:string>follows-or-is</g:string>
     </g:choice>
   </g:production>
 

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -23843,7 +23843,7 @@ return $f(xs:date('2025-03-01'))</eg></fos:expression>
             <code>"&gt;"</code>, <code>">="</code>, <code>"!="</code>, <code>"eq"</code>,
             <code>"lt"</code>, <code>"le"</code>, <code>"gt"</code>, <code>"ge"</code>,
             <code>"ne"</code>, <code>"&lt;&lt;"</code>, <code>"&gt;&gt;"</code>,
-            <code>"precedes"</code>, <code>"follows"</code>,
+            <code>"precedes"</code>, <code>"follows"</code>, <code>"precedes-or-is"</code>, <code>"follows-or-is"</code>,
             <code>"is"</code>, <code>"is-not"</code>, <code>"||"</code>, <code>"|"</code>, <code>"union"</code>,
             <code>"except"</code>, <code>"intersect"</code>, <code>"to"</code>,
             <code>"otherwise"</code>.</p>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -297,7 +297,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
                in the <bibref ref="xpath-40"/> language; indeed, in the interests of avoiding duplication, the majority of
                operators (including all higher-order operators such as <code>x/y</code>, <code>x!y</code>, and <code>x[y]</code>,
                as well simple operators such as <code>x,y</code>, <code>x and y</code>, <code>x or y</code>,            
-            <code>x&lt;&lt;y</code>, <code>x>>y</code>, <code>x precedes y</code>, <code>x follows y</code>, <code>x is y</code>, <code>x is-not y</code>, <code>x||y</code>, <code>x|y</code>,
+               <code>x&lt;&lt;y</code>, <code>x>>y</code>, <code>x precedes y</code>, <code>x follows y</code>, <code>x precedes-or-is y</code>, <code>x follows-or-is y</code>, <code>x is y</code>, <code>x is-not y</code>, <code>x||y</code>, <code>x|y</code>,
             <code>x union y</code>, <code>x except y</code>, <code>x intersect y</code>, <code>x to y</code>
             and <code>x otherwise y</code>) are now defined entirely within <bibref ref="xpath-40"/>.</p>
             

--- a/specifications/xquery-40/src/ebnf.xml
+++ b/specifications/xquery-40/src/ebnf.xml
@@ -970,7 +970,7 @@
           <td>5</td>
           <td>
             <nt def="ValueComp">eq, ne, lt, le, gt, ge</nt>, <nt def="GeneralComp">=, !=, &lt;,
-              &lt;=, &gt;, &gt;=</nt>, <nt def="NodeComp">is, is-not, &lt;&lt;, &gt;&gt;, precedes, follows</nt>
+              &lt;=, &gt;, &gt;=</nt>, <nt def="NodeComp">is, is-not, &lt;&lt;, &gt;&gt;, precedes, follows, precedes-or-is, follows-or-is</nt>
           </td>
           <td>NA</td>
         </tr>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -14715,6 +14715,11 @@ of this value comparison is <code>true</code>.</p>
                   Operators <code>precedes</code> and <code>follows</code> are introduced as synonyms
                   for operators <code>&lt;&lt;</code> and <code>&gt;&gt;</code>.
                </change>
+               <change date="2025-08-22" PR="2130">
+                  Operators <code>precedes-or-is</code> and <code>follows-or-is</code> are introduced as synonyms
+                  for the union of operators <code>&lt;&lt;</code> and <code>is</code> and for the union of 
+                  operators <code>&gt;&gt;</code> and <code>is</code>, respectively.
+               </change>
             </changes>
             
             <p>GNode comparisons are used to compare two <termref def="dt-GNode">GNodes</termref>
@@ -14783,6 +14788,26 @@ is <code>true</code>. See <bibref
 <termref
                         def="dt-document-order"
                         >document order</termref>; otherwise it returns <code>false</code>.</p>
+               </item>
+               
+               <item>
+                  
+                  <p>A comparison with the <code>precedes-or-is</code> operator returns <code>true</code> 
+                     if the left operand <termref def="dt-GNode"/> precedes the right operand GNode in
+                     
+                     <termref
+                        def="dt-document-order">document order</termref> or if the values of two operands 
+                     are the same GNode; otherwise it returns <code>false</code>.</p>
+               </item>
+
+               <item>
+                  
+                  <p>A comparison with the <code>follows-or-is</code> operator returns <code>true</code> 
+                     if the left operand <termref def="dt-GNode"/> follows the right operand GNode in
+                     
+                     <termref
+                        def="dt-document-order">document order</termref> or if the values of two operands 
+                     are the same GNode; otherwise it returns <code>false</code>.</p>
                </item>
             </olist>
             <p>Here are some examples of GNode comparisons:</p>


### PR DESCRIPTION
In #2130 we introduced `is-not`, which is the union of `precedes` and `follows`. This PR follows that lead by creating two new operators, one for the union of `precedes` with `is` and the other for the union of `follows` with `is`. 

I realize this modification provides only a convenience and not new utility, so if it is deemed unnecessary by the CG, that's okay.

I have opted for `precedes-or-is` and not `is-or-precedes` on analogy with `ancestor-or-self::*`.