### PR TITLE
2183 Improve rendition of cross-spec references

### DIFF
--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -6458,16 +6458,16 @@ if the data model is constructed from a PSVI:</p>
 <bibl id="xml-names11"        key="Namespaces in XML 1.1"/>
 <bibl id="xml-id"             key="xml:id"/>
 
-<bibl id="xpath-datamodel"    key="XQuery 1.0 and XPath 2.0 Data Model (XDM)"/>
-<bibl id="xpath-40"           key="XML Path Language (XPath) 4.0"/>
-<bibl id="xpath-functions-40" key="XQuery and XPath Functions and Operators 4.0"/>
+<bibl id="xpath-datamodel"    key="XDM 4.0"/>
+<bibl id="xpath-40"           key="XPath 4.0"/>
+<bibl id="xpath-functions-40" key="Functions and Operators 4.0"/>
 
 <bibl id="xmlschema-1"        key="Schema Part 1"/>
 <bibl id="xmlschema-2"        key="Schema Part 2"/>
 <bibl id="xmlschema11-1"      key="Schema 1.1 Part 1"/>
 <bibl id="xmlschema11-2"      key="Schema 1.1 Part 2"/>
 
-<bibl id="xslt-xquery-serialization-40" key="XSLT and XQuery Serialization 4.0"/>
+<bibl id="xslt-xquery-serialization-40" key="Serialization 4.0"/>
 
 <bibl id="xquery-semantics"   key="XQuery 1.0 and XPath 2.0 Formal Semantics"/>
 <bibl id="RFC2119"            key="RFC 2119"/>

--- a/specifications/xquery-40/src/back-matter.xml
+++ b/specifications/xquery-40/src/back-matter.xml
@@ -634,14 +634,14 @@ of the declared type).</p></item><item role="xquery"><p>Limits on ranges of valu
       See <loc href="http://www.w3.org/TR/xmlschema11-1/" id="schema1-11">http://www.w3.org/TR/xmlschema11-1/</loc>,
       and <loc href="http://www.w3.org/TR/xmlschema11-2/" id="schema2-11">http://www.w3.org/TR/xmlschema11-2/</loc>.</bibl>
 
-<bibl id="xpath-datamodel-40" key="XQuery and XPath Data Model (XDM) 4.0"/>
+<bibl id="xpath-datamodel-40" key="XDM 4.0"/>
 
-<bibl id="xpath-functions-40" key="XQuery and XPath Functions and Operators 4.0"/>
+<bibl id="xpath-functions-40" key="Functions and Operators 4.0"/>
   
   <bibl id="xpath-40" key="XPath 4.0"/>
   
 
-<bibl id="xslt-xquery-serialization-40" key="XSLT and XQuery Serialization 4.0"/>
+<bibl id="xslt-xquery-serialization-40" key="Serialization 4.0"/>
 
 <!--<bibl id="xquery-update-30" key="XQuery Update Facility 3.0" role="xquery"/>-->
 
@@ -656,14 +656,14 @@ of the declared type).</p></item><item role="xquery"><p>Limits on ranges of valu
 <bibl id="xquery-30-requirements" key="XQuery 3.0 Requirements" role="xquery"/>
 <bibl id="xquery-31-requirements" key="XQuery 3.1 Requirements" role="xquery"/>
 
-<bibl id="xquery-30" key="XQuery 3.0: An XML Query Language" role="xquery"/>
-<bibl id="xquery-31" key="XQuery 3.1: An XML Query Language" role="xpath"/>
+<bibl id="xquery-30" key="XQuery 3.0" role="xquery"/>
+<bibl id="xquery-31" key="XQuery 3.1" role="xpath"/>
 
 <bibl id="xquery-semantics" key="XQuery 1.0 and XPath 2.0 Formal Semantics"/>
 
 <!--<bibl id="xqueryx-31" key="XQueryX 3.1" role="xquery"/>-->
 
-<bibl id="xslt-40" key="XSL Transformations (XSLT) Version 4.0"/>
+<bibl id="xslt-40" key="XSLT 4.0"/>
 
 <bibl id="DOM" key="Document Object Model" role="xquery">World Wide Web Consortium. <emph>Document Object Model (DOM) Level 3 Core Specification.</emph> W3C Recommendation, April 7, 2004. See <loc href="http://www.w3.org/TR/DOM-Level-3-Core/">http://www.w3.org/TR/DOM-Level-3-Core/</loc>.</bibl>
 
@@ -672,12 +672,12 @@ Consortium. <emph>XML Information Set (Second Edition).</emph> W3C Recommendatio
 <loc href="http://www.w3.org/TR/xml-infoset/">http://www.w3.org/TR/xml-infoset/</loc>
 </bibl>
 
-<bibl key="XML Path Language (XPath) Version 1.0" id="xpath"/>
+<bibl key="XPath 1.0" id="xpath"/>
 
-<bibl key="XML Path Language (XPath) Version 2.0" id="xpath20"/>
+<bibl key="XPath 2.0" id="xpath20"/>
 
-<bibl key="XML Path Language (XPath) Version 3.0" id="xpath-30"/>
-<bibl key="XML Path Language (XPath) Version 3.1" id="xpath-31" role="xquery"/>
+<bibl key="XPath 3.0" id="xpath-30"/>
+<bibl key="XPath 3.1" id="xpath-31" role="xquery"/>
 
 <bibl id="XPTR" key="XPointer">World Wide Web Consortium. <emph>XML
 Pointer Language (XPointer).</emph> W3C Last Call Working Draft 8 January 2001.

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -3269,14 +3269,12 @@ tree T2.</p>
                <termdef term="typed value" id="dt-typed-value"
                   >The <term>typed
                      value</term> of a node is a sequence of atomic items and can be
-                  extracted by applying the <xspecref
-                     spec="FO40" ref="func-data"/> function to the
+                  extracted by applying the <function>data</function> function to the
                   node.</termdef>
                <termdef id="dt-string-value" term="string value"
                   >The
                   <term>string value</term> of a node is a string and can be extracted
-                  by applying the <xspecref
-                     spec="FO40" ref="func-string"/>
+                  by applying the <function>string</function>
                   function to the node.</termdef>
             </p>
             
@@ -3584,9 +3582,7 @@ value. <termdef id="dt-ebv"
                   term="effective boolean value"
                      >The
 <term>effective boolean value</term> of a value is defined as the result
-of applying the <function>fn:boolean</function> function to the value, as
-defined in <xspecref
-                     spec="FO40" ref="func-boolean"/>.</termdef>
+of applying the <function>fn:boolean</function> function to the value.</termdef>
             </p>
 
             <p>The dynamic semantics of <function>fn:boolean</function> are repeated here for convenience:</p>

--- a/specifications/xslt-40/src/function-catalog.xml
+++ b/specifications/xslt-40/src/function-catalog.xml
@@ -2,7 +2,7 @@
 <!-- Current changes labelled at="S" -->
 <fos:functions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                xmlns:fos="http://www.w3.org/xpath-functions/spec/namespace"
