### PR TITLE
2299 Expand pipeline to allow arrow expression in path expression

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1674,17 +1674,21 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   </g:production>
 
   <g:production name="UnsignedUnaryExpr">
-    <g:ref name="ValueExpr"/>
+    <g:ref name="ValueExprU"/>
   </g:production>
 
   <g:production name="ValueExpr">
+    <g:ref name="SimpleMapExpr"/>
+  </g:production>
+
+  <g:production name="ValueExprU">
     <g:choice>
       <g:ref name="ValidateExpr" if="xquery40"/>
       <g:ref name="ExtensionExpr" if="xquery40"/>
       <g:ref name="SimpleMapExpr"/>
     </g:choice>
   </g:production>
-  
+
   
   <g:production name="SequenceArrowTarget" if="xpath40 xquery40 xslt40-patterns">
     <g:string>=></g:string>

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1655,17 +1655,28 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
       </g:choice>
     </g:zeroOrMore>
   </g:production>
-  
+
   <g:production name="UnaryExpr">
-    <g:zeroOrMore>
+    <g:choice>
+      <g:ref name="SignedUnaryExpr"/>
+      <g:ref name="UnsignedUnaryExpr"/>
+    </g:choice>
+  </g:production>
+
+  <g:production name="SignedUnaryExpr">
+    <g:oneOrMore>
       <g:choice>
         <g:string>-</g:string>
         <g:string>+</g:string>
       </g:choice>
-    </g:zeroOrMore>
+    </g:oneOrMore>
     <g:ref name="ValueExpr"/>
   </g:production>
-  
+
+  <g:production name="UnsignedUnaryExpr">
+    <g:ref name="ValueExpr"/>
+  </g:production>
+
   <g:production name="ValueExpr">
     <g:choice>
       <g:ref name="ValidateExpr" if="xquery40"/>

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1647,17 +1647,33 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   </g:production>
   
   <g:production name="ArrowExpr">
-    <g:ref name="UnaryExpr"/>
+    <g:choice>
+      <g:ref name="ArrowExprS"/>
+      <g:ref name="UnsignedUnaryExpr"/>
+    </g:choice>
+  </g:production>
+
+  <g:production name="UnaryExpr">
+    <!-- This one is used only in XPath 4.0 prose -->
+    <g:choice>
+      <g:ref name="SignedUnaryExpr"/>
+      <g:ref name="UnsignedUnaryExpr"/>
+    </g:choice>
+  </g:production>
+
+  <g:production name="ArrowExprS">
+    <!-- always with a leading unary sign -->
+    <g:ref name="SignedUnaryExpr"/>
     <g:zeroOrMore>
       <g:ref name="ArrowTarget"/>
     </g:zeroOrMore>
   </g:production>
 
-  <g:production name="UnaryExpr">
-    <g:choice>
-      <g:ref name="SignedUnaryExpr"/>
-      <g:ref name="UnsignedUnaryExpr"/>
-    </g:choice>
+  <g:production name="ArrowExprU">
+    <!-- always with one `ArrowTarget` -->
+    <!-- this works because it is an optional part of `RelativePathExprU` -->
+    <g:ref name="UnsignedUnaryExpr"/>
+    <g:ref name="ArrowTarget"/>
   </g:production>
 
   <g:production name="SignedUnaryExpr">
@@ -1667,22 +1683,22 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
         <g:string>+</g:string>
       </g:choice>
     </g:oneOrMore>
-    <g:ref name="ValueExpr"/>
+    <g:ref name="ValueExprS"/>
   </g:production>
 
   <g:production name="UnsignedUnaryExpr">
     <g:ref name="ValueExprU"/>
   </g:production>
 
-  <g:production name="ValueExpr">
-    <g:ref name="SimpleMapExpr"/>
+  <g:production name="ValueExprS">
+    <g:ref name="SimpleMapExprS"/>
   </g:production>
 
   <g:production name="ValueExprU">
     <g:choice>
       <g:ref name="ValidateExpr" if="xquery40"/>
       <g:ref name="ExtensionExpr" if="xquery40"/>
