### PR TITLE
2219 A method can be applied to multiple maps

### DIFF
--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -10594,6 +10594,27 @@ return $vat(doc('wares.xml')/shop/article)
 ]]></eg>
                                  </example>
             
+            <example>
+               <head>Applying multiple functions</head>
+               
+               <p>A dynamic function call can call zero or more functions with the same arguments, returning
+               the <termref def="dt-sequence-concatenation"/> of the result. For example:</p>
+               
+               <eg role="parse-test">(abs#1, round#1, floor#1, ceiling#1)(3.2)</eg>
+               
+               <p>returns the sequence <code>(3.2, 3, 3, 4)</code>.</p>            
+               
+               <p>A common case for supplying a sequence of functions arises when the functions are arrays.
+               For example:</p>
+               
+               <eg>csv-to-arrays( string-join(("a,b,c", "p,q,r", "x,y,z"), char(10)) ) (2)</eg>
+               
+               <p>returns the sequence <code>("b", "q", "y")</code>.</p>
+               
+               <p>If the base expression evaluates to an empty sequence, the result
+               is an empty sequence.</p>
+            </example>
+            
             
             
                <note diff="add" at="A"><p>Keyword arguments are not allowed in a dynamic function call.</p></note>
@@ -21707,6 +21728,10 @@ return $f($map, <var>X</var>, <var>Y</var>, ...)</eg>
             <p>(where <code>$map</code> and <code>$f</code>
                   are otherwise unused variable names).</p>
             
+              <note><p>The left-hand operand can be a sequence of maps. For example, given <code>$rectangle</code>
+              defined as in the first example above, the expression <code>((1 to 2) ! $rectangle =?> resize(.)) =?> area()</code>
+              returns the sequence <code>(12, 48)</code>.</p></note>
+            
                <p>The argument list in a method call must not include an argument placeholder; that is,
                the call must not be a partial function application (<errorref class="ST" code="0003"/>).</p>
                   
@@ -23520,7 +23545,7 @@ return string-join($chopped, '; ')
             or a map or array constructor.</change>
          </changes>
          
-         <p>Arrow expressions apply a function to a value, using the value of the
+         <p>Arrow expressions apply a function (or more generally, a sequence of functions) to a value, using the value of the
          left-hand expression as the first argument to the function.</p>
 
          <scrap>
@@ -23574,7 +23599,7 @@ return string-join($chopped, '; ')
             
          <ulist>
             <item><p>The <code>-></code> operator takes an arbitrary expression as its right-hand operand,
-            whereas the <code>=></code> operator only accepts a function call.</p></item>
+            whereas the <code>=></code> operator requires the right-hand operand to be a function call.</p></item>
             <item><p>When the right hand operand is a function call, the first argument
             is omitted in the case of the <code>=></code> operator, but is included explicitly
             (as a context value expression, <code>.</code>) in the case of the <code>-></code> operator.</p></item>
@@ -23647,10 +23672,19 @@ return string-join($chopped, '; ')
          <p>The construct on the right-hand side of the arrow operator (<code>=></code>) can
          either be a static function call, or a restricted form of dynamic function call. The
          restrictions are there to ensure that the two forms can be distinguished by the parser
-         with limited lookahead. For a dynamic call, the function item to be called can be 
+         with limited lookahead. For a dynamic call, the function item(s) to be called can be 
          expressed as a variable reference, an inline function expression, a named function reference, 
          a map constructor, or an array constructor. Any other expression used to return the required function
          item must be enclosed in parentheses.</p>
+         
+         <p>Because the semantics of the arrow operator (<code>=></code>) are defined in terms of
+         static and dynamic functions calls, it is possible for the right-hand side to deliver
+         a sequence of functions; the result of the arrow expression is the sequence-concatenation
+         of the results of the function calls. For example,</p>
+         
+         <eg>"London" => (upper-case#1, lower-case#1, string-length#1)</eg>
+         
+         <p>returns the sequence <code>("LONDON", "london", 6)</code>.</p>
          
         
          


### PR DESCRIPTION
The PR clarifies with examples that

(a) a dynamic function call can include several functions: `(upper-case#1, lower-case#1)("London")`
(b) an arrow expression can include several functions: `"London" => (upper-case#1, lower-case#1)`
(c) a method call can apply to multiple maps: `for $size in 1 to 3 return $rectangle =?> resize($size) =?> area()`

None of this actually represents a change to the spec, just a clarification that it is already allowed.

I'm not in favour of the change proposed in issue #2219 allowing the RHS of `=?>` to select zero or more functions. If we wanted to allow that, we probably wouldn't want to restrict the RHS to be an NCName. Using an NCName gives better potential for optimization and for static error detection, and I think it makes sense to require it (as now) to select a single function from each input map.

Fix #2219