### PR TITLE
Fix various build warnings

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -7724,45 +7724,45 @@ Tak, tak, tak! - da kommen sie.
                <code>fn:non-match</code> element.</p>
          <p>More specifically, the function starts by matching the regular expression against the string,
             using the supplied <code>$flags</code>, to obtain the <termref def="dt-disjoint-matching-segments"/>.
-            For each such segment it constructs an <code>fn:match</code> child, whose string value is
-            the string value of the segment. Before, between, or after these <code>fn:match</code>
-            elements, as required to ensure that the string value of the <code>fn:analyze-string-result</code>
-            element is the same as <code>$value</code>, it inserts <code>fn:non-match</code> elements.
-            The content of an <code>fn:non-match</code> element is always a single (non-empty) text node,
-            and two <code>fn:non-match</code> elements never appear as adjacent siblings.</p>  
+            For each such segment it constructs an <code role="element-name">fn:match</code> child, whose string value is
+            the string value of the segment. Before, between, or after these <code role="element-name">fn:match</code>
+            elements, as required to ensure that the string value of the <code role="element-name">fn:analyze-string-result</code>
+            element is the same as <code>$value</code>, it inserts <code role="element-name">fn:non-match</code> elements.
+            The content of an <code role="element-name">fn:non-match</code> element is always a single (non-empty) text node,
+            and two <code role="element-name">fn:non-match</code> elements never appear as adjacent siblings.</p>  
             
             
          
          <p>The captured groups for each <termref def="dt-disjoint-matching-segments">disjoint matching segment</termref>
-            are represented using <code>fn:group</code> or <code>fn:lookahead-group</code>
-            children of the corresponding <code>fn:match</code> element. Groups captured by a subexpression within
+            are represented using <code role="element-name">fn:group</code> or <code role="element-name">fn:lookahead-group</code>
+            children of the corresponding <code role="element-name">fn:match</code> element. Groups captured by a subexpression within
          a lookahead assertion are referred to as lookahead groups; those not within a lookahead
          assertion are called ordinary groups.</p>
 
-         <p>The content of a <code>fn:match</code> element is in general:</p>
+         <p>The content of a <code> role="element-name"fn:match</code> element is in general:</p>
          
          <ulist>
-            <item><p>A sequence of text nodes and <code>fn:group</code> element children,
+            <item><p>A sequence of text nodes and <code role="element-name">fn:group</code> element children,
             whose string-values when concatenated comprise the string value of the matching segment,
             followed by</p></item>
-            <item><p>A sequence of zero or more <code>fn:lookahead-group</code> elements, 
+            <item><p>A sequence of zero or more <code role="element-name">fn:lookahead-group</code> elements, 
             representing the lookahead groups</p></item>
          </ulist>
          
-         <p>The string value of an <code>fn:match</code> element may be empty.</p>
+         <p>The string value of an <code role="element-name">fn:match</code> element may be empty.</p>
          
-         <p>An <code>fn:group</code> element
+         <p>An <code role="element-name">fn:group</code> element
             with a <code>nr</code> attribute having the integer value <var>N</var> identifies 
             the substring captured by an ordinary group, specifically the string value of the <var>Nth</var> captured group. 
             For each ordinary capturing subexpression there will be at most one corresponding
-               <code>fn:group</code> element in each <code>fn:match</code> element in the
+               <code role="element-name">fn:group</code> element in each <code>fn:match</code> element in the
             result.</p>
          
-         <p>By contrast, lookahead groups are represented by <code>fn:lookahead-group</code> elements,
-         which (if they appear at all) must follow all text node and <code>fn:group</code> element children
-         of the <code>fn:match</code> element. These groups may overlap the matching and non-matching substrings, and
+         <p>By contrast, lookahead groups are represented by <code role="element-name">fn:lookahead-group</code> elements,
+         which (if they appear at all) must follow all text node and <code role="element-name">fn:group</code> element children
+         of the <code role="element-name">fn:match</code> element. These groups may overlap the matching and non-matching substrings, and
          indeed may overlap each other. They must appear in ascending numerical order of group number.
