### PR TITLE
2288 XSLT implicit document nodes

### DIFF
--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -17570,12 +17570,11 @@ return $tree =?> depth()]]></eg>
          <div2 id="variable-values">
             <head>Values of Variables and Parameters</head>
             <changes>
-               <change issue="2009" PR="2015" date="2025-05-20">
+               <change issue="2009 2288" PR="2015 2296" date="2025-05-20">
                   A variable-binding with no <code>as</code> or <code>select</code> attribute no longer
                   attempts to create an implicit document node if the sequence constructor contains
-                  an <elcode>xsl:map</elcode>, <elcode>xsl:map-entry</elcode>, <elcode>xsl:array</elcode>, 
-                  <elcode>xsl:array-member</elcode>, or <elcode>xsl:select</elcode>
-                  child instruction.
+                  certain instructions (such as <elcode>xsl:map</elcode>, <elcode>xsl:array</elcode>, 
+                  <elcode>xsl:record</elcode>, and <elcode>xsl:select</elcode>).
                </change>
             </changes>
             <p>A <termref def="dt-variable-binding-element">variable-binding element</termref> may


### PR DESCRIPTION
1. Adds xsl:record, xsl:map-entry, xsl:array-member to the list of instructions that inhibit creating of an implicit document node. (It makes no sense to wrap an array or map in a document node)
2. Mentions the revised rules in places where one would expect it to be mentioned.