### PR TITLE
Updated RELAX NG grammar for XSLT 4.0 stylesheets

### DIFF
--- a/specifications/xslt-40/src/schema-for-xslt40.rnc
+++ b/specifications/xslt-40/src/schema-for-xslt40.rnc
@@ -36,7 +36,7 @@ start =
   | package.element  
   | literal-result-element-as-stylesheet
   
-sequence-constructor.model = (instruction.category | literal-result-element | text)*
+sequence-constructor.model = (instruction.category | record.element | literal-result-element | text)*
 
 literal-result-element-as-stylesheet =
   element * - xsl:* {
@@ -79,6 +79,7 @@ literal-result-element-no-version.atts =
  & attribute xsl:use-attribute-sets { eqnames.datatype }?
  & attribute xsl:use-when { expression.datatype }?
  & attribute xsl:xpath-default-namespace { xsd:anyURI }?
+ & attribute xsl:schema-role { ncname.datatype }?
  & (attribute xsl:type { eqname.datatype }
     | attribute xsl:validation { "strict" | "lax" | "preserve" | "strip" })?
 
@@ -260,6 +261,7 @@ instruction.category =
  | assert.element
  | fallback.element
  | result-document.element
+ | select.element
 package.element =
    element package {
       extension.atts,
@@ -499,24 +501,28 @@ mode.element =
    element mode {
       extension.atts,
       global.atts,
-      attribute name { eqname.datatype }?,
-      attribute _name { avt.datatype }?,
-      attribute streamable { boolean.datatype }?,
-      attribute _streamable { avt.datatype }?,
-      attribute on-no-match { "deep-copy" | "shallow-copy" | "shallow-copy-all" | "deep-skip" | "shallow-skip" | "text-only-copy" | "fail" }?,
-      attribute _on-no-match { avt.datatype }?,
-      attribute on-multiple-match { "use-last" | "fail" }?,
-      attribute _on-multiple-match { avt.datatype }?,
-      attribute warning-on-no-match { boolean.datatype }?,
-      attribute _warning-on-no-match { avt.datatype }?,
-      attribute warning-on-multiple-match { boolean.datatype }?,
-      attribute _warning-on-multiple-match { avt.datatype }?,
-      attribute typed { boolean.datatype | "strict" | "lax" | "unspecified" }?,
-      attribute _typed { avt.datatype }?,
-      attribute visibility { "public" | "private" | "final" }?,
-      attribute _visibility { avt.datatype }?,
-      attribute use-accumulators { tokens.datatype }?,
-      attribute _use-accumulators { avt.datatype }?,
+      (attribute as { sequence-type.datatype }?
+      | attribute _as { avt.datatype }?),
+      (attribute copy-namespaces { boolean.datatype }?
+      | attribute _copy-namespaces { boolean.datatype }?),
+      (attribute name { eqname.datatype }?
+      | attribute _name { avt.datatype }?),
+      (attribute streamable { boolean.datatype }?
+      | attribute _streamable { avt.datatype }?),
+      (attribute on-no-match { "deep-copy" | "shallow-copy" | "shallow-copy-all" | "deep-skip" | "shallow-skip" | "text-only-copy" | "fail" }?
+      | attribute _on-no-match { avt.datatype }?),
+      (attribute on-multiple-match { "use-last" | "fail" }?
+      | attribute _on-multiple-match { avt.datatype }?),
+      (attribute warning-on-no-match { boolean.datatype }?
+      | attribute _warning-on-no-match { avt.datatype }?),
+      (attribute warning-on-multiple-match { boolean.datatype }?
+      | attribute _warning-on-multiple-match { avt.datatype }?),
+      (attribute typed { boolean.datatype | "strict" | "lax" | "unspecified" }?
+      | attribute _typed { avt.datatype }?),
+      (attribute visibility { "public" | "private" | "final" }?
+      | attribute _visibility { avt.datatype }?),
+      (attribute use-accumulators { tokens.datatype }?
+      | attribute _use-accumulators { avt.datatype }?),
       empty
    }
 context-item.element =
@@ -715,20 +721,20 @@ function.element =
       global.atts,
       (attribute name { eqname.datatype }
       | attribute _name { avt.datatype })+,
-      attribute as { sequence-type.datatype }?,
-      attribute _as { avt.datatype }?,
-      attribute visibility { "public" | "private" | "final" | "abstract" }?,
-      attribute _visibility { avt.datatype }?,
-      attribute streamability { "unclassified" | "absorbing" | "inspection" | "filter" | "shallow-descent" | "deep-descent" | "ascent" | eqname.datatype }?,
-      attribute _streamability { avt.datatype }?,
-      attribute override-extension-function { boolean.datatype }?,
-      attribute _override-extension-function { avt.datatype }?,
-      attribute override { boolean.datatype }?,
-      attribute _override { avt.datatype }?,
-      attribute new-each-time { "yes" | "true" | "1" | "no" | "false" | "0" | "maybe" }?,
-      attribute _new-each-time { avt.datatype }?,
-      attribute cache { boolean.datatype }?,
-      attribute _cache { avt.datatype }?,
+      (attribute as { sequence-type.datatype }?
+      | attribute _as { avt.datatype }?),
+      (attribute visibility { "public" | "private" | "final" | "abstract" }?
+      | attribute _visibility { avt.datatype }?),
+      (attribute streamability { "unclassified" | "absorbing" | "inspection" | "filter" | "shallow-descent" | "deep-descent" | "ascent" | eqname.datatype }?
+      | attribute _streamability { avt.datatype }?),
+      (attribute override-extension-function { boolean.datatype }?
+      | attribute _override-extension-function { avt.datatype }?),
+      (attribute override { boolean.datatype }?
+      | attribute _override { avt.datatype }?),
+      (attribute new-each-time { "yes" | "true" | "1" | "no" | "false" | "0" | "maybe" }?
+      | attribute _new-each-time { avt.datatype }?),
+      (attribute cache { boolean.datatype }?
+      | attribute _cache { avt.datatype }?),
       (param.element*, sequence-constructor.model)
    }
 evaluate.element =
@@ -828,9 +834,46 @@ processing-instruction.element =
       extension.atts,
       global.atts,
       (attribute name { ncname.datatype | avt.datatype }
-      | attribute _name { avt.datatype })+,
+      | attribute _name { avt.datatype }),
       select-or-sequence-constructor.model
    }