-         The attributes of the <code>fn:lookahead-group</code> element are as follows:</p>
+         The attributes of the <code role="element-name">fn:lookahead-group</code> element are as follows:</p>
          
          <ulist>
             <item><p><code>nr</code>: the group number, based on the position of the capturing subexpression

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -1710,7 +1710,7 @@ This differs from <bibref ref="xmlschema-2"/>, which defines
                     an <code>xs:decimal</code> if called with two <code>xs:integer</code> operands,
                     and <code>op:numeric-integer-divide</code> which always returns an <code>xs:integer</code>.</p>
             <p>If the two operands of an arithmetic expression are not of the same type, they
-               may be converted to a common type as described in <xspecref spec="XP40" ref="id-arithmetic-expressions"/>. </p>
+               may be converted to a common type as described in <xspecref spec="XP40" ref="id-arithmetic"/>. </p>
             <p>The result type of operations depends on their argument datatypes and is defined
                     in the following table:</p>
             <table role="no-code-break data">

--- a/specifications/xpath-functions-40/style/xpath-functions.xsl
+++ b/specifications/xpath-functions-40/style/xpath-functions.xsl
@@ -592,7 +592,7 @@
     <var><xsl:value-of select="translate(., '''', '&#x2032;')"/></var>
   </xsl:template>  
 
-<xsl:template match="code[matches(., '^(fn|op|math|map|array):[-a-zA-Z0-9]+(#[0-9]+)?$')][not(@role='example')]">
+<xsl:template match="code[matches(., '^(fn|op|math|map|array):[-a-zA-Z0-9]+(#[0-9]+)?$')][not(@role=('example','element-name'))]">
   <!-- Simplified 2016-09-20 in response to bug 29825; as a result much of the logic here is redundant -->
   <xsl:variable name="raw-name">
     <xsl:choose>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -11580,7 +11580,7 @@ return $incrementors[2](4)]]></eg>
             duplicates eliminated.</p>
             
             <p>Any map or array that is present in the context value is first
-            coerced to a JNode by applying the <function>JNode</function> function.</p>
+            coerced to a JNode by applying the <function>fn:jtree</function> function.</p>
          
          <p>If (after this coercion) the context value is not a sequence of GNodes, a
 	 <termref
@@ -11684,14 +11684,14 @@ return $incrementors[2](4)]]></eg>
                <p>The path operator <code>/</code> is primarily used for 
                   locating GNodes within GTrees. The value of the left-hand operand
                   may include maps and arrays; such items are implicitly converted to JNodes
-                  as if by a call on the <function>jnode</function> function.
+                  as if by a call on the <function>fn:jtree</function> function.
                   After this conversion, the left-hand operand must return 
                   a sequence of GNodes. The result of the operator is either a sequence of GNodes
                   (in document order, with no duplicates), or a sequence of non-GNodes.</p>
 
                <p>The operation <code><var>E1</var>/<var>E2</var></code> is evaluated as follows: Expression <var>E1</var> 
                   is evaluated. Any maps or arrays in the result are converted to JNodes
-                  by applying the <function>JNode</function> function. If the result is not a 
+                  by applying the <function>fn:jtree</function> function. If the result is not a 
                   (possibly empty) sequence <var>S</var> of GNodes, 
                   a <termref def="dt-type-error">type error</termref> is raised <errorref class="TY"
                      code="0019"
@@ -11781,7 +11781,7 @@ return if (every $r in $R satisfies $r instance of gnode())
             not restricted to an <termref def="dt-axis-step"/>.</p></note>
             
             <p>If the context value for an <termref def="dt-axis-step"/> includes a map or array, this is implicitly
-               converted to a JNode as if by applying the <function>fn:jnode</function> function.
+               converted to a JNode as if by applying the <function>fn:jtree</function> function.
                If, after this conversion, the sequence contains a value that is not a GNode, 
                a <termref def="dt-type-error">type error</termref> is
 		         raised <errorref class="TY" code="0020"/>. The result of evaluating the axis step
@@ -11874,7 +11874,7 @@ return if (every $r in $R satisfies $r instance of gnode())
                      </note>
                      
                      <p>If the origin is a JNode, these are the JNodes returned
-                     by the <xspecref spec="DM40" ref="dm-jnode-children"/> accessor.</p>
+                     by the <xtermref spec="DM40" ref="dt-j-children"/> accessor.</p>
                                       
                   </item>
 
@@ -12714,7 +12714,7 @@ return <var>Axis</var>::*[some($selector, atomic-equal(?, jnode-selector()))]
             <head>Predicates within Steps</head>
 
             <scrap>
