### PR TITLE
2216 All atomic types become ordered

### DIFF
--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -1470,11 +1470,11 @@ an attribute node that has no parent.</p>
       
       <ulist>
         <item><p>A context-free, transitive, and error-free equality relation defined by the
-        <function>fn:atomic-equal</function> function. This is used primarily for the comparison
+        <code>fn:atomic-equal</code> function. This is used primarily for the comparison
           of atomic items used as keys in a map.
         </p></item>
         <item><p>A context-sensitive, transitive, and error-free ordering relation
-        defined by the <function>fn:compare</function> function.</p></item>
+        defined by the <code>fn:compare</code> function.</p></item>
       </ulist>
       
       <p>These two primitives form the foundation for all other functions and operators that compare

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -835,6 +835,10 @@ size and scope of the processing context.</p>
 
 <div3 id="types-predefined" diff="chg" at="2023-09-28">
 <head>Predefined Types</head>
+  
+  <changes>
+    <change issue="2216">An ordering is now defined for all instances of <code>xs:duration</code>.</change>
+  </changes>
  
   
   <p>The three atomic types <code>xs:anyAtomicType</code>,
@@ -846,8 +850,12 @@ size and scope of the processing context.</p>
   <note>
     <p>The types <code>xs:dayTimeDuration</code>, and
       <code>xs:yearMonthDuration</code> have a special status in these specifications because many
-    arithmetic operations (such as comparing two durations) are available in XPath only on these
+    arithmetic operations are available in XPath only on these
     subtypes of <code>xs:duration</code>, not on the primitive type <code>xs:duration</code> itself.</p>
+    
+    <p>In 4.0, however, ordering is defined over all instances of <code>xs:duration</code>, not
+    only over these subtypes.</p>
+    
     <p>The datatype <code>xs:anyAtomicType</code> is an atomic type that
       includes all atomic items (and no values that are not atomic). Its
       base type is <code>xs:anySimpleType</code>, from which all simple
@@ -1419,6 +1427,92 @@ an attribute node that has no parent.</p>
 </item>
 </ulist>
 </div2>
