### PR TITLE
657 Allow user-defined functions in no namespace

### DIFF
--- a/specifications/xquery-40/src/back-matter.xml
+++ b/specifications/xquery-40/src/back-matter.xml
@@ -1063,6 +1063,14 @@ See
     to global variables and local variable bindings introduces an incompatibility in the case of variables
     whose value is a function item. Previously it was possible to supply a function item that accepted a wider
     range of argument values than those declared in the variable's type declaration; this is no longer the case.</p>
+    
+    <p>Use of an unprefixed function name in a function declaration has a different meaning from XQuery 3.1. In
+    3.1 and previous versions, this declared a function in the <termref def="dt-default-function-namespace"/>
+    (which would cause an error unless the default function namespace was explicitly set to something other than
+    the <code>fn</code> namespace). In XQuery 4.0, the function name will be in no namespace. The distinction will rarely
+    be noticed, because an unprefixed function name in a call of such a function will still work in the same way.
+    It could make a difference, however, if a function call uses a prefixed name in which the prefix is explicitly
+    bound to the default function namespace.</p>
   </div2>
 
 <div2 id="id-incompatibilities-30">

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -501,11 +501,36 @@ The term URI has been retained in preference to IRI to avoid introducing new nam
                <item><p><termdef id="dt-no-namespace-rule" term="no-namespace rule">When an unprefixed lexical QName
                is expanded using the <term>no-namespace rule</term>, it is interpreted as having an absent namespace URI.</termdef>
                </p></item>
-               <item><p><termdef id="dt-default-function-namespace-rule" term="default function namespace rule">When 
-                  an unprefixed lexical QName
-               is expanded using the <term>default function namespace rule</term>, it uses the <termref def="dt-default-function-namespace"/>
-                  from the <termref def="dt-static-context"/>.</termdef>
-               </p></item>
+               <item>
+                  <p><termdef id="dt-default-function-namespace-rule" term="default function namespace rule">When 
+                     an unprefixed lexical QName
+                     is expanded using the <term>default function namespace rule</term>, 
+                     the processor searches for a matching function definition as follows: 
+                     first, if the static context includes a no-namespace function definition 
+                     with the required local name and arity, then that function definition is used; 
+                     otherwise, the name is expanded using the <termref def="dt-default-function-namespace"/> from 
+                     the <termref def="dt-static-context"/>.</termdef>
+                  </p>
+                  <note><p>The implication of this rule is that if there is a user-defined function in no namespace
+                  with the same local name as a system-defined function in the <code>fn</code>
+                     namespace, then a function call using the unprefixed function name invokes the user-defined
+                     function in preference to the system-defined function.</p>
+                     <p>It is generally advisable to avoid any danger of user confusion by keeping the names
+                        of user-defined functions noticably distinct from the names of system-defined functions,
+                        for example by using different naming conventions (for example, leading upper-case letters
+                        leading underscores, or <code>camelCase</code>).</p>
+                     <p>There may however be cases where a user-defined function deliberately has the same local name
+                        as a system-defined function, but with modified semantics. For example a user might choose
+                        to define a function <code>Q{}current-date()</code> that returns a date with no timezone:
+                        this might be defined in XQuery as:</p>
+                     <eg>declare function current-date() as xs:date {
+   fn:current-date() => fn:adjust-date-to-timezone(())
+}</eg>
+                     
+                     
+                     </note>
+               
+               </item>
                <item><p><termdef id="dt-default-type-namespace-rule" term="default type namespace rule">When 
                   an unprefixed lexical QName
                is expanded using the <term>default type namespace rule</term>, it uses the 

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -1565,6 +1565,12 @@ declare context value as document-node()* := collection($uri); </eg>
         Optional parameters are given a default value, which can be any expression, including one that
         depends on the context of the caller (so an argument can default to the context value).
       </change>
+      <change issue="657">
+        A user-defined function whose name is given as an unprefixed QName is now in no namespace.
+        In previous versions of the language, it represented a name in the <termref def="dt-default-function-namespace"/>
+        (which only worked if the <termref def="dt-default-function-namespace"/> was explicitly set to an unreserved
+        namespace, which was rarely done because it caused other problems).
+      </change>
     </changes>
     <p diff="chg" at="variadicity">In addition to the <termref def="dt-system-function">system functions</termref>, XQuery
       allows users to declare functions of their own. A function declaration declares a family of functions
