### PR TITLE
2276 Relax XSLT rules on Extension Attributes

### DIFF
--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -2527,82 +2527,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
             </div3>
          </div2>
 
-         <div2 id="extension-attributes">
-            <head>Extension Attributes</head>
-            <p>
-               <termdef id="dt-extension-attribute" term="extension attribute">An element from the
-                  XSLT namespace may have any attribute not from the XSLT namespace, provided that
-                  the <termref def="dt-expanded-qname">expanded QName</termref> (see <bibref ref="xpath-40"/>) of the attribute has a non-null namespace URI. These
-                  attributes are referred to as <term>extension attributes</term>.</termdef> The
-               presence of an extension attribute <rfc2119>must not</rfc2119> cause the <termref def="dt-principal-result"/> or any <termref def="dt-secondary-result"/> of the transformation to be different from the
-                  results
-                that a conformant XSLT 4.0
-               processor might produce. They <rfc2119>must not</rfc2119> cause the processor to fail
-               to raise an error that a conformant processor is required to raise. This means that
-               an extension attribute <rfc2119>must not</rfc2119> change the effect of any <termref def="dt-instruction">instruction</termref> except to the extent that the effect is
-                  <termref def="dt-implementation-defined">implementation-defined</termref> or
-                  <termref def="dt-implementation-dependent">implementation-dependent</termref>.</p>
-            <p>Furthermore, if serialization is performed using one of the serialization methods
-                   described in <bibref ref="xslt-xquery-serialization-40"/>, the presence of an extension attribute must
-               not cause the serializer to behave in a way that is inconsistent with the mandatory
-               provisions of that specification.</p>
-            <note>
-               <p>
-                  <termref def="dt-extension-attribute">Extension attributes</termref> may be used
-                  to modify the behavior of <termref def="dt-extension-function">extension
-                     functions</termref> and <termref def="dt-extension-instruction">extension
-                     instructions</termref>. They may be used to select processing options in cases
-                  where the specification leaves the behavior <termref def="dt-implementation-defined">implementation-defined</termref> or <termref def="dt-implementation-dependent">implementation-dependent</termref>. They may
-                  also be used for optimization hints, for diagnostics, or for documentation.</p>
-               <p>
-                  <termref def="dt-extension-attribute">Extension attributes</termref> may also be
-                  used to influence the behavior of the standard serialization methods <code>xml</code>,
-                     <code>xhtml</code>, <code>html</code>, <code>text</code>, <code>json</code>, 
-                  and <code>adaptive</code>, to the extent that
-                  the behavior of the serialization method is <termref def="dt-implementation-defined"/> 
-                  or <termref def="dt-implementation-dependent">implementation-dependent</termref>. For example, an extension attribute might
-                  be used to define the amount of indentation to be used when
-                     <code>indent="yes"</code> is specified. If a serialization method other than
-                  one of these four is requested (using a namespaced QName in the method parameter)
-                  then extension attributes may influence its behavior in arbitrary ways. Extension
-                  attributes <rfc2119>must not</rfc2119> be used to cause the standard serialization methods to
-                  behave in a non-conformant way, for example by failing to report serialization
-                  errors that a serializer is required to report. An implementation that wishes to
-                  provide such options must create a new serialization method for the purpose.</p>
-               <p>An implementation that does not recognize the name of an extension attribute, or
-                  that does not recognize its value, must perform the transformation as if the
-                  extension attribute were not present. As always, it is permissible to produce
-                  warning messages.</p>
-               <p>The namespace used for an extension attribute will be copied to the <termref def="dt-result-tree">result tree</termref> in the normal way if it is in scope
-                  for a <termref def="dt-literal-result-element">literal result element</termref>.
-                  This can be prevented using the <code>[xsl:]exclude-result-prefixes</code>
-                  attribute.</p>
-            </note>
-            <example>
-               <head>An Extension Attribute for <code>xsl:message</code>
-               </head>
-               <p>The following code might be used to indicate to a particular implementation that
-                  the <elcode>xsl:message</elcode> instruction is to ask the user for confirmation
-                  before continuing with the transformation:</p>
-               <eg xml:space="preserve" role="xslt-instruction">&lt;xsl:message abc:pause="yes"
-    xmlns:abc="http://vendor.example.com/xslt/extensions"&gt;
-       Phase 1 complete
-&lt;/xsl:message&gt;
-</eg>
-               <p>Implementations that do not recognize the namespace
-                     <code>http://vendor.example.com/xslt/extensions</code> will simply ignore the
-                  extra attribute, and evaluate the <elcode>xsl:message</elcode> instruction in the
-                  normal way.</p>
-            </example>
-            <p>
-               <error spec="XT" type="static" class="SE" code="0090">
-                  <p>It is a <termref def="dt-static-error">static error</termref> for an element
-                     from the XSLT namespace to have an attribute whose namespace is either null
-                     (that is, an attribute with an unprefixed name) or the XSLT namespace, other
-                     than attributes defined for the element in this document.</p>
-               </error>
-            </p>
-         </div2>
+         
          <div2 id="xslt-media-type">
             <head>XSLT Media Type</head>
             <p>The media type <code>application/xslt+xml</code>