-               <prodrecap ref="AxisStep"/>
+               <prodrecap ref="Predicate"/>
             </scrap>
             <p id="dt-predicate"
                   >A predicate within an <nt def="AxisStep">AxisStep</nt> has similar syntax and semantics
@@ -13877,12 +13877,12 @@ the results are the same.
 for $e in $m/child::* except $m/child::xx 
 return ...</eg>
             
-            <note><p>Because the <function>jnode</function> creates a new JTree root,
+            <note><p>Because the <function>fn:jtree</function> creates a new JTree root,
             calling it twice potentially creates two different trees, in which the JNodes have
             different identity. The expression <code>$map/child::* except $map/child::xx</code>
             might therefore have the wrong effect, because JNodes in two different trees 
             are being compared. For more details see the specification of the
-            <function>jnode</function> function.</p></note>
+            <function>fn:jtree</function> function.</p></note>
             
             <p>In addition to the sequence operators described here, see <xspecref spec="FO40"
                   ref="sequence-functions"/> for functions defined on sequences.
@@ -21526,7 +21526,7 @@ processing with JSON processing.</p>
                   <code>$m?code = 3</code> and <code>$m/code = 3</code> have the same effect.
                   Path expressions, however, have more power, and with it, more complexity.
                   The expression <code>$m/code = 3</code> (unless simplified by an optimizer)
-                  effectively expands the expression to <code>(jtree($m)/child::get("code") => jnode-value()) = 3</code>:
+                  effectively expands the expression to <code>(jtree($m)/child::get("code") => jnode-content()) = 3</code>:
                   that is, the supplied map is wrapped in a JNode, the child axis returns a sequence of JNodes,
                   and the <term>·content·</term> properties of these JNodes are compared with the
                   supplied value <code>3</code>.</p>
@@ -21550,7 +21550,7 @@ processing with JSON processing.</p>
                   <termref def="dt-coercion-rules"/>: for example if the value is used in an
                   arithmetic expression or a value comparison, atomization of the JNode
                   automatically extracts its <term>·content·</term>. In other cases the value can
-                  be extracted explicitly by a call of the <function>jnode-value</function> function.</p>
+                  be extracted explicitly by a call of the <function>jnode-content</function> function.</p>
                   
 
                   <p>Lookup expressions on arrays result in a dynamic error if the subscript is out

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -1480,7 +1480,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
     
     <p>If a result tree is to be constructed from the <termref def="dt-raw-result"/>, then this is done
     by applying the rules for the process of <xtermref spec="SE40" ref="sequence-normalization"/> as defined in 
-       <bibref ref="xslt-xquery-serialization-30"/>. This process takes as input the serialization parameters defined in the
+       <bibref ref="xslt-xquery-serialization-40"/>. This process takes as input the serialization parameters defined in the
     unnamed <termref def="dt-output-definition"/> of the <termref def="dt-top-level-package"/>; though the only parameter
     that is actually used by this process is <code>item-separator</code>. <phrase diff="del" at="2022-01-01">In particular, sequence normalization is carried
        out regardless of any <code>method</code> attribute in the unnamed <termref def="dt-output-definition"/>.</phrase>
@@ -2755,7 +2755,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
                statically. These error codes are used to label error conditions in this
                specification, and are summarized in <specref ref="error-summary"/>. </p>
             <p>Errors defined in related specifications (<bibref ref="xpath-40"/>, <bibref ref="xpath-functions-40"/>
-               <bibref ref="xslt-xquery-serialization-30"/>) use QNames with a similar structure, in
+               <bibref ref="xslt-xquery-serialization-40"/>) use QNames with a similar structure, in
                the same namespace. When errors occur in processing XPath expressions, an XSLT
                processor <rfc2119>should</rfc2119> use the original error code reported by the XPath
                processor, unless a more specific XSLT error code is available.</p>
@@ -2923,7 +2923,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
                   <termref def="dt-implementation-defined">implementation-defined</termref> or
                   <termref def="dt-implementation-dependent">implementation-dependent</termref>.</p>
             <p>Furthermore, if serialization is performed using one of the serialization methods
-                   described in <bibref ref="xslt-xquery-serialization-30"/>, the presence of an extension attribute must
+                   described in <bibref ref="xslt-xquery-serialization-40"/>, the presence of an extension attribute must
                not cause the serializer to behave in a way that is inconsistent with the mandatory
                provisions of that specification.</p>
             <note>