-      <g:ref name="SimpleMapExpr"/>
+      <g:ref name="SimpleMapExprU"/>
     </g:choice>
   </g:production>
 
@@ -1821,12 +1837,30 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   </g:production>
 
   <g:production name="SimpleMapExpr" condition="&gt; 1" if="xpath40 xquery40  xslt40-patterns">
+    <!-- This one is used only in XPath 4.0 prose -->
+    <g:choice>
+      <g:ref name="SimpleMapExprS"/>
+      <g:ref name="SimpleMapExprU"/>
+    </g:choice>
+  </g:production>
+
+  <g:production name="SimpleMapExprS" condition="&gt; 1" if="xpath40 xquery40  xslt40-patterns">
     <g:ref name="PathExpr"/>
     <g:zeroOrMore>
       <g:string>!</g:string>
       <g:ref name="PathExpr"/>
     </g:zeroOrMore>
   </g:production>
+
+  <g:production name="SimpleMapExprU" condition="&gt; 1" if="xpath40 xquery40  xslt40-patterns">
+    <g:ref name="PathExprU"/>
+    <g:zeroOrMore>
+      <g:string>!</g:string>
+      <g:ref name="PathExpr"/>
+      <!-- NB: other operands cannot contain `ArrowExprU`, so `PathExpr` instead of `PathExprU` is used here -->
+    </g:zeroOrMore>
+  </g:production>
+
 
   <!-- ] end OrExpr etc -->
 
@@ -1838,7 +1872,15 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
       <g:ref name="RelativePathExpr"/>
     </g:choice>
   </g:production>
-  
+
+  <g:production name="PathExprU" xgc-id="leading-lone-slash">
+    <g:choice break="true" name="PathExprChoicesU">
+      <g:ref name="AbsolutePathExpr"/>
+      <g:ref name="RelativePathExprU"/>
+    </g:choice>
+  </g:production>
+
+
   <g:production name="AbsolutePathExpr">
     <g:choice>
       <g:sequence>
@@ -1858,6 +1900,16 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   <g:production name="RelativePathExpr" node-type="void">
     <g:ref name="StepExpr"/>
     <g:zeroOrMore name="RelativePathExprTail">
+      <g:ref name="RelativePathTarget"/>
+    </g:zeroOrMore>
+  </g:production>
+
+  <g:production name="RelativePathExprU" node-type="void">
+    <g:choice>
+      <g:ref name="ArrowExprU"/>
+      <g:ref name="StepExpr"/>
+    </g:choice>
+    <g:zeroOrMore name="RelativePathExprTailU">
       <g:ref name="RelativePathTarget"/>
     </g:zeroOrMore>
   </g:production>

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1858,12 +1858,16 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   <g:production name="RelativePathExpr" node-type="void">
     <g:ref name="StepExpr"/>
     <g:zeroOrMore name="RelativePathExprTail">
-      <g:choice name="RelativePathExprStepSep">
-        <g:string>/</g:string>
-        <g:string>//</g:string>
-      </g:choice>
-      <g:ref name="StepExpr"/>
+      <g:ref name="RelativePathTarget"/>
     </g:zeroOrMore>
+  </g:production>
+
+  <g:production name="RelativePathTarget">
+    <g:choice name="RelativePathExprStepSep">
+      <g:string>/</g:string>
+      <g:string>//</g:string>
+    </g:choice>
+    <g:ref name="StepExpr"/>
   </g:production>
 
   <g:production name="StepExpr" node-type="void">

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1649,10 +1649,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   <g:production name="ArrowExpr">
     <g:ref name="UnaryExpr"/>
     <g:zeroOrMore>