-               xsi:schemaLocation="http://www.w3.org/xpath-functions/spec/namespace ../../xpath-functions-30/src/fos.xsd">
+               xsi:schemaLocation="http://www.w3.org/xpath-functions/spec/namespace ../../xpath-functions-40/src/fos.xsd">
    <fos:global-variables>
       <fos:variable name="po" as="element()">&lt;PurchaseOrder&gt; &lt;line-item&gt;
          &lt;description&gt;Large widget&lt;/description&gt; &lt;price&gt;8.95&lt;/price&gt;
@@ -1095,7 +1095,7 @@
          <p>Each of these absolute URI references is then processed as follows. Any fragment
             identifier that is present in the URI reference is removed, and the resulting absolute
             URI is cast to a string and then passed to the <xfunction>doc</xfunction> function
-            defined in <bibref ref="xpath-functions-30"/>. This returns a document node. If an error
+            defined in <bibref ref="xpath-functions-40"/>. This returns a document node. If an error
             occurs during evaluation of the <xfunction>doc</xfunction> function, the processor
                <rfc2119>may</rfc2119> either raise this error in the normal way, or
                <rfc2119>may</rfc2119> recover by ignoring the failure, in which case the failing URI
@@ -1187,7 +1187,7 @@
             the document containing the node supplied as the 
                value of the <code>$doc</code> argument. It
             returns the zero-length <code>xs:anyURI</code> if there is no such entity. This function
-            maps to the <code>dm:unparsed-entity-system-id</code> accessor defined in <bibref ref="xpath-datamodel-30"/>.</p>
+            maps to the <code>dm:unparsed-entity-system-id</code> accessor defined in <bibref ref="xpath-datamodel-40"/>.</p>
 
       </fos:rules>
       <fos:errors>
@@ -1252,7 +1252,7 @@
             <code>$entity-name</code> argument, in the document containing the node supplied as the 
                value of the <code>$doc</code> argument. It returns the zero-length string if
             there is no such entity, or if the entity has no public identifier. This function maps
-            to the <code>dm:unparsed-entity-public-id</code> accessor defined in <bibref ref="xpath-datamodel-30"/>.</p>
+            to the <code>dm:unparsed-entity-public-id</code> accessor defined in <bibref ref="xpath-datamodel-40"/>.</p>
 
       </fos:rules>
       <fos:errors>