@@ -12389,7 +12389,7 @@ return $tree =?> depth()]]></eg>
                   prevented using <code>[xsl:]inherit-namespaces="no"</code> on the instruction that
                   creates the parent element.</p>
                <note>
-                  <p>This has implications on serialization, defined in <bibref ref="xslt-xquery-serialization-30"/>. It means that it is possible to create
+                  <p>This has implications on serialization, defined in <bibref ref="xslt-xquery-serialization-40"/>. It means that it is possible to create
                         <termref def="dt-final-result-tree">final result trees</termref> that cannot
                      be faithfully serialized as XML 1.0 documents. When such a result tree is
                      serialized as XML 1.0, namespace declarations written for the parent element
@@ -27365,11 +27365,11 @@ the same group, and the-->
             </note>-->
             
             <p>Conceptually, the processor uses the <function>fn:analyze-string</function>
-            instruction to construct an <code>fn:analyze-string-result</code> element
-            containing a sequence of <code>fn:match</code> and <code>fn:non-match</code>
-            children. It then processes this sequence of children: for each <code>fn:match</code>
+            instruction to construct an <code role="element-name">fn:analyze-string-result</code> element
+            containing a sequence of <code role="element-name">fn:match</code> and <code role="element-name">fn:non-match</code>
+            children. It then processes this sequence of children: for each <code role="element-name">fn:match</code>
             child, it evaluates the <elcode>xsl:matching-substring</elcode> element, and
-            for each <code>fn:non-match</code> child, it evaluates the <elcode>xsl:non-matching-substring</elcode>
+            for each <code role="element-name">fn:non-match</code> child, it evaluates the <elcode>xsl:non-matching-substring</elcode>
             element.</p>
 
             <!--<p>The processor starts by setting the current position to position
@@ -39695,7 +39695,7 @@ return ($m?price - $m?discount)</eg>
                   <olist>
                      <item>
                         <p>The element is serialized to textual XML form, according to the rules
-                           defined in <bibref ref="xslt-xquery-serialization-30"/> using the XML
+                           defined in <bibref ref="xslt-xquery-serialization-40"/> using the XML
                            output method, with all parameters defaulted. Note that this process
                            discards any existing <termref def="dt-type-annotation">type
                               annotations</termref>.</p>
@@ -39889,7 +39889,7 @@ return ($m?price - $m?discount)</eg>
             Stylesheet authors can use <elcode>xsl:output</elcode> declarations to specify how they
             wish result trees to be serialized. If a processor serializes a final result tree, it
                <rfc2119>must</rfc2119> do so as specified by these declarations.</p>
-         <p>The rules governing the output of the serializer are defined in <bibref ref="xslt-xquery-serialization-30"/>. 
+         <p>The rules governing the output of the serializer are defined in <bibref ref="xslt-xquery-serialization-40"/>. 
             The serialization is controlled using a number
             of serialization parameters. The values of these serialization parameters may be set
             within the <termref def="dt-stylesheet">stylesheet</termref>, using the
@@ -40045,7 +40045,7 @@ return ($m?price - $m?discount)</eg>
                   <rfc2119>must</rfc2119> (if present) be a valid <termref def="dt-eqname">EQName</termref>. 
                   If it is a <termref def="dt-lexical-qname">lexical
                      QName</termref> in no namespace, then it identifies a method specified in
-                     <bibref ref="xslt-xquery-serialization-30"/> and <rfc2119>must</rfc2119> be one
+                     <bibref ref="xslt-xquery-serialization-40"/> and <rfc2119>must</rfc2119> be one
                   of <code>xml</code>, <code>html</code>, <code>xhtml</code>, 
                   <code>text</code>, <code>json</code>, or <code>adaptive</code>.</p>
             </error> If it is a <termref def="dt-lexical-qname">lexical QName</termref> with a
@@ -40287,7 +40287,7 @@ return ($m?price - $m?discount)</eg>
                <termdef id="dt-character-map" term="character map">A <term>character map</term>
                   allows a specific character appearing in a text or attribute node in the <termref def="dt-final-result-tree">final result tree</termref> to be substituted by a
                   specified string of characters during serialization.</termdef> The effect of
