### PR TITLE
QT4CG-131-02 Expand on existing example for deconstructed variable bindings

### DIFF
--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -18300,17 +18300,47 @@ return $a + $b + $local:c</eg>
                   </example>
                   <example>
                      <head>Example:</head>
-                     <p>Consider the element <var>$E</var> := <code>&lt;e A="p q r" B="x y z"/></code>, where
-                     <var>$E</var> has been validated against a schema that defines both attributes
-                     <code>A</code> and <code>B</code> as being lists of strings.</p>
-                     <p>Then the expression:</p>
-                     <eg>let $( $a, $b ) := $E/(@A, @B)</eg>
-                     <p>binds <code>$a</code> to the sequence <code>("p", "q", "r")</code>
-                     and <code>$b</code> to the sequence <code>("x", "y", "z")</code>.
-                     The evaluation of the expression <code>$E/(@A, @B)</code>
-                        returns a sequence of two attribute nodes;
-                     the value of <code>$a</code> is formed by atomizing the first of these
-                     nodes, while <code>$b</code> is formed by atomizing the second.</p>
+                     <p>Consider the element <var>$E</var> := <code>&lt;e A="p q r" B="x y z"/></code>.</p>
+                     
+                     <p>Then consider the expression:</p>
+                     <eg>let $( $a, $b ) := $E!(@A, @B)</eg>
+                     
+                     <p>Here the binding sequence is a sequence of two attribute nodes, so
+                        <code>$a</code> is bound to the attribute <code>@A</code>, and <code>$b</code>
+                        is bound to the attribute node <code>@B</code>.</p>
+                     
+                     <p>If the operator <code>"!"</code> were replaced by <code>"/"</code>, or if
+                        <code>","</code> were replaced by <code>"|"</code>, then the binding sequence
+                        would be sorted into document order, and since the order of attributes is
+                        not defined, this would make it unpredictable which variable is bound
+                        to which attribute node.</p>
+                     
+                     <p>Now consider what happens when a declared sequence type is added:</p>
+                     
+                     <eg>let $( $a, $b ) as xs:string* := $E!(@A, @B)</eg>
+                     
+                     <p>The sequence of two attribute nodes is now atomized to form a sequence of strings.
+                        The first string in this sequence is bound to <code>$a</code>, and the remainder
+                        of the sequence is bound to <code>$b</code>. If the element <code>$E</code> is untyped,
+                        this will result in <code>$a</code> being bound to the <code>xs:untypedAtomic</code>
+                        value <code>"p q r"</code>, while <code>$b</code> is bound to the <code>xs:untypedAtomic</code>
+                        value <code>"x y z"</code>.</p>
+                     
+                     <p>However, suppose that the element <code>$E</code> has been validated against a schema
+                        that defines both attributes <code>@A</code> and <code>@B</code> as list types with
+                        item type <code>xs:string</code>. In this case, the atomized value of <code>$E</code>
+                        will be a sequence of six strings. The variable <code>$a</code> is bound to the first
+                        of these strings (that is, <code>"p"</code>), while <code>$b</code> is bound to a
+                        sequence containing the remaining five strings (that is, <code>("q", "r", "x", "y", "z")</code>).</p>
+                     
+                     <p>By contrast, if the expression is written as:</p>
+                     
+                     <eg>let $( $a as xs:string*, $b as xs:string* ) := $E!(@A, @B)</eg>
+                     
+                     <p>then <code>$a</code> is bound to the result of atomizing the first attribute
+                     (the <code>untypedAtomic</code> value <code>"p q r"</code> in the untyped case, or
+                     the sequence of three strings <code>("p", "q", "r")</code> in the schema-validated case),
+                     while <code>$b</code> is similarly bound to the result of atomizing the second attribute.</p>
                      
                   </example>
                <example>
@@ -20372,17 +20402,47 @@ return $a + $b + $local:c</eg>
                   </example>
                   <example>
                      <head>Example:</head>
-                     <p>Consider the element <var>$E</var> := <code>&lt;e A="p q r" B="x y z"/></code>, where
-                     <var>$E</var> has been validated against a schema that defines both attributes
-                     <code>A</code> and <code>B</code> as being lists of strings.</p>
-                     <p>Then the expression:</p>
-                     <eg>let $( $a as xs:string*, $b as xs:string* ) := $E/(@A, @B)</eg>
-                     <p>binds <code>$a</code> to the sequence <code>("p", "q", "r")</code>
-                     and <code>$b</code> to the sequence <code>("x", "y", "z")</code>.
-                     The evaluation of the expression <code>$E/(@A, @B)</code>
-                        returns a sequence of two attribute nodes;
-                     the value of <code>$a</code> is formed by atomizing the first of these
-                     nodes, while <code>$b</code> is formed by atomizing the second.</p>
+                     <p>Consider the element <var>$E</var> := <code>&lt;e A="p q r" B="x y z"/></code>.</p>
+                     
+                     <p>Then consider the expression:</p>
+                     <eg>let $( $a, $b ) := $E!(@A, @B)</eg>
+                     
+                     <p>Here the binding sequence is a sequence of two attribute nodes, so
+                        <code>$a</code> is bound to the attribute <code>@A</code>, and <code>$b</code>
+                        is bound to the attribute node <code>@B</code>.</p>
+                     
+                     <p>If the operator <code>"!"</code> were replaced by <code>"/"</code>, or if
+                        <code>","</code> were replaced by <code>"|"</code>, then the binding sequence
+                        would be sorted into document order, and since the order of attributes is
+                        not defined, this would make it unpredictable which variable is bound
+                        to which attribute node.</p>
+                     
+                     <p>Now consider what happens when a declared sequence type is added:</p>
+                     
+                     <eg>let $( $a, $b ) as xs:string* := $E!(@A, @B)</eg>
+                     
+                     <p>The sequence of two attribute nodes is now atomized to form a sequence of strings.
+                        The first string in this sequence is bound to <code>$a</code>, and the remainder
+                        of the sequence is bound to <code>$b</code>. If the element <code>$E</code> is untyped,
+                        this will result in <code>$a</code> being bound to the <code>xs:untypedAtomic</code>
+                        value <code>"p q r"</code>, while <code>$b</code> is bound to the <code>xs:untypedAtomic</code>
+                        value <code>"x y z"</code>.</p>
+                     
+                     <p>However, suppose that the element <code>$E</code> has been validated against a schema
+                        that defines both attributes <code>@A</code> and <code>@B</code> as list types with
+                        item type <code>xs:string</code>. In this case, the atomized value of <code>$E</code>
+                        will be a sequence of six strings. The variable <code>$a</code> is bound to the first
+                        of these strings (that is, <code>"p"</code>), while <code>$b</code> is bound to a
+                        sequence containing the remaining five strings (that is, <code>("q", "r", "x", "y", "z")</code>).</p>
+                     
+                     <p>By contrast, if the expression is written as:</p>
+                     
+                     <eg>let $( $a as xs:string*, $b as xs:string* ) := $E!(@A, @B)</eg>
+                     
+                     <p>then <code>$a</code> is bound to the result of atomizing the first attribute
+                     (the <code>untypedAtomic</code> value <code>"p q r"</code> in the untyped case, or
+                     the sequence of three strings <code>("p", "q", "r")</code> in the schema-validated case),
+                     while <code>$b</code> is similarly bound to the result of atomizing the second attribute.</p>
                      
                   </example>
                   


### PR DESCRIPTION
Expands on the existing example as actioned in QT4CG-131-02 and QT4CG-131-03.

The example turned out to have rather more complexity than I imagined.

(Note, it unfortunately contains text that is replicated between the XPath and XQuery specs).