### PR TITLE
Updated schema for XSLT 4.0 stylesheets

### DIFF
--- a/specifications/xslt-40/src/schema-for-xslt40.xsd
+++ b/specifications/xslt-40/src/schema-for-xslt40.xsd
@@ -178,7 +178,8 @@ of problems processing the schema using various tools
                       xsl:processing-instruction
                       xsl:record 
                       xsl:record-type 
-                      xsl:result-document 
+                      xsl:result-document
+                      xsl:select
                       xsl:sequence 
                       xsl:sort 
                       xsl:source-document 
@@ -202,9 +203,9 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           This complex type provides a generic supertype for all XSLT elements; it
-           contains the definitions of the standard attributes that may appear on
-           any element.
+           This complex type provides a generic supertype for all XSLT elements except 
+           <code>xsl:record</code>; it contains the definitions of the standard attributes 
+           that may appear on any element.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -216,6 +217,7 @@ of problems processing the schema using various tools
     <xs:attribute name="exclude-result-prefixes" type="xsl:prefix-list-or-all"/>
     <xs:attribute name="expand-text" type="xsl:yes-or-no"/>
     <xs:attribute name="extension-element-prefixes" type="xsl:prefix-list"/>
+    <xs:attribute name="schema-role" type="xs:NCName"/>
     <xs:attribute name="use-when" type="xsl:expression"/>
     <xs:attribute name="xpath-default-namespace" type="xs:anyURI"/>
     <xs:attribute name="_default-collation" type="xs:string"/>
@@ -224,6 +226,7 @@ of problems processing the schema using various tools
     <xs:attribute name="_exclude-result-prefixes" type="xs:string"/>
     <xs:attribute name="_expand-text" type="xs:string"/>
     <xs:attribute name="_extension-element-prefixes" type="xs:string"/>
+    <xs:attribute name="_schema-role" type="xs:string"/>
     <xs:attribute name="_use-when" type="xs:string"/>
     <xs:attribute name="_xpath-default-namespace" type="xs:string"/>
     <xs:anyAttribute namespace="##other" processContents="lax"/>
@@ -239,12 +242,14 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>This complex type provides a generic supertype for all XSLT elements with
-                the exception of <code>xsl:output</code>; it contains the
+                the exception of <code>xsl:output</code> and <code>xsl:record</code>; it contains the
                 definitions of the <code>version</code> attribute that may appear on any element.
                 </p>
         <p>The <code>xsl:output</code> element does not use this definition because, although it
              has a <code>version</code> attribute, the syntax and semantics of this attribute are
              unrelated to the standard <code>version</code> attribute allowed on other elements.</p>
+        <p>Similarly <code>xsl:record</code> does not use this definition because it expects
+        standard attributes (including [xsl:]version) to be in the XSLT namespace.</p>
       </xs:documentation>
     </xs:annotation>
     <xs:complexContent>
@@ -329,6 +334,7 @@ of problems processing the schema using various tools
     </xs:annotation>
     <xs:choice>
       <xs:element ref="xsl:instruction"/>
+      <xs:element ref="xsl:record"/>
       <xs:group ref="xsl:result-elements"/>
     </xs:choice>
   </xs:group>
@@ -484,9 +490,17 @@ of problems processing the schema using various tools
     </xs:complexType>
   </xs:element>
   
-  <xs:element name="array"
-              substitutionGroup="xsl:instruction"
-              type="xsl:sequence-constructor-or-select"/>
+  <xs:element name="array" 
+              substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:sequence-constructor-or-select">
+          <xs:attribute name="for-each" type="xsl:expression"/>
+          <xs:attribute name="_for-each" type="xs:string"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
   
   <xs:element name="array-member"
               substitutionGroup="xsl:instruction"
@@ -994,7 +1008,7 @@ of problems processing the schema using various tools
                       minOccurs="0"
                       maxOccurs="unbounded"/>
           </xs:sequence>
-          <xs:attribute name="name" type="xsl:EQName-in-namespace"/>
+          <xs:attribute name="name" type="xsl:EQName"/>
           <xs:attribute name="override" type="xsl:yes-or-no" default="yes"/>
           <xs:attribute name="as" type="xsl:sequence-type" default="item()*"/>
           <xs:attribute name="visibility" type="xsl:visibility-not-hidden-type"/>
@@ -1279,6 +1293,7 @@ of problems processing the schema using various tools
             <xs:element ref="xsl:fallback"/> 
           </xs:choice>
           <xs:attribute name="as" type="xsl:sequence-type"/>
