### PR TITLE
2299 Allow SimpleMapExpr after ArrowExpr

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1812,13 +1812,14 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   <g:production name="SimpleMapExpr" condition="&gt; 1" if="xpath40 xquery40  xslt40-patterns">
     <g:ref name="PathExpr"/>
     <g:zeroOrMore>
-      <g:ref name="SimpleMapTarget"/>
+      <g:string>!</g:string>
+      <g:ref name="PathExpr"/>
     </g:zeroOrMore>
   </g:production>
 
   <g:production name="SimpleMapTarget" if="xpath40 xquery40  xslt40-patterns">
     <g:string>!</g:string>
-    <g:ref name="PathExpr"/>
+    <g:ref name="StepExpr"/>
   </g:production>
 
   <!-- ] end OrExpr etc -->

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -23471,7 +23471,7 @@ return string-join($chopped, '; ')
          </scrap>
 
          <scrap>
-            <prodrecap ref="ArrowExpr"/>
+            <prodrecap ref="SimpleMapTarget"/>
          </scrap>
 
          <p>


### PR DESCRIPTION
Fix #2299

Allow the form `A => B() ! C` and make it equivalent to `( A => B() ) ! C`.  Also, allow all operators from `PostfixExpr` in the same manner.