-      <g:choice>
-        <g:ref name="SequenceArrowTarget"/>
-        <g:ref name="MappingArrowTarget"/>
-      </g:choice>
+      <g:ref name="ArrowTarget"/>
     </g:zeroOrMore>
   </g:production>
 
@@ -1689,18 +1686,25 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     </g:choice>
   </g:production>
 
-  
+
+  <g:production name="ArrowTarget" if="xpath40 xquery40 xslt40-patterns">
+    <g:choice>
+      <g:ref name="SequenceArrowTarget"/>
+      <g:ref name="MappingArrowTarget"/>
+    </g:choice>
+  </g:production>
+
   <g:production name="SequenceArrowTarget" if="xpath40 xquery40 xslt40-patterns">
     <g:string>=></g:string>
-    <g:ref name="ArrowTarget"/>
+    <g:ref name="ArrowTargetCall"/>
   </g:production>
   
   <g:production name="MappingArrowTarget" if="xpath40 xquery40 xslt40-patterns">
     <g:string>=!></g:string>
-    <g:ref name="ArrowTarget"/>
+    <g:ref name="ArrowTargetCall"/>
   </g:production>
   
-  <g:production name="ArrowTarget" if="xpath40 xquery40 xslt40-patterns">
+  <g:production name="ArrowTargetCall" if="xpath40 xquery40 xslt40-patterns">
     <g:choice>
       <g:ref name="FunctionCall"/>
       <g:ref name="RestrictedDynamicCall"/>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -11603,10 +11603,18 @@ return $incrementors[2](4)]]></eg>
                Path expressions are extended to handle JNodes (found in trees of maps and arrays)
                as well as XNodes (found in trees representing parsed XML).
             </change>
+            <change issue="2299" PR="2345" date="2025-11-25">
+               The leftmost operand of a
+               <termref def="dt-relative-path-expression"/>
+               can now be an <termref def="dt-arrow-expression"/>.
+            </change>
          </changes>
 
          <scrap>
             <prodrecap ref="PathExpr"/>
+         </scrap>
+         <scrap>
+            <prodrecap ref="PathExprU"/>
          </scrap>
 
          <p><termdef id="dt-path-expression" term="path expression">A <term>path expression</term>
@@ -11623,7 +11631,8 @@ return $incrementors[2](4)]]></eg>
          
          <p><termdef id="dt-relative-path-expression" term="relative path expression">
             A <term>relative path expression</term> is a <termref def="dt-non-trivial"/>
-            instance of the production <nt def="RelativePathExpr">RelativePathExpr</nt>:
+            instance of the production <nt def="RelativePathExpr">RelativePathExpr</nt>
+            or <nt def="RelativePathExprU">RelativePathExprU</nt>:
             it consists of two or more operand expressions 
             separated by <code>/</code> or <code>//</code> operators.</termdef></p>
             
@@ -11637,6 +11646,17 @@ return $incrementors[2](4)]]></eg>
          context, not necessarily as a <termref def="dt-step"/> in a path
          expression.</p></note>
          
+         <note diff="add" at="issue2299">
+            <p>
+               The grammar distinguishes between <nt def="PathExpr">PathExpr</nt>
+               and <nt def="PathExprU">PathExprU</nt>.
+               In <nt def="PathExpr">PathExpr</nt>, the left-hand side operand
+               is limited to <nt def="AbsolutePathExpr">AbsolutePathExpr</nt>
+               and <nt def="RelativePathExpr">RelativePathExpr</nt>,
+               while in <nt def="PathExprU">PathExprU</nt> the left-hand side operand
+               may also be <nt def="ArrowExprU">ArrowExprU</nt>.
+            </p>
+         </note>
             
          <p>A path expression is typically used to locate <termref def="dt-GNode">GNodes</termref> 
             within <termref def="dt-GTree">GTrees</termref>. </p>
@@ -11651,7 +11671,7 @@ return $incrementors[2](4)]]></eg>
                <termref def="dt-XTree"/> or a <termref def="dt-JTree"/>.</p></item>
             </ulist>
          </note>