+          <xs:attribute name="copy-namespaces" type="xsl:yes-or-no" default="yes"/>
           <xs:attribute name="name" type="xsl:EQName"/>
           <xs:attribute name="streamable" type="xsl:yes-or-no" default="no"/>
           <xs:attribute name="use-accumulators" type="xsl:accumulator-names"/>
@@ -1299,6 +1314,7 @@ of problems processing the schema using various tools
             </xs:simpleType>
           </xs:attribute>
           <xs:attribute name="_as" type="xs:string"/>
+          <xs:attribute name="_copy-namespaces" type="xs:string"/>
           <xs:attribute name="_name" type="xs:string"/>
           <xs:attribute name="_streamable" type="xs:string"/>
           <xs:attribute name="_use-accumulators" type="xs:string"/>
@@ -1656,6 +1672,21 @@ of problems processing the schema using various tools
     </xs:complexType>
   </xs:element>
   
+  <xs:element name="record">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:sequence-constructor">  
+          <xs:attribute name="as" form="qualified" type="xsl:sequence-type"/>
+          <xs:attribute name="duplicates" form="qualified" type="xsl:sequence-type"/>
+          <xs:attribute name="_as" form="qualified" type="xs:string"/>
+          <xs:attribute name="_duplicates" form="qualified" type="xs:string"/>
+          <xs:attributeGroup ref="xsl:literal-result-element-attributes"/>
+          <xs:anyAttribute namespace="##local" processContents="lax"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  
   <xs:element name="record-type" substitutionGroup="xsl:declaration">
     <xs:complexType>
       <xs:complexContent>
@@ -1744,6 +1775,28 @@ of problems processing the schema using various tools
               <xs:documentation>
                 <p>The <code>type</code> and <code>validation</code> attributes are mutually exclusive
                   (if one is present, the other must be absent).</p>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:assert>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  
+  <xs:element name="select"
+              substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:versioned-element-type">
+          <xs:sequence>
+            <xs:element ref="xsl:fallback" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>  
+          <xs:attribute name="as" type="xsl:sequence-type"/>
+          <xs:attribute name="_as" type="xs:string"/>
+          <xs:assert test="empty(xsl:fallback/preceding-sibling::text()[normalize-space()])">
+            <xs:annotation>
+              <xs:documentation>
+                <p>An xsl:fallback child must not be preceded by a non-whitespace text node.</p>
               </xs:documentation>
             </xs:annotation>
           </xs:assert>
@@ -2218,12 +2271,13 @@ of problems processing the schema using various tools
     <xs:attribute name="exclude-result-prefixes" 
                   form="qualified" 
                   type="xsl:prefix-list-or-all"/>
-    <xs:attribute name="xpath-default-namespace" 
-                  form="qualified" 
-                  type="xs:anyURI"/>
     <xs:attribute name="inherit-namespaces"
                   form="qualified"
                   type="xsl:yes-or-no"
+                  default="yes"/>
+    <xs:attribute name="schema-role"
+                  form="qualified"
+                  type="xs:NCName"
                   default="yes"/>
     <xs:attribute name="use-attribute-sets"
                   form="qualified"
@@ -2241,6 +2295,9 @@ of problems processing the schema using various tools
     <xs:attribute name="validation" 
                   form="qualified" 
                   type="xsl:validation-type"/>
+    <xs:attribute name="xpath-default-namespace" 
+                  form="qualified" 
+                  type="xs:anyURI"/>
   </xs:attributeGroup>
 
   <xs:group name="result-elements">
@@ -2705,7 +2762,7 @@ of problems processing the schema using various tools
            An extended QName. This schema does not use the built-in type <code>xs:QName</code>,
            but rather defines its own QName type. This may be either a local name,
            or a prefixed QName, or a name written using the extended QName notation
-           <code>Q{uri}local</code>
+           <code>Q{uri}[prefix:]local</code>
         </p>
         <p>In XSLT 4.0, where a QName is used in the <code>name</code> attribute
         of (say) <code>xsl:template</code> or <code>xsl:call-template</code>, the prefix
@@ -2725,7 +2782,7 @@ of problems processing the schema using various tools
       </xs:simpleType>
       <xs:simpleType>
         <xs:restriction base="xs:token">
-          <xs:pattern value="Q\{[^{}]*\}[\i-[:]][\c-[:]]*"/>
+          <xs:pattern value="Q\{[^{}]*\}[\i-[:]][\c-[:]]*(:[\i-[:]][\c-[:]]*)?"/>
         </xs:restriction>
       </xs:simpleType>
     </xs:union>


### PR DESCRIPTION
Updated schema for XSLT 4.0 stylesheets (verified against the current test cases using test catalog-005).

Changes include: xsl:record, xsl:array, xsl:select, @schema-role, mode/@copy-namespaces, EQName syntax, xsl:function/@name