### PR TITLE
2280 Usability of xsl:array-member

### DIFF
--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -28588,10 +28588,8 @@ the same group, and the-->
        select="(., substring(., 1, 3))"/>]]></eg>
                   <p>This constructs an array with five members, each being a sequence of two
                      strings: <code>[('Monday', 'Mon'), ('Tuesday', 'Tue'), ('Wednesday', 'Wed'), ('Thursday', 'Thu'), ('Friday', 'Fri')]</code></p>
-                  <p>The values, of course, do not need to be literals.</p>
                   <p>A more complex example might be:</p>
-                  <eg><![CDATA[<xsl:array for-each="unparsed-text-lines('data.txt')"
-       select="tokenize(.)"/>]]></eg>
+                  <eg><![CDATA[<xsl:array for-each="unparsed-text-lines('data.txt')" select="tokenize(.)"/>]]></eg>
                   <p>which creates an array with one member for each line of an input file, the relevant member
                   being a sequence of words appearing on that line.</p>
                </item>
@@ -28626,74 +28624,93 @@ the same group, and the-->
             <p>The detailed rules follow.</p>
             
             <olist>
-               <item><p>If the <code>select</code> attribute is present then the instruction must
-              have empty content, except for <elcode>xsl:fallback</elcode> instructions which an
-               XSLT 4.0 processor ignores.</p>
-               <p>The result then depends on whether there is a <code>for-each</code> attribute.</p>
-                  
-               <olist>
-                  <item><p>If the <code>for-each</code> attribute is absent,
-                  the result of the instruction is an array containing one singleton
-                  member for each item in the sequence selected by the <code>select</code> expression,
-                  retaining order.</p></item>
-                  <item><p>If the <code>for-each</code> attribute is present, then it is evaluated:
-                     let the result be <var>R</var>.
-               For each item <var>M</var> in <var>R</var>, one array member is constructed, the value of that member
-               being the result of evaluating the <code>select</code> expression with a <termref def="dt-focus"/>
-                  in which the <termref def="dt-context-item"/> is <var>M</var>, the <termref def="dt-context-position"/>
-                     is the 1-based position of <var>M</var> within <var>R</var>, and the <termref def="dt-context-size"/>
-                     is the number of items in <var>R</var>. 
-               </p></item>
-               </olist>   
+               <item><p>In these rules, the term <term>parcel</term> denotes a function item
+               with arity zero having an implementation-defined 
+                  <xtermref spec="DM40" ref="dt-function-annotation">function annotation</xtermref> that identifies
+               it as having been constructed by the <elcode>xsl:array-member</elcode> instruction.
+               The implementation-defined function annotation should use a reserved namespace such
+               that functions with this annotation can be created only by using the
+               <elcode>xsl:array-member</elcode> instruction.</p> 
+                  <p>A parcel encapsulates a value,
+               which may be any sequence; the value of the parcel is the result of calling the
+               corresponding function item with no arguments.</p></item>
+               <item><p>The effect of the <elcode>xsl:array-member</elcode> instruction is to return
+               a <term>parcel</term> that encapsulates the sequence obtained by evaluating its
+               <code>select</code> attribute or its contained sequence constructor.</p></item>
+               <item><p>The <elcode>xsl:array</elcode> instruction is evaluated as follows.</p></item>
                
-               </item>
-               
-               <item>
-                  <p>If the <code>select</code> attribute is absent, then the contained sequence constructor
-                  is used in its place. The effect depends on whether the <code>for-each</code> 
-                  attribute is present.</p>
-                  
+               <item><p>If the <code>for-each</code> attribute is absent, then:</p>
                   <olist>
