### PR TITLE
2221 fn:unparsed-text: Encoding, BOM handling

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19278,49 +19278,43 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             to recognize are <code>utf-8</code>, <code>utf-16</code>, <code>utf-16le</code>,
             and <code>utf-16be</code>.</p>
 
-         <p>The implicit encoding <var>E</var> of the external resource is determined as follows:</p>
+         <p>The encoding candidate <var>E</var> is chosen as follows:</p>
          <olist>
             <item>
-               <p>External encoding information is chosen if available.</p>
+               <p>external encoding information if available; otherwise</p>
             </item>
             <item>
-               <p>Otherwise, if the media type of the resource is <code>text/xml</code> or
-                     <code>application/xml</code> (see <bibref
-                     ref="rfc2376"
-                     />), or if it matches
-                  the conventions <code>text/*+xml</code> or <code>application/*+xml</code> (see
-                     <bibref
-                     ref="rfc7303"
-                     /> and/or its successors), then the encoding is recognized
-                  as specified in <bibref
-                     ref="xml"/>.</p>
+               <p>the encoding recognized as specified in <bibref ref="xml"/> if the media type
+                  of the resource is <code>text/xml</code> or <code>application/xml</code>
+                  (see <bibref ref="rfc2376"/>), or if it matches the conventions
+                  <code>text/*+xml</code> or <code>application/*+xml</code>
+                  (see <bibref ref="rfc7303"/> and/or its successors); otherwise</p>
             </item>
             <item>
-               <p>Otherwise, the value of the <code>encoding</code> option is chosen if present.</p>
+               <p>the value of the <code>encoding</code> option if present.</p>
             </item>
          </olist>
 
-         <p>The effective encoding is chosen as follows:</p>
+         <p>The effective encoding is determined as follows:</p>
          <olist>
-           <item><p><code>utf-8</code>
-              if <var>E</var> is <code>utf-8</code> or absent,
-              and if the initial octets <code>xEF</code>, <code>xBB</code> and
-              <code>xBF</code> can be consumed; otherwise,</p></item>
-           <item><p><code>utf-16le</code>
-              if <var>E</var> is <code>utf-16</code>, <code>utf-16le</code> or absent,
-              and if the initial octets <code>xFF</code> and
-              <code>xFE</code> can be consumed; otherwise,</p></item>
-           <item><p><code>utf-16be</code>
-              if <var>E</var> is <code>utf-16</code>, <code>utf-16be</code> or absent,
-              and if the initial octets <code>xFE</code> and <code>xFF</code> can be consumed;
-              otherwise,</p></item>
-           <item><p><code>utf-16be</code>
-              if <var>E</var> is <code>utf-16</code>; otherwise,</p></item>
-           <item><p>the value of <var>E</var> if present; otherwise,</p></item>
+           <item><p><code>utf-8</code> if <var>E</var> is
+              <code>utf-8</code> or absent, and if the initial octets <code>xEF</code>,
+              <code>xBB</code> and <code>xBF</code> can be consumed; otherwise</p></item>
+           <item><p><code>utf-16le</code> if <var>E</var> is
+              <code>utf-16</code>, <code>utf-16le</code> or absent, and if the initial octets
+              <code>xFF</code> and <code>xFE</code> can be consumed; otherwise</p></item>
+           <item><p><code>utf-16be</code> if <var>E</var> is
+              <code>utf-16</code>, <code>utf-16be</code> or absent, and if the initial octets
+              <code>xFE</code> and <code>xFF</code> can be consumed; otherwise</p></item>
+           <item><p><code>utf-16be</code> if <var>E</var> is
+              <code>utf-16</code>; otherwise</p></item>
+           <item><p>the value of <var>E</var> if present; otherwise</p></item>
            <item><p><code>utf-8</code>, or a value that results from
-              <termref def="implementation-defined">implementation-defined</termref>
-              heuristics.</p></item>
+              <termref def="implementation-defined"/> heuristics.</p></item>
          </olist>
+
+         <p>The result of the function is a string containing the string representation of the
+            resource retrieved using the URI, decoded according to the effective encoding.</p>
       </fos:rules>
       <fos:errors>
          <p>A dynamic error is raised <errorref class="UT" code="1170"

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19271,9 +19271,14 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                resources</xtermref> component of the dynamic context.</p>
          <p>If the <code>$source</code> argument is an empty sequence, the function
             returns an empty sequence.</p>
+         <p>The <code>encoding</code> option, if present 
+            <phrase diff="add" at="2022-12-19"> and non-empty</phrase>, is the name of an encoding.
+            The values for this option follow the same rules as for the <code>encoding</code> attribute
+            in an XML declaration. The values which an implementation is <rfc2119>required</rfc2119>
+            to recognize are <code>utf-8</code>, <code>utf-16</code>, <code>utf-16le</code>,
+            and <code>utf-16be</code>.</p>
 
-         <p>The implicit encoding <var>E1</var> of the external resource is determined by applying
-            the following rules:</p>
+         <p>The implicit encoding <var>E</var> of the external resource is determined as follows:</p>
          <olist>
             <item>
                <p>External encoding information is chosen if available.</p>
@@ -19291,38 +19296,31 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                      ref="xml"/>.</p>
             </item>
             <item>
-               <p>Otherwise, if the initial octets represent a byte order mark in a known encoding,
-               these octets are skipped and the corresponding encoding is chosen:
-               <code>xEF</code>, <code>xBB</code> and <code>xBF</code> imply <code>utf-8</code>,
-               <code>xFE</code> and <code>xFF</code> imply <code>utf-16le</code>,
-               <code>xFF</code> and <code>xFE</code> imply <code>utf-16be</code>.</p>
-            </item>
-            <item>
-               <p>Otherwise, the processor <rfc2119>may</rfc2119> use
-                  <termref def="implementation-defined">implementation-defined</termref>
-                  heuristics to determine the likely encoding.</p>
+               <p>Otherwise, the value of the <code>encoding</code> option is chosen if present.</p>
             </item>
          </olist>
-
-         <p>If the <code>encoding</code> option is present <phrase diff="add" at="2022-12-19"> and
-            non-empty</phrase>, it is interpreted as the name of an encoding <var>E2</var>, and
-            it follows the same rules as for the <code>encoding</code> attribute in an XML declaration.
-            The values which every implementation is <rfc2119>required</rfc2119> to recognize are
-            <code>utf-8</code>, <code>utf-16</code>, <code>utf-16le</code>, and <code>utf-16be</code>.
-         </p>
 
          <p>The effective encoding is chosen as follows:</p>
          <olist>
-           <item><p>If both <var>E1</var> and <var>E2</var> are absent, <code>utf-8</code>
-              is assumed.</p></item>
-           <item><p>Otherwise, if only one of the values is present, or if
-              <var>E1</var> and <var>E2</var> are equal, this value is used.</p></item>
-           <item><p>Otherwise, if <var>E1</var> is <code>utf-16le</code> or <code>utf-16be</code>
-              and if <var>E2</var> is <code>utf-16</code>, <var>E1</var> is used.</p></item>
-           <item><p>Otherwise, <errorref class="UT" code="1200"/> is raised.</p></item>
+           <item><p><code>utf-8</code>
+              if <var>E</var> is <code>utf-8</code> or absent,
+              and if the initial octets <code>xEF</code>, <code>xBB</code> and
+              <code>xBF</code> can be consumed; otherwise,</p></item>
+           <item><p><code>utf-16le</code>
+              if <var>E</var> is <code>utf-16</code>, <code>utf-16le</code> or absent,
+              and if the initial octets <code>xFF</code> and
+              <code>xFE</code> can be consumed; otherwise,</p></item>
+           <item><p><code>utf-16be</code>
+              if <var>E</var> is <code>utf-16</code>, <code>utf-16be</code> or absent,
+              and if the initial octets <code>xFE</code> and <code>xFF</code> can be consumed;
+              otherwise,</p></item>
+           <item><p><code>utf-16be</code>
+              if <var>E</var> is <code>utf-16</code>; otherwise,</p></item>
+           <item><p>the value of <var>E</var> if present; otherwise,</p></item>
+           <item><p><code>utf-8</code>, or a value that results from
+              <termref def="implementation-defined">implementation-defined</termref>
+              heuristics.</p></item>
          </olist>
-         <p>If the effective encoding is <code>utf-16</code>, it is interpreted as
-            <code>utf-16be</code>.</p>
       </fos:rules>
       <fos:errors>
          <p>A dynamic error is raised <errorref class="UT" code="1170"
@@ -19339,9 +19337,10 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             decoded into Unicode <termref def="character">characters</termref> using the specified
             encoding, or if any resulting character is not a
             <termref def="dt-permitted-character">permitted character</termref>.</p>
-         <p>A dynamic error is raised <errorref class="UT" code="1200"/> if the <code>encoding</code>
-            option is absent and the processor cannot infer the encoding using external information
-            and the actual encoding is not UTF-8, or if no effective encoding can be determined.</p>
+         <p>A dynamic error is raised <errorref class="UT" code="1200"
+            /> if the <code>encoding</code> option
+            is absent and the processor cannot infer the
+            encoding using external information and the actual encoding is not UTF-8.</p>
       </fos:errors>
 
       <fos:notes>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19312,6 +19312,8 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
            <item><p><code>utf-8</code>, or a value that results from
               <termref def="implementation-defined"/> heuristics.</p></item>
          </olist>
+         <p>If a Unicode encoding is determined, and if the input starts with a byte order mark,
+            it is ignored.</p>
 
          <p>The result of the function is a string containing the string representation of the
             resource retrieved using the URI, decoded according to the effective encoding.</p>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19271,19 +19271,15 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                resources</xtermref> component of the dynamic context.</p>
          <p>If the <code>$source</code> argument is an empty sequence, the function
             returns an empty sequence.</p>
-         <p>The <code>encoding</code> option, if present 
-            <phrase diff="add" at="2022-12-19"> and non-empty</phrase>, is the name of an encoding. The values
-            for this option follow the same rules as for the <code>encoding</code> attribute in
-            an XML declaration. The only values which every
-            implementation is <rfc2119>required</rfc2119> to recognize are
-               <code>utf-8</code> and <code>utf-16</code>.</p>
-         <p>The encoding of the external resource is determined by applying the following rules, in order:</p>
+
+         <p>The implicit encoding <var>E1</var> of the external resource is determined by applying
+            the following rules:</p>
          <olist>
             <item>
-               <p>External encoding information is used if available.</p>
+               <p>External encoding information is chosen if available.</p>
             </item>
             <item>
-               <p>If the media type of the resource is <code>text/xml</code> or
+               <p>Otherwise, if the media type of the resource is <code>text/xml</code> or
                      <code>application/xml</code> (see <bibref
                      ref="rfc2376"
                      />), or if it matches
@@ -19295,32 +19291,38 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                      ref="xml"/>.</p>
             </item>
             <item>
-               <p>The <code>encoding</code> option is used if present.</p>
+               <p>Otherwise, if the initial octets represent a byte order mark in a known encoding,
+               these octets are skipped and the corresponding encoding is chosen:
+               <code>xEF</code>, <code>xBB</code> and <code>xBF</code> imply <code>utf-8</code>,
+               <code>xFE</code> and <code>xFF</code> imply <code>utf-16le</code>,
+               <code>xFF</code> and <code>xFE</code> imply <code>utf-16be</code>.</p>
             </item>
             <item>
-               <p>If the initial octets represent a byte order mark in a known encoding,
-               then the corresponding encoding is used: specifically:</p>
-               <ulist>
-                  <item><p>Initial octets <code>FE FF</code> imply UTF-16LE.</p></item>
-                  <item><p>Initial octets <code>FF FE</code> imply UTF-16BE.</p></item>
-                  <item><p>Initial octets <code>EF BB BF</code> imply UTF-8.</p></item>
-               </ulist>
-            </item>
-            <item>
-               <p>The processor <rfc2119>may</rfc2119> use <termref def="implementation-defined"
-                     >implementation-defined</termref> heuristics to determine the likely encoding.</p>
-            </item>
-            <item>
-               <p>UTF-8 is assumed.</p>
+               <p>Otherwise, the processor <rfc2119>may</rfc2119> use
+                  <termref def="implementation-defined">implementation-defined</termref>
+                  heuristics to determine the likely encoding.</p>
             </item>
          </olist>
-         <p>The result of the function is a string containing the string representation of the
-            resource retrieved using the URI, decoded according to the specified encoding.
-            If the first codepoint, after decoding, is <char>U+FEFF</char>, then it is assumed
-            to represent a byte order mark and is discarded from the result.</p>
-         
-         
-         
+
+         <p>If the <code>encoding</code> option is present <phrase diff="add" at="2022-12-19"> and
+            non-empty</phrase>, it is interpreted as the name of an encoding <var>E2</var>, and
+            it follows the same rules as for the <code>encoding</code> attribute in an XML declaration.
+            The values which every implementation is <rfc2119>required</rfc2119> to recognize are
+            <code>utf-8</code>, <code>utf-16</code>, <code>utf-16le</code>, and <code>utf-16be</code>.
+         </p>
+
+         <p>The effective encoding is chosen as follows:</p>
+         <olist>
+           <item><p>If both <var>E1</var> and <var>E2</var> are absent, <code>utf-8</code>
+              is assumed.</p></item>
+           <item><p>Otherwise, if only one of the values is present, or if
+              <var>E1</var> and <var>E2</var> are equal, this value is used.</p></item>
+           <item><p>Otherwise, if <var>E1</var> is <code>utf-16le</code> or <code>utf-16be</code>
+              and if <var>E2</var> is <code>utf-16</code>, <var>E1</var> is used.</p></item>
+           <item><p>Otherwise, <errorref class="UT" code="1200"/> is raised.</p></item>
+         </olist>
+         <p>If the effective encoding is <code>utf-16</code>, it is interpreted as
+            <code>utf-16be</code>.</p>
       </fos:rules>
       <fos:errors>
          <p>A dynamic error is raised <errorref class="UT" code="1170"
@@ -19337,10 +19339,9 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             decoded into Unicode <termref def="character">characters</termref> using the specified
             encoding, or if any resulting character is not a
             <termref def="dt-permitted-character">permitted character</termref>.</p>
-         <p>A dynamic error is raised <errorref class="UT" code="1200"
-            /> if the <code>encoding</code> option
-            is absent and the processor cannot infer the
-            encoding using external information and the actual encoding is not UTF-8.</p>
+         <p>A dynamic error is raised <errorref class="UT" code="1200"/> if the <code>encoding</code>
+            option is absent and the processor cannot infer the encoding using external information
+            and the actual encoding is not UTF-8, or if no effective encoding can be determined.</p>
       </fos:errors>
 
       <fos:notes>
@@ -19403,20 +19404,6 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             implementations are not required to support this feature.</p>
       </fos:notes>
 
-
-
-      <!--
-      <imp-def-feature>The set of encodings recognized by the
-         <function>unparsed-text</function> function, other than <code>utf-8</code> and
-         <code>utf-16</code>, is <termref def="implementation-defined"
-            >implementation-defined</termref>.</imp-def-feature>
-      
-      <imp-def-feature>If no encoding is specified on a call to the
-         <function>unparsed-text</function> function, the processor
-         <rfc2119>may</rfc2119> use <termref def="implementation-defined"
-            >implementation-defined</termref> heuristics to determine the likely
-         encoding.</imp-def-feature>-->
-
       <fos:examples>
          <fos:example>
             <p>This XSLT example attempts to read a file containing “boilerplate” HTML and copy it
@@ -19445,8 +19432,9 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             <rfc2119>recommended</rfc2119> that all Unicode characters should 
                be accepted.</p>
          </fos:change>
-         <fos:change issue="1704">
-            <p>The specification now describes how an initial BOM should be handled.</p>
+         <fos:change issue="2221" PR="2248">
+            <p>The specification now describes in more detail how to determine the effective
+               encoding value.</p>
          </fos:change>
       </fos:changes>
    </fos:function>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -14386,9 +14386,9 @@ ISBN 0 521 77752 6.</bibl>
             <error class="UT" code="1200" label="Cannot infer encoding of external resource."
                type="dynamic">
                <p>Raised by <function>fn:unparsed-text</function> or <function>fn:unparsed-text-lines</function>
-                  if the <code>$encoding</code> argument is absent and the processor cannot infer the
-                  encoding using external information and the encoding is not UTF-8, or
-                  if no effective encoding can be determined.</p>
+                  if the <code>$encoding</code> argument is absent and the processor
+                  cannot infer the encoding using external information and the
+                  encoding is not UTF-8.</p>
             </error>
             <error class="UR" code="0001" label="Invalid IPv6/IPvFuture authority"
                type="dynamic">

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -14386,9 +14386,9 @@ ISBN 0 521 77752 6.</bibl>
             <error class="UT" code="1200" label="Cannot infer encoding of external resource."
                type="dynamic">
                <p>Raised by <function>fn:unparsed-text</function> or <function>fn:unparsed-text-lines</function>
-                  if the <code>$encoding</code> argument is absent and the processor
-                  cannot infer the encoding using external information and the
-                  encoding is not UTF-8.</p>
+                  if the <code>$encoding</code> argument is absent and the processor cannot infer the
+                  encoding using external information and the encoding is not UTF-8, or
+                  if no effective encoding can be determined.</p>
             </error>
             <error class="UR" code="0001" label="Invalid IPv6/IPvFuture authority"
                type="dynamic">


### PR DESCRIPTION
Closes #2221

Note that this PR is also a revision of #1950, which I felt was a bit ambiguous, and did not cover all possible cases. I believe that the proposed changes are compatible with 3.1. In particular, it states more clearly what is going to happen if both an implicit encoding is determined (for example, via a BOM), and an explicit encoding is supplied.