@@ -29118,7 +29043,13 @@ the same group, and the-->
             </change>
          </changes>
          
-         <p>XSLT allows two kinds of extension, extension instructions and extension functions.</p>
+         <p>XSLT allows three kinds of extension: extension attributes, extension instructions, 
+            and extension functions.</p>
+         <p>
+            <termdef id="dt-extension-attribute" term="extension attribute">An <term>extension attribute</term>
+               is an attribute appearing on an <termref def="dt-xslt-element"/>, where the name
+               of the attribute is in a non-null namespace other than the <termref def="dt-xslt-namespace"/>.</termdef>
+         </p>
          <p>
             <termdef id="dt-extension-instruction" term="extension instruction">An <term>extension
                   instruction</term> is an element within a <termref def="dt-sequence-constructor">sequence constructor</termref> that is in a namespace (not the <termref def="dt-xslt-namespace">XSLT namespace</termref>) designated as an extension
@@ -29131,7 +29062,9 @@ the same group, and the-->
          
     
          <p>This specification does not define any mechanism for creating or binding implementations
-            of <termref def="dt-extension-instruction">extension instructions</termref> or <termref def="dt-extension-function">extension functions</termref>, and it is not
+            of <termref def="dt-extension-attribute">extension attributes</termref>,
+            <termref def="dt-extension-instruction">extension instructions</termref>,
+            or <termref def="dt-extension-function">extension functions</termref>, and it is not
                <rfc2119>required</rfc2119> that implementations support any such mechanism. Such
             mechanisms, if they exist, are <termref def="dt-implementation-defined">implementation-defined</termref>. Therefore, an XSLT stylesheet that must be
             portable between XSLT implementations cannot rely on particular extensions being
@@ -29144,13 +29077,110 @@ the same group, and the-->
          <p>
             <error spec="XT" type="static" class="SE" code="0085">
                <p>It is a <termref def="dt-static-error"/> to use a <termref def="dt-reserved-namespace"/>
-                  in the name of any <termref def="dt-extension-function"/> or <termref def="dt-extension-instruction"/>,
+                  in the name of any <termref def="dt-extension-attribute"/>, 
+                  <termref def="dt-extension-function"/>, or <termref def="dt-extension-instruction"/>,
                   other than a function or instruction defined in this specification or in a normatively 
                   referenced specification. It is a <termref def="dt-static-error"/> to use a prefix bound 
                   to a reserved namespace in the <code>[xsl:]extension-element-prefixes</code> attribute.
                </p>
             </error>
          </p>