+record.element = 
+   element record {
+      (attribute as { sequence-type.datatype }?
+      | attribute _as { avt.datatype }?),
+      (attribute duplicates { expression.datatype }?
+      | attribute _duplicates { avt.datatype }?),
+      sequence-constructor.model
+  }
+record-type.element = 
+   element record-type {
+      (attribute name { ncname.datatype | avt.datatype }
+      | attribute _name { avt.datatype }),
+      (attribute extensible { boolean.datatype }?
+      | attribute _extensible { avt.datatype }?),
+      (attribute visibility { "public" | "private" | "final" | "abstract" | "hidden" }?
+      | attribute _visibility { avt.datatype }?),
+      field.element*
+  }
+field.element = 
+   element field {
+      (attribute name { ncname.datatype | avt.datatype }
+      | attribute _name { avt.datatype }),
+      (attribute as { sequence-type.datatype }?
+      | attribute _as { avt.datatype }?),
+      (attribute required { boolean.datatype }?
+      | attribute _required { avt.datatype }?),
+      (attribute \default { expression.datatype }?
+      |attribute _default { expression.datatype }?),
+      empty
+  }
+
+select.element = 
+   element select {
+      (attribute as { sequence-type.datatype }?
+      | attribute _as { avt.datatype }?),
+      (fallback.element | text)*
+  }
 namespace.element =
    element namespace {
       extension.atts,
@@ -1123,11 +1166,12 @@ key.element =
    }
 map.element =
    element map {
+      (attribute duplicates { expression.datatype }?
+      | attribute _duplicates { avt.datatype }?),
       extension.atts,
       global.atts,
       select-or-sequence-constructor.model
    }
-# TODO: add @duplicates
 
 map-entry.element =
    element map-entry {
@@ -1140,6 +1184,8 @@ map-entry.element =
 
 array.element =
   element array {
+    (attribute for-each { expression.datatype }
+     | attribute _for-each { expression.datatype }),
     extension.atts,
     global.atts,
     select-or-sequence-constructor.model


### PR DESCRIPTION
This is mostly a copy of #2290, translated into the RELAX NG grammar.

I think the grammar still needs review, but I’m trying to keep it up-to-date with the XSD in the meantime.