### PR TITLE
QT4CG-141-01 Fix formal equivalent of array:for-each

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -30711,9 +30711,9 @@ $array
       <fos:equivalent style="xpath-expression">
 array:of-members(
   for-each(array:members($array), 
-  fn($member, $pos) {
-    { 'value': $action($member, $pos) }
-  })
+           fn($member, $pos) {
+              { 'value': $action(map:get($member, 'value'), $pos) }
+           })
 )
       </fos:equivalent>
       <fos:examples>


### PR DESCRIPTION
Need `$member?value` not `$member`