-         
+
          <p>The following definitions are copied from the data model specification,
          for convenience:</p>
          
@@ -11815,8 +11835,16 @@ return $incrementors[2](4)]]></eg>
          <div3 id="id-relative-path-expressions">
             <head>Relative Path Expressions</head>
 
+            <changes>
+               <change issue="2299" PR="2345" date="2025-11-25">
+                  The left hand operand of the path operators <code>/</code> and <code>//</code>
+                  can now be an <termref def="dt-arrow-expression"/>.
+               </change>
+            </changes>
+
             <scrap>
                <prodrecap ref="RelativePathExpr"/>
+               <prodrecap ref="RelativePathExprU"/>
             </scrap>
 
             <p>
@@ -11825,6 +11853,18 @@ return $incrementors[2](4)]]></eg>
           at the GNodes in the context value (which may be any kind of GNode,
           not necessarily the root of the tree).
           </p>
+
+            <note diff="add" at="issue2299">
+               <p>
+                  The grammar distinguishes between <nt def="RelativePathExpr">RelativePathExpr</nt>
+                  and <nt def="RelativePathExprU">RelativePathExprU</nt>.
+                  In <nt def="RelativePathExpr">RelativePathExpr</nt>, the left-hand side operand
+                  is limited to <nt def="StepExpr">StepExpr</nt>,
+                  while in <nt def="RelativePathExprU">RelativePathExprU</nt> the left-hand side operand
+                  may also be <nt def="ArrowExprU">ArrowExprU</nt>.
+               </p>
+            </note>
+
             <p>
           Each non-initial occurrence of <code>//</code> in a path expression is
           expanded as described in <specref ref="id-recursive-path-operator"/>, leaving a
@@ -23551,6 +23591,13 @@ return string-join($chopped, '; ')
       <div2 id="id-map-operator">
          <head>Simple map operator (<code>!</code>)</head>
 
+         <changes>
+            <change issue="2299" PR="2345" date="2025-11-25">
+               The left hand operand of the simple map operator <code>!</code>
+               can now be an <termref def="dt-arrow-expression"/>.
+            </change>
+         </changes>
+
 
          <scrap>
             <prodrecap ref="SimpleMapExpr"/>
@@ -23581,6 +23628,21 @@ return string-join($chopped, '; ')
             The returned sequence preserves the orderings within and among the subsequences 
             generated by the evaluations of <var>E2</var>.
          </p>
+
+   <note diff="add" at="issue2299">
+      <p>
+         The grammar distinguishes between <nt def="SimpleMapExprS">SimpleMapExprS</nt>
+         and <nt def="SimpleMapExprU">SimpleMapExprU</nt>.
+         In <nt def="SimpleMapExprS">SimpleMapExprS</nt>, the left-hand side operand
+         is defined as a <nt def="PathExpr">PathExpr</nt>,
+         while in <nt def="SimpleMapExprU">SimpleMapExprU</nt>
+         it is defined as <nt def="PathExprU">PathExprU</nt>,
+         which can contains <nt def="ArrowExprU">ArrowExprU</nt>.
+         That is, the latter allows the use of arrow expressions
+         as the initial input on the left of the <code>!</code> operator,
+         whereas the former only allows path expressions as the initial input.
+      </p>
+   </note>
 
          <p>Simple map operators have functionality similar to <specref ref="id-path-operator"
             />.
@@ -23664,6 +23726,29 @@ return string-join($chopped, '; ')
             </ulist>
          </example>
 