@@ -1634,7 +1640,12 @@ local:summary(doc("acme_corp.xml")//employee[location = "Denver"])</eg>
       
       <ulist>
         <item><p>The name of <var>F</var> is the <termref def="dt-expanded-qname"/> obtained by expanding the <code>EQName</code>
-          that follows the keyword <code>function</code> using the <termref def="dt-default-function-namespace-rule"/>.</p></item>
+          that follows the keyword <code>function</code> using the <termref def="dt-no-namespace-rule"/>.
+        That is, an unprefixed name represents a name in no namespace.</p>
+        <note><p>This is a change from previous XQuery versions, where an unprefixed name was resolved using the
+        <termref def="dt-default-function-namespace"/>. This option was rarely used because it would work only
+        when the <termref def="dt-default-function-namespace"/> was an unreserved namespace, which is rarely
+        the case.</p></note></item>
         <item><p>The parameters of <var>F</var> are derived from the <code>ParamWithDefault</code> entries in the
           <code>ParamListWithDefaults</code>:</p>
           <ulist>
@@ -1671,12 +1682,20 @@ local:summary(doc("acme_corp.xml")//employee[location = "Denver"])</eg>
         <change issue="1954" PR="1956" date="2025-04-24">
           Private functions declared in a library module are no longer required to be in the module namespace.
         </change>
+        <change issue="657">
+          A user-defined function whose name is given as an unprefixed QName is now in no namespace.
+          In previous versions of the language, it represented a name in the <termref def="dt-default-function-namespace"/>
+          (which only worked if the <termref def="dt-default-function-namespace"/> was explicitly set to an unreserved
+          namespace, which was rarely done because it caused other problems).
+        </change>
       </changes>
       
-      
-      <p>Every declared function must be in a namespace; that is, every declared function name must
-        (when expanded) have a non-null namespace URI <errorref class="ST" code="0060"/>.</p>
-      
+      <note>
+      <p>In XQuery 4.0 it is no longer the case that all declared functions must be in a namespace; the
+        function name can be unprefixed, in which case it represents a no-namespace function name,
+        which will match an unprefixed name in a function call in preference to a system function
+        with the same name.</p>
+      </note>
       
         
         <p>A <termref def="dt-public-function"/> 
@@ -1734,13 +1753,13 @@ local:summary(doc("acme_corp.xml")//employee[location = "Denver"])</eg>
         </ulist>
       </p>
       
-      <p>If the function name in a function declaration has no namespace prefix, it is considered to be in the
-        <termref def="dt-default-function-namespace"/>. This will result in a static error if the default function
-        namespace is a <termref def="dt-reserved-namespaces">reserved namespace</termref>.</p>
+      <p>If the function name in a function declaration has no namespace prefix, it is considered to be 
+      in no namespace.</p>
                
       
       <p>In order to allow modules to declare functions for local use within the module without
-        defining a new namespace, XQuery predefines the namespace prefix <code>local</code> to the
+        defining a new namespace, and without any risk of conflicts with the 
+        standard <code>fn</code> namespace, XQuery predefines the namespace prefix <code>local</code> to the
         namespace <code>http://www.w3.org/2005/xquery-local-functions</code>. It is suggested (but not
         required) that this namespace be used for defining local functions, including 
         <termref def="dt-private-function">private functions</termref> declared in 

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -20224,6 +20224,10 @@ return $tree =?> depth()]]></eg>
                <change issue="155" PR="159" date="2022-09-30">Parameters on functions
                declared using <elcode>xsl:function</elcode> can now be defined as optional,
                with a default value supplied.</change>
+               <change issue="657">User-defined functions can now have names that are in
+               no namespace. An unprefixed name appearing in a function call is resolved
+               to a no-namespace function with matching local name in preference to
+               a function in the standard <code>fn</code> namespace.</change>
             </changes>
             
             
@@ -20277,14 +20281,19 @@ return $tree =?> depth()]]></eg>
                <p>The name of the function is given by the <code>name</code>
                   attribute.</p>
                
-               <p>
+               <note><p>XSLT 4.0 allows the function name to be unprefixed. This represents a QName
+               in no namespace. A function call using an unprefixed function name is resolved to
+               a no-namespace function name in preference to a function in the default function namespace,
+               which for XSLT is always the <code>fn</code> namespace.</p></note>
+               
+               <!--<p>
                   <error spec="XT" type="static" class="SE" code="0740">
                      <p>It is a <termref def="dt-static-error">static error</termref> if a <termref def="dt-stylesheet-function">stylesheet function</termref> has a name
                         that is in no namespace.</p>
-                  </error></p>
+                  </error></p>-->
                
                <note>
-                  <p>To prevent the namespace declaration used for the function name appearing in
+                  <p>To prevent the namespace URI used for the function name appearing in
                      the result document, use the <code>exclude-result-prefixes</code> attribute on
                      the <elcode>xsl:stylesheet</elcode> element: see <specref ref="lre-namespaces"/>.</p>
                   <p>The name of the function must not be in a <termref def="dt-reserved-namespace">reserved namespace</termref>: <errorref spec="XT" class="SE" code="0080"/>
@@ -20330,8 +20339,12 @@ return $tree =?> depth()]]></eg>
 <xsl:function name="f:compare" as="xs:boolean">
   <xsl:param name="arg1" as="xs:double"/>
   <xsl:param name="arg2" as="xs:double"/>
-  <xsl:param name="options" as="map(*)" required="no" select="{ 'order': 'ascending' }"/>
-  <xsl:if test="$options?order = 'descending'" then="$arg1 gt $arg2" else="$arg2 gt $arg1"/>
+  <xsl:param name="options" as="map(*)" 
+             required="no" 
+             select="{ 'order': 'ascending' }"/>
+  <xsl:if test="$options?order = 'descending'" 
+          then="$arg1 gt $arg2" 
+          else="$arg2 gt $arg1"/>
 </xsl:function>]]></eg>
 
               


### PR DESCRIPTION
1. User functions declared in XQuery or XSLT can be in no namespace
2. Unprefixed function names used in static function calls and user function references are resolved first against no-namespace functions with matching local name (and arity), and secondly against functions in the default function namespace, which will normally be the `fn` namespace.