@@ -1968,7 +1968,7 @@ serialize($input, {
             recognized by the processor, in some <termref def="dt-implementation-dependent">implementation-dependent</termref> order.</p>
          <p>The prefix part of a returned QName is <termref def="dt-implementation-dependent"/>.</p>
          
-         <p>The function is <xtermref spec="FO30" ref="dt-deterministic">deterministic</xtermref>: that is, the
+         <p>The function is <xtermref spec="FO40" ref="dt-deterministic">deterministic</xtermref>: that is, the
             set of available system properties does not vary during the course of a transformation.</p>
       </fos:rules>
       <fos:notes>
@@ -2387,7 +2387,7 @@ serialize($input, {
       </fos:rules>
       <fos:errors>
          <p>If the URI is invalid, such that a call on <xfunction>doc-available</xfunction> would raise an error, then 
-            <function>stream-available</function> raises the same error: <xerrorref spec="FO30" class="DC" code="0005"/>.</p>
+            <function>stream-available</function> raises the same error: <xerrorref spec="FO40" class="DC" code="0005"/>.</p>
       </fos:errors>
  
    </fos:function>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -11,9 +11,9 @@
       <w3c-doctype>W3C Editor's Draft</w3c-doctype>
       <pubdate>
          <!-- The value from the build.xml file is used in preference -->
-         <day>8</day>
-         <month>June</month>
-         <year>2017</year>
+         <day>5</day>
+         <month>Sept</month>
+         <year>2025</year>
       </pubdate> 
       <publoc>
          <loc href="https://qt4cg.org/specifications/xslt-40/"
@@ -137,7 +137,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
             published on 8 June 2017. Changes are presented in <specref ref="whats-new-in-xslt4"/>. </p>
          <p>XSLT 4.0 is designed to be used in conjunction with XPath 4.0, which is defined in
                <bibref ref="xpath-40"/>. XSLT shares the same data model as XPath 4.0, which is
-            defined in <bibref ref="xpath-datamodel-30"/>, and it uses the library of functions and
+            defined in <bibref ref="xpath-datamodel-40"/>, and it uses the library of functions and
             operators defined in <bibref ref="xpath-functions-40"/>. XPath 4.0 and the underlying
             function library introduce a number of enhancements, for example the availability of
             union and record types. </p>
@@ -181,7 +181,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
                HTML, XHTML, or SVG. However, XSLT is used for a wide range of transformation tasks,
                not exclusively for formatting and presentation applications.</p>
             <p>A transformation expressed in XSLT describes rules for transforming input data into output data. The inputs and outputs
-                  will all be instances of the XDM data model, described in <bibref ref="xpath-datamodel-30"/>. In the simplest and most common case, the input is
+                  will all be instances of the XDM data model, described in <bibref ref="xpath-datamodel-40"/>. In the simplest and most common case, the input is
                   an XML document referred to as the source document or <termref def="dt-source-tree">source tree</termref>, and the output is an XML document
                   referred to as the <termref def="dt-result-tree">result tree</termref>. It is also possible to process multiple source
                   documents, to generate multiple result documents, and to handle formats other than
@@ -278,7 +278,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
                   performs the functions of an <termref def="dt-processor">XSLT processor</termref>
                   is referred to as an <term>implementation</term>.</termdef></p>
             <p>
-               <termdef id="dt-tree" term="tree">The term <term>tree</term> is used (as in <bibref ref="xpath-datamodel-30"/>) to refer to the aggregate consisting of a
+               <termdef id="dt-tree" term="tree">The term <term>tree</term> is used (as in <bibref ref="xpath-datamodel-40"/>) to refer to the aggregate consisting of a
                   parentless node together with all its descendant nodes, plus all their attributes
                   and namespaces.</termdef>
             </p>
@@ -297,14 +297,14 @@ Michael Sperberg-McQueen (1954–2024).</p>
             <olist>
                <item>
                   <p><termdef id="dt-principal-result" term="principal result">A <term>principal
-                           result</term>: this can be any sequence of items (as defined in <bibref ref="xpath-datamodel-30"/>).</termdef> The principal result is the value
+                           result</term>: this can be any sequence of items (as defined in <bibref ref="xpath-datamodel-40"/>).</termdef> The principal result is the value
                      returned by the function or template in the stylesheet that is nominated as the
                      entry point, as described in <specref ref="initiating"/>.</p>
                </item>
                <item>
                   <p><termdef id="dt-secondary-result" term="secondary result">Zero or more
                            <term>secondary results</term>: each secondary result can be any sequence
-                        of items (as defined in <bibref ref="xpath-datamodel-30"/>).</termdef> A
+                        of items (as defined in <bibref ref="xpath-datamodel-40"/>).</termdef> A
                      secondary result is the value returned by evaluating the body of an
                         <elcode>xsl:result-document</elcode> instruction.</p>
                </item>
@@ -399,16 +399,16 @@ Michael Sperberg-McQueen (1954–2024).</p>
                that allow the user to influence the behavior.</p>
             <p>A paragraph labeled as a <term>Note</term> or described as an <term>example</term> is
                non-normative.</p>
-            <p>Many terms used in this document are defined in the XPath specification <bibref ref="xpath-40"/> or the XDM specification <bibref ref="xpath-datamodel-30"/>.
+            <p>Many terms used in this document are defined in the XPath specification <bibref ref="xpath-40"/> or the XDM specification <bibref ref="xpath-datamodel-40"/>.
                Particular attention is drawn to the following:</p>
             <ulist>
                <item>
                   <p>
                      <termdef id="dt-atomization" term="atomize">The term <term>atomization</term>
                         is defined in <xspecref spec="XP40" ref="id-atomization"/>. It is a process that takes as input a sequence of
-                           items, and returns a sequence of
+                        items, and returns a sequence of
                         atomic items, in which the nodes are replaced by their typed values as
-                        defined in <bibref ref="xpath-datamodel-30"/>. 
+                        defined in <bibref ref="xpath-datamodel-40"/>. 
                         <phrase diff="del" at="2022-01-01">If the XPath 3.1 feature is implemented,
                         then</phrase> Arrays (see <specref ref="arrays"/>) are atomized by atomizing their
                         members, recursively.</termdef> For some items (for example, elements with element-only
@@ -418,7 +418,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
                <item>
                   <p>
                      <termdef id="dt-typed-value" term="typed value">The term <term>typed
-                           value</term> is defined in <xspecref spec="DM30" ref="dm-typed-value"/>.
+                           value</term> is defined in <xspecref spec="DM40" ref="dm-typed-value"/>.
                         Every node, other than an element whose type
                            annotation identifies it as having element-only content, has a
                            <termref def="dt-string-value">typed value</termref>. For example, the
@@ -431,7 +431,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
                   <p>
                      <termdef id="dt-string-value" term="string value">The term <term>string
                            value</term> is defined in
-                           <!--<bibref ref="xpath-datamodel-30"/>--><xspecref spec="DM30" ref="dm-string-value"/>. Every node has a <termref def="dt-string-value">string value</termref>. For example, the <termref def="dt-string-value">string value</termref> of an element is the concatenation of the
+                           <xspecref spec="DM40" ref="dm-string-value"/>. Every node has a <termref def="dt-string-value">string value</termref>. For example, the <termref def="dt-string-value">string value</termref> of an element is the concatenation of the
                            <termref def="dt-string-value">string values</termref> of all its
                         descendant text nodes.</termdef>
                   </p>
@@ -1045,7 +1045,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
                            as is the processing that is carried out to construct a tree representing
                            the resource retrieved using a given URI. Some possible ways of
                            constructing a document (specifically, rules for constructing a document
-                           from an Infoset or from a PSVI) are described in <bibref ref="xpath-datamodel-30"/>.</p>
+                           from an Infoset or from a PSVI) are described in <bibref ref="xpath-datamodel-40"/>.</p>
                      </note>
                   </item>
                </ulist>
@@ -1479,7 +1479,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
     <head>Result Tree Construction</head>
     
     <p>If a result tree is to be constructed from the <termref def="dt-raw-result"/>, then this is done
-    by applying the rules for the process of <xtermref spec="SER30" ref="sequence-normalization"/> as defined in 
+    by applying the rules for the process of <xtermref spec="SE40" ref="sequence-normalization"/> as defined in 
        <bibref ref="xslt-xquery-serialization-30"/>. This process takes as input the serialization parameters defined in the
     unnamed <termref def="dt-output-definition"/> of the <termref def="dt-top-level-package"/>; though the only parameter
     that is actually used by this process is <code>item-separator</code>. <phrase diff="del" at="2022-01-01">In particular, sequence normalization is carried
@@ -1568,7 +1568,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
                      <termref def="dt-top-level-package"/>.</p>
                   
                   <note>
-                     <p>The first phase of serialization, called <xtermref spec="SER30" ref="sequence-normalization"/>,
+                     <p>The first phase of serialization, called <xtermref spec="SE40" ref="sequence-normalization"/>,
                      takes place for some output methods but not others. For example, if the <code>json</code> output method
                         (defined in <bibref ref="xslt-xquery-serialization-40"/>) is selected, then the process of constructing
                      a tree is bypassed.</p>
@@ -1883,14 +1883,14 @@ Michael Sperberg-McQueen (1954–2024).</p>
 
             <p>The <termref def="dt-stylesheet">stylesheet</termref> does not describe how a
                   <termref def="dt-source-tree">source tree</termref> is constructed. Some possible
-               ways of constructing source trees are described in <bibref ref="xpath-datamodel-30"/>. Frequently an <termref def="dt-implementation">implementation</termref> will
+               ways of constructing source trees are described in <bibref ref="xpath-datamodel-40"/>. Frequently an <termref def="dt-implementation">implementation</termref> will
                operate in conjunction with an XML parser (or more strictly, in the terminology of
                   <bibref ref="REC-xml"/>, an <emph>XML processor</emph>), to build a source tree
                from an input XML document. An implementation <rfc2119>may</rfc2119> also provide an
                application programming interface allowing the tree to be constructed directly, or
                allowing it to be supplied in the form of a DOM Document object (see <bibref ref="DOM-Level-2-Core"/>). This is outside the scope of this specification. Users
                should be aware, however, that since the input to the transformation is a tree
-               conforming to the XDM data model as described in <bibref ref="xpath-datamodel-30"/>,
+               conforming to the XDM data model as described in <bibref ref="xpath-datamodel-40"/>,
                constructs that might exist in the original XML document, or in the DOM, but which
                are not within the scope of the data model, cannot be processed by the <termref def="dt-stylesheet">stylesheet</termref> and cannot be guaranteed to remain
                unchanged in the transformation output. Such constructs include CDATA section
@@ -2165,7 +2165,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
                an expression such as <code>data(.) instance of xs:integer</code> the system needs to
                know whether the type named in the type annotation of the context node is derived by
                restriction from the type <code>xs:integer</code>. This information is not explicitly
-               available in an XDM tree, as defined in <bibref ref="xpath-datamodel-30"/>. The
+               available in an XDM tree, as defined in <bibref ref="xpath-datamodel-40"/>. The
                implementation may choose one of several strategies for dealing with this
                situation:</p>
             <olist>
@@ -2176,7 +2176,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
                </item>
                <item>
                   <p>The processor may maintain additional metadata, beyond that described in
-                        <bibref ref="xpath-datamodel-30"/>, that allows the source document to be
+                        <bibref ref="xpath-datamodel-40"/>, that allows the source document to be
                      processed as if all the necessary schema information had been imported using
                         <elcode>xsl:import-schema</elcode>. Such metadata might be held in the data
                      structure representing the source document itself, or it might be held in a
@@ -2800,7 +2800,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
                   <p><termdef id="dt-native-namespace-bindings" term="native namespace bindings">
                      The <term>native namespace bindings</term> for any element in an XSLT <termref def="dt-stylesheet-module"/>
                      are the prefix-uri mappings defined by the namespace nodes of that element, according to the rules in
-                     <bibref ref="xpath-datamodel-30"/>.</termdef></p> 
+                     <bibref ref="xpath-datamodel-40"/>.</termdef></p> 
                   <p>For example, a namespace declaration of the form 
                      <code>xmlns:math="http://www.w3.org/2005/xpath-functions/math</code> establishes a binding 
                      of the prefix <code>math</code> to the namespace URI <code>http://www.w3.org/2005/xpath-functions/math</code>,
@@ -6504,7 +6504,7 @@ there is no need to make it needlessly implausible.</p>-->
                   document.</termdef>
             </p>
             <note>
-               <p>A stylesheet module is represented by an XDM element node (see <bibref ref="xpath-datamodel-30"/>). In the case of a standard stylesheet module, this
+               <p>A stylesheet module is represented by an XDM element node (see <bibref ref="xpath-datamodel-40"/>). In the case of a standard stylesheet module, this
                   will be an <elcode>xsl:stylesheet</elcode> or <elcode>xsl:transform</elcode>
                   element. In the case of a simplified stylesheet module, it can be any element (not
                   in the <termref def="dt-xslt-namespace">XSLT namespace</termref>) that has an
@@ -7923,7 +7923,7 @@ and <code>version="1.0"</code> otherwise.</p>
             <note>
                <p>In order for such an attribute value to be used as a fragment identifier in a URI,
                   the XDM attribute node must generally have the <code>is-id</code> property: see
-                     <xspecref spec="DM30" ref="dm-is-id"/>. This property will typically be set if
+                     <xspecref spec="DM40" ref="dm-is-id"/>. This property will typically be set if
                   the attribute is defined in a DTD as being of type <code>ID</code>, or if it is
                   defined in a schema as being of type <code>xs:ID</code>. It is also necessary that
                   the media type of the containing document should support the use of ID values as
@@ -8768,8 +8768,8 @@ and <code>version="1.0"</code> otherwise.</p>
       </div1>
       <div1 id="data-model">
          <head>Data Model</head>
-         <p>The data model used by XSLT is the XPath 3.0 and XQuery
-               3.0 data model (XDM), as defined in <bibref ref="xpath-datamodel-30"/>. XSLT
+         <p>The data model used by XSLT is the XPath 4.0 and XQuery
+               4.0 data model (XDM), as defined in <bibref ref="xpath-datamodel-40"/>. XSLT
             operates on source, result and stylesheet documents using the same data model.</p>
          <p>This section elaborates on some particular features of XDM as it is used by XSLT:</p>
          <p>The rules in <specref ref="stylesheet-stripping"/> and <specref ref="strip"/> make use
@@ -8788,7 +8788,7 @@ and <code>version="1.0"</code> otherwise.</p>
          </note>
          <div2 id="xml-versions">
             <head>XML Versions</head>
-            <p>The XDM data model defined in <bibref ref="xpath-datamodel-30"/> is capable of
+            <p>The XDM data model defined in <bibref ref="xpath-datamodel-40"/> is capable of
                representing either an XML 1.0 document (conforming to <bibref ref="REC-xml"/> and
                   <bibref ref="xml-names"/>) or an XML 1.1 document (conforming to <bibref ref="xml11"/> and <bibref ref="xml-names11"/>), and it makes no distinction
                between the two. In principle, therefore, XSLT 4.0
@@ -8831,16 +8831,9 @@ and <code>version="1.0"</code> otherwise.</p>
          </div2>
          <div2 id="xdm-versions">
             <head>XDM versions</head>
-            <p diff="chg" at="2022-01-01">XSLT 4.0 <rfc2119>requires</rfc2119> a processor to support XDM 3.1 as defined in
-                  <bibref ref="xpath-datamodel-31"/>.</p>
-            <!--<p>A processor <rfc2119>may</rfc2119> also provide a user option to support XDM 3.1 as
-               defined in <bibref ref="xpath-datamodel-31"/>, in which case it must do so as defined
-               in <specref ref="xpath31-feature"/>.</p>
-            <note>
-               <p>The essential differences between XDM 3.0 (with the extensions defined in this
-                  specification) and XDM 3.1 are that XDM 3.1 adds support for arrays, and for the
-                     <code>xs:numeric</code> union type.</p>
-            </note>-->
+            <p diff="chg" at="2022-01-01">XSLT 4.0 <rfc2119>requires</rfc2119> a processor to support XDM 4.0 as defined in
+                  <bibref ref="xpath-datamodel-40"/>.</p>
+            
             <p>A processor <rfc2119>may</rfc2119> also provide a user option to support versions of
                XDM later than 3.1, in which case the way it does so is <termref def="dt-implementation-defined"/>.</p>
 
@@ -8920,7 +8913,7 @@ and <code>version="1.0"</code> otherwise.</p>
             <p>
                <termdef id="dt-type-annotation" term="type annotation">The term <term>type
                      annotation</term> is used in this specification to refer to the value returned
-                  by the <code>dm:type-name</code> accessor of a node: see <xspecref spec="DM30" ref="dm-type-name"/>.</termdef>
+                  by the <code>dm:type-name</code> accessor of a node: see <xspecref spec="DM40" ref="dm-type-name"/>.</termdef>
             </p>
             <p>There is sometimes a requirement to write stylesheets that produce the same results
                whether or not the source documents have been validated against a schema. To achieve
@@ -9094,7 +9087,7 @@ and <code>version="1.0"</code> otherwise.</p>
                before stripping of whitespace text nodes, so this situation will not occur if
                   <code>input-type-annotations="strip"</code> is specified.</p>
             <note>
-               <p>In <bibref ref="xpath-datamodel-30"/>, processes are described for constructing an
+               <p>In <bibref ref="xpath-datamodel-40"/>, processes are described for constructing an
                   XDM tree from an Infoset or from a PSVI. Those processes deal with whitespace
                   according to their own rules, and the provisions in this section apply to the
                   resulting tree. In practice this means that elements that are defined in a DTD or
@@ -9114,7 +9107,7 @@ and <code>version="1.0"</code> otherwise.</p>
          </div2>
          <div2 id="id-in-data-model">
             <head>Attribute Types and DTD Validation</head>
-            <p>The mapping from the Infoset to the XDM data model, described in <bibref ref="xpath-datamodel-30"/>, does not retain attribute types. This means, for
+            <p>The mapping from the Infoset to the XDM data model, described in <bibref ref="xpath-datamodel-40"/>, does not retain attribute types. This means, for
                example, that an attribute described in the DTD as having attribute type
                   <code>NMTOKENS</code> will be annotated in the XDM tree as
                   <code>xs:untypedAtomic</code> rather than <code>xs:NMTOKENS</code>, and its typed
@@ -9244,7 +9237,7 @@ and <code>version="1.0"</code> otherwise.</p>
          </div2>
          <div2 id="limits">
             <head>Limits</head>
-            <p>The XDM data model (see <bibref ref="xpath-datamodel-30"/>) leaves it to the host
+            <p>The XDM data model (see <bibref ref="xpath-datamodel-40"/>) leaves it to the host
                language to define limits. This section describes the limits that apply to XSLT.</p>
             <p>Limits on some primitive datatypes are defined in <bibref ref="xmlschema-2"/>. Other
                limits, listed below, are <termref def="dt-implementation-defined">implementation-defined</termref>. Note that this does not necessarily mean that
@@ -9374,7 +9367,7 @@ and <code>version="1.0"</code> otherwise.</p>
                <p>
                   <termdef id="dt-expanded-qname" term="expanded QName">An <term>expanded
                         QName</term> is a value in the value space of the <code>xs:QName</code>
-                     datatype as defined in the XDM data model (see <bibref ref="xpath-datamodel-30"/>): that is, a triple containing namespace prefix (optional), namespace URI
+                     datatype as defined in the XDM data model (see <bibref ref="xpath-datamodel-40"/>): that is, a triple containing namespace prefix (optional), namespace URI
                      (optional), and local name. Two expanded QNames are equal if the namespace URIs
                      are the same (or both absent) and the local names are the same. The prefix
                      plays no part in the comparison, but is used only if the expanded QName needs
@@ -9421,7 +9414,7 @@ and <code>version="1.0"</code> otherwise.</p>
                      <p>If the lexical QName has a prefix, then the prefix is expanded into a URI
                         reference using the namespace declarations in effect on its <termref def="dt-defining-element">defining element</termref>. The <termref def="dt-expanded-qname">expanded QName</termref> consisting of the local
                         part of the name and the possibly null URI reference is used as the name of
-                        the object. The default namespace of the defining element (see <xspecref spec="DM30" ref="ElementNode"/>) is <emph>not</emph> used for unprefixed
+                        the object. The default namespace of the defining element (see <xspecref spec="DM40" ref="ElementNode"/>) is <emph>not</emph> used for unprefixed
                         names.</p>
                      <p>
                         <error spec="XT" type="static" class="SE" code="0280">
@@ -9609,7 +9602,7 @@ and <code>version="1.0"</code> otherwise.</p>
                <p>If the effective value of the attribute is a zero-length string, which will be the
                   case if it is explicitly set to a zero-length string or if it is not specified at
                   all, then an unprefixed element name or type name refers to a name that is in no
-                  namespace. The default namespace of the parent element (see <xspecref spec="DM30" ref="ElementNode"/>) 
+                  namespace. The default namespace of the parent element (see <xspecref spec="DM40" ref="ElementNode"/>) 
                   is <emph>not</emph> used.</p>
                   <p>The attribute does not affect other names, for example function names, 
                      variable names, or template names, or strings that are interpreted 
@@ -10093,7 +10086,7 @@ and <code>version="1.0"</code> otherwise.</p>
                      <p><term>Static base URI</term>: In a conventional interpreted 
                         environment, the static base URI of an expression in the stylesheet is the base URI 
                         of the containing element in the stylesheet. The concept of the base URI of a node 
-                        is defined in <xspecref spec="DM30" ref="dm-base-uri"/>.</p>
+                        is defined in <xspecref spec="DM40" ref="dm-base-uri"/>.</p>
                         
                      <p>When stylesheets are executed in an environment where no source code is present
                         (for example, because the code of the stylesheet has been compiled and is distributed 
@@ -10227,7 +10220,7 @@ and <code>version="1.0"</code> otherwise.</p>
                      <item>
                         <p><termdef id="dt-context-item" term="context item">The <term>context
                                  item</term> is the item currently being processed. An item (see
-                                 <bibref ref="xpath-datamodel-30"/>) is either an atomic item (such
+                                 <bibref ref="xpath-datamodel-40"/>) is either an atomic item (such
                               as an integer, date, or string), a node, or
                                  a function item. It changes whenever instructions such as
                                  <elcode>xsl:apply-templates</elcode> and
@@ -10668,9 +10661,8 @@ and <code>version="1.0"</code> otherwise.</p>
                <p><termdef id="dt-non-contextual-function-call" term="non-contextual function call">The term <term>non-contextual function
                         call</term> is used to refer to function calls that do not pass the dynamic
                      context to the called function. This includes all calls on <termref def="dt-stylesheet-function">stylesheet functions</termref> and all
-                        <xtermref spec="XP40" ref="dt-dynamic-function-invocation">dynamic function
-                        invocations</xtermref>, (that is calls to function items as permitted by
-                     XPath 3.0). It excludes calls to some
+                        <xtermref spec="XP40" ref="dt-dynamic-function-call">dynamic function
+                        calls</xtermref>, (that is calls to function items). It excludes calls to some
                         functions in the namespace
                            <code>http://www.w3.org/2005/xpath-functions</code>, in
                      particular those that explicitly depend on the context, such as the
@@ -12281,7 +12273,7 @@ return $tree ?> depth()]]></eg>
             <div3 id="namespace-fixup">
                <head>Namespace Fixup</head>
                <p>In a tree supplied to or constructed by an XSLT processor, the constraints
-                  relating to namespace nodes that are specified in <bibref ref="xpath-datamodel-30"/>
+                  relating to namespace nodes that are specified in <bibref ref="xpath-datamodel-40"/>
                   <rfc2119>must</rfc2119> be satisfied. For example:</p>
                <ulist>
                   <item>
@@ -12374,7 +12366,7 @@ return $tree ?> depth()]]></eg>
                         <xfunction>collection</xfunction> functions, a document returned by an
                      extension function or extension instruction, or a document supplied as a
                      stylesheet parameter) is required to satisfy the constraints described in
