### PR TITLE
Build fix to make xspecref and bibliography references relative

### DIFF
--- a/style/xmlspec-2016.xsl
+++ b/style/xmlspec-2016.xsl
@@ -47,6 +47,7 @@
 
 <xsl:output method="html" version="5.0" encoding="UTF-8" indent="yes" />
 
+<xsl:variable name="qt4cg" select="'https://qt4cg.org/specifications/'"/>
 <xsl:variable name="fo31" select="doc('../build/etc/FO31.xml')"/>
 
 <!--
@@ -2303,14 +2304,22 @@
   <xsl:template match="titleref">
     <xsl:choose>
       <xsl:when test="@href">
-        <a href="{@href}">
+        <a>
+          <xsl:attribute name="href"
+                         select="if (starts-with(@href, $qt4cg))
+                                 then '../' || substring-after(@href, $qt4cg)
+                                 else @href"/>
           <cite>
             <xsl:apply-templates/>
           </cite>
         </a>
       </xsl:when>
       <xsl:when test="ancestor::bibl/@href">
-        <a href="{ancestor::bibl/@href}">
+        <a>
+          <xsl:attribute name="href"
+                         select="if (starts-with(ancestor::bibl/@href, $qt4cg))
+                                 then '../' || substring-after(ancestor::bibl/@href, $qt4cg)
+                                 else ancestor::bibl/@href"/>
           <cite>
             <xsl:apply-templates/>
           </cite>

--- a/style/xsl-query-2016.xsl
+++ b/style/xsl-query-2016.xsl
@@ -732,8 +732,15 @@
     <xsl:variable name="doc" select="document(concat('../build/etc/', @spec, '.xml'))"/>
     <xsl:variable name="div" select="$doc//*[@id=$ref]"/>
     <xsl:variable name="nt" select="($doc//*[@def=$ref])[1]"/>
-    <xsl:variable name="uri" select="replace($doc/document-summary/@uri, '^http:', 'https:')"/>
+
+    <xsl:variable name="link-uri" select="replace($doc/document-summary/@uri, '^http:', 'https:')"/>
+    <xsl:variable name="uri"
+                  select="if (starts-with($link-uri, $qt4cg))
+                          then '../' || substring-after($link-uri, $qt4cg)
+                          else $link-uri"/>
+
     <xsl:variable name="shortSpec" select="replace(@spec, '40$', '')"/>
+
     <xsl:choose>
       <xsl:when test="$div">
         


### PR DESCRIPTION
This makes spec cross-references and bibliography references relative between our specifications. It's a bit brute-force, but I think it works.