+         <p>The following examples illustrate the use of simple map operators combined with arrow expressions
+           (the <termref def="dt-sequence-arrow-operator"/> and <termref def="dt-mapping-arrow-operator"/>).
+         </p>
+
+         <example>
+            <ulist>
+               <item>
+                  <p>
+                     <code role="parse-test"
+                        >$string => tokenize() ! concat("id-", .)</code>
+                  </p>
+                  <p>This expression is equivalent to <code> ( $string => tokenize() ) ! concat("id-", .)</code>.</p>
+               </item>
+               <item>
+                  <p>
+                     <code role="parse-test"
+                        >child::span =!> string() ! lower-case(.)</code>
+                  </p>
+                  <p>This expression is equivalent to <code> ( child::span =!> string() ) ! lower-case(.)</code>.</p>
+               </item>
+            </ulist>
+         </example>
+
       </div2>
 
       <div2 id="id-arrow-operator">
@@ -23681,13 +23766,22 @@ return string-join($chopped, '; ')
 
          <scrap>
             <prodrecap ref="ArrowExpr"/>
+            <prodrecap ref="ArrowExprU"/>
          </scrap>
-         
+
+         <p><termdef id="dt-arrow-expression" term="arrow expression">
+            An <term>arrow expression</term>
+            is a <termref def="dt-non-trivial"/> instance of the production <nt def="ArrowExprU">ArrowExprU</nt>
+            or <nt def="ArrowExprS">ArrowExprS</nt>.
+            </termdef>
+            <!-- do we need the separate terms like "unsigned arrow expression" and "signed arrow expression"? -->
+         </p>
+
          <p>The arrow syntax is particularly helpful when applying multiple
             functions to a value in turn. For example, the following
             expression invites syntax errors due to misplaced parentheses:
          </p>
-         
+
          <eg role="parsetest"
             ><![CDATA[tokenize((normalize-unicode(upper-case($string))),"\s+")]]></eg>
          
@@ -23723,8 +23817,22 @@ return string-join($chopped, '; ')
          <p diff="add" at="2023-07-24">would return the original sequence of three items, <code>(1, 2, 3)</code>, 
             each item being the average of itself.</p>
          
-         
-         
+
+
+         <note diff="add" at="issue2299">
+            <p>
+               The grammar distinguishes between <nt def="ArrowExprS">ArrowExprS</nt> and <nt def="ArrowExprU">ArrowExprU</nt>
+               to provide control over where the arrow operators may occur in the syntax.
+               <nt def="ArrowExprS">ArrowExprS</nt> represents a simpler form of the arrow operators, where the left-hand side operand
+               is limited to <nt def="SignedUnaryExpr">SignedUnaryExpr</nt> (always with a leading unary sign).
+               In contrast, <nt def="ArrowExprU">ArrowExprU</nt> is a more generalized form
+               where the left-hand side is <nt def="UnsignedUnaryExpr">UnsignedUnaryExpr</nt> (always without a leading unary sign),
+               which can itself be another arrow expression, and as a whole, it may be the leftmost operand
+               of the <nt def="SimpleMapExprU">simple map expression</nt>
+               and <nt def="RelativePathExprU">relative path expression</nt>.
+            </p>
+         </note>
+
          <p>There are two significant differences between the <termref def="dt-pipeline-operator"/> <code>-></code>
             and the <termref def="dt-sequence-arrow-operator"/> <code>=></code>:</p>
             


### PR DESCRIPTION
Fix #2299 
Supersedes PR #2309 

Allow an arrow expression in a path expression (and, by implication, in a simple map expression):
```xquery
$x => B() / foo ! bar => C() ! baz / quz
```

This implementation does not change the relative precedence of `/` and `!`.

---

In this implementation we divide `UnaryExpr` to `SignedUnaryExpr` (always with a leading unary sign) and `UnsignedUnaryExpr` (always without a leading unary sign). And the new feature is supported only in the latter case, since in the former case we cannot avoid ambiguity:
  - an expression `- aaa => B() / ccc => D()` can be parsed both:
      - as `(- aaa ) => B() / ccc => D()`
      - and as  `- ( aaa => B() / ccc ) => D()`
       - because `aaa => B() ` is the left-hand side operand of `/`; see also a [comment](https://github.com/qt4cg/qtspecs/issues/2299#issuecomment-3544885512).