-                        <bibref ref="xpath-datamodel-30"/>, including the constraints imposed by the
+                        <bibref ref="xpath-datamodel-40"/>, including the constraints imposed by the
                      namespace fixup process. The effect of supplying a pseudo-document that does
                      not meet these constraints is <termref def="dt-implementation-dependent">implementation-dependent</termref>.</p>
                </note>
@@ -12443,7 +12435,7 @@ return $tree ?> depth()]]></eg>
                identifiers of external entities or the value of the <code>xml:base</code> attribute,
                must follow the rules in their respective specifications.</p>
             <p><!--bug 17595-->The base URI of an element node in the stylesheet
-               is determined as defined in <xspecref spec="DM30" ref="dm-base-uri"/>. Some
+               is determined as defined in <xspecref spec="DM40" ref="dm-base-uri"/>. Some
                implementations may allow the output of the static analysis phase of stylesheet
                processing (a “compiled stylesheet”) to be evaluated in a different location from
                that where static analysis took place. Furthermore, stylesheet authors may in such
@@ -17838,7 +17830,7 @@ return $tree ?> depth()]]></eg>
          <p>
             <termdef id="dt-value" term="value">A variable is a binding between a name and a value.
                The <term>value</term> of a variable is any sequence (of nodes, atomic items,
-                  and/or function items), as defined in <bibref ref="xpath-datamodel-30"/>.</termdef>
+                  and/or function items), as defined in <bibref ref="xpath-datamodel-40"/>.</termdef>
          </p>
 
          <div2 id="variables">