-               character maps is defined in <bibref ref="xslt-xquery-serialization-30"/>.</p>
+               character maps is defined in <bibref ref="xslt-xquery-serialization-40"/>.</p>
             <p>The character map that is supplied as a parameter to the serializer is determined
                from the <elcode>xsl:character-map</elcode> elements referenced from the
                   <elcode>xsl:output</elcode> declaration for the selected <termref def="dt-output-definition">output definition</termref>.</p>
@@ -40491,7 +40491,7 @@ return ($m?price - $m?discount)</eg>
                processor that implements the serialization option <rfc2119>should</rfc2119> offer
                the ability to disable output escaping, and there is no conformance level that
                requires this feature.</p>
-            <p>This feature requires the serializer (described in <bibref ref="xslt-xquery-serialization-30"/>) 
+            <p>This feature requires the serializer (described in <bibref ref="xslt-xquery-serialization-40"/>) 
                to be extended as follows. Conceptually, the <termref def="dt-final-result-tree">final result tree</termref> provides an additional
                boolean property <code>disable-escaping</code> associated with every character in a
                text node. When this property is set, the normal action of the serializer to escape
@@ -40874,7 +40874,7 @@ return ($m?price - $m?discount)</eg>
             </p>
 
             <p>A processor that claims conformance with the Serialization
-               Feature must satisfy the mandatory requirements of <bibref ref="xslt-xquery-serialization-30"/>. It <rfc2119>must</rfc2119> provide a mode of
+               Feature must satisfy the mandatory requirements of <bibref ref="xslt-xquery-serialization-40"/>. It <rfc2119>must</rfc2119> provide a mode of
                operation which conforms to the 3.0 version of that specification. It
                   <rfc2119>may</rfc2119> also provide a mode of operation which conforms to a later
                version of that specification; in such cases the detail of how XSLT 3.0 interacts
@@ -40882,7 +40882,7 @@ return ($m?price - $m?discount)</eg>
                serialization properties) is <termref def="dt-implementation-defined"/>.</p>
 
             <imp-def-feature id="idf-spec-serialization">It is <termref def="dt-implementation-defined"/> whether (and if so how) an XSLT 3.0 processor is
-               able to work with versions of <bibref ref="xslt-xquery-serialization-30"/> later than
+               able to work with versions of <bibref ref="xslt-xquery-serialization-40"/> later than
                3.1.</imp-def-feature>
          </div2>
          <div2 id="backwards-compatibility-feature">
@@ -41077,7 +41077,7 @@ See <loc href="http://www.w3.org/TR/xpath-functions/"/>
                <bibl id="ISO21320" key="ISO 21320">ISO (International Organization for
                   Standardization) <emph>Information technology — Document Container File, Part 1: Core</emph> 
                   ISO 21320-1:2015, October 2015. See <loc href="https://www.iso.org/obp/ui/#iso:std:iso-iec:21320:-1:ed-1:v1:en"/>.</bibl>
-               <!--<bibl id="xslt-xquery-serialization-30" key="XSLT and XQuery Serialization"/>
+               <!--<bibl id="xslt-xquery-serialization-40" key="XSLT and XQuery Serialization"/>
                <bibl id="xslt-xquery-serialization-31" key="XSLT and XQuery Serialization 3.1"/>-->
                <bibl id="xslt-xquery-serialization-40" key="Serialization 4.0"/>
                <!--<bibl id="UNICODE-NORMALIZATION" key="Unicode Normalization">Unicode Consortium.

--- a/style/assemble-spec.xsl
+++ b/style/assemble-spec.xsl
@@ -142,9 +142,9 @@
     <xsl:variable name="duplicate" as="xs:integer" 
       select="count(preceding::prodrecap[@ref=current()/@ref][not(../@role='example')]) + 1"/>
 
-    <xsl:if test="$duplicate != 1">
+    <!--<xsl:if test="$duplicate != 1">
       <xsl:message expand-text="1">*** Duplicate prodrecap {@ref} ***</xsl:message>
-    </xsl:if>
+    </xsl:if>-->
     
     <xsl:variable name="id-prefix" as="xs:string">
       <xsl:choose>


### PR DESCRIPTION
Fixes various warning messages from the build, mainly relating to incorrect cross-spec references, incorrect inferences that names beginning fn: are function names, etc. Includes one or two small stylesheet tweaks.