+         
+         <div2 id="extension-attributes">
+            <head>Extension Attributes</head>
+            <changes>
+               <change issue="2276" date="2025-11-12">The conformance requirements for extension
+                  attributes have been relaxed: the requirement to maintain strict conformance
+               to the specification in the presence of extension attributes is now a <rfc2119>should</rfc2119>
+               rather than a <rfc2119>must</rfc2119>, and extension attributes are allowed to modify
+               the form of serialized output without limitation.</change>
+            </changes>
+            <p>
+               An element from the
+                  XSLT namespace may have any attribute not from the XSLT namespace, provided that
+                  the <termref def="dt-expanded-qname">expanded QName</termref> (see <bibref ref="xpath-40"/>) 
+               of the attribute has a non-null namespace URI. These
+                  attributes are referred to as <termref def="dt-extension-attribute">extension attributes</termref>.</p>
+            
+            <p>It is not necessary to declare the namespace used for an extension attribute using
+            <code>[xsl:]extension-element-prefixes</code> or otherwise.</p>
+            
+            <p>The presence of an extension attribute <rfc2119>should not</rfc2119> 
+               cause the <termref def="dt-principal-result"/> or any <termref def="dt-secondary-result"/> 
+               of the transformation to be different from the results
+                that a conformant XSLT 4.0
+               processor might produce. They <rfc2119>should not</rfc2119> cause the processor to fail
+               to raise an error that a conformant processor is required to raise. This means that
+               an extension attribute <rfc2119>should not</rfc2119> change the effect of any 
+               <termref def="dt-instruction">instruction</termref> except to the extent that the effect is
+                  <termref def="dt-implementation-defined">implementation-defined</termref> or
+                  <termref def="dt-implementation-dependent">implementation-dependent</termref>.</p>
+            
+            <p>A processor <rfc2119>may</rfc2119> make an exception to the above rule in certain cases, for
+            example:</p>
+            
+            <ulist>
+               <item><p>To allow the user to opt out of some provision in the specification that has
+               undesirable performance implications (for example, the requirement that functions like
+               <xfunction>doc</xfunction> and <xfunction>collection</xfunction> be deterministic).</p></item>
+               <item><p>To enable interoperability with third-party software that is not otherwise
+               achievable.</p></item>
+               <item><p>To allow the user to disable functionality for security reasons.</p></item>
+            </ulist>
+            <p>Extension attributes <rfc2119>may</rfc2119> change the form of serialized output
+               in a way that overrides the provisions of <bibref ref="xslt-xquery-serialization-40"/>, 
+               including the suppression of error conditions defined in that specification.</p>
+            <note>
+               <p>
+                  <termref def="dt-extension-attribute">Extension attributes</termref> may be used
+                  to modify the behavior of <termref def="dt-extension-function">extension
+                     functions</termref> and <termref def="dt-extension-instruction">extension
+                     instructions</termref>. They may be used to select processing options in cases
+                  where the specification leaves the behavior 
+                  <termref def="dt-implementation-defined">implementation-defined</termref> 
+                  or <termref def="dt-implementation-dependent">implementation-dependent</termref>. They may
+                  also be used for optimization hints, for diagnostics, or for documentation.</p>
+               <p>
+                  <termref def="dt-extension-attribute">Extension attributes</termref> may also be
+                  used to influence the behavior of the standard serialization methods <code>xml</code>,
+                     <code>xhtml</code>, <code>html</code>, <code>text</code>, <code>json</code>, 
+                  and <code>adaptive</code>. For example, an extension attribute might
+                  be used to define the amount of indentation to be used when
+                     <code>indent="yes"</code> is specified.</p>
+               <p>An implementation that does not recognize the name of an extension attribute, or
+                  that does not recognize its value, must perform the transformation as if the
+                  extension attribute were not present. As always, it is permissible to produce
+                  warning messages.</p>
+               <p>The namespace used for an extension attribute will be copied to the <termref def="dt-result-tree">result tree</termref> in the normal way if it is in scope
+                  for a <termref def="dt-literal-result-element">literal result element</termref>.
+                  This can be prevented using the <code>[xsl:]exclude-result-prefixes</code>
+                  attribute.</p>
+            </note>
+            <example>
+               <head>An Extension Attribute for <code>xsl:message</code>
+               </head>
+               <p>The following code might be used to indicate to a particular implementation that
+                  the <elcode>xsl:message</elcode> instruction is to ask the user for confirmation
+                  before continuing with the transformation:</p>
+               <eg xml:space="preserve" role="xslt-instruction">&lt;xsl:message abc:pause="yes"
+    xmlns:abc="http://vendor.example.com/xslt/extensions"&gt;
+       Phase 1 complete
+&lt;/xsl:message&gt;
+</eg>
+               <p>Implementations that do not recognize the namespace
+                     <code>http://vendor.example.com/xslt/extensions</code> will simply ignore the
+                  extra attribute, and evaluate the <elcode>xsl:message</elcode> instruction in the
+                  normal way.</p>
+            </example>
+            <p>
+               <error spec="XT" type="static" class="SE" code="0090">
+                  <p>It is a <termref def="dt-static-error">static error</termref> for an element
+                     from the XSLT namespace to have an attribute whose namespace is either null
+                     (that is, an attribute with an unprefixed name) or the XSLT namespace, other
+                     than attributes defined for the element in this document.</p>
+               </error>
+            </p>
+         </div2>
 
          <div2 id="extension-functions">
             <head>Extension Functions</head>


### PR DESCRIPTION
Changes the rule for extension attributes, instead of saying they MUST NOT cause non-conformant behaviour, we now say SHOULD NOT, and give examples where it might be appropriate to break this rule, e.g. for security. Also, extension attributes can now modify the behaviour of the serializer in any way they like.

The PR also moves the section on Extension Attributes to a more logical place in the spec.