@@ -18467,7 +18459,7 @@ return $tree ?> depth()]]></eg>
 &lt;/xsl:variable&gt;</eg>
             </note>
             <p>The base URI of the document node is taken from the base URI of the variable binding
-               element in the stylesheet. (See <xspecref spec="DM30" ref="dm-base-uri"/> in <bibref ref="xpath-datamodel-30"/>)</p>
+               element in the stylesheet. (See <xspecref spec="DM40" ref="dm-base-uri"/>)</p>
             <p>No document-level validation takes place (which means, for example, that there is no
                checking that ID values are unique). However, <termref def="dt-type-annotation">type
                   annotations</termref> on nodes within the new tree are copied unchanged.</p>
@@ -18912,7 +18904,7 @@ return $tree ?> depth()]]></eg>
                   </tr>
                   <tr>
                      <td rowspan="1" colspan="1">Static Base URI</td>
-                     <td rowspan="1" colspan="1">The base URI of the containing element in the stylesheet document (see <xspecref spec="DM30" ref="dm-base-uri"/>)</td>
+                     <td rowspan="1" colspan="1">The base URI of the containing element in the stylesheet document (see <xspecref spec="DM40" ref="dm-base-uri"/>)</td>
                   </tr>
                   <tr>
                      <td rowspan="1" colspan="1">Statically known documents</td>
