### PR TITLE
2190 Drop binary input for parse-csv and parse-json

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -27758,7 +27758,7 @@ element-to-map-plan((<a><b/><b/></a>, <a><b/><c/></a>))
    <fos:function name="parse-csv" prefix="fn">
       <fos:signatures>
          <fos:proto name="parse-csv" return-type-ref="parsed-csv-structure-record" return-type-ref-occurs="?">
-            <fos:arg name="value" type="(xs:string | xs:hexBinary | xs:base64Binary)?" example="'&lt;a/&gt;'"/>
+            <fos:arg name="value" type="xs:string?" example="'&lt;a/&gt;'"/>
             <fos:arg name="options" type="map(*)?" usage="inspection" default="{}"/>
          </fos:proto>
       </fos:signatures>
@@ -27775,13 +27775,8 @@ element-to-map-plan((<a><b/><b/></a>, <a><b/><c/></a>))
 
          <p>If <code>$value</code> is the empty sequence, the function returns the empty sequence.</p>
 
-         <p>If <code>$value</code> is supplied as a binary value, it is converted to a string.
-            The function detects the encoding using the same rules as the <function>unparsed-text</function>
-            function, except that the special handling of media types such as <code>text/xml</code>
-            and <code>application/xml</code> may be skipped. Otherwise, if <code>$value</code>
-            is a string, it is processed unchanged.</p>
-
-         <p>The resulting input is CSV data, as defined in <bibref ref="rfc4180"/>. The function
+         <p>The input supplied in <code>$value</code> is CSV data, as defined
+            in <bibref ref="rfc4180"/>. The function
             first parses the input using <function>fn:csv-to-arrays</function>, and then
             further processes the result. The initial parsing is exactly as defined for
             <function>fn:csv-to-arrays</function>, and can be controlled using the same options.
@@ -28797,7 +28792,7 @@ return document {
    <fos:function name="parse-json" prefix="fn">
       <fos:signatures>
          <fos:proto name="parse-json" return-type="item()?">
-            <fos:arg name="value" type="(xs:string | xs:hexBinary | xs:base64Binary)?" example="'[22, 23]'"/>
+            <fos:arg name="value" type="xs:string?" example="'[22, 23]'"/>
             <fos:arg name="options" type="map(*)?" usage="inspection" default="{}"/>
          </fos:proto>
       </fos:signatures>
@@ -28825,11 +28820,7 @@ return document {
             <p>If the input is <code>"null"</code>, the result will also be an empty sequence.</p>
          </note>
 
-         <p>If <code>$value</code> is supplied as a binary value, it is converted to a string.
-            The function detects the encoding using the same rules as the <function>unparsed-text</function>
-            function, except that the special handling of media types such as <code>text/xml</code>
-            and <code>application/xml</code> may be skipped. Otherwise, if <code>$value</code>
-            is a string, it is processed unchanged.</p>
+        
 
          <p>The <code>$options</code> argument can be used to control the way in which the parsing
             takes place. The <termref
@@ -29122,7 +29113,7 @@ return document {
          <p>The serializer provides an option to output data in <term>json-lines</term> format. This is a format for structured data
             containing one JSON value (usually but not necessarily a JSON object) on each line. There is no corresponding
          option to parse <term>json-lines</term> input, but this can be achieved using the expression
-         <code>unparsed-text-lines($uri) => parse-json()</code>.</p>
+         <code>unparsed-text-lines($uri) =!> parse-json()</code>.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -29205,9 +29196,9 @@ return document {
          <fos:change issue="1651" PR="1703" date="2025-01-14">
             <p>The order of entries in maps is retained.</p>
          </fos:change>
-         <fos:change issue="748" PR="2013" date="2025-05-20">
+         <!--<fos:change issue="748" PR="2013" date="2025-05-20">
             <p>Support for binary input has been added.</p>
-         </fos:change>
+         </fos:change>-->
       </fos:changes>
    </fos:function>
 
@@ -29231,7 +29222,19 @@ return document {
             calling the two-argument form with an empty map as the value of the <code>$options</code>
             argument.</p>
          <p>The effect of the two-argument function call <code>fn:json-doc($H, $M)</code>is equivalent to the function composition
-            <code>fn:unparsed-binary($H) => fn:parse-json($M)</code>.</p>
+            <code>fn:unparsed-text($H) => fn:parse-json($M)</code>, except that:</p>
+         
+         <ulist>
+            <item><p>The function may accept a resource in any encoding. [RFC 7159] requires 
+               UTF-8, UTF-16, or UTF-32 to be accepted, but it is not an error if a different encoding 
+               is used. Unless external encoding information is available, the function must assume 
+               that the encoding is one of UTF-8, UTF-16, or UTF-32, and must distinguish these cases 
+               by examination of the initial octets of the resource.</p></item>
+            <item><p>Having established the encoding, the function must accept any codepoint that
+               can validly occur in a JSON text, with the exception of unpaired surrogates.</p></item>
+         </ulist>
+         
+         
          <p>If <code>$source</code> is the empty sequence, the function returns the empty sequence.</p>
       </fos:rules>
       <fos:errors>


### PR DESCRIPTION
This PR reverts the change to parse-csv() and parse-json() allowing them to take binary input.

The change was made primarily for consistency with parse-xml() and parse-html(). However, those functions have a legitimate reason to accept binary input, because discerning the encoding may be intermingled with parsing in the case of input documents that use custom syntax to define their own encoding. This is not the case for CSV and JSON, where standard decoding tools may be used.

In addition, there was no good reason to add the option to parse-csv() and not to csv-to-arrays() or csv-to-xml().