### PR TITLE
2327 Rename sequence-join as intersperse

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -15523,9 +15523,9 @@ for-each(1 to $count, fn($item, $pos) { $input })
       </fos:changes>
    </fos:function>
    
-   <fos:function name="intersperse" prefix="fn">
+   <fos:function name="insert-separator" prefix="fn">
       <fos:signatures>
-         <fos:proto name="intersperse" return-type="item()*">
+         <fos:proto name="insert-separator" return-type="item()*">
             <fos:arg name="input" type="item()*" usage="navigation"/>
             <fos:arg name="separator" type="item()*" usage="navigation"/>
          </fos:proto>
@@ -15552,29 +15552,29 @@ for-each($input, fn($item, $pos) {
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>intersperse(1 to 5, "|")</fos:expression>
+               <fos:expression>insert-separator(1 to 5, "|")</fos:expression>
                <fos:result>1, "|", 2, "|" , 3, "|", 4, "|", 5</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>intersperse((), "|")</fos:expression>
+               <fos:expression>insert-separator((), "|")</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>intersperse("A", "|")</fos:expression>
+               <fos:expression>insert-separator("A", "|")</fos:expression>
                <fos:result>"A"</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>intersperse(1 to 3, ("⅓", "⅔"))</fos:expression>
+               <fos:expression>insert-separator(1 to 3, ("⅓", "⅔"))</fos:expression>
                <fos:result>1, "⅓", "⅔", 2, "⅓", "⅔", 3</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>Insert an empty <code>hr</code> element between adjacent paragraphs:</p>
-            <eg><![CDATA[intersperse(./para, <hr/>)]]></eg>
+            <eg><![CDATA[insert-separator(./para, <hr/>)]]></eg>
          </fos:example>
       </fos:examples>
       <fos:changes>
-         <fos:change issue="2 868" PR="1504" date="2022-09-27"><p>New in 4.0</p></fos:change>
+         <fos:change issue="2 868 2327" PR="1504 2329" date="2022-09-27"><p>New in 4.0</p></fos:change>
       </fos:changes>
    </fos:function>
    

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -1328,8 +1328,8 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
             <div3 id="func-insert-before">
                <head><?function fn:insert-before?></head>
             </div3>
-            <div3 id="func-intersperse" diff="add" at="A">
-               <head><?function fn:intersperse?></head>
+            <div3 id="func-insert-separator">
+               <head><?function fn:insert-separator?></head>
             </div3>
             <div3 id="func-items-at" diff="add" at="2022-11-16">
                <head><?function fn:items-at?></head>


### PR DESCRIPTION
Reverts the function to its original name.

The name `sequence-join` seems to be based on a false analogy with string-join (which joins multiple strings with an optional separator) and array-join (which joins multiple arrays with an optional separator). The sequence-join function is quite different, it does not join multiple sequences. The name `intersperse` far better describes what the function actually does.