@@ -21913,7 +21905,7 @@ return $tree ?> depth()]]></eg>
                         <termref def="dt-native-namespace-bindings">native namespace binding</termref>,
                         not in a <termref def="dt-fixed-namespace-bindings">fixed namespace binding</termref>.</p></note>
                      <p>The default namespace of the parent element of the
-                           <code>[xsl:]exclude-result-prefixes</code> attribute (see <xspecref spec="DM30" ref="ElementNode"/>) may be designated as an excluded
+                           <code>[xsl:]exclude-result-prefixes</code> attribute (see <xspecref spec="DM40" ref="ElementNode"/>) may be designated as an excluded
                         namespace by including <code>#default</code> in the list of namespace
                         prefixes.</p>
                      <p>
@@ -22369,7 +22361,7 @@ return $tree ?> depth()]]></eg>
                      QName</termref> representing the name of the new element node. In the event of
                   a conflict a prefix may subsequently be added, changed, or removed during the
                   namespace fixup process (see <specref ref="namespace-fixup"/>).<!--Text inserted by erratum E6 change 3"--> The term <emph>conflict</emph>
-                  here means any violation of the constraints defined in <bibref ref="xpath-datamodel-30"/>, for example the use of the same prefix to refer to
+                  here means any violation of the constraints defined in <bibref ref="xpath-datamodel-40"/>, for example the use of the same prefix to refer to
                   two different namespaces in the element and in one of its attributes, the use of
                   the prefix <code>xml</code> to refer to a namespace other than the XML namespace,
                   or any use of the prefix
@@ -22530,7 +22522,7 @@ return $tree ?> depth()]]></eg>
                process (see <specref ref="namespace-fixup"/>). If the attribute is in a non-null
                namespace and no prefix is specified, then the namespace fixup process will invent a
                prefix. The term <emph>conflict</emph> here means any violation of the constraints
-               defined in <bibref ref="xpath-datamodel-30"/>, for example the use of the same prefix
+               defined in <bibref ref="xpath-datamodel-40"/>, for example the use of the same prefix
                to refer to two different namespaces in the element and in one of its attributes, the
                use of the prefix <code>xml</code> to refer to a namespace other than the XML
                namespace, or any use of the prefix <code>xmlns</code>.</p>
@@ -25713,7 +25705,7 @@ the same group, and the-->
                   <elcode>xsl:merge-source</elcode> element in the stylesheet.</p>
 
             <p><termdef id="dt-merge-input-sequence" term="merge input sequence">A <term>merge input
-                     sequence</term> is an arbitrary <xtermref spec="DM30" ref="dt-sequence">sequence</xtermref> of items which is already sorted according to the <termref def="dt-merge-key-specification">merge key specification</termref> for the
+                     sequence</term> is an arbitrary <xtermref spec="DM40" ref="dt-sequence">sequence</xtermref> of items which is already sorted according to the <termref def="dt-merge-key-specification">merge key specification</termref> for the
                   corresponding <termref def="dt-merge-source-definition">merge source
                      definition</termref>.</termdef></p>
 
@@ -29141,7 +29133,7 @@ the same group, and the-->
             <p><termdef id="dt-utype" term="U-type">A <term>U-type</term> is a set of <termref def="dt-fundamental-item-type">fundamental item types</termref>.</termdef></p>
 
             <p><termdef id="dt-fundamental-item-type" term="fundamental item type">There are 28
-                     <term>fundamental item types</term>: the 7 node kinds defined in <bibref ref="xpath-datamodel-30"/> (element, attribute, etc.), the 19 primitive atomic
+                     <term>fundamental item types</term>: the 7 node kinds defined in <bibref ref="xpath-datamodel-40"/> (element, attribute, etc.), the 19 primitive atomic
                   types defined in <bibref ref="xmlschema-2"/>, plus the types
                      <code>fn(*)</code> and <code>xs:untypedAtomic</code>. The fundamental
                   item types are disjoint, and every item is an instance of exactly one of
@@ -38595,7 +38587,7 @@ return ($m?price - $m?discount)</eg>
             <olist>
                <item><p>The <termref def="dt-raw-result"/> may be delivered <emph>as is</emph>.</p></item>
                <item><p>The <termref def="dt-raw-result"/> may be used to construct a <termref def="dt-final-result-tree"/>
-               by invoking the process of <xtermref spec="SER30" ref="sequence-normalization"/>.</p></item>
+               by invoking the process of <xtermref spec="SE40" ref="sequence-normalization"/>.</p></item>
                <item><p>The <termref def="dt-raw-result"/> may be serialized to a sequence of octets (which
                may then, optionally, be saved to a persistent storage location).</p></item>
             </olist>
@@ -38610,7 +38602,7 @@ return ($m?price - $m?discount)</eg>
                value of the <code>build-tree</code> attribute. If the <termref def="dt-effective-value"/> of
                the <code>build-tree</code> attribute is <code>yes</code>, then 
                   a <termref def="dt-final-result-tree"/> is created
-               by invoking the process of <xtermref spec="SER30" ref="sequence-normalization"/>. <phrase diff="del" at="2022-01-01">The default for the
+               by invoking the process of <xtermref spec="SE40" ref="sequence-normalization"/>. <phrase diff="del" at="2022-01-01">The default for the
                   <code>build-tree</code> attribute depends on the serialization method. For the
                   <code>xml</code>, <code>html</code>, <code>xhtml</code>, and <code>text</code>
                methods the default value is <code>yes</code>. For
@@ -38659,7 +38651,7 @@ return ($m?price - $m?discount)</eg>
             <p>The <code>parameter-document</code> attribute allows serialization
                parameters to be supplied in an external document. The external document must contain
                an <code>output:serialization-parameters</code> element with the format described in
-                  <xspecref spec="SER30" ref="serparams-in-xdm-instance"/>, and the parameters are
+                  <xspecref spec="SE40" ref="serparams-in-xdm-instance"/>, and the parameters are
                interpreted as described in that specification.</p>
             <p>If present, the <termref def="dt-effective-value"/> of the URI supplied in the
                   <code>parameter-document</code> attribute is dereferenced, after resolution
@@ -38811,7 +38803,7 @@ return ($m?price - $m?discount)</eg>
                   a <termref def="dt-final-result-tree"/>, and to determine the <termref def="dt-type-annotation">type
                   annotation</termref> that elements and attributes within the <termref def="dt-final-result-tree">final result tree</termref> will carry. The permitted
                values and their semantics are described in <specref ref="validating-document-nodes"/>. Any such validation is applied to the
-               document node produced as the result of <xtermref spec="SER30" ref="sequence-normalization"/>.
+               document node produced as the result of <xtermref spec="SE40" ref="sequence-normalization"/>.
                If sequence normalization does not take place (typically because the <termref def="dt-raw-result"/>
                is delivered to the application directly, or because the selected serialization method
                does not involve sequence normalization) then the <code>validation</code> and
