### PR TITLE
2148b XDM Recognize that Base URI property may be invalid

### DIFF
--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -1695,16 +1695,16 @@ valid URIs or IRIs, but they are <emph>not required</emph> to do so.
   <div2 id="id-base-uri">
     <head>Base URI</head>
     
-    <p>This data model defines a property called <term>Base URI</term> that is associated with
-    a document node and with every element node. In an ideal world, the value of this
-    property will conform with the <bibref ref="xmlbase"/> Recommendation.</p>
+    <p>Section <specref ref="dm-base-uri"/> defines an accessor <code>dm:base-uri</code>
+      representing the Base URI property of a node.</p>
     
     <note>
       <p>The Base URI property of a document node that derives from parsing an XML document at
       some location typically indicates the location from which the document was retrieved. For a document node
       constructed by a query or stylesheet, it is generally derived from the base URI of the query or
-      stylesheet. The base URI property of element nodes may vary from that of the containing document node:
-      the most common reasons for this are (a) that parts of the document may derive from parsing of
+      stylesheet.</p> 
+      <p>The base URI property of element nodes may vary from that of the containing document node.
+      The most common reasons for this are (a) that parts of the document may derive from parsing of
       XML external entities at different locations, and (b) the Base URI property may be explicitly set
       using an <code>xml:base</code> attribute.</p>
     </note>
@@ -1713,15 +1713,20 @@ valid URIs or IRIs, but they are <emph>not required</emph> to do so.
       that no value for the property is known. This can happen, for example, when a document is constructed
       by parsing a stream of characters or octets that is not associated with any known location.</p>
     
-    <p>It is also possible that the algorithm defined in <bibref ref="xmlbase"/> for computing a base URI
+    <p> In an ideal world, the value of the Base URI property will conform with the
+      <bibref ref="xmlbase"/> Recommendation. It is possible, however, that the algorithm 
+      defined in <bibref ref="xmlbase"/> for computing a base URI
     fails to deliver a valid URI. This can arise for various reasons: many software products that construct
     representations of XML documents are liberal in what they accept; some even pre-date the <bibref ref="xmlbase"/>
     Recommendation. The <bibref ref="xml-infoset"/> Recommendation itself acknowledges the concept of
+
     “synthetic infosets” that do not adhere to all defined constraints. Pragmatically, this specification
     therefore acknowledges the possibility of a third state: the base URI of a document or element node is either
-    a valid URI, or it is absent, or it may be invalid. The accessor <code>dm:base-uri</code> when applied to 
+    a valid URI, or it is absent, or it may be invalid. The accessor <code>dm:base-uri</code> when applied to
     a node may therefore deliver either a URI, or the special value <termref def="dt-absent"/>, or it may
-    raise an error indicating that the value is invalid.</p>
+    raise an error indicating that the value is invalid. If the Base URI property of a node is invalid,
+    then operations that depend on the Base URI (the most obvious example being the <function>fn:base-uri</function>
+    function) may raise a dynamic error.</p>
   </div2>
 
   


### PR DESCRIPTION
This PR is intended to complement PR #2224 by recognising in the XDM specification that the base URI property of a document or element node may be either a URI, or absent, or invalid.