### PR TITLE
Fix bibliographic reference

### DIFF
--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -622,7 +622,7 @@ of <bibref ref="xmlschema-2"/>.</p>
 </item>
 <item>
 <p>The following types, which were originally defined in
-<bibref ref="xpath-datamodel"/> and were subsequently adopted by
+<bibref ref="xpath-datamodel-30"/> and were subsequently adopted by
 <bibref ref="xmlschema11-2"/>:
 <code>xs:anyAtomicType</code>, <code>xs:dayTimeDuration</code>,
 <code>xs:yearMonthDuration</code>.
@@ -6458,7 +6458,8 @@ if the data model is constructed from a PSVI:</p>
 <bibl id="xml-names11"        key="Namespaces in XML 1.1"/>
 <bibl id="xml-id"             key="xml:id"/>
 
-<bibl id="xpath-datamodel"    key="XDM 4.0"/>
+<bibl id="xpath-datamodel-30" key="XDM 3.0"/>
+<bibl id="xpath-datamodel-40" key="XDM 4.0"/>
 <bibl id="xpath-40"           key="XPath 4.0"/>
 <bibl id="xpath-functions-40" key="Functions and Operators 4.0"/>
 


### PR DESCRIPTION
I think the bibliographic reference in 

```xml
<p>The following types, which were originally defined in
<bibref ref="xpath-datamodel-30"/> and were subsequently adopted by
<bibref ref="xmlschema11-2"/>:
<code>xs:anyAtomicType</code>, <code>xs:dayTimeDuration</code>,
<code>xs:yearMonthDuration</code>.
</p>
```

Really should be to the 3.0 specification, not the current 4.0 specification. I've fixed that, but left in the bibliographic reference to the current spec.