@@ -39475,8 +39467,8 @@ return ($m?price - $m?discount)</eg>
                      </item>
                      <item>
                         <p>The PSVI produced in the previous step is converted back into the XDM
-                           data model by the mapping described in <bibref ref="xpath-datamodel-30"/>
-                              (<xspecref spec="DM30" ref="PSVI2Types"/>). This process creates nodes
+                           data model by the mapping described in <bibref ref="xpath-datamodel-40"/>
+                              (<xspecref spec="DM40" ref="PSVI2Types"/>). This process creates nodes
                            with simple or complex <termref def="dt-type-annotation">type
                               annotations</termref> based on the types established during schema
                            validation.</p>
@@ -39489,7 +39481,7 @@ return ($m?price - $m?discount)</eg>
                   <note>
                      <p> As an alternative to steps 1 and 2, the XDM tree may be converted to an
                         Infoset directly, using the mapping rules given for each kind of node in
-                           <bibref ref="xpath-datamodel-30"/> (Section 6). </p>
+                           <bibref ref="xpath-datamodel-40"/> (Section 6). </p>
                   </note>
                   <p>Validating an attribute using strict or lax validation requires a modified
                      version of this procedure. A copy of the attribute is first added to an element
@@ -39707,7 +39699,7 @@ return ($m?price - $m?discount)</eg>
                <code>cdata-section-elements</code>
             and <code>suppress-indentation</code> attributes, the
             output definition uses the union of the values from all the constituent
-               <elcode>xsl:output</elcode> declarations. For the <code>use-character-maps</code>
+            <elcode>xsl:output</elcode> declarations. For the <code>use-character-maps</code>
             attribute, the output definition uses the concatenation of the sequences of <termref def="dt-expanded-qname">expanded QNames</termref> values from all the constituent
                <elcode>xsl:output</elcode> declarations, taking them in order of increasing <termref def="dt-import-precedence">import precedence</termref>, or where several have the
             same import precedence, in <termref def="dt-declaration-order">declaration
@@ -39717,7 +39709,7 @@ return ($m?price - $m?discount)</eg>
          <p>The <code>parameter-document</code> attribute allows serialization
             parameters to be supplied in an external document. The external document must contain an
                <code>output:serialization-parameters</code> element with the format described in
-               <xspecref spec="SER30" ref="serparams-in-xdm-instance"/>, and the parameters are
+               <xspecref spec="SE40" ref="serparams-in-xdm-instance"/>, and the parameters are
             interpreted as described in that specification.</p>
          <p>If present, the URI supplied in the <code>parameter-document</code>
             attribute is dereferenced, after resolution against the base URI of the
@@ -40388,7 +40380,7 @@ return ($m?price - $m?discount)</eg>
             that feature.</p>
 
          
-         <p>An XSLT processor takes as its inputs a stylesheet and zero or more XDM trees conforming to the data model defined in <bibref ref="xpath-datamodel-30"/>. It is not <rfc2119>required</rfc2119> that the processor
+         <p>An XSLT processor takes as its inputs a stylesheet and zero or more XDM trees conforming to the data model defined in <bibref ref="xpath-datamodel-40"/>. It is not <rfc2119>required</rfc2119> that the processor
             supports any particular method of constructing XDM trees, but conformance can only be
             tested if it provides a mechanism that enables XDM trees representing the stylesheet and
             primary source document to be constructed and supplied as input to the processor.</p>
@@ -40804,11 +40796,11 @@ return ($m?price - $m?discount)</eg>
             <head>Normative References</head>
 
             <blist>
-               <bibl id="xpath-datamodel-30" key="XDM 3.0"/>
-               <bibl id="xpath-datamodel-31" key="XDM 3.1"/>
+               <!--<bibl id="xpath-datamodel-30" key="XDM 3.0"/>
+               <bibl id="xpath-datamodel-31" key="XDM 3.1"/>-->
                <bibl id="xpath-datamodel-40" key="XDM 4.0"/>
-               <bibl id="xpath-functions-30" key="Functions and Operators 3.0"/>
-               <bibl id="xpath-functions-31" key="Functions and Operators 3.1"/>
+               <!--<bibl id="xpath-functions-30" key="Functions and Operators 3.0"/>
+               <bibl id="xpath-functions-31" key="Functions and Operators 3.1"/>-->
                <bibl id="xpath-functions-40" key="Functions and Operators 4.0">
                  <emph>CITATION: T.B.D.</emph>
                </bibl>
@@ -40841,9 +40833,9 @@ See <loc href="http://www.w3.org/TR/xpath-functions/"/>
                <bibl id="ISO21320" key="ISO 21320">ISO (International Organization for
                   Standardization) <emph>Information technology — Document Container File, Part 1: Core</emph> 
                   ISO 21320-1:2015, October 2015. See <loc href="https://www.iso.org/obp/ui/#iso:std:iso-iec:21320:-1:ed-1:v1:en"/>.</bibl>
-               <bibl id="xslt-xquery-serialization-30" key="XSLT and XQuery Serialization"/>
-               <bibl id="xslt-xquery-serialization-31" key="XSLT and XQuery Serialization 3.1"/>
-               <bibl id="xslt-xquery-serialization-40" key="XSLT and XQuery Serialization 4.0"/>
+               <!--<bibl id="xslt-xquery-serialization-30" key="XSLT and XQuery Serialization"/>
+               <bibl id="xslt-xquery-serialization-31" key="XSLT and XQuery Serialization 3.1"/>-->
+               <bibl id="xslt-xquery-serialization-40" key="Serialization 4.0"/>
                <!--<bibl id="UNICODE-NORMALIZATION" key="Unicode Normalization">Unicode Consortium.
 					<emph>Unicode Normalization Forms</emph>. Unicode Standard Annex #15.
 					See <loc href="http://www.unicode.org/unicode/reports/tr15/"/>
@@ -40892,8 +40884,8 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
                <bibl id="xmlschema-2" key="XML Schema Part 2"/>
                <bibl id="xmlschema11-1" key="XML Schema 1.1 Part 1"/>
                <bibl id="xmlschema11-2" key="XML Schema 1.1 Part 2"/>
-               <bibl id="xpath-30" key="XPath 3.0"/>
-               <bibl id="xpath-31" key="XPath 3.1"/>
+               <!--<bibl id="xpath-30" key="XPath 3.0"/>
+               <bibl id="xpath-31" key="XPath 3.1"/>-->
                <bibl id="xpath-40" key="XPath 4.0">
                  <emph>CITATION: T.B.D.</emph>
                </bibl>

--- a/specifications/xslt-xquery-serialization-40/src/bibl.xml
+++ b/specifications/xslt-xquery-serialization-40/src/bibl.xml
@@ -8,14 +8,10 @@
 <bibl id="charmod-norm"
       key="Character Model for the World Wide Web 1.0: Normalization"/>
 
-<!--* <bibl id="xpath-datamodel-30" key="XQuery and XPath Data Model (XDM) 3.0"/> *-->
-<bibl id="xpath-datamodel-40" key="XQuery and XPath Data Model (XDM) 4.0"/>
-
-<!--* <bibl id="xpath-functions-30"
-      key="XQuery and XPath Functions and Operators 3.0"/> *-->
+<bibl id="xpath-datamodel-40" key="XDM 4.0"/>
 
 <bibl id="xpath-functions-40"