+    
+    <div2 id="comparing-atomics">
+      <head>Comparing Atomic Items</head>
+      <changes>
+        <change issue="2216">Atomic types are categorized into type families to make it clear
+        which values are comparable. All atomic types now define an ordering.</change>
+      </changes>
+      
+      <p><termdef id="dt-type-family" term="type family">For the purpose 
+        of comparing atomic items, the primitive atomic types are divided
+      into a number of <term>type families</term>: atomic items belonging to types in the same 
+      family are mutually comparable, items belonging to different type families are not.</termdef></p>
+      
+      <p>The type families are as follows:</p>
+      
+      <ulist>
+        <item><p>The <term>string-like</term> types: <code>xs:string</code>, <code>xs:anyURI</code>,
+        and <code>xs:untypedAtomic</code>.</p></item>
+        <item><p>The <term>numeric</term> types: <code>xs:decimal</code>, <code>xs:double</code>,
+        and <code>xs:float</code>.</p></item>
+        <item><p>The <term>binary</term> types: <code>xs:hexBinary</code> and <code>xs:base64Binary</code>.</p></item>
+        <item><p>Each of the remaining primitive atomic types is in a family of its own:</p>
+           <ulist>
+             <item><p><code>xs:boolean</code></p></item>
+             <item><p><code>xs:duration</code></p></item>
+             <item><p><code>xs:dateTime</code></p></item>
+             <item><p><code>xs:date</code></p></item>
+             <item><p><code>xs:time</code></p></item>
+             <item><p><code>xs:gYear</code></p></item>
+             <item><p><code>xs:gYearMonth</code></p></item>
+             <item><p><code>xs:gMonth</code></p></item>
+             <item><p><code>xs:gMonthDay</code></p></item>
+             <item><p><code>xs:gDay</code></p></item>
+             <item><p><code>xs:QName</code></p></item>
+             <item><p><code>xs:NOTATION</code></p></item>
+           </ulist>
+        </item>
+      </ulist>
+      
+      <p>There are two fundamental relations among the atomic items in each type family:</p>
+      
+      <ulist>
+        <item><p>A context-free, transitive, and error-free equality relation defined by the
+        <function>fn:atomic-equal</function> function. This is used primarily for the comparison
+          of atomic items used as keys in a map.
+        </p></item>
+        <item><p>A context-sensitive, transitive, and error-free ordering relation
+        defined by the <function>fn:compare</function> function.</p></item>
+      </ulist>
+      
+      <p>These two primitives form the foundation for all other functions and operators that compare
+      atomic items: for example the comparison operators such as <code>=</code> and <code>&lt;</code>,
+      <code>eq</code> and <code>lt</code>, and higher-level operations such as sorting, merging, and
+      grouping. In some cases, however, the semantics are modified for special cases such as the
+      handling of <code>NaN</code> or negative zero. Some higher-level operations allow atomic items
+      to be compared across type families (in which case atomic items from different
+      type families are always treated as not equal.)</p>
+      
+      <p>An overview of atomic comparison operations can be found in 
+        <xspecref spec="XP40" ref="id-atomic-comparisons"/>.</p>
+      
+      <note>
+        <p>Unlike previous versions of these specifications, 4.0 defines an ordering between any two <code>xs:duration</code>
+        values. A duration is defined to consist of an integer number of months plus a decimal number
+        of seconds, and the ordering relation takes the number of the months as the primary key
+        and the number of seconds as the secondary key. This gives sensible results in cases where
+        the number of seconds in the duration is less than the number of seconds in the shortest
+        month; in other cases, such as when comparing the durations <code>P1M</code> (one month)
+        and <code>P1000D</code> (one thousand days), the results are well defined and well behaved
+        (for example, the relation is transitive and symmetric), but the answer may make little
+        sense in terms of the real-world calendar.</p>
+        <p>Restrictions on arithmetic with durations remain in 4.0: it is not permitted, for example,
+        to subtract one day (<code>P1D</code>) from a duration of one month (<code>P1M</code>).</p>
+      </note>
+      
+      <note>
+        <p>The way in which numeric values of different types are compared has changed in 
+        version 4.0. Except for the special values <code>NaN</code>, <code>INF</code>,
+        and <code>-INF</code>, numeric values are now compared according to their
+        exact mathematical magnitude: this means, for example, that <code>xs:double("1.1")</code>
+          and <code>xs:decimal("1.1")</code> no longer compare equal, because the exact 
+          mathematical magnitude of the number written as <code>xs:double("1.1")</code>
+          is actually <code>1.100000000000000088817841970012523233890533447265625</code>.
+        </p>
+      </note>
+    </div2>
 
   </div1>
   

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -4941,15 +4941,20 @@ translate(value := '٢٠٢٣', replace := '٠١٢٣٤٥٦٧٨٩', with := '01234
             the first value is less than, equal to, or greater than the second value.</p>
       </fos:summary>
       <fos:rules>
-         <p>Compares two atomic items <code>$value1</code> and <code>$value2</code> for order, and
-            returns the integer value <code>-1</code>, <code>0</code>, or <code>1</code>,
+         <p>The function compares two atomic items <code>$value1</code> and <code>$value2</code> for order, and
+            returns the integer value <code>-1</code>, <code>0</code>, or <code>+1</code>,
             depending on whether <code>$value1</code> is less than, equal to, or greater than
             <code>$value2</code>, respectively.</p>
-         <p>This function differs from the operators <code>lt</code>, <code>eq</code>,
-            and <code>gt</code> in that decimal values are not converted to doubles. This means that
-            the comparison is fully transitive, which makes it safe for use in sorting algorithms.
-            It is used to underpin sorting in XQuery 4.0 and XSLT 4.0, and is also available as a
-            free-standing function in its own right.</p>
+         <p>This function is transitive and symmetric. For example:</p>
+         
+         <ulist>
+            <item><p>If <code>compare(A, B)</code> returns zero, then <code>compare(B, A)</code>
+            returns zero.</p></item>
+            <item><p>If <code>compare(A, B)</code> returns -1, then <code>compare(B, A)</code>
+            returns +1.</p></item>
+            <item><p>If <code>compare(A, B)</code> and <code>compare(B, C)</code> both
+            return -1, then <code>compare(A, C)</code> also returns -1.</p></item>
+         </ulist>
          <p>If either <code>$value1</code> or <code>$value2</code> is the empty sequence,
             the function returns the empty sequence.</p>
          <p>Otherwise, the result is determined as follows:</p>
@@ -4962,10 +4967,14 @@ translate(value := '٢٠٢٣', replace := '٠١٢٣٤٥٦٧٨٩', with := '01234
                   result reflects the order according to the rules of the collation that is used.</p>
                <p>The collation is determined according to the rules in
                   <specref ref="choosing-a-collation"/>.</p>
-               <p><phrase diff="chg" at="2023-01-17">When used with the default collation,</phrase>
+               <note><p>Using the default collation may be inappropriate for some strings,
+               for example URIs or manufacturing part numbers. In such cases it is safest
+               to supply <code>"http://www.w3.org/2005/xpath-functions/collation/codepoint"</code>
+               explicitly as the third argument.</p></note>
+               <!--<p><phrase diff="chg" at="2023-01-17">When used with the default collation,</phrase>
                   the function defines the semantics of the <code>eq</code>, <code>ne</code>,
                   <code>gt</code>, <code>lt</code>, <code>le</code> and <code>ge</code>
-                  operators on <code>xs:string</code> values.</p>
+                  operators on <code>xs:string</code> values.</p>-->
             </item>
             <item>
                <p>If both <code>$value1</code> and <code>$value2</code> are instances of
@@ -4990,102 +4999,146 @@ translate(value := '٢٠٢٣', replace := '٠١٢٣٤٥٦٧٨٩', with := '01234
                      implementation whose limits are such that all <code>xs:double</code> values can
                      be represented precisely.</p></item>
                </olist>
+               <note>
+                  <p>Every <code>xs:double</code> other than <code>NaN</code> and <code>±INF</code>,
+                     has a mathematical value of the form <code>m × 2^e</code>, 
+                     where <var>m</var> is an integer whose absolute value is less than 2^53, 
+                     and <var>e</var> is an integer between -1075 and 970, inclusive. This is the value
+                     that is used in comparisons.</p>
+                  <p>Practical difficulties arise because the typical string representations of 
+                  an <code>xs:double</code>, such as <code>3.1</code>, cannot be precisely
+                  represented by values of the form <code>m × 2^e</code>, but are instead converted
+                  to the best available approximation, which will often not be exactly equal
+                  to an <code>xs:decimal</code> expressed using the same lexical form.</p>
+               </note>
             </item>
             <item>
                <p>If both <code>$value1</code> and <code>$value2</code> are instances of
-                  <code>xs:boolean</code>, then:</p>
-               <olist>
-                  <item><p><code>-1</code> is returned if
-                     <code>op:boolean-less-than($value1, $value2)</code> returns <code>true</code>.</p>
-                  </item>
-                  <item><p><code>0</code> is returned if
-                     <code>op:boolean-equal($value1, $value2)</code> returns <code>true</code>.</p>
-                  </item>
-                  <item><p><code>1</code> is returned otherwise.</p></item>
-               </olist>
+                  <code>xs:boolean</code>, the result is 
+                  <code>fn:compare(xs:integer($value1), xs:integer($value2))</code></p>
+               
+               <note><p>This means that <code>false</code> is 
+                  treated as less than <code>true</code>.</p></note>
+   
             </item>
             <item>
                <p>If <code>$value1</code> is an instance of <code>xs:hexBinary</code> or
                   <code>xs:base64Binary</code>, and if <code>$value2</code> is an instance of
                   <code>xs:hexBinary</code> or <code>xs:base64Binary</code>, then:</p>
                <olist>
-                  <item><p><code>-1</code> is returned if
-                     <code>op:binary-less-than($value1, $value2)</code> returns <code>true</code>.</p>
+                  <item><p>Let <code>$A</code> be the sequence of integers, in the range (0 to 255), representing
+                     the octets of <code>$value1</code>, in order; and let <code>$B</code> similarly
+                     be the sequence of integers representing the octets of <code>$value2</code>.</p>
                   </item>
-                  <item><p><code>0</code> is returned if
-                     <code>op:binary-equal($value1, $value2)</code> returns <code>true</code>.</p>
-                  </item>
-                  <item><p><code>1</code> is returned otherwise.</p></item>
+                  <item><p>If <code>$A</code> is empty and <code>$B</code> is empty return zero.</p></item>
+                  <item><p>If <code>$A</code> is empty and <code>$B</code> is not empty return -1.</p></item>
+                  <item><p>Let <code>$C</code> be the value of <code>fn:compare(fn:head($A), fn:head($B))</code>.</p></item>
+                  <item><p>If <code>$C</code> is non-zero, then return <code>$C</code>.</p></item>
+                  <item><p>Otherwise, return the result of applying these rules recursively
+                  to <code>fn:tail($A)</code> and <code>fn:tail($B)</code></p></item>
+                 
                </olist>
             </item>
+            
             <item>
                <p>If both <code>$value1</code> and <code>$value2</code> are instances of
-                  <code>xs:date</code>, then:</p>
+                  the same primitive type <var>T</var>, where <var>T</var> is one of the
+                  types <code>xs:dateTime</code>, <code>xs:date</code>, <code>xs:time</code>,
+                  <code>xs:gYear</code>, <code>xs:gYearMonth</code>, <code>xs:gMonth</code>,
+                  <code>gMonthDay</code>, or <code>gDay</code>, then:</p>
                <olist>
-                  <item><p><code>-1</code> is returned if
-                     <code>op:date-less-than($value1, $value2)</code> returns <code>true</code>.</p>
+                  <item><p>Each of the values is converted to an <code>xs:dateTime</code>
+                     value as follows:</p>
+                     <olist>
+                        <item><p>The value is considered as a tuple with seven fields
+                        (year, month, day, hours, minutes, seconds, timezone) as defined by
+                        the functions <function>fn:year-from-dateTime</function>,
+                        <function>fn:months-from-dateTime</function>, and so on.</p></item>
+                        <item><p>Any absent components, other than the timezone, are substituted 
+                           with the corresponding components of the (arbitrary)
+                           <code>xs:dateTime</code> value <code>1972-01-01T00:00:00</code>
+                        to produce an <code>xs:dateTime</code> value.</p></item>
+                        <item><p>If the timezone component is absent, it is substituted
+                        with the implicit timezone from the dynamic context.</p></item>
+                        
+                     </olist>
                   </item>
-                  <item><p><code>0</code> is returned if
-                     <code>op:date-equal($value1, $value2)</code> returns <code>true</code>.</p>
+                  <item><p>The result of the function is then the result of comparing the
+                     <term>starting instants</term> of these two <code>xs:dateTime</code>
+                     values according to the algorithm defined in section 3.2.7.4 of <bibref
+               ref="xmlschema-2"/> (
+            <quote>Order relation on dateTime</quote> for <code>xs:dateTime</code> values with
+            timezones).</p>
                   </item>
-                  <item><p><code>1</code> is returned otherwise.</p></item>
+                  
                </olist>
             </item>
+            
             <item>
                <p>If both <code>$value1</code> and <code>$value2</code> are instances of
-                  <code>xs:time</code>, then:</p>
-               <olist>
-                  <item><p><code>-1</code> is returned if
-                     <code>op:time-less-than($value1, $value2)</code> returns <code>true</code>.</p>
-                  </item>
-                  <item><p><code>0</code> is returned if
-                     <code>op:time-equal($value1, $value2)</code> returns <code>true</code>.</p>
-                  </item>
-                  <item><p><code>1</code> is returned otherwise.</p></item>
+                  <code>xs:duration</code>, then:</p>
+               
+                  <olist>
+                     <item><p>Let <code>$M1</code> and <code>$M2</code>
+                  be the months components of the two durations, and let <code>$S1</code>
+                  and <code>$S2</code> be the seconds components of the two durations.</p></item>
+                     <item><p>Let <code>$C</code> be <code>fn:compare($M1, $M2)</code>.</p></item>
+                     <item><p>If <code>$C</code> is non-zero, return <code>$C</code>.</p></item>
+                     <item><p>Otherwise, return <code>fn:compare($S1, $S2)</code>.</p></item>
+               
                </olist>
+               <note><p>The result matches the real-world semantics of durations in many cases,
+               for example:</p>
+               
+               <ulist>
+                  <item><p>When both values are zero-length durations.</p></item>
+                  <item><p>When both values are have an equal months component (in particular when
+                     both have a zero months component).</p></item>
+                  <item><p>When both values are have an equal seconds component (in particular when
+                     both have a zero seconds component).</p></item>
+                  <item><p>When both values have a seconds component that is less than the number
+                  of seconds in the shortest month.</p></item>
+               </ulist>
+                  
+                  <p>In other cases the result is well defined and well behaved (for example it
+                  is symmetric and transitive) but may be counter-intuitive. For example,
+                  one month (<code>PT1M</code>) is considered greater than one hundred days
+                  (<code>PT100D</code>).</p>
+                  
+                  <p>Previous versions of this specification allowed durations to be compared
+                  only if both were instances of <code>xs:dateTimeDuration</code> or
+                  <code>xs:yearMonthDuration</code>. This requirement has been relaxed in the
+                  interests of allowing all atomic items to be sorted; in some cases the actual sort
+                  order matters little, so long as it is consistent.</p>
+               </note>
+            </item>
+            
+            <item>
+               <p>If both <code>$value1</code> and <code>$value2</code> are instances of
+                  <code>xs:QName</code>, then:</p>
+               
+                  <olist>
+                     <item><p>Let <code>$N1</code> and <code>$N2</code>
+                  be the result of applying the function <function>fn:namespace-uri-from-QName</function>
+                        to the two values, and let <code>$L1</code>
+                  and <code>$L2</code> be the result of applying the function
+                        <function>local-name-from-QName</function> to the two values.</p></item>
+                     <item><p>Let <code>$CPC</code> be <code>"http://www.w3.org/2005/xpath-functions/collation/codepoint"</code>.</p></item>
+                     <item><p>Let <code>$C</code> be <code>fn:compare($N1, $N2, $CPC)</code>.</p></item>
+                     <item><p>If <code>$C</code> is non-zero, return <code>$C</code>.</p></item>
+                     <item><p>Otherwise, return <code>fn:compare($L1, $L2, $CPC)</code>.</p></item>
+               
+                  </olist>
             </item>
             <item>
-               <p>If both <code>$value1</code> and <code>$value2</code> are instances of
-                  <code>xs:dateTime</code>, then:</p>
-               <olist>
-                  <item><p><code>-1</code> is returned if
-                     <code>op:dateTime-less-than($value1, $value2)</code> returns <code>true</code>.</p>
-                  </item>
-                  <item><p><code>0</code> is returned if
-                     <code>op:dateTime-equal($value1, $value2)</code> returns <code>true</code>.</p>
-                  </item>
-                  <item><p><code>1</code> is returned otherwise.</p></item>
-               </olist>
-            </item>
-            <item>
-               <p>If both <code>$value1</code> and <code>$value2</code> are instances of
-                  <code>xs:dayTimeDuration</code>, then:</p>
-               <olist>
-                  <item><p><code>-1</code> is returned if
-                     <code>op:dayTimeDuration-less-than($value1, $value2)</code> returns <code>true</code>.</p>
-                  </item>
-                  <item><p><code>0</code> is returned if
-                     <code>op:duration-equal($value1, $value2)</code> returns <code>true</code>.</p>
-                  </item>
-                  <item><p><code>1</code> is returned otherwise.</p></item>
-               </olist>
-            </item>
-            <item>
-               <p>If both <code>$value1</code> and <code>$value2</code> are instances of
-                  <code>xs:yearMonthDuration</code>, then:</p>
-               <olist>
-                  <item><p><code>-1</code> is returned if
-                     <code>op:yearMonthDuration-less-than($value1, $value2)</code> returns <code>true</code>.</p>
-                  </item>
-                  <item><p><code>0</code> is returned if
-                     <code>op:duration-equal($value1, $value2)</code> returns <code>true</code>.</p>
-                  </item>
-                  <item><p><code>1</code> is returned otherwise.</p></item>
-               </olist>
+               <p>If both <code>$value1</code> and <code>$value2</code> are instances of 
+                  <code>xs:NOTATION</code>, return <code>fn:compare(xs:QName($value1), xs:QName($value2))</code>.</p>
             </item>
             <item>
                <p>For any other combination of types, a type error
-                  <xerrorref spec="XP" class="TY" code="0004"/> is raised.</p>
+                  <xerrorref spec="XP" class="TY" code="0004"/> is raised. In particular, this means that
+               an error is raised when comparing two atomic items that belong to different
+               <xspecref spec="DM40" ref="dt-type-family">type families</xspecref>.</p>
             </item>
          </olist>
       </fos:rules>
@@ -5185,8 +5238,32 @@ translate(value := '٢٠٢٣', replace := '٠١٢٣٤٥٦٧٨٩', with := '01234
                <fos:result>1</fos:result>
             </fos:test>
             <fos:test>
+               <fos:expression>compare(xs:time('12:00:00Z'), xs:time('13:00:00+01:00'))</fos:expression>
+               <fos:result>0</fos:result>
+            </fos:test>
+            <fos:test>
                <fos:expression>compare(xs:date('2001-01-01+01:00'), xs:date('2001-01-01+00:00'))</fos:expression>
                <fos:result>-1</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>compare(xs:duration('P1Y'), xs:duration('P13M'))</fos:expression>
+               <fos:result>-1</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>compare(xs:duration('P1Y'), xs:duration('P1Y3M4D'))</fos:expression>
+               <fos:result>-1</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>compare(xs:duration('P1Y'), xs:duration('P1000D'))</fos:expression>
+               <fos:result>+1</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>compare(#space, #xml:space)</fos:expression>
+               <fos:result>-1</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>compare(#Q{http://example.ns/}index, #Q{http://example.ns/}xmp:index)</fos:expression>
+               <fos:result>0</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -8005,7 +8082,8 @@ Tak, tak, tak! - da kommen sie.
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Determines whether or not any of the supplied strings, when tokenized at whitespace boundaries, contains the supplied token,
+         <p>Determines whether or not any of the supplied strings, when 
+            tokenized at whitespace boundaries, contains the supplied token,
             under the rules of the supplied collation.</p>
       </fos:summary>
       <fos:rules>
@@ -13105,7 +13183,7 @@ fn:parse-QName("xmp:person")</eg></fos:expression>
             <function>fn:in-scope-namespaces</function> function; the semantics are unchanged.</p></fos:change>
       </fos:changes>
    </fos:function>
-   <fos:function name="binary-equal" prefix="op">
+   <!--<fos:function name="binary-equal" prefix="op">
       <fos:signatures>
          <fos:proto name="binary-equal" return-type="xs:boolean">
             <fos:arg name="value1" type="(xs:hexBinary | xs:base64Binary)"/>
@@ -13175,7 +13253,7 @@ fn:parse-QName("xmp:person")</eg></fos:expression>
          <fos:change issue="911 2139" PR="980" date="2024-01-30"><p>Atomic items of types <code>xs:hexBinary</code> 
             and <code>xs:base64Binary</code> are now mutually comparable.</p></fos:change>
       </fos:changes>
-   </fos:function>
+   </fos:function>-->
 
   
 
@@ -14509,22 +14587,18 @@ return count(distinct-ordered-nodes(
       </fos:properties>
       <fos:summary>
          <p>Returns a sequence of positive integers giving the positions within the sequence
-               <code>$input</code> of items that are equal to <code>$target</code>.</p>
+               <code>$input</code> of items that are <termref def="dt-contextually-equal"/> 
+            to <code>$target</code>.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function returns a sequence of positive integers giving the positions within the
-            sequence <code>$input</code> of items that are equal to <code>$target</code>.</p>
+         <p>The function returns a sequence of positive integers giving the 1-based positions within the
+            sequence <code>$input</code> of items that are <termref def="dt-contextually-equal"/> 
+            to <code>$target</code>.</p>
          <p>The collation used by this function is determined according to the rules in <specref
                ref="choosing-a-collation"
             />. This collation is used when string comparison is
             required.</p>
-         <p>The items in the sequence <code>$input</code> are compared with <code>$target</code> under
-            the rules for the <code>eq</code> operator. Values of type <code>xs:untypedAtomic</code>
-            are compared as if they were of type <code>xs:string</code>. Values that cannot be
-            compared, because the <code>eq</code> operator is not defined for their types, are
-            considered to be distinct. If an item compares equal, then the position of that item in
-            the sequence <code>$input</code> is included in the result.</p>
-         <p>The first item in a sequence is at position 1, not position 0.</p>
+         
          <p>The result sequence is in ascending numeric order.</p>
       </fos:rules>
       <fos:notes>
@@ -14589,6 +14663,12 @@ return count(distinct-ordered-nodes(
                attribute node to produce a sequence of three <code>xs:NMTOKEN</code> values.</p>
          </fos:example>
       </fos:examples>
+      <fos:changes>
+         <fos:change issue="2216"><p>In the interests of consistency,
+         the <function>index-of</function> function now defines equality to mean
+         <termref def="dt-contextually-equal"/>. This has the implication that
+         <code>NaN</code> is now considered equal to <code>NaN</code>.</p></fos:change>
+      </fos:changes>
    </fos:function>
    <fos:function name="empty" prefix="fn">
       <fos:signatures>
@@ -14823,14 +14903,11 @@ return exists($break)
       </fos:summary>
       <fos:rules>
          <p>The function returns the sequence that results from removing from <code>$values</code> all
-            but one of a set of values that are considered equal to one another. 
-            <phrase>Two items <var>$J</var> and <var>$K</var> in the input sequence 
-               (after atomization, as required by the function signature)
-            are considered equal if <code>fn:deep-equal($J, $K, $coll)</code> is <code>true</code>,
-            where <code>$coll</code> is the collation selected according to the rules in <specref
-                  ref="choosing-a-collation"
-            />.</phrase> This collation is used when string comparison is
-            required.</p>
+            but one of a set of values that are 
+            <termref def="dt-contextually-equal"/> to one another,
+            when compared using the collation selected according to the rules in <specref
+                  ref="choosing-a-collation"/> and the implicit timezone from the dynamic context.
+            </p>
 
 
          <p>The ordering of the result is as follows:</p>
@@ -14935,7 +15012,7 @@ filter($values,
             returned if the set contains more than one value.</p>
          
          <p>Specifically, the function returns those items in <code>$values</code> that are
-         equal (under this definition) to exactly one item appearing earlier in the sequence</p>
+         <termref def="dt-contextually-equal"/> to exactly one item appearing earlier in the sequence.</p>
          
          <p>This means that the ordering of the result is as follows:</p>
          
@@ -16883,19 +16960,14 @@ declare function equal-strings(
                            <code>equal-strings($i1, $i2, $collation, $options)</code>
                            returns <code>true</code>.
                         </p></item>
-                        <item><p>If both <code>$i1</code> and <code>$i2</code> are instances of
-                           <code>xs:date</code>, <code>xs:time</code> or <code>xs:dateTime</code>,
-                           <code>$i1 eq $i2</code>
-                           returns <code>true</code>.
-                        </p></item>
 
-                        <item><p>Otherwise, <code>fn:atomic-equal($i1, $i2)</code>
-                           returns <code>true</code>.
+                        <item><p>Otherwise, <code>fn:compare($i1, $i2)</code>
+                           returns zero.
                         </p></item>
                      </olist>
-                     <note><p>If <code>$i1</code> and <code>$i2</code> are not comparable, that is,
-                        if the expression <code>($i1 eq $i2)</code> would raise an error, then the function
-                     returns <code>false</code>; it does not report an error.</p></note>
+                     <p>If <code>$i1</code> and <code>$i2</code> are not comparable, that is,
+                        if the expression <code>compare($i1, $i2)</code>  raises an error, then the function
+                     returns <code>false</code>; it does not report an error.</p>
                   </item>
                   
                   <item>
@@ -17680,29 +17752,17 @@ declare function equal-strings(
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns a value that is equal to the highest value appearing in the input sequence.</p>
+         <p>Returns a value that is greater than or equal to every other value appearing in the input sequence.</p>
       </fos:summary>
       <fos:rules>
          <p>Any item in <code>$values</code> that is an instance of <code>xs:untypedAtomic</code>
             is first cast to <code>xs:double</code>. The resulting sequence is referred to as the
             converted sequence.</p>
          
-         <p>All pairs of values in the converted sequence must be mutually comparable. Two values are mutually
-            comparable if one or more of the following conditions applies:</p>
-         <olist>
-            <item><p>Both values are instances of <code>xs:string</code> or <code>xs:anyURI</code>.</p></item>
-            <item><p>Both values are instances of <code>xs:numeric</code>.</p></item>
-            <item><p>Both values are instances of <code>xs:hexBinary</code> or <code>xs:base64Binary</code>.</p></item>
-            <item><p>Both values are instances of <code>xs:date</code>.</p></item>
-            <item><p>Both values are instances of <code>xs:dateTime</code>.</p></item>
-            <item><p>Both values are instances of <code>xs:time</code>.</p></item>
-            <item><p>Both values are instances of <code>xs:dayTimeDuration</code>.</p></item>
-            <item><p>Both values are instances of <code>xs:yearMonthDuration</code>.</p></item>
-            <item><p>Both values are instances of <code>xs:boolean</code>.</p></item>
-         </olist>
+         <p>All pairs of values in the converted sequence must be mutually comparable. Two values <var>A</var>
+            and <var>B</var> are mutually
+            comparable if <code>fn:compare(<var>A</var>, <var>B</var>)</code> raises no error.</p>
          
-         <p>If the converted sequence contains a single value then it must be comparable to itself under the above rules. (So the
-            input cannot be, for example, a singleton <code>xs:QName</code>.)</p>
          
          <p>If the converted sequence is empty, the function returns the empty sequence.</p>
          
@@ -17710,18 +17770,11 @@ declare function equal-strings(
             <code>NaN</code> is returned
             <phrase>(as an <code>xs:float</code> or <code>xs:double</code> as appropriate)</phrase>.</p>
          
-         <p>Two items <code>$v1</code> and <code>$v2</code> from the converted sequence are compared as follows:</p>
-         
-         <olist>
-            <item><p>If both values are instances of <code>xs:string</code> or <code>xs:anyURI</code>, they
-               are compared using <code>fn:compare($v1, $v2, $collation)</code>, where <code>$collation</code>
-               is determined by the rules in <specref ref="choosing-a-collation"/>.</p>
-               <note><p>In other cases, <code>$collation</code> is ignored.</p></note></item>
-            <item><p>If both values are instances of <code>xs:numeric</code>, they are compared
-               using <code>fn:compare($v1, $v2)</code>.</p></item>
-            <item><p>In all other cases, the values are compared using the <code>lt</code> and <code>eq</code>
-               operators appropriate to their type.</p></item>
-         </olist>
+         <p>Two items <var>A</var>
+            and <var>B</var> from the converted sequence are compared 
+            by calling <code>fn:compare(<var>A</var>, <var>B</var>, $collation)</code>, 
+            where <code>$collation</code>
+               is determined by the rules in <specref ref="choosing-a-collation"/>:</p>
          
          <p>The result of the function is a value from the converted sequence that is greater than 
             or equal to every other value under the above rules. If there is more than one such value, then it is 
@@ -17842,29 +17895,17 @@ declare function equal-strings(
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns a value that is equal to the lowest value appearing in the input sequence.</p>
+         <p>Returns a value that is less than or equal to every other value appearing in the input sequence.</p>
       </fos:summary>
       <fos:rules>
          <p>Any item in <code>$values</code> that is an instance of <code>xs:untypedAtomic</code>
-         is first cast to <code>xs:double</code>. The resulting sequence is referred to as the
-         converted sequence.</p>
+            is first cast to <code>xs:double</code>. The resulting sequence is referred to as the
+            converted sequence.</p>
          
-         <p>All pairs of values in the converted sequence must be mutually comparable. Two values are mutually
-         comparable if one or more of the following conditions applies:</p>
-         <olist>
-            <item><p>Both values are instances of <code>xs:string</code> or <code>xs:anyURI</code>.</p></item>
-            <item><p>Both values are instances of <code>xs:numeric</code>.</p></item>
-            <item><p>Both values are instances of <code>xs:hexBinary</code> or <code>xs:base64Binary</code>.</p></item>
-            <item><p>Both values are instances of <code>xs:date</code>.</p></item>
-            <item><p>Both values are instances of <code>xs:dateTime</code>.</p></item>
-            <item><p>Both values are instances of <code>xs:time</code>.</p></item>
-            <item><p>Both values are instances of <code>xs:dayTimeDuration</code>.</p></item>
-            <item><p>Both values are instances of <code>xs:yearMonthDuration</code>.</p></item>
-            <item><p>Both values are instances of <code>xs:boolean</code>.</p></item>
-         </olist>
+         <p>All pairs of values in the converted sequence must be mutually comparable. Two values <var>A</var>
+            and <var>B</var> are mutually
+            comparable if <code>fn:compare(<var>A</var>, <var>B</var>)</code> raises no error.</p>
          
-         <p>If the converted sequence contains a single value then it must be comparable to itself under the above rules. (So the
-         input cannot be, for example, a singleton <code>xs:QName</code>.)</p>
          
          <p>If the converted sequence is empty, the function returns the empty sequence.</p>
          
@@ -17872,24 +17913,17 @@ declare function equal-strings(
             <code>NaN</code> is returned
             <phrase>(as an <code>xs:float</code> or <code>xs:double</code> as appropriate)</phrase>.</p>
          
-         <p>Two items <code>$v1</code> and <code>$v2</code> from the converted sequence are compared as follows:</p>
-         
-         <olist>
-            <item><p>If both values are instances of <code>xs:string</code> or <code>xs:anyURI</code>, they
-            are compared using <code>fn:compare($v1, $v2, $collation)</code>, where <code>$collation</code>
-            is determined by the rules in <specref ref="choosing-a-collation"/>.</p>
-            <note><p>In other cases, <code>$collation</code> is ignored.</p></note></item>
-            <item><p>If both values are instances of <code>xs:numeric</code>, they are compared
-            using <code>fn:compare($v1, $v2)</code>.</p></item>
-            <item><p>In all other cases, the values are compared using the <code>lt</code> and <code>eq</code>
-               operators appropriate to their type.</p></item>
-         </olist>
+         <p>Two items <var>A</var>
+            and <var>B</var> from the converted sequence are compared 
+            by calling <code>fn:compare(<var>A</var>, <var>B</var>, $collation)</code>, 
+            where <code>$collation</code>
+               is determined by the rules in <specref ref="choosing-a-collation"/>:</p>
          
          <p>The result of the function is a value from the converted sequence that is less than 
             or equal to every other value under the above rules. If there is more than one such value, then it is 
             <termref def="implementation-dependent">implementation-dependent</termref>
             which of them is returned.</p>
-         
+
  
       </fos:rules>
       <fos:errors>
@@ -24190,45 +24224,23 @@ return ($type ? name,
                      <p><code>$value2</code> is an instance of <code>xs:decimal</code>, <code>xs:double</code>, or <code>xs:float</code></p>
                   </item>
                   <item>
-                     <p>One of the following conditions is true:</p>
-                     <olist>
-                        <item>
-                           <p>Both <code>$value1</code> and <code>$value2</code> are <code>NaN</code></p>
-                           <note>
-                              <p><code>xs:double('NaN')</code> compares equal to <code>xs:float('NaN')</code></p>
-                           </note>
-                        </item>
-                        <item>
-                           <p>Both <code>$value1</code> and <code>$value2</code> are positive infinity</p>
-                           <note>
-                              <p><code>xs:double('INF')</code> compares equal to <code>xs:float('INF')</code></p>
-                           </note>
-                        </item>
-                        <item>
-                           <p>Both <code>$value1</code> and <code>$value2</code> are negative infinity</p>
-                           <note>
-                              <p><code>xs:double('-INF')</code> compares equal to <code>xs:float('-INF')</code></p>
-                           </note>
-                        </item>
-                        <item>
-                           <p><code>$value1</code> and <code>$value2</code> when converted to decimal numbers with no rounding or loss of precision
-                           are mathematically equal.</p>
-                           <note>
-                              <p>Every instance of <code>xs:double</code>, <code>xs:float</code>, and <code>xs:decimal</code> can be represented
-                              exactly as a decimal number provided enough digits are available both before and after the decimal point. Unlike the <code>eq</code>
-                              relation, which converts both operands to <code>xs:double</code> values, possibly losing precision in the process, this
-                              comparison is transitive.</p>
-                           </note>
-                           <note>
-                              <p>Positive and negative zero compare equal.</p>
-                           </note>
-                        </item>
-                     </olist>
+                     <p><code>fn:compare($value1, $value2)</code> returns zero.</p>
+                  
+                     <note><p><code>NaN</code> is equal to <code>NaN</code>, <code>INF</code>
+                     is equal to <code>INF</code>, <code>-INF</code> is equal to <code>-INF</code>,
+                     positive zero equals negative zero. This applies both to <code>xs:double</code>
+                     amd <code>xs:float</code> values, including comparisons across these two types.</p>
+      
+                     
+                        <p>Ordinary values (numeric values other than the special values mentioned above)
+                           are compared according to their mathematical magnitude. 
+                           Every instance of <code>xs:double</code>, <code>xs:float</code>, and <code>xs:decimal</code> can be represented
+                              exactly as a decimal number provided enough digits are available both before and after the decimal point.
+                              This comparison is therefore transitive.</p>
+                           
+                     </note>
                   </item>
-               </olist>
-
-            </item>
-
+                  
             <item>
                <p>All of the following conditions are true:</p>
                <olist>
@@ -24258,7 +24270,7 @@ return ($type ? name,
                   </item>
                   <item>
                      <p>
-                        <code>$value1 eq $value2</code>
+                        <code>fn:compare($value1, $value2)</code> returns zero.
                      </p>
                   </item>
 
@@ -24277,7 +24289,7 @@ return ($type ? name,
                      <p><code>$value2</code> is an instance of <code>xs:hexBinary</code> or <code>xs:base64Binary</code></p>
                   </item>
                   <item>
-                     <p><code>op:binary-equal($value1, $value2)</code></p>
+                     <p><code>fn:compare($value1, $value2)</code> returns zero.</p>
                   </item>
                </olist>
             </item>
@@ -24296,14 +24308,14 @@ return ($type ? name,
 
                   <item>
                      <p>
-                        <code>$value1 eq $value2</code>
+                        <code>fn:compare($value1, $value2)</code> returns zero.
                      </p>
                   </item>
                </olist>
             </item>
             
          </olist>
-
+            </item></olist>    
       </fos:rules>
 
       <fos:notes>
@@ -24334,11 +24346,11 @@ return ($type ? name,
          <p>Two atomic items may be distinguishable even though they are equal under this comparison. For example: they may have
          different type annotations; dates and times may have different timezones; <code>xs:QName</code> values may have different
          prefixes.</p>
-         <p>Unlike the <code>eq</code> operator and the <function>fn:deep-equal</function> function, <code>xs:hexBinary</code> and
-         <code>xs:base64Binary</code> values are considered distinct. This decision was made in order to preserve backwards
-         compatibility: if the values were treated as interchangeable, it would become impossible to construct certain maps that
-         could be validly constructed using earlier versions of the specification, and it would be difficult to make maps fully
-         interoperable between processors supporting different language versions, for example when calling <function>fn:transform</function>.</p>
+         <p>Unlike previous versions of this specification, <code>xs:hexBinary</code> and
+         <code>xs:base64Binary</code> values are mutually comparable. This decision affects backwards
+         compatibility: it is no longer possible to construct certain maps that
+         could be validly constructed using earlier versions of the specification. This may also cause problems
+         passing data from a 3.1 processor to a 4.0 processor.</p>
          <p>As always, any algorithm that delivers the right result is acceptable. For example, when testing whether an <code>xs:double</code>
          value <var>D</var> is the same key as an <code>xs:decimal</code> value that has <var>N</var> significant digits, it is not
          necessary to know all the digits in the decimal expansion of <var>D</var> to establish the result: computing the first <var>N+1</var> 
@@ -24346,22 +24358,6 @@ return ($type ? name,
       </fos:notes>
       <fos:examples>
          <fos:example>
-            <fos:test>
-               <fos:expression>atomic-equal(3, 3)</fos:expression>
-               <fos:result>true()</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>atomic-equal(3, 3e0)</fos:expression>
-               <fos:result>true()</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>atomic-equal(3.1, 3.1e0)</fos:expression>
-               <fos:result>false()</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>atomic-equal(xs:double('NaN'), xs:float('NaN'))</fos:expression>
-               <fos:result>true()</fos:result>
-            </fos:test>
             <fos:test>
                <fos:expression>atomic-equal("a", "a")</fos:expression>
                <fos:result>true()</fos:result>
@@ -24382,8 +24378,52 @@ return ($type ? name,
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
+               <fos:expression>atomic-equal(3, 3)</fos:expression>
+               <fos:result>true()</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>atomic-equal(3, 3e0)</fos:expression>
+               <fos:result>true()</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>atomic-equal(3.1, 3.1e0)</fos:expression>
+               <fos:result>false()</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>atomic-equal(xs:double('NaN'), xs:float('NaN'))</fos:expression>
+               <fos:result>true()</fos:result>
+            </fos:test>           
+            <fos:test>
                <fos:expression>atomic-equal(12, "12")</fos:expression>
                <fos:result>false()</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>atomic-equal(xs:time('16:00:00Z'), xs:time('17:00:00+01:00'))</fos:expression>
+               <fos:result>true()</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>atomic-equal(xs:time('16:00:00Z'), xs:time('16:00:00'))</fos:expression>
+               <fos:result>false()</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>atomic-equal(xs:duration('PT1H'), xs:duration('PT60M'))</fos:expression>
+               <fos:result>true()</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>atomic-equal(xs:duration('PT0S'), xs:duration('P0Y'))</fos:expression>
+               <fos:result>true()</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>atomic-equal(xs:duration('P30D'), xs:duration('P1M'))</fos:expression>
+               <fos:result>false()</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>atomic-equal(#Q{http://example.com}name, #Q{http://example.com}prefix:name)</fos:expression>
+               <fos:result>true()</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>atomic-equal(xs:hexBinary(""), xs:base64Binary(""))</fos:expression>
+               <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -33479,56 +33519,35 @@ return every($dl/*, fn($elem, $pos) {
 
 
       <fos:summary>
-         <p>Returns those items from a supplied sequence that have the highest value of a sort key, where
-            the sort key can be computed using a caller-supplied function.</p>
+         <p>Returns a value that is greater than or equal to every other value appearing in the input sequence.</p>
       </fos:summary>
       <fos:rules>
-         <p>The second argument, <code>$collation</code>, defaults to <code>()</code>.</p>
-         <p>Supplying an empty
-            sequence as <code>$collation</code> is equivalent to supplying 
-            <code>fn:default-collation()</code>. For more
-            information on collations see <specref
-               ref="choosing-a-collation"/>.</p>
+         <p>Any item in <code>$values</code> that is an instance of <code>xs:untypedAtomic</code>
+            is first cast to <code>xs:double</code>. The resulting sequence is referred to as the
+            converted sequence.</p>
          
-         <p>The third argument defaults to the function <code>data#1</code>.</p>
+         <p>All pairs of values in the converted sequence must be mutually comparable. Two values <var>A</var>
+            and <var>B</var> are mutually
+            comparable if <code>fn:compare(<var>A</var>, <var>B</var>)</code> raises no error.</p>
          
-         <p>Let <code>$modified-key</code> be the function:</p>
-         <eg>
-fn($item) {
-  $key($item) => data() ! (
-    if (. instance of xs:untypedAtomic)
-    then xs:double(.)
-    else .
-  )
-}</eg>
          
-         <p>That is, the supplied function for computing key values is wrapped in a function that
-         converts any <code>xs:untypedAtomic</code> values in its result to <code>xs:double</code>. This makes
-         the function consistent with the behavior of <function>fn:min</function> and <function>fn:max</function>,
-         but inconsistent with <function>fn:sort</function>, which treats untyped values as strings.</p>
+         <p>If the converted sequence is empty, the function returns the empty sequence.</p>
          
-         <p>The result of the function is obtained as follows:</p>
-         <ulist>
-            <item>
-               <p>If the input is an empty sequence, the result is an empty sequence.</p>
-            </item>
-            <item>
-               <p>The input sequence is sorted, by applying the function 
-                  <code>fn:sort($input, $collation, $modified-key)</code>.</p>
-            </item>
-            <item>
-               <p>Let <var>$C</var> be the selected collation, or the default collation where applicable.</p>
-            </item>
-            <item>
-               <p>Let <var>$B</var> be the last item in the sorted sequence.</p>
-            </item>
-            <item>
-               <p>The function returns those items <var>$A</var> from the input sequence such that
-               <code>(fn:deep-equal($key($A), $key($B), $C)</code>, retaining their order.
-            </p>
-            </item>
-
-         </ulist>
+         <p>If the converted sequence contains the value <code>NaN</code>, the value
+            <code>NaN</code> is returned
+            <phrase>(as an <code>xs:float</code> or <code>xs:double</code> as appropriate)</phrase>.</p>
+         
+         <p>Two items <var>A</var>
+            and <var>B</var> from the converted sequence are compared 
+            by calling <code>fn:compare(<var>A</var>, <var>B</var>, $collation)</code>, 
+            where <code>$collation</code>
+               is determined by the rules in <specref ref="choosing-a-collation"/>:</p>
+         
+         <p>The result of the function is a value from the converted sequence that is greater than 
+            or equal to every other value under the above rules. If there is more than one such value, then it is 
+            <termref def="implementation-dependent">implementation-dependent</termref>
+            which of them is returned.</p>
+         
       </fos:rules>
       <fos:errors>
          <p>If the set of computed keys contains <code>xs:untypedAtomic</code> values that are not 
@@ -33878,8 +33897,9 @@ return $item
                <p>Let <var>$B</var> be the first item in the sorted sequence.</p>
             </item>
             <item>
-               <p>The function returns those items <var>$A</var> from the input sequence such that
-                  <code>(fn:deep-equal($key($A), $key($B), $C)</code>, retaining their order.
+               <p>The function returns those items <var>$A</var> from the input sequence 
+                  that are <termref def="dt-contextually-equal"/> to <code>$B</code>, 
+                  retaining their order.
                </p>
             </item>
             
@@ -34065,7 +34085,8 @@ exists(filter($input, $predicate))
 
 
       <fos:summary>
-         <p>Returns <code>true</code> if all items in a supplied sequence (after atomization) are equal.</p>
+         <p>Returns <code>true</code> if all items in a supplied sequence (after atomization) are 
+            <termref def="dt-contextually-equal"/>.</p>
       </fos:summary>
 
       <fos:rules>
@@ -34104,6 +34125,12 @@ exists(filter($input, $predicate))
          <fos:example>
             <fos:test>
                <fos:expression>all-equal(())</fos:expression>
+               <fos:result>true()</fos:result>
+            </fos:test>
+         </fos:example>        
+         <fos:example>
+            <fos:test>
+               <fos:expression>all-equal((xs:float('NaN'), xs:double('NaN')))</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
@@ -34147,7 +34174,8 @@ exists(filter($input, $predicate))
 
 
       <fos:summary>
-         <p>Returns <code>true</code> if no two items in a supplied sequence are equal.</p>
+         <p>Returns <code>true</code> if no two items in a supplied sequence are 
+            <termref def="dt-contextually-equal"/>.</p>
       </fos:summary>
 
       <fos:rules>
@@ -34160,7 +34188,8 @@ exists(filter($input, $predicate))
          <p>The result of the function <code>fn:all-different($values, $collation)</code> is <code>true</code> if and only if the result
             of <code>fn:count(fn:distinct-values($values, $collation)) eq fn:count($values)</code> is <code>true</code> 
             (that is, if the sequence
-            is empty, or if all the items in the sequence are distinct under the rules of the 
+            is empty, or if all the items in the sequence are 
+            <termref def="dt-contextually-equal">contextually unequal</termref> under the rules used by the 
             <function>fn:distinct-values</function> function).</p>
       </fos:rules>
       

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -5108,7 +5108,7 @@ translate(value := '٢٠٢٣', replace := '٠١٢٣٤٥٦٧٨٩', with := '01234
                   <p>Previous versions of this specification allowed durations to be compared
                   only if both were instances of <code>xs:dateTimeDuration</code> or
                   <code>xs:yearMonthDuration</code>. This requirement has been relaxed in the
-                  interests of allowing all atomic items to be sorted; in some cases the actual sort
+                  interests of allowing all atomic items to be sorted; in some applications the actual sort
                   order matters little, so long as it is consistent.</p>
                </note>
             </item>
@@ -5234,6 +5234,14 @@ translate(value := '٢٠٢٣', replace := '٠١٢٣٤٥٦٧٨٩', with := '01234
                <fos:result>0</fos:result>
             </fos:test>
             <fos:test>
+               <fos:expression>compare(xs:hexBinary('0001'), xs:hexBinary('0002'))</fos:expression>
+               <fos:result>-1</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>compare(xs:hexBinary('00FF'), xs:hexBinary('FF'))</fos:expression>
+               <fos:result>-1</fos:result>
+            </fos:test>
+            <fos:test>
                <fos:expression>compare(xs:time('23:59:59'), xs:time('00:00:00'))</fos:expression>
                <fos:result>1</fos:result>
             </fos:test>
@@ -5262,7 +5270,7 @@ translate(value := '٢٠٢٣', replace := '٠١٢٣٤٥٦٧٨٩', with := '01234
                <fos:result>-1</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>compare(#Q{http://example.ns/}index, #Q{http://example.ns/}xmp:index)</fos:expression>
+               <fos:expression>compare(#Q{http://example.com/ns}index, #Q{http://example.com/ns}xmp:index)</fos:expression>
                <fos:result>0</fos:result>
             </fos:test>
          </fos:example>
@@ -5395,10 +5403,7 @@ translate(value := '٢٠٢٣', replace := '٠١٢٣٤٥٦٧٨٩', with := '01234
          <p>If XPath 1.0 compatibility mode is set to true in the static context of a
             static function call to <function>fn:concat</function>, then each supplied argument 
             <code>$v</code> is first reduced to a single
-            string, the result of the expression <code>xs:string($v[1])</code>. This is special-case
-            processing for the <function>fn:concat</function> function, it is not something
-            that follows from the general rules for calling variadic functions. This reflects the fact that
-            <function>fn:concat</function> had custom behavior in XPath 1.0. This rule applies only to
+            string, the result of the expression <code>xs:string($v[1])</code>. This rule applies only to
             static function calls.</p>
          
          <p>A named function reference can be used to create a function item with any arity: for example
@@ -5630,8 +5635,9 @@ return normalize-unicode(concat($v1, $v2))</eg>
          <p>
             <code>fn:round($start) &lt;= $p</code>
          </p>
-         <p>In the above computations, the rules for <code>op:numeric-less-than</code> <phrase diff="del" at="2022-11-27">and
-               op:numeric-greater-than</phrase> apply.</p>
+         <p>In the above computations, the operators such as <code>&lt;=</code> and <code>+</code>
+            are evaluated according to the rules of the XPath 4.0 specification.</p>
+ 
       </fos:rules>
       <fos:notes>
          <p>The first character of a string is located at position 1, not position 0.</p>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -14670,7 +14670,7 @@ return count(distinct-ordered-nodes(
          </fos:example>
       </fos:examples>
       <fos:changes>
-         <fos:change issue="2216"><p>In the interests of consistency,
+         <fos:change issue="2216" PR="2256" date="2025-12-01"><p>In the interests of consistency,
          the <function>index-of</function> function now defines equality to mean
          <termref def="dt-contextually-equal"/>. This has the implication that
          <code>NaN</code> is now considered equal to <code>NaN</code>.</p></fos:change>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -1369,6 +1369,22 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
             <head>Comparison functions</head>
             <p>The functions in this section perform comparisons between the items in one or more
             sequences.</p>
+            
+            <p>Many of these functions require atomic items to be compared for equality.</p>
+            
+            <p><termdef id="dt-contextually-equal" term="contextually equal">Two atomic items
+            <var>A</var> and <var>B</var> are said to be <term>contextually equal</term>
+            if the function call <code>fn:compare(<var>A</var>, <var>B</var>)</code>
+            returns zero when evaluated with a specified or context-determined collation
+            and implicit timezone.</termdef> If two values are not contextually equal,
+            they are considered to be <term>contextually unequal</term>, even in the case when comparing
+            them using <function>fn:compare</function> raises an error.</p>
+            
+            <note><p>Except where explicitly stated otherwise, an appeal to 
+            <termref def="dt-contextually-equal">contextual equality</termref> implies
+            that <code>NaN</code> is treated as equal to <code>NaN</code>.</p></note>
+            
+            
             <?local-function-index?>
             <div3 id="func-atomic-equal">
                <head><?function fn:atomic-equal?></head>
@@ -1396,7 +1412,8 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
             </div3>
             <div3 id="func-starts-with-subsequence" diff="add" at="B">
                <head><?function fn:starts-with-subsequence?></head>
-            </div3>  
+            </div3>
+            
             
          </div2>
          <div2 id="cardinality-functions">
@@ -1432,25 +1449,7 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
            
             
          </div2>
-         <!--<div2 id="union-intersection-except">
-            <head>Union, intersection and difference</head>
-            <?local-function-index?>
-            <p>As in the previous sections, for the illustrative examples below, assume an
-                    XQuery or transformation operating on a Purchase Order document containing a
-                    number of line-item elements. The variables <code>$item1</code>,
-                    <code>$item2</code>, etc. are bound to individual line-item nodes in the
-                    sequence. We use sequences of these nodes in some of the examples below.</p>
-            
-            <div3 id="func-union">
-               <head><?function op:union?></head>
-            </div3>
-            <div3 id="func-intersect">
-               <head><?function op:intersect?></head>
-            </div3>
-            <div3 id="func-except">
-               <head><?function op:except?></head>
-            </div3>
-         </div2>-->
+         
          <div2 id="aggregate-functions">
             <head>Aggregate functions</head>
             <p>Aggregate functions take a sequence as argument and return a single value
@@ -1588,21 +1587,19 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                <head><?function fn:false?></head>
             </div3>
          </div2>
-         <div2 id="op.boolean">
+         <!--<div2 id="op.boolean">
             <head>Operators on Boolean values</head>
             <p>The following functions define the semantics of operators on boolean values in
                         <bibref ref="xquery-40"/> and <bibref ref="xpath-40"/>:</p>
             <?local-function-index?>
-            <p>The ordering operator <code>op:boolean-less-than</code> is provided for application purposes
-                    and for compatibility with <bibref ref="xpath"/>. The <bibref ref="xmlschema-2"/>
-                    datatype <code>xs:boolean</code> is not ordered.</p>
+            
             <div3 id="func-boolean-equal">
                <head><?function op:boolean-equal?></head>
             </div3>
             <div3 id="func-boolean-less-than">
                <head><?function op:boolean-less-than?></head>
             </div3>
-         </div2>
+         </div2>-->
          <div2 id="boolean-value-functions">
             <head>Functions on Boolean values</head>
             <p>The following functions are defined on boolean values:</p>
@@ -1986,25 +1983,20 @@ This differs from <bibref ref="xmlschema-2"/>, which defines
                <change issue="986">Comparison of mixed numeric types (for example <code>xs:double</code>
                and <code>xs:decimal</code>) now generally converts both values to <code>xs:decimal</code>.</change>
             </changes>
-            <p diff="chg" at="A">The six value comparison operators <code>eq</code>, <code>ne</code>, <code>lt</code>,
-               <code>le</code>, <code>gt</code>, and <code>ge</code> are defined in terms of two
-               underlying functions: <code>op:numeric-equal</code> and <code>op:numeric-less-than</code>.
-               These functions are defined to operate on values of the same type.</p>
-            <!--<p>If the arguments are of different types, one argument is promoted to the type of the other
-               as described above in <specref ref="op.numeric"/>. Each comparison operator returns a
-               boolean value.</p>-->
+            <p>Numeric values can be compared using the function <function>fn:compare</function>.</p>
+            
+            <p diff="chg" at="A">This function underpins the six value comparison operators <code>eq</code>, <code>ne</code>, <code>lt</code>,
+               <code>le</code>, <code>gt</code>, and <code>ge</code> and the six general comparison
+               operators <code>=</code>, <code>!=</code>, <code>&lt;</code>, <code>&lt;=</code>,
+               <code>></code>, and <code>>=</code>, which are all defined in terms of 
+               the <function>fn:compare</function> function.</p>
+            
             <note><p diff="add" at="2023-12-05">For a description of the different ways of comparing numeric
-               values using the operators <code>=</code> and <code>eq</code> and the functions
-               <function>fn:deep-equal</function> and <function>fn:atomic-equal</function>, 
+               values using the operators <code>=</code> and <code>eq</code> and functions
+               such as <function>fn:deep-equal</function>, <function>fn:compare</function>,
+               and <function>fn:atomic-equal</function>, 
                see <xspecref spec="XP40" ref="id-atomic-comparisons"/>.</p></note>
-            <note><p diff="add" at="2023-12-18">See also the function <function>fn:compare</function>.</p></note>
-            <?local-function-index?>
-            <div3 id="func-numeric-equal">
-               <head><?function op:numeric-equal?></head>
-            </div3>
-            <div3 id="func-numeric-less-than">
-               <head><?function op:numeric-less-than?></head>
-            </div3>
+            
          </div2>
          <div2 id="numeric-value-functions">
             <head>Functions on numeric values</head>
@@ -4191,8 +4183,11 @@ WildcardEsc         ::= '.'
                   <p><code>xs:dayTimeDuration</code></p>
                </item>
             </ulist>
-            <p>No ordering relation is defined on <code>xs:duration</code> values.
-			Two <code>xs:duration</code> values may however be compared for equality.</p>
+            <p>Arithmetic on durations is defined only on these subtypes:
+               this is because the results of some operations (for example one month minus one day)
+               have no representation in the value space.</p>
+         
+			   <p>Two <code>xs:duration</code> values may however be compared.</p>
 	     
 	     <div2 id="duration-data-types">
 	        <head>Duration data types</head>
@@ -4282,27 +4277,23 @@ WildcardEsc         ::= '.'
 	     
 		 <div2 id="comp.duration">
 		 <head>Comparing durations</head>
-		    <?local-function-index?>
-			            <p>The following comparison operators are defined on the <bibref ref="xmlschema-2"/>
-                    duration datatypes. Each operator takes two operands of the same
-                    type and returns an <code>xs:boolean</code> result. As discussed in <bibref ref="xmlschema-2"/>, the
-                    order relation on <code>xs:duration</code> is a partial order rather than 
-                    a total order. For this reason, only equality is defined on <code>xs:duration</code>. 
-					A full complement of comparison and
-                    arithmetic functions are defined on the two subtypes of duration described in
-                        <specref ref="duration-subtypes"/> which do have a total order.</p>
-
+		    
+		    <p>Duration values may be compared using the <function>fn:compare</function>
+		    function.</p>
+		    
+		    <p>In this version of the specification, all <code>xs:duration</code> values
+		    are mutually comparable: comparison operations are no longer restricted
+		    to the two subtypes <code>xs:yearMonthDuration</code> and <code>xs:dayTimeDuration</code>.
+		    However, although a total ordering is defined over all durations, the result
+		    is not always meaningful: while it makes sense that <code>P1Y1D</code> (one year and a day)
+		    is greater than <code>P1Y</code> (one year), it makes little sense that <code>P32D</code>
+		    (thirty-two days) is less than <code>P1M</code> (one month).</p>
+		    
+		    <p>Durations are treated as tuples with two components, the months and seconds
+		    components, and they are compared by treating the months as the primary key and the seconds
+		    as the primary key.</p>
+			            
 	
-            
-		 	<div3 id="func-yearMonthDuration-less-than">
-               <head><?function op:yearMonthDuration-less-than?></head>
-            </div3>
-            <div3 id="func-dayTimeDuration-less-than">
-               <head><?function op:dayTimeDuration-less-than?></head>
-            </div3>
-		    <div3 id="func-duration-equal">
-               <head><?function op:duration-equal?></head>
-            </div3>
 		 </div2>
         <div2 id="component-extraction-durations">
             <head>Extracting components of durations</head>
@@ -4508,12 +4499,10 @@ See <bibref ref="Working-With-Timezones"/> for a disquisition on working with da
 
          <div2 id="comp.datetime">
             <head>Comparing date and time values</head>
-            <?local-function-index?>
-            <p>The following comparison operators are defined on the <bibref ref="xmlschema-2"/>
-                    date/time datatypes. Each operator takes two operands of the same
-                    type and returns an <code>xs:boolean</code> result.</p>
+            <!--<?local-function-index?>-->
+            <p>Date and time values can be compared using the function <function>fn:compare</function>.</p>
             <p>
-               <bibref ref="xmlschema-2"/> also states that the
+               <bibref ref="xmlschema-2"/>  states that the
                     order relation on date and time datatypes is
                     not a total order but a partial order because these
 datatypes may or may not have a timezone.  This is handled as follows.
@@ -4607,7 +4596,7 @@ the <code>year</code>, <code>month</code> and <code>day</code> components are re
 			   or arithmetic, which makes the choice of reference date less critical.-->
             </note>
 
-            <div3 id="func-dateTime-equal">
+            <!--<div3 id="func-dateTime-equal">
                <head><?function op:dateTime-equal?></head>
             </div3>
             <div3 id="func-dateTime-less-than">
@@ -4639,7 +4628,7 @@ the <code>year</code>, <code>month</code> and <code>day</code> components are re
             </div3>
             <div3 id="func-gDay-equal">
                <head><?function op:gDay-equal?></head>
-            </div3>
+            </div3>-->
          </div2>
          <div2 id="component-extraction-dateTime">
             <head>Extracting components of dates and times</head>
@@ -6037,7 +6026,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
       </div1>
       <div1 id="binary-functions">
          <head>Processing binary values</head>
-         <div2 id="binary-value-comparisons">
+         <!--<div2 id="binary-value-comparisons">
             <head>Comparing base64Binary and hexBinary values</head>
             <p diff="chg" at="2023-11-03">The following comparison operators on 
                <code>xs:hexBinary</code> and <code>xs:base64Binary</code> values are defined. 
@@ -6054,7 +6043,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <div3 id="func-binary-less-than">
                <head><?function op:binary-less-than?></head>
             </div3>
-         </div2>
+         </div2>-->
       </div1>
       
       <div1 id="node-functions">
@@ -14888,6 +14877,10 @@ ISBN 0 521 77752 6.</bibl>
               has no effect. Processors may provide an option that allows such regular expressions to be
               accepted for compatibility reasons.</p>
 
+           </item>
+           
+           <item>
+              <p>The <function>index-of</function> now treats <code>NaN</code> as equal to <code>NaN</code>.</p>
            </item>
         </olist>
  

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -321,18 +321,16 @@ Michael Sperberg-McQueen (1954–2024).</p>
             <head>Operators</head>
             <p>Despite its title, this document does not attempt to define the semantics of all the operators available
                in the <bibref ref="xpath-40"/> language; indeed, in the interests of avoiding duplication, the majority of
-               operators (including all higher-order operators such as <code>x/y</code>, <code>x!y</code>, and <code>x[y]</code>,
-               as well simple operators such as <code>x,y</code>, <code>x and y</code>, <code>x or y</code>,            
-               <code>x&lt;&lt;y</code>, <code>x>>y</code>, <code>x precedes y</code>, <code>x follows y</code>, <code>x precedes-or-is y</code>, <code>x follows-or-is y</code>, <code>x is y</code>, <code>x is-not y</code>, <code>x||y</code>, <code>x|y</code>,
-            <code>x union y</code>, <code>x except y</code>, <code>x intersect y</code>, <code>x to y</code>
-            and <code>x otherwise y</code>) are now defined entirely within <bibref ref="xpath-40"/>.</p>
+               operators are now defined entirely within <bibref ref="xpath-40"/> (for XQuery, the definitions are also found
+               in <bibref ref="xquery-40"/>, and are generally identical).</p>
             
-            <p>The remaining operators that are described in this publication are those where the semantics of the operator
+            <p>The remaining operators that are described in this publication are the arithmetic operators, 
+               where the semantics of the operator
             depend on the types of the arguments. For these operators, the language specification describes rules for selecting
             an internal function defined in this specification to underpin the operator. For example, when the operator <code>x+y</code>
             is applied to two operands of type <code>xs:double</code>, the function <code>op:numeric-add</code> is selected.</p>
             
-            <p>XPath defines a range of comparison operators <code>x=y</code>, <code>x!=y</code>, <code>x&lt;y</code>, 
+            <!--<p>XPath defines a range of comparison operators <code>x=y</code>, <code>x!=y</code>, <code>x&lt;y</code>, 
                <code>x>y</code>, <code>x&lt;=y</code>, <code>x>=y</code>, <code>x eq y</code>, <code>x ne y</code>, <code>x lt y</code>, 
                <code>x gt y</code>, <code>x le y</code>, <code>x ge y</code>, which apply to a variety of operand types including
             for example numeric values, strings, dates and times, and durations. For each relevant data type, two functions
@@ -343,10 +341,11 @@ Michael Sperberg-McQueen (1954–2024).</p>
                <code>></code>, <code>&lt;=</code>, and <code>>=</code> are defined by reference to 
                <code>eq</code>, <code>ne</code>, <code>lt</code>, 
                <code>gt</code>, <code>le</code>, and <code>ge</code> respectively.</p>
-            
-            <note><p>Previous versions of this specification also defined a third comparison function of the form
-            <code role="example">op:date-greater-than</code>. This has been dropped, as it is always the inverse of the <code>-less-than</code>
-            form.</p></note>
+            -->
+            <note><p>Previous versions of this specification also defined the value comparison operators such as 
+                  <code>eq</code>, <code>lt</code>, and <code>gt</code> in terms of functions such as
+            <code role="example">op:date-greater-than</code>. These have been dropped; for most data types the semantics
+                  of the value comparison operators are defined by reference to the <function>fn:compare</function> function.</p></note>
          </div2>
          
          <div2 id="conformance">
@@ -14731,10 +14730,11 @@ ISBN 0 521 77752 6.</bibl>
 	        <head>Editorial Changes</head>
 	        <p>These changes are not highlighted in the change-marked version of the specification.</p>
 	        <olist>
-	           <item><p>The operator mapping table has been simplified so all the value comparison operators
-	              are now defined in terms of two functions (for each data type): <code role="example">op:XX-equal</code>,
-	              and <code role="example">op:XX-less-than</code>. The entries for <code role="example">op:XX-greater-than</code>
-	           have therefore been removed.</p></item>
+	           <item><p>The value comparison operators such as <code>eq</code>, <code>lt</code>, and <code>gt</code>
+	                 are now defined in <bibref ref="xpath-40"/> by reference to <function>fn:compare</function>
+	                 and other functions. The datatype-specific functions <code role="example">op:XX-equal</code>,
+	                 <code role="example">op:XX-less-than</code>, and <code role="example">op:XX-greater-than</code>
+	                 have therefore been dropped.</p></item>
 	           <item><p>The names of parameters appearing in function signatures have been changed. This
 	           is to reflect the introduction of keyword arguments in XPath 4.0; the names chosen
 	           for parameters are now more consistent across the function library.</p>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -249,7 +249,8 @@ referred to as the <termref def="dt-default-in-scope-namespace"/> for the elemen
 As of XPath 2.0, the namespace axis is deprecated and need not be supported by a host language. A host language that does not support the namespace axis need not represent namespace bindings in the form of nodes.</p>
       <note role="xquery">
          <p>In <bibref ref="xpath"
-               />, the in-scope namespaces of an element node are represented by a collection of <term>namespace nodes</term> arranged on a <term>namespace axis</term>, which is optional and deprecated in <bibref
+               />, the in-scope namespaces of an element node are represented by a collection of <term>namespace nodes</term>
+            arranged on a <term>namespace axis</term>, which is optional and deprecated in <bibref
                ref="xpath-40"
             />. XQuery does not support the namespace axis and does not represent namespace bindings in the form of nodes.</p>
 
@@ -19993,237 +19994,105 @@ return $product/@code</eg>
             </scrap>
             
             <p>The purpose of an <code>order by</code> clause is to impose a value-based ordering on the tuples in the tuple stream. The output tuple stream of the <code>order by</code> clause contains the same tuples as its input tuple stream, but the tuples may be in a different order.</p>
-            <p>An <code>order by</code> clause contains one or more ordering specifications, called <nt
-                  def="OrderSpec"
-                  >orderspecs</nt>, as shown in the grammar. For each tuple in the input tuple stream, the orderspecs are evaluated, using the variable bindings in that tuple. The relative order of two tuples is determined by comparing the values of their orderspecs, working from left to right until a pair of unequal values is encountered. If an orderspec specifies a <termref
-                  def="dt-collation"
-                  >collation</termref>, that collation is used in comparing values of type <code>xs:string</code>, <code>xs:anyURI</code>, or types derived from them (otherwise, the <termref
-                  def="dt-def-collation"
-                  >default collation</termref> is used in comparing values of these types). If an orderspec specifies a collation by a relative URI, that relative URI is  <termref
-                  def="dt-resolve-relative-uri"
-                  >resolved to an absolute URI</termref> using the <termref def="dt-static-base-uri"
-                  >Static Base URI</termref>. 
-If an orderspec specifies a collation that is not found in <termref
-                  def="dt-static-collations"
-                  >statically known collations</termref>, an error is raised <errorref class="ST"
-                  code="0076"/>.</p>
-            <p>The process of evaluating and comparing the orderspecs is based on
-the following rules:</p>
-
-            <ulist>
-
-               <item>
-                  <p>
-                     <termref def="dt-atomization"
-                        >Atomization</termref> is applied to the result of the expression
-    in each orderspec.  If the result of atomization is neither a single atomic item nor an empty sequence, a <termref
-                        def="dt-type-error">type error</termref> is raised <errorref class="TY"
-                        code="0004"/>.</p>
-               </item>
-
-
-
-
-               <item>
-                  <p>If the resulting sequence contains values that are instances of more than one primitive type (meaning the 19 primitive types defined in <xspecref
-                        spec="XS2" ref="built-in-primitive-datatypes"/>, then:</p>
-                  <olist>
-                     <item>
-                        <p>If each value is an instance of one of the types <code>xs:string</code> or <code>xs:anyURI</code>, then all values are cast to type <code>xs:string</code>.</p>
-                     </item>
-                     <item>
-                        <p>If each value is an instance of one of the types <code>xs:decimal</code> or <code>xs:float</code>, then all values are cast to type <code>xs:float</code>.</p>
-                     </item>
-                     <item>
-                        <p>If each value is an instance of one of the types <code>xs:decimal</code>, <code>xs:float</code>, or <code>xs:double</code>, then all values are cast to type <code>xs:double</code>.</p>
-                     </item>
-                     <item>
-                        <p>Otherwise, a <termref def="dt-type-error"
-                              >type error</termref> is raised <errorref class="TY" code="0004"
-                           />.</p>
-                        <note>
-                           <p>The primitive type of an <code>xs:integer</code> value for this purpose is <code>xs:decimal</code>.</p>
-                        </note>
-                     </item>
-                  </olist>
-               </item>
-            </ulist>
-
-
-            <!-- <change diff="chg" at="XQ.E17"> -->
-            <p>For the purpose of determining their relative position in the ordering sequence, the <emph>greater-than</emph>
-             relationship between two orderspec values <var>W</var> and <var>V</var> is defined as follows:</p>
-            <ulist>
-               <item>
-                  <p>When the orderspec specifies <code>empty least</code>,
-                   the following rules are applied in order:
-                </p>
-                  <olist>
-                     <item>
-                        <p>If <var>V</var> is an empty sequence and <var>W</var> is not an empty sequence,
-                         then <var>W</var>
-                           <emph>greater-than</emph>
-                           <var>V </var> is true.</p>
-                     </item>
-                     <item>
-                        <p>If <var>V</var> is <code>NaN</code> and <var>W</var> is neither <code>NaN</code>
-                         nor an empty sequence, then
-                         <var>W</var>
-                           <emph>greater-than</emph>
-                           <var>V</var> is true.</p>
-                     </item>
-                     <item>
-                        <p>If <var>V</var> and <var>W</var> are both instances of <code>xs:string</code>,
-                        <code>xs:anyURI</code>, or <code>xs:untypedAtomic</code>, they are compared
-                           using the function <code>fn:compare(V, W, C)</code> where <var>C</var> is the
-                        requested collation, defaulting to the default collation from the static context.</p>
-                        
-                        <p>If <code>fn:compare(V, W, C)</code> is less than
-                         zero, then <emph>W</emph>
-                           <emph>greater-than</emph>
-                           <emph>V</emph> is true; otherwise <emph>W</emph>
-                           <emph>greater-than</emph>
-                           <emph>V</emph> is false.</p>
-                     </item>
-                     <item>
-                        <p>If <var>V</var> and <var>W</var> are both instances of <code>xs:numeric</code>,
-                           they are compared
-                           using the function <code>fn:compare(V, W)</code>.</p>
-                        
-                        <p>If <code>fn:compare(V, W)</code> is less than
-                           zero, then <var>W</var>
-                           <emph>greater-than</emph>
-                           <var>V</var> is true; otherwise <var>W</var>
-                           <emph>greater-than</emph>
-                           <var>V</var> is false.</p>
-                     </item>
-                     <item>
-                        <p>If none of the above rules apply, then:</p>
-                        <p>If <code>W gt V</code> is true,
-                         then <var>W</var>
-                           <emph>greater-than</emph>
-                           <var>V</var> is true; otherwise <var>W</var>
-                           <emph>greater-than</emph>
-                           <var>V</var> is false.</p>
-                     </item>
-                  </olist>
-               </item>
-               <item>
-                  <p>When the orderspec specifies <code>empty greatest</code>,
-                   the following rules are applied in order:
-                </p>
-                  <olist>
-                     <item>
-                        <p>If <var>W</var> is an empty sequence and <emph>V</emph> is not an empty sequence,
-                         then <var>W</var>
-                           <emph>greater-than</emph>
-                           <var>V</var> is true.</p>
-                     </item>
-                     <item>
-                        <p>If <var>W</var> is <code>NaN</code> and <var>V</var> is neither <code>NaN</code>
-                         nor an empty sequence, then
-                         <var>W</var>
-                           <emph>greater-than</emph>
-                           <var>V</var> is true.</p>
-                     </item>
-                     <item>
-                        <p>If <var>V</var> and <var>W</var> are both instances of <code>xs:string</code>,
-                           <code>xs:anyURI</code>, or <code>xs:untypedAtomic</code>, they are compared
-                           using the function <code>fn:compare(V, W, C)</code> where <var>C</var> is the
-                           requested collation, defaulting to the default collation from the static context.</p>
-                        
-                        <p>If <code>fn:compare(V, W, C)</code> is less than
-                           zero, then <emph>W</emph>
-                           <emph>greater-than</emph>
-                           <emph>V</emph> is true; otherwise <emph>W</emph>
-                           <emph>greater-than</emph>
-                           <emph>V</emph> is false.</p>
-                     </item>
-                     <item>
-                        <p>If <var>V</var> and <var>W</var> are both instances of <code>xs:numeric</code>,
-                           they are compared
-                           using the function <code>fn:compare(V, W)</code>.</p>
-                        
-                        <p>If <code>fn:compare(V, W)</code> is less than
-                           zero, then <var>W</var>
-                           <emph>greater-than</emph>
-                           <var>V</var> is true; otherwise <var>W</var>
-                           <emph>greater-than</emph>
-                           <var>V</var> is false.</p>
-                     </item>
-                     <item>
-                        <p>If none of the above rules apply, then:</p>
-                        <p>If <code>W gt V</code> is true,
-                           then <var>W</var>
-                           <emph>greater-than</emph>
-                           <var>V</var> is true; otherwise <var>W</var>
-                           <emph>greater-than</emph>
-                           <var>V</var> is false.</p>
-                     </item>
-                  </olist>
-               </item>
-               <item>
-                  <p>When the orderspec specifies neither <code>empty least</code>
-                   nor <code>empty greatest</code>, the
-                   <termref
-                        def="dt-default-empty-order"
-                        >default order for empty
-                   sequences</termref> in the
-                   <termref
-                        def="dt-static-context"
-                        >static context</termref>
-                   determines whether the rules for <code>empty least</code>
-                   or <code>empty greatest</code> are used.
-                </p>
-               </item>
-            </ulist>
-            <!-- </change> -->
-
-            <p>If <emph>T1</emph> and <emph>T2</emph> are two tuples in the input tuple stream, and <emph>V1</emph> and <emph>V2</emph> are the first pair of  values encountered when evaluating their orderspecs  from left to right for which one value is <emph>greater-than</emph> the other (as defined above), then:</p>
-
-
+            
+            <p>For any two tuples <var>T1</var> and <var>T2</var> in the input tuple stream, the relative position
+               of <var>T1</var> and <var>T2</var> in the output tuple stream is determined as follows:</p>
+            
             <olist>
+               <item><p>The two tuples <var>T1</var> and <var>T2</var> are compared using each <nt def="OrderSpec">OrderSpec</nt>
+               in turn. If an <nt def="OrderSpec">OrderSpec</nt> determines that the two tuples are equal, then
+               they are compared using the next <nt def="OrderSpec">OrderSpec</nt>; the first <nt def="OrderSpec">OrderSpec</nt>
+               for which they compare not equal determines the final ordering. If the two tuples compare equal under
+               every <nt def="OrderSpec">OrderSpec</nt> then their final relative position depends on the <code>stable</code>
+               specification, as described below.</p></item>
+               
+               <item><p>The result of comparing two tuples <var>T1</var> and <var>T2</var> under <nt def="OrderSpec">OrderSpec</nt> 
+               <var>K</var> is obtained as follows:</p>
+                  <olist>
+                     <item><p>The <term>effective empty order</term> of <var>K</var> is <term>empty least</term> if
+                           <var>K</var> specifies <code>empty least</code>, <term>empty greatest</term> if <var>K</var>
+                           specifies <code>empty greatest</code>, or by default, the <termref def="dt-default-empty-order"
+                           >default order for empty sequences</termref> in the <termref def="dt-static-context"
+                           >static context</termref>.
+                           </p></item>
+                     <item><p>The <term>effective collation</term> of <var>K</var> is the collation specified
+                           by <var>K</var> if present, or the default collation from the <termref def="dt-static-context"
+                           >static context</termref> otherwise. If the collation specified
+                           by <var>K</var> is a relative URI, that relative URI is  <termref
+                           def="dt-resolve-relative-uri"
+                           >resolved to an absolute URI</termref> using the <termref def="dt-static-base-uri"
+                           >Static Base URI</termref>. 
+                           If an <code>OrderSpec</code> specifies a collation that is not found in <termref
+                           def="dt-static-collations"
+                           >statically known collations</termref>, an error is raised <errorref class="ST"
+                           code="0076"/>.
+                           </p></item>
+                     <item><p>The sort key expression (the <nt def="ExprSingle">ExprSingle</nt> within <var>K</var>)
+                     is evaluated for both tuples to produce two sort key values <var>V1</var> and <var>V2</var>,
+                     using the variable bindings in that tuple.</p>
+                     <note><p>The focus for this evaluation is the focus for the FLWOR expression as a whole. The context
+                     item is not changed.</p></note>
+                     </item>
+                     <item><p><var>V1</var> and <var>V2</var> are <termref def="dt-atomization">atomized</termref> 
+                        to produce two atomic sort key values <var>A1</var> and <var>A2</var>.</p>
+                     </item>
+                     <item><p>If either <var>A1</var> or <var>A2</var> is a sequence containing more than one item,
+                        a <termref def="dt-type-error">type error</termref> is raised <errorref class="TY" code="0004"/>.</p>
+                     </item>
+                     <item>
+                        <p>Let <var>P</var> be:</p>
+                        <olist>
+                           <item><p>If <var>A1</var> and <var>A2</var> are both empty, then 0.</p></item>
+                           <item><p>If <var>A1</var> is empty and <var>A2</var> is not, then -1 if
+                              the <term>effective empty order</term> is <term>empty least</term>, otherwise +1.</p>
+                           </item>
+                           <item><p>If <var>A2</var> is empty and <var>A1</var> is not, then +1 if
+                              the <term>effective empty order</term> is <term>empty least</term>, otherwise -1.</p>
+                           </item>                       
+                           <item>
+                              <p>Otherwise, the result of <code>fn:compare(<var>A1</var>, <var>A2</var>, <var>C</var>)</code>,
+                              where <var>C</var> is the <term>effective collation</term> of <var>K</var>.</p>
+                           </item>
+                           <item><p>If <var>A1</var> and <var>A2</var> are not comparable (that is, if
+                              <function>fn:compare</function> raises an error when applied to these two values), then 
+                              a <termref def="dt-type-error">type error</termref> is raised <errorref class="TY" code="0004"/>.</p>
+                           </item>
+                        </olist>
+                     </item>
+                     <item>
+                        <p>Let <var>Q</var>
+                        be minus <var>P</var> if <code>descending</code> is specified, or <var>P</var>
+                        otherwise.</p>
+                     </item>
+                     <item><p>Then <var>T1</var> precedes <var>T2</var> in the result if <var>Q</var> is negative;
+                        <var>T1</var> follows <var>T2</var> in the result if <var>Q</var> is positive; while if <var>Q</var>
+                        is zero, the process continues to consider the next <nt def="OrderSpec">OrderSpec</nt>.</p>
+                     </item>
+                     
+                     
 
-
-
-
-               <item>
-                  <p>If <emph>V1</emph> is <emph>greater-than</emph>
-                     <emph>V2:</emph> If the orderspec specifies <code>descending</code>, then <emph>T1</emph> precedes <emph>T2</emph> in the output tuple stream; otherwise, <emph>T2</emph> precedes <emph>T1</emph> in the output tuple stream.</p>
+                  </olist>
                </item>
-
-
-
+               
                <item>
-                  <p>If <emph>V2</emph> is <emph>greater-than</emph>
-                     <emph>V1</emph>: If the orderspec specifies <code>descending</code>, then <emph>T2</emph> precedes <emph>T1</emph> in the output tuple stream; otherwise, <emph>T1</emph> precedes <emph>T2</emph> in the output tuple stream.</p>
-               </item>
-
-
-
-            </olist>
-            <p>If neither <emph>V1</emph> nor <emph>V2</emph> is <emph>greater-than</emph> the other for any pair of orderspecs for tuples <emph>T1</emph> and <emph>T2</emph>, the following rules apply.</p>
-
-            <olist>
-
-
-
-               <item>
-                  <p>If <code>stable</code> is specified, the original order of <emph>T1</emph> and <emph>T2</emph> is preserved in the output tuple stream.</p>
-               </item>
-
-
-
-               <item>
-                  <p>If <code>stable</code> is not specified, the order of <emph>T1</emph> and <emph>T2</emph> in the output tuple stream is <termref
-                        def="dt-implementation-dependent">implementation-dependent</termref>.</p>
+                  <p>If <var>T1</var> and <var>T2</var> are equal under all <nt def="OrderSpec">OrderSpecs</nt>,
+                     the outcome depends on whether <code>stable</code> is specified:</p>
+                     
+                     <olist>
+   
+                         <item>
+                            <p>If <code>stable</code> is specified, the original order of <var>T1</var> and <var>T2</var> 
+                               is preserved in the output tuple stream.</p>
+                         </item>
+                        <item>
+                           <p>If <code>stable</code> is not specified, the order of <var>T1</var> and <var>T2</var> 
+                              in the output tuple stream is <termref
+                                 def="dt-implementation-dependent">implementation-dependent</termref>.</p>
+                        </item>
+                  </olist>
                </item>
             </olist>
-            <note>
-               <p>If two orderspecs return the special floating-point values positive and negative zero, neither of these values is <emph>greater-than</emph> the other, since <code
-                     role="parse-test">+0.0 gt -0.0</code> and <code role="parse-test"
-                     >-0.0 gt +0.0</code> are both <code>false</code>.</p>
-            </note>
+            
             <p>Examples:</p>
             <ulist>
 
@@ -20263,7 +20132,7 @@ return $e/name]]></eg>
             </ulist>
             <note>
                <p>If a collation name is specified, it must be supplied as a literal string; it cannot
-                  be computed dynamically. Two possible workarounds are to use the <function>fn:sort</function> function
+                  be computed dynamically. Two possible workarounds are to use the <function>fn:sort-by</function> function
                or the <function>fn:collation-key</function> function.</p>
                <p>Using <function>fn:sort</function> the expression</p>
                <eg role="parse-test">for $b in $books/book[price &lt; 100]
@@ -20273,10 +20142,11 @@ return $b</eg>
                <p>can be replaced with the following, which uses a dynamically-chosen collation:</p>
 
                <eg role="parse-test">
-sort(
+sort-by(
   $books/book[price &lt; 100],
-  $collation,
-  function($book) { $book/title }
+  {'key': function($book) { $book/title },
+   'collation': $collation
+  }
 )
 </eg>
                
@@ -20292,7 +20162,7 @@ return $b</eg>
                
             </note>
 
-
+               
          </div3>
          <div3 id="id-return-clause" role="xquery">
             <head>Return Clause</head>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -14745,7 +14745,8 @@ must be followed; thus <code>&lt;</code> must be written as
                </change>
             </changes>
             
-            <p>The value comparison operators are <code>eq</code>, <code>ne</code>, <code>lt</code>, <code>le</code>, <code>gt</code>, and <code>ge</code>. Value comparisons are used for comparing single values.</p>
+            <p>The value comparison operators are <code>eq</code>, <code>ne</code>, <code>lt</code>, <code>le</code>, <code>gt</code>, and <code>ge</code>. 
+               Value comparisons are used for comparing single <termref def="dt-atomic-item">atomic items</termref>.</p>
             <p>The first step in evaluating a value comparison is to evaluate its operands. The order in which the operands are evaluated is <termref
                   def="dt-implementation-dependent"
                >implementation-dependent</termref>. Each operand is evaluated by applying the following steps, in order:</p>
@@ -14761,11 +14762,11 @@ must be followed; thus <code>&lt;</code> must be written as
                </item>
 
                <item>
-                  <p>If an atomized operand is an empty sequence, the result of
+                  <p>If either or both of the atomized operands is an empty sequence, the result of
     the value comparison is an empty sequence, and the implementation
     need not evaluate the other operand or apply the operator. However,
-    an implementation may choose to evaluate the other operand in order
-    to determine whether it raises an error.</p>
+    an implementation may choose to evaluate the other operand and may raise
+    an error if evaluation fails.</p>
                </item>
 
                <item>
@@ -14775,45 +14776,86 @@ length greater than one, a <termref
                         code="0004"/>.</p>
                </item>
 
-               <item>
+               <!--<item>
                   <p>If an  atomized operand is of type
   <code>xs:untypedAtomic</code> or <code>xs:anyURI</code>, then it is cast to
   <code>xs:string</code>.</p>
                   
-               </item>
-
-               <!--<item>
-
-
-                  <p>If the two operands are instances of different primitive types (meaning the 19 primitive types defined in <xspecref
-                        spec="XS2" ref="built-in-primitive-datatypes"/>), then:
-    <olist>
-                        <item>
-                           <p>If each operand is an instance of one of the types <code>xs:string</code> 
-                              or <code>xs:anyURI</code>, then both operands are cast to type 
-                              <code>xs:string</code>.</p>
-                        </item>
-                        <item>
-                           <p>If each operand is an instance of one of the types <code>xs:decimal</code> 
-                              or <code>xs:float</code>, then both operands are cast to type <code>xs:float</code>.</p>
-                        </item>
-                        <item>
-                           <p>If each operand is an instance of one of the types <code>xs:decimal</code>, 
-                              <code>xs:float</code>, or <code>xs:double</code>, then both operands are cast to type <code>xs:double</code>.</p>
-                        </item>
-                        <item>
-                           <p>Otherwise, a <termref def="dt-type-error"
-                                 >type error</termref> is raised <errorref class="TY" code="0004"
-                              />.</p>
-                           <note>
-                              <p>The primitive type of an <code>xs:integer</code> value for this purpose is <code>xs:decimal</code>.</p>
-                           </note>
-                        </item>
-                     </olist>
-                  </p>
                </item>-->
+
+               <item><p>If either or both of the atomized operands is <code>NaN</code>, then the result is
+               <code>false</code> if the operator is <code>eq</code>, <code>lt</code>, <code>gt</code>,
+               <code>le</code>, or <code>ge</code>, but <code>true</code> if the operator
+               is <code>ne</code>.</p>
+               <note><p>When an operand is <code>NaN</code>, the effect of a value comparison
+               expression differs from the result of the <function>fn:compare</function>
+               function.</p></note></item>
                
-               <item>
+               <item><p>The function <function>fn:compare</function> is then called, supplying
+               the two atomized operands as the first two arguments. The collation used
+               by <function>fn:compare</function> is the default collation from the static
+               context, and the implicit timezone used by the function is the implicit
+               timezone from the dynamic context.</p>
+               
+               <note><p>The effect of this rule is that <code>xs:untypedAtomic</code>
+               values (which typically result from atomizing a node) are treated as strings.</p></note>
+               </item>
+               
+               <item><p>If <function>fn:compare</function> raises an error (typically because
+               the two operands belong to different 
+                  <xtermref spec="DM40" ref="dt-type-family">type families</xtermref>),
+               then the value comparison fails with that error.</p></item>
+               
+               <item><p>The result of the <function>fn:compare</function> determines
+               the result of the value comparison, according to the following table:</p>
+               
+               <table>
+                  <caption>Result of a Value Comparison</caption>
+                  <thead>
+                     <tr>
+                        <th>Result of <function>fn:compare</function></th>
+                        <th><code>eq</code></th>
+                        <th><code>ne</code></th>
+                        <th><code>lt</code></th>
+                        <th><code>le</code></th>
+                        <th><code>gt</code></th>
+                        <th><code>ge</code></th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td><code>-1</code></td>
+                        <td><code>false</code></td>
+                        <td><code>true</code></td>
+                        <td><code>true</code></td>
+                        <td><code>true</code></td>
+                        <td><code>false</code></td>
+                        <td><code>false</code></td>
+                     </tr>
+                     <tr>
+                        <td><code>0</code></td>
+                        <td><code>true</code></td>
+                        <td><code>false</code></td>
+                        <td><code>false</code></td>
+                        <td><code>true</code></td>
+                        <td><code>false</code></td>
+                        <td><code>true</code></td>
+                     </tr>
+                     <tr>
+                        <td><code>+1</code></td>
+                        <td><code>false</code></td>
+                        <td><code>true</code></td>
+                        <td><code>false</code></td>
+                        <td><code>false</code></td>
+                        <td><code>true</code></td>
+                        <td><code>true</code></td>
+                     </tr>
+                  </tbody>
+               </table>
+               </item>
+            </olist>
+               
+               <!--<item>
                   <p>Expressions using operators other than <code>eq</code> and <code>lt</code>
                   are rewritten as follows:</p>
                   <slist>
@@ -14822,9 +14864,9 @@ length greater than one, a <termref
                      <sitem><code>A gt B</code> becomes <code>B lt A</code></sitem>
                      <sitem><code>A ge B</code> becomes <code>B lt A or B eq A</code></sitem>
                   </slist>
-               </item>
+               </item>-->
 
-               <item>
+               <!--<item>
                   <p>If the types of the two operands correspond to an entry
                      in the table below, the operator is applied to the
                      operands by applying the appropriate function from the table.</p>
@@ -14918,7 +14960,7 @@ is raised <errorref class="TY" code="0004"/>.</p>
                   function with two arguments; this implies that the comparison is performed
                   using the <termref def="dt-def-collation"/> from the
                   <termref def="dt-static-context"/>.</p>
-            </note>
+            </note>-->
             
 
             <p>Here are some examples of value comparisons:</p>
@@ -14927,7 +14969,13 @@ is raised <errorref class="TY" code="0004"/>.</p>
 
 
                <item>
-                  <p>The following comparison atomizes the node(s) that are returned by the expression <code>$book/author</code>. The comparison is true only if the result of atomization is the value "Kennedy" as an instance of <code>xs:string</code> or <code>xs:untypedAtomic</code>. If the result of atomization is an empty sequence, the result of the comparison is an empty sequence. If the result of atomization is a sequence containing more than one value, a <termref
+                  <p>The following comparison atomizes the node(s) that are returned 
+                     by the expression <code>$book/author</code>. The comparison is true 
+                     only if the result of atomization is the value "Kennedy" as an 
+                     instance of <code>xs:string</code> or <code>xs:untypedAtomic</code>. 
+                     If the result of atomization is an empty sequence, the result of 
+                     the comparison is an empty sequence. If the result of atomization 
+                     is a sequence containing more than one value, a <termref
                         def="dt-type-error">type error</termref> is raised <errorref class="TY"
                         code="0004"/>.</p>
                   <eg role="parse-test"><![CDATA[$book1/author eq "Kennedy"]]></eg>
@@ -14935,18 +14983,26 @@ is raised <errorref class="TY" code="0004"/>.</p>
 
 
                <item>
-                  <p>The following comparison is <code>true</code> because atomization converts an array to its member sequence:</p>
+                  <p>The following comparison is <code>true</code> because atomization 
+                     converts an array to its member sequence:</p>
                   <eg role="parse-test"><![CDATA[[ "Kennedy" ] eq "Kennedy"]]></eg>
                </item>
 
                <item>
                   <p>The following <termref def="dt-path-expression"
-                        >path expression</termref> contains a predicate that selects products whose weight is greater than 100. For any product that does not have a <code>weight</code> subelement, the value of the predicate is the empty sequence, and the product is not selected. This example assumes that <code>weight</code> is a validated element with a numeric type.</p>
+                        >path expression</termref> contains a predicate that selects 
+                     products whose weight is greater than 100. For any product that 
+                     does not have a <code>weight</code> subelement, the value of the 
+                     predicate is the empty sequence, and the product is not selected. 
+                     This example assumes that <code>weight</code> is a validated element 
+                     with a numeric type.</p>
                   <eg role="parse-test"><![CDATA[//product[weight gt 100]]]></eg>
                </item>
 
                <item role="xquery">
-                  <p>The following comparisons are true because, in each case, the two constructed nodes have the same value after atomization, even though they have different identities and/or names:</p>
+                  <p>The following comparisons are true because, in each case, the two constructed 
+                     nodes have the same value after atomization, even though they have different 
+                     identities and/or names:</p>
                   <eg role="parse-test"
                      >&lt;a&gt;5&lt;/a&gt; eq &lt;a&gt;5&lt;/a&gt;</eg>
                   <eg role="parse-test"
@@ -14954,7 +15010,9 @@ is raised <errorref class="TY" code="0004"/>.</p>
                </item>
 
                <item>
-                  <p>The following comparison is true if <code>my:hatsize</code> and <code>my:shoesize</code> are both user-defined types that are derived by restriction from a primitive <termref
+                  <p>The following comparison is true if <code>my:hatsize</code> and 
+                     <code>my:shoesize</code> are both user-defined types that are derived 
+                     by restriction from a primitive <termref
                         def="dt-numeric">numeric</termref> type:</p>
                   <eg role="parse-test"><![CDATA[my:hatsize(5) eq my:shoesize(5)]]></eg>
                </item>
@@ -14983,6 +15041,8 @@ QName("http://example.com/ns1", "that:color")]]></eg>
                   not previously the case.</p></note>
                </item>
             </ulist>
+            
+            
          </div3>
          <div3 id="id-general-comparisons">
             <head>General Comparisons</head>
@@ -15002,7 +15062,8 @@ always <code>true</code> or <code>false</code>.</p>
          
             
             <p role="xpath">If <termref def="dt-xpath-compat-mode"
-                  >XPath 1.0 compatibility mode</termref> is <code>true</code>, a general comparison is evaluated by applying the following rules, in order:</p>
+                  >XPath 1.0 compatibility mode</termref> is <code>true</code>, a general 
+               comparison is evaluated by applying the following rules, in order:</p>
 
             <olist role="xpath">
 
@@ -15016,7 +15077,8 @@ always <code>true</code> or <code>false</code>.</p>
                <item>
                   <p>
                      <termref def="dt-atomization"
-                     >Atomization</termref> is applied to each operand. After atomization, each operand is a sequence of atomic items.</p>
+                     >Atomization</termref> is applied to each operand. After atomization, 
+                     each operand is a sequence of atomic items.</p>
 
                </item>
 
@@ -15081,7 +15143,8 @@ of this value comparison is <code>true</code>.</p>
                <item>
                   <p>
                      <termref def="dt-atomization"
-                     >Atomization</termref> is applied to each operand. After atomization, each operand is a sequence of atomic items.</p>
+                     >Atomization</termref> is applied to each operand. After atomization, each 
+                     operand is a sequence of atomic items.</p>
 
                </item>
 
@@ -15095,7 +15158,8 @@ applying the following rules. If a <code>cast</code> operation called for by the
                         spec="FO40" class="RG" code="0001"/>
                   </p>
                   <note role="xquery">
-                     <p>The purpose of these rules is to preserve compatibility with XPath 1.0, in which (for example) <code
+                     <p>The purpose of these rules is to preserve a level of 
+                        compatibility with XPath 1.0, in which (for example) <code
                            role="parse-test"
                            >x &lt; 17</code> is a numeric comparison if <code>x</code> is an untyped value. 
                         Users should be aware that the value comparison operators have different rules 
@@ -15125,8 +15189,10 @@ applying the following rules. If a <code>cast</code> operation called for by the
                               <note><p>Casting to <code>xs:decimal</code> might fail if <var>V</var>
                               uses exponential notation or is positive or negative infinity. Casting to
                               <code>xs:float</code> might fail because of numeric overflow.</p></note>
+                              
+                              
                            </item>
-                           <item>
+                           <!--<item>
                               <p>If <var>T</var> is <code>xs:dayTimeDuration</code> or is derived from
                       <code>xs:dayTimeDuration</code>,
                       then <var>V</var> is cast to <code>xs:dayTimeDuration</code>.</p>
@@ -15135,18 +15201,18 @@ applying the following rules. If a <code>cast</code> operation called for by the
                               <p>If <var>T</var> is <code>xs:yearMonthDuration</code> or is derived from
                       <code>xs:yearMonthDuration</code>,
                       then <var>V</var> is cast to <code>xs:yearMonthDuration</code>.</p>
-                           </item>
+                           </item>-->
                            <item>
                               <p>In all other cases, <var>V</var> is cast to the primitive base type of <var>T</var>.</p>
                            </item>
                         </olist>
-                        <note>
+                        <!--<note>
                            <p>
                 The special treatment of the duration types is required to avoid
                 errors that may arise when comparing the primitive type
                 <code>xs:duration</code> with any duration type.
              </p>
-                        </note>
+                        </note>-->
                      </item>
                      <item>
                         <p>After performing the conversions described above, the atomic items are
@@ -15158,12 +15224,18 @@ of this value comparison is <code>true</code>.</p>
                   </olist>
                </item>
             </olist>
-            <p>When evaluating a general comparison in which either operand is a sequence of items, an implementation may return <code>true</code> as soon as it finds an item in the first operand and an item in the second operand that have the required <term>magnitude relationship</term>. Similarly, a general comparison may raise a <termref
+            <p>When evaluating a general comparison in which either operand is a sequence of items, 
+               an implementation may return <code>true</code> as soon as it finds an item in the 
+               first operand and an item in the second operand that have the required 
+               <term>magnitude relationship</term>. Similarly, a general comparison may raise a <termref
                   def="dt-dynamic-error"
-               >dynamic error</termref> as soon as it encounters an error in evaluating either operand, or in comparing a pair of items from the two operands. As a result of these rules, the result of a general comparison is not deterministic in the presence of errors.</p>
+               >dynamic error</termref> as soon as it encounters an error in evaluating 
+               either operand, or in comparing a pair of items from the two operands. 
+               As a result of these rules, the result of a general comparison is not 
+               deterministic in the presence of errors.</p>
 
 
-            <p>Here are some examples of  general comparisons:</p>
+            <p>Here are some examples of general comparisons:</p>
 
             <ulist>
 
@@ -15185,6 +15257,13 @@ of this value comparison is <code>true</code>.</p>
                   the <code>xs:untypedAtomic</code> value of the element node is converted
                   to type <code>xs:decimal</code>, and the two <code>xs:decimal</code>
                   values are compared.</p>
+               </item>
+               
+               <item>
+                  <p>Given the input <code>&lt;item price="10.30"/></code>, the expression 
+                  <code>@discount != "25%"</code> returns false, because there is no 
+                  <code>discount</code> attribute that meets the specified criteria. By contrast,
+                  the expression <code>not(@discount = "25%")</code> returns true.</p>
                </item>
 
                <item>
@@ -19621,10 +19700,10 @@ group by $g1, $g2, $g3 collation "Spanish"]]></eg>
      reference to the <function>fn:deep-equal</function> function
      ensures that the empty sequence is equivalent only to the empty
      sequence, that <code>NaN</code> is equivalent to
-     <code>NaN</code>, that untypedAtomic items are compared as
-     strings, and that values for which the <code>eq</code> operator
-     is not defined are considered
-     non-equivalent.</p>
+     <code>NaN</code>, that <code>xs:untypedAtomic</code> items are compared as
+     strings, and that values from different 
+                           <xtermref spec="DM40" ref="dt-type-family">atomic type families</xtermref>
+     are considered non-equivalent.</p>
                      </note> </item> <item>
                      <p>The appropriate collation for comparing two grouping keys is the collation
    specified in the pertinent <nt
@@ -19943,17 +20022,6 @@ the following rules:</p>
                </item>
 
 
- <!--              <item>
-                  <p>If the value of an orderspec has the <termref def="dt-dynamic-type"
-                        >dynamic type</termref>
-                     <code>xs:untypedAtomic</code> (such as character
-    data in a schemaless document), it is cast to the type <code>xs:string</code>.</p>
-                  <note>
-                     <p>Consistently treating untyped values as strings enables the sorting process to begin without complete knowledge of the types of all the values to be sorted.</p>
-                  </note>
-               </item>
-
-
 
 
                <item>
@@ -19978,7 +20046,7 @@ the following rules:</p>
                         </note>
                      </item>
                   </olist>
-               </item>-->
+               </item>
             </ulist>
 
 
@@ -22312,9 +22380,8 @@ raised <errorref class="TY" code="0004"/>. In the absence of a switch comparand,
             <item>
                <p>Otherwise, the <termref def="dt-singleton"/> <term>switch value</term> is compared individually
                with each item in the <term>case value</term> in turn, and a match
-               occurs if and only if these two atomic items compare equal under the rules of
-               the <function>fn:deep-equal</function> function with default options, using the default 
-               collation in the static context.</p>
+               occurs if and only if these two atomic items are <xtermref spec="FO40" ref="dt-contextually-equal"/>,
+               using the default collation in the static context.</p>
             </item>
          </olist>
 

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -14744,6 +14744,9 @@ must be followed; thus <code>&lt;</code> must be written as
                   to a decimal without loss of precision. This may affect compatibility in edge cases involving comparison of
                   values that are numerically very close.
                </change>
+               <change issue="2216" PR="2256" date="2025-12-01">
+                  An ordering is now defined for all data types.
+               </change>
             </changes>
             
             <p>The value comparison operators are <code>eq</code>, <code>ne</code>, <code>lt</code>, <code>le</code>, <code>gt</code>, and <code>ge</code>. 
@@ -14784,10 +14787,12 @@ length greater than one, a <termref
                   
                </item>-->
 
-               <item><p>If either or both of the atomized operands is <code>NaN</code>, then the result is
+               <item><p>If both operands are instances of <code>xs:numeric</code>, and
+                     if either or both of the atomized operands is <code>NaN</code>, then the result is
                <code>false</code> if the operator is <code>eq</code>, <code>lt</code>, <code>gt</code>,
                <code>le</code>, or <code>ge</code>, but <code>true</code> if the operator
                is <code>ne</code>.</p>
+                  
                <note><p>When an operand is <code>NaN</code>, the effect of a value comparison
                expression differs from the result of the <function>fn:compare</function>
                function.</p></note></item>
@@ -14807,7 +14812,7 @@ length greater than one, a <termref
                   <xtermref spec="DM40" ref="dt-type-family">type families</xtermref>),
                then the value comparison fails with that error.</p></item>
                
-               <item><p>The result of the <function>fn:compare</function> determines
+               <item><p>The result of the <function>fn:compare</function> function determines
                the result of the value comparison, according to the following table:</p>
                
                <table>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -23635,20 +23635,15 @@ return if ($i le count($S))
                   <item><p><code>(1, 2)</code> precedes <code>(1, 2, 3)</code></p></item>
                   <item><p><code>()</code> precedes <code>(1, 2)</code></p></item>
                </ulist>
-            <p diff="chg" at="2023-12-06">Individual atomic items are compared as follows:</p>
-               <olist diff="chg" at="2023-12-06">
-                  <item><p>If both values are instances of <code>xs:string</code>, <code>xs:anyURI</code>,
-                  or <code>xs:untypedAtomic</code>, they are compared using the appropriate collation,
-                  as described in the next section.</p></item>
-                  <item><p>If both values are instances of <code>xs:numeric</code>, they are compared
-                  using the <xfunction>compare</xfunction> function.</p>
-                  <note><p>This is a change from earlier versions, since <code>xs:decimal</code> values are now compared
-                  as decimals, rather than being first converted to <code>xs:double</code>.</p></note></item>
-                  <item><p>In all other cases, values are compared according to the rules
-                     of the XPath <code>lt</code> operator. This will raise an error if the values are
+            <p>Individual atomic items are compared by calling the function 
+               <code>fn:compare(<var>A1</var>, <var>A2</var>, <var>C</var>)</code>,
+               where <var>C</var> is the appropriate collation,
+                  as described in the next section.
+               This will raise an error if the values are
                   not comparable (for example, if one is an <code>xs:integer</code> and the other is
-                  an <code>xs:date</code>).</p></item>
-               </olist>
+                  an <code>xs:date</code>).</p>
+               
+                  
                   
  
                <p>
@@ -23657,16 +23652,14 @@ return if ($i le count($S))
                            <termref def="dt-sort-key-value">sort key values</termref> evaluated for
                         all the items in the <termref def="dt-initial-sequence">initial
                            sequence</termref>, after any type conversion requested, contains a pair
-                        of atomic items for which the result of the XPath <code>lt</code>
-                        operator is an error. If the processor is
+                        of atomic items that are not comparable using the <function>fn:compare</function>. If the processor is
                            able to detect the error statically, it <rfc2119>may</rfc2119> optionally
                            raise it as a <termref def="dt-static-error">static
                            error</termref>.</p>
                   </error>
                </p>
                <note>
-                  <p>The above error condition may occur if the values to be sorted are of a type
-                     that does not support ordering (for example, <code>xs:QName</code>) or if the
+                  <p>The above error condition may occur if the
                      sequence is heterogeneous (for example, if it contains both strings and
                      numbers). The error can generally be prevented by invoking a cast or
                      constructor function within the sort key component.</p>
@@ -23675,6 +23668,9 @@ return if ($i le count($S))
                      raises an error. For example, if there are several sort key components, then a
                      processor is not required to evaluate or compare minor sort key values unless
                      the corresponding major sort key values are equal.</p>
+                  <p>In XSLT 4.0 the error can no longer occur if the items in the sequence
+                  all have the same data type. An order relation is now defined for all
+                  atomic types (including, for example, <code>xs:duration</code>).</p>
                </note>
  
                


### PR DESCRIPTION
This is work in progress, pushing it mainly so I can review the diffs.

The first benefit is that nearly all comparisons can now be described by reference to `compare(A, B) = 0`.