-                     <item><p>If the <code>for-each</code> attribute is absent, then the sequence
-                     constructor is evaluated. The result must be a sequence of zero or more zero-arity
-                     function items (typically but not necessarily constructed using the <elcode>xsl:array-member</elcode>
-                     instruction described below).</p>
-                     <p>The result of the <elcode>xsl:array</elcode> instruction contains one member
-                     for each of these zero-arity function items, the value of the array member being
-                     the result of evaluating the corresponding function item.</p></item>
-                     
-                     <item><p>If the <code>for-each</code> attribute is present, then it is evaluated:
-                     let the result be <var>R</var>.
-                     For each item <var>M</var> in <var>R</var>, one array member is constructed, the value of that member
-                     being the result of evaluating the contained sequence constructor with a <termref def="dt-focus"/>
-                  in which the <termref def="dt-context-item"/> is <var>M</var>, the <termref def="dt-context-position"/>
-                     is the 1-based position of <var>M</var> within <var>R</var>, and the <termref def="dt-context-size"/>
-                     is the number of items in <var>R</var>.</p></item>
+                     <item><p>Let <var>S</var> be the sequence that results from
+                     evaluation of the <code>select</code> expression or the contained
+                     sequence constructor.</p></item>
+                     <item><p>The result of the <elcode>xsl:array</elcode> instruction is
+                     an array having one member for each item <var>S/i</var> in <var>S</var>,
+                        retaining order:
+                        <ulist>
+                           <item><p>If <var>S/i</var> is a <term>parcel</term>, then
+                           the array member is the value encapsulated by the parcel (which may
+                           be any sequence).</p></item>
+                           <item><p>Otherwise,
+                           the array member is the singleton item <var>S/i</var>.</p></item>
+                        </ulist>
+                     </p></item>
                   </olist>
-                  
                </item>
                
+               <item><p>If the <code>for-each</code> attribute is present, then:</p>
+                  <olist>
+                     <item><p>Let <var>F</var> = <var>F/1</var>, <var>F/2</var>, ..., <var>F/n</var>
+                        be the sequence that results from evaluation
+                     of the <code>for-each</code> attribute.</p></item>
+                     <item><p>The resulting array contains one member for each item in <var>F</var>,
+                     retaining order.</p></item>
+                     <item><p>The member corresponding to a particular item <var>F/i</var> is
+                     as follows:</p>
+                     <olist>
+                        <item><p>Let <var>S</var> be the result of evaluating the <code>select</code> expression 
+                           or the contained sequence constructor with a <termref def="dt-focus"/>
+                     in which the <termref def="dt-context-item"/> is <var>F/i</var>, the <termref def="dt-context-position"/>
+                     is <var>i</var> (the 1-based position of <var>F/i</var> within <var>F</var>), 
+                           and the <termref def="dt-context-size"/>
+                     is <var>n</var> (the number of items in <var>F</var>). </p></item>
+                     
+                        <item><p>If <var>S</var> contains a single item and that item is a <term>parcel</term>, 
+                        then the array member is the value encapsulated by the parcel.</p></item>
+                        <item><p>If <var>S</var> contains multiple items and one of those items is a <term>parcel</term>,
+                        then a dynamic error is raised:</p>
+                        <p><error spec="XT" type="dynamic" class="DE" code="4060"><p>It 
+                           is a <termref def="dt-dynamic-error"/> if an <elcode>xsl:array</elcode>
+                        instruction with a <code>for-each</code> attribute includes items constructed
+                        using an <elcode>xsl:array-member</elcode> instruction mixed (in the same array member)
+                        with items not so constructed.</p></error></p></item>
+                        <item>Otherwise, the array member is the sequence <var>S</var>.</item>
+                     
+                  </olist>
+                        <note><p>When the <code>for-each</code> attribute is present, then it is not necessary
+                        to use the <code>xsl:array-member</code> instruction, since each evaluation
+                        of the <code>select</code> attribute or the containing sequence constructor
+                        generates one array member. However, use of <code>xsl:array-member</code>
+                        to construct the array member is permitted, provided that it constructs
+                        the entire array member and not an individual item within it.</p></note>
                
+                     </item>
                
             </olist>
+               </item>
+            </olist>
             
-            <p>The effect of the <elcode>xsl:array-member</elcode> instruction is to return a zero-arity function
-            whose result, when called, is the result of evaluating either the <code>select</code> attribute
-            or the contained <termref def="dt-sequence-constructor"/>, as appropriate.</p>
             