-      key="XQuery and XPath Functions and Operators 4.0"/>
+      key="Functions and Operators 4.0"/>
 
 <bibl id="html5" key="HTML5"/>
 
@@ -33,18 +29,6 @@
 
 <bibl id="RFC2854" key="RFC2854"/>
 
-<!-- bibl id="RFC2376" key="RFC2376">E. Whitehead, M. Murata.  <emph>XML
-Media Types</emph>. IETF RFC 2376.
-See <loc href="http://www.ietf.org/rfc/rfc2376.txt"/>.</bibl -->
-
-<!-- bibl id="RFC2396" key="RFC2396">T. Berners-Lee, R. Fielding, and
-L. Masinter.  <emph>Uniform Resource Identifiers (URI): Generic
-Syntax</emph>. IETF RFC 2396.
-See <loc href="http://www.ietf.org/rfc/rfc2396.txt"/>.</bibl -->
-
-<!-- bibl id="RFC3023" key="RFC3023">M. Murata, S. St.Laurent, D. Kohn.  <emph>XML
-Media Types</emph>. IETF RFC 3023.
-See <loc href="http://www.ietf.org/rfc/rfc3023.txt"/>.</bibl -->
 
 <bibl id="RFC3236" key="RFC3236"/>
 
@@ -83,13 +67,11 @@ Maintained by Ian Ward.
 
 <bibl id="xmlschema-1" key="XML Schema"/>
 
-<!--* <bibl id="xpath-30" key="XML Path Language (XPath) 3.0"/> *-->
-<bibl id="xpath-40" key="XML Path Language (XPath) 4.0"/>
+<bibl id="xpath-40" key="XPath 4.0"/>
 
-<!--* <bibl id="xquery-30" key="XQuery 3.0: An XML Query Language"/> *-->
-<bibl id="xquery-40" key="XQuery 4.0: An XML Query Language"/>
+<bibl id="xquery-40" key="XQuery 4.0"/>
 
-<bibl id="xslt-40" key="XSL Transformations (XSLT) Version 4.0"/>
+<bibl id="xslt-40" key="XSLT 4.0"/>
 
 <bibl id="xx-ECMA-404" key="The JSON Data Interchange Format" diff="del" at="2014-09-22">
 <titleref href="http://www.ecma-international.org/publications/standards/Ecma-404.htm">The JSON Data Interchange Format</titleref>,
@@ -127,7 +109,7 @@ ECMA International.
   <emph>XHTML Media Types W3C Note 1 August 2002</emph>
   See <loc href="http://www.w3.org/TR/xhtml-media-types/">http://www.w3.org/TR/xhtml-media-types/</loc>.</bibl -->
 
-<bibl id="xpath-datamodel" key="XQuery 1.0 and XPath 2.0 Data Model"/>
+<bibl id="xpath-datamodel" key="XDM 4.0"/>
 
    <bibl id="serialization-10-2ed" key="XSLT 2.0 and XQuery 1.0 Serialization (Second Edition)">
       <titleref href="http://www.w3.org/TR/2010/REC-xslt-xquery-serialization-20101214/"

--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -104,7 +104,6 @@ for transition to Proposed Recommendation. </p>'>
    <loc href="https://www.w3.org/TR/xslt-xquery-serialization-31/">Serialization version 3.1</loc>.</p>'>
 
 <!ENTITY status-section SYSTEM "../../../etc/status-general.xml">
-
 ]>
 <spec id="spec-top" w3c-doctype="&doc.w3c-doctype;" status="int-review">
 
@@ -193,9 +192,11 @@ for transition to Proposed Recommendation. </p>'>
     <change>Sections with significant changes are marked Δ in the table of contents.</change>
   </changes>
 
-<p>This document defines serialization of the W3C XQuery
-and XPath Data Model 4.0 (XDM),
-which is the data model of at least <bibref ref="xpath-40"/>,
+<p>This document defines methods of serializing of the W3C XQuery
+and XPath Data Model 4.0 (<bibref ref="xpath-datamodel-40"/>),
+  that is, methods of representing instances of the data model
+  as strings or octet sequences. This
+is the data model used by <bibref ref="xpath-40"/>,
 <bibref ref="xslt-40"/>, and
 <bibref ref="xquery-40"/>, and any other specifications that reference it.</p>
 
@@ -315,7 +316,7 @@ in <xspecref spec="XP40" ref="id-atomization"/>.</termdef></p>
 
 <item>
 <p><termdef id="dt-node" term="node">The term <term>node</term>
-is defined as part of   <xspecref spec="DM40" ref="Node"/>. 
+is defined in <xspecref spec="XP40" ref="id-basics"/>. 
 There are seven kinds of <termref def="dt-node">nodes</termref> in the data model: document, element, attribute, text, namespace, processing instruction, and comment.</termdef></p>
 </item>
 

--- a/style/xsl-query-2016.xsl
+++ b/style/xsl-query-2016.xsl
@@ -736,13 +736,29 @@
     <xsl:variable name="shortSpec" select="replace(@spec, '40$', '')"/>
     <xsl:choose>
       <xsl:when test="$div">
+        
+        <!-- construct and render a suitable bibref. To reuse the bibref template
+          rule, we can't create a new bibref in a new document, we need to find
+          an appropriate bibref within the current document -->
+        <xsl:variable name="bibref" 
+                      select="map{'XP': 'xpath-40', 
+                                  'XQ': 'xquery-40', 
+                                  'XT': 'xslt-40', 
+                                  'SER': 'xslt-xquery-serialization-40', 
+                                  'SE': 'xslt-xquery-serialization-40', 
+                                  'DM': 'xpath-datamodel-40', 
+                                  'FO': 'xpath-functions-40'}($shortSpec)"/>
+        <xsl:if test="$bibref">
+          <xsl:apply-templates select="(//bibref[@ref=$bibref])[1]"/>
+          <xsl:text> section </xsl:text>
+        </xsl:if>        
+        
         <xsl:variable name="linktext">
           <xsl:choose>
             <xsl:when test="$div/self::prod">
               <xsl:value-of select="$div"/>
             </xsl:when>
-            <xsl:otherwise>
-              <xsl:text>Section </xsl:text>
+            <xsl:otherwise>      
               <xsl:value-of select="$div/head"/>
             </xsl:otherwise>
           </xsl:choose>
@@ -758,11 +774,14 @@
             <xsl:sequence select="$linktext"/>
           </xsl:otherwise>
         </xsl:choose>
-        <sup>
-          <small>
-            <xsl:value-of select="$shortSpec"/>
-          </small>
-        </sup>
+        
+        <xsl:if test="not($bibref)">
+          <sup>
+            <small>
+              <xsl:value-of select="$shortSpec"/>
+            </small>
+          </sup>
+        </xsl:if>
       </xsl:when>
       <xsl:when test="$nt">
         <xsl:choose>


### PR DESCRIPTION
This PR:

- Changes the rendition of xspecref elements to use the form `[XPath 4.0] section [3.2.2 Heading]`
- Standardises the form of bibref references to other specs (e.g. `[XPath 4.0]`) across the various specifications
- Updates a number of references that were out of date (e.g. XDM 3.0 -> XDM 4.0)
- Tidies up a few individual cases where the references were inappropriate or incorrect

Note: contains stylesheet changes