-            <note><p>The content of an array is effectively a sequence of sequences, which the XDM data
-            model does not permit. Representing the value as a sequence of zero-arity functions provides
-            a convenient workaround. When the <code>select</code> and <code>for-each</code> attributes
-            are both absent, the result of the <termref def="dt-sequence-constructor"/> must be a sequence
-            of zero-arity functions, each of which encapsulates the value of one member of the array.
-            The <elcode>xsl:array-member</elcode> instruction provides a convenient and readable way
-            of constructing the required zero-arity functions, but it is not necessary to use this
-            instruction for the purpose; neither is <elcode>xsl:array-member</elcode> restricted
-            to being used only for array construction.</p>
+            <note>
+               <p>The content of an array is effectively a sequence of sequences, which the XDM data
+            model cannot represent directly. Representing an array member as a <term>parcel</term> 
+               (technically, a zero-arity function) provides
+            a convenient workaround.</p>
             
-            <p><emph>As a general rule, <elcode>xsl:array-member</elcode> should be used
-            if and only if the <code>select</code> and <code>for-each</code> attributes
-            of <code>xsl:array</code> are both absent.</emph></p></note>
+               <p><emph>As a general rule, <elcode>xsl:array-member</elcode> should be used
+               if and only if the <code>select</code> and <code>for-each</code> attributes
+               of <code>xsl:array</code> are both absent.</emph></p>
+            </note>
             
             <p>If the <elcode>xsl:array</elcode> instruction has a <code>select</code> attribute then
             the sequence constructor must be empty, except for any <elcode>xsl:fallback</elcode> instructions
@@ -28705,7 +28722,7 @@ the same group, and the-->
             
             
             
-            
+               
             
             <example>
                <head>Constructing an array whose members are single items</head>
@@ -28719,10 +28736,12 @@ the same group, and the-->
                <p>The following example constructs an array containing items computed using nested instructions:</p>
                <eg><![CDATA[<xsl:array>
    <xsl:for-each-group select="0 to 19" group-adjacent=". idiv 4">
-     <xsl:array-member select="string-join(current-group(), '-')"/>
+     <xsl:sequence select="string-join(current-group(), '-')"/>
    </xsl:for-each-group>
 </xsl:array>]]></eg>
                <p>The result is the array <code>[ "0-1-2-3", "4-5-6-7", "8-9-10-11", "12-13-14-15", "16-17-18-19" ]</code>.</p>
+               <p>Note that in this last example, the <elcode>xsl:array-member</elcode> instruction could be used
+               in place of <code>xsl:sequence</code>.</p>
             </example>
             
             <example>
@@ -28736,6 +28755,10 @@ the same group, and the-->
                <eg><![CDATA[<xsl:array for-each="*">                 
    <xsl:apply-templates select="."/>
 </xsl:array>]]></eg>
+            </example>
+                  
+            <example>
+               <head>Constructing a heterogeneous array</head>      
                <p>The following example constructs a heterogeneous array containing a number
                of properties of a supplied node, some of which are sequence-valued:</p>
                <eg><![CDATA[<xsl:array>
@@ -28746,7 +28769,19 @@ the same group, and the-->
      <xsl:array-member select="$node/@*/string()"/>  
 </xsl:array>]]></eg>
                
-                        
+               <p>When applied to an input element such as</p>
+               
+               <eg><![CDATA[<e xmlns="http://example.com/ns" xml:base="http://example.com/loc" x="2"/>]]></eg>
+               
+               <p>the result would be the array:</p>
+               
+               <eg>["e", 
+ "http://example.com/ns", 
+ "http://example.com/loc", 
+ ("http://example.com/ns", "http://www.w3.org/XML/1998/namespace"),
+ ("http://example.com/loc", "2")
+]</eg>
+                 
             </example>
             
             <example>
@@ -28799,15 +28834,7 @@ the same group, and the-->
    <xsl:array select="$input/*[$index]"/>
 </xsl:array>]]></eg>
                
-            </example>
-            
-               
-            
-            
-            
-            
-            
-              
+            </example>      
             
          </div2>
          


### PR DESCRIPTION
Fix #2280

This PR revises the spec of xsl:array and xsl:array-member in the light of experience writing test cases.

The zero-arity function item constructed by `xsl:array-member` now carries a function annotation which means that it can be unambiguously recognized as having been so constructed. This allows better error checking and diagnostics, and it also allows `xsl:array` to be more tolerant of using `xsl:array-member` to create singleton array members in circumstances where it is not strictly required.