### PR TITLE
708 An alternative proposal for generators

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -37933,6 +37933,24 @@ return $array/descendant::jnode(*, array(*))[. > 25] =!> jvalue()</eg></fos:expr
          
             
       </fos:rules>
+      
+      <fos:equivalent style="xquery-function">
+declare function generate(
+  $init   as item(),
+  $step as function(item(), xs:integer) as item()?
+) as item()* {
+  generate-helper($init, $step, 1)
+};
+declare %private function generate-helper (
+  $init   as item(),
+  $step as function(item(), xs:integer) as item()?,
+  $position as xs:integer
+) as item()* {
+  let $next := $step($init, $position)
+  while exists($next)
+  return ($next, generate-helper($next, $step, $position+1))
+};
+      </fos:equivalent>
       <fos:notes>
          <p>The evaluation technique used to implement pipelined operation is often called
          <term>lazy evaluation</term>. This specification does not mandate any particular
@@ -37945,12 +37963,12 @@ return $array/descendant::jnode(*, array(*))[. > 25] =!> jvalue()</eg></fos:expr
          representing succesive states. There is no constraint on how states are represented; in many cases it will be useful
          to represent states as records with a method conventionally named <code>next</code> that delivers
          the next state in the sequence (as in the example using <function>fn:random-number-generator</function>).</p>
-         <p>Although <function>generate-sequence</function> is designed to be capable of delivering an unbounded
+         <p>Although <function>generate</function> is designed to be capable of delivering an unbounded
          sequence, it can also be a convenient way of generating a finite sequence. For example,</p>
-         <eg>generate-sequence(., fn{..})</eg>
+         <eg>generate(., fn{..})</eg>
          <p>returns the ancestors of a node, ending at the root of the containing tree.</p>
          <p>An implementation is allowed to place limits on the number of items in a sequence. Even though
-         some operations are defined to be pipelined, there may be constraints such as a limit on the
+         some operations are defined to be incrementally evaluated, there may be constraints such as a limit on the
          size of the integer returned by <function>fn:position</function>.</p>
          <p>Operations that consume a sequence in its entirety should be avoided if the sequence
          might be unbounded. Examples of such operations include:</p>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -37899,4 +37899,117 @@ return $array/descendant::jnode(*, array(*))[. > 25] =!> jvalue()</eg></fos:expr
       </fos:changes>
    </fos:function>
    
+   <fos:function name="generate-sequence" prefix="fn">
+      <fos:signatures>
+         <fos:proto name="generate-sequence" return-type="item()*">
+            <fos:arg name="initial-state" type="item()" usage="navigation"/>
+            <fos:arg name="step" type="function(item()) as item()?" usage="inspection"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:summary>
+         <p>Delivers a potentially unbounded sequence based on a supplied initial state, together
+         with a function for computing the next state.</p>
+      </fos:summary>
+      <fos:rules>
+         <p>The first item in the returned sequence is <code>$initial-state</code>; the
+         second item is the result of <code>$initial-state => $step()</code>; the third item
+         is the result of <code>$initial-state => $step() => step()</code>, and so on.</p>
+         
+         <p>If the <code>$step</code> function returns an empty sequence, this marks the end
+         of the generated sequence. However, the generated sequence is potentially unbounded,
+         and the specification defines that certain operations on sequences are <termref def="dt-pipelined"/>,
+         ensuring that unbounded sequences can be processed without exhausting available resources.</p>
+         
+         <p>For example, the function call:</p>
+            
+            <eg>generate-sequence(random-number-generator($seed), fn{?next}) ? number => slice(end=1000)</eg>
+            
+         <p>returns an sequence of one thousand random numbers. The reason this works is that the lookup
+            operator (<code>?</code>) and the <function>slice</function> function are both defined to be
+            pipelined, which guarantees that the operation is capable of handling an unbounded input
+            sequence.
+         </p>   
+            
+            
+      </fos:rules>
+      <fos:notes>
+         <p>The evaluation technique used to implement pipelined operation is often called
+         <term>lazy evaluation</term>. This specification does not mandate any particular
+         implementation technique, it only requires that the evaluation of pipelined operations
+         is not constrained by available memory. For example, a processor with access to SIMD
+         hardware is free to take advantage of this. This has the practical implication that
+         an application cannot assume there will be zero lookahead in the pipeline, nor that
+         such lookahead will be error-free.</p>
+         <p>The <function>generate-sequence</function> function delivers a sequence of items
+         representing succesive states. There is no constraint on how states are represented; in many cases it will be useful
+         to represent states as records with a method conventionally named <code>next</code> that delivers
+         the next state in the sequence (as in the example using <function>fn:random-number-generator</function>).</p>
+         <p>Although <function>generate-sequence</function> is designed to be capable of delivering an unbounded
+         sequence, it can also be a convenient way of generating a finite sequence. For example,</p>
+         <eg>generate-sequence(., fn{..})</eg>
+         <p>returns the ancestors of a node, ending at the root of the containing tree.</p>
+         <p>An implementation is allowed to place limits on the number of items in a sequence. Even though
+         some operations are defined to be pipelined, there may be constraints such as a limit on the
+         size of the integer returned by <function>fn:position</function>.</p>
+         <p>Operations that consume a sequence in its entirety should be avoided if the sequence
+         might be unbounded. Examples of such operations include:</p>
+         
+         <ulist>
+            <item><p>Aggregation functions such as <function>count</function>, <function>sum</function>, 
+                  <function>string-join</function>, or <function>distinct-values</function>.</p></item>
+            <item><p>Reordering operations, such as <function>sort-by</function>, <function>reverse</function>,
+            the <code>permute</code> method of <function>random-number-generator</function>, or the
+            implicit sort into document order performed by the <code>/</code>, <code>union</code>,
+            <code>intersect</code>, and <code>except</code> operators.</p></item>
+            <item><p>The function <function>last</function>.</p></item>
+            <item><p>Searching operations, such as predicates, <function>index-of</function>,
+            <function>filter</function>, and <function>some</function>,
+                  unless the user has good reason to believe these will always find a match.</p></item>
+            <item><p>Binding an unbounded sequence to a variable.</p></item>
+         </ulist>
+         
+         <p>Using such operations on an unbounded sequence may result in catastrophic failure (for example, running out of memory),
+         or in non-termination.</p>
+         
+         <p>There are a number of ways of reliably processing a bounded subsequence of an unbounded input sequence:</p>
+         
+         <ulist>
+            <item><p>Use of the functions <function>subsequence</function> or <function>slice</function>
+            with a defined end point.</p></item>
+            <item><p>Use of numeric predicates, for example <code>$in[100]</code> or <code>$in[1 to 100]</code>.</p></item>
+            <item><p>Use of the function <function>starts-with-subsequence</function>.</p></item>
+         </ulist>
+      </fos:notes>
+
+      <fos:examples>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>let $array := [1, 3, 4.5, 7, "eight", 10]
+return $array / child::type(xs:integer) =!> jnode-selector()</eg></fos:expression>
+               <fos:result>1, 2, 4, 6</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>let $map := {'Mo': 'Monday', 'Tu': 'Tuesday', 'We': 'Wednesday'}
+return $map / child::get(("Mo", "We", "Fr", "Su")) =!> jnode-selector()</eg></fos:expression>
+               <fos:result>"Mo", "We"</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>let $array := [[4, 18], [30, 4, 22]]
+return $array / descendant::*[. > 25] / ancestor-or-self::* =!> jnode-selector()</eg></fos:expression>
+               <fos:result>2, 1</fos:result>
+            </fos:test>
+         </fos:example>
+         
+      </fos:examples>
+      
+      <fos:changes>
+         <fos:change issue="2025" PR="2031" date="2025-06-12"><p>New in 4.0</p></fos:change>
+      </fos:changes>
+   </fos:function>
+   
 </fos:functions>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -37899,11 +37899,11 @@ return $array/descendant::jnode(*, array(*))[. > 25] =!> jvalue()</eg></fos:expr
       </fos:changes>
    </fos:function>
    
-   <fos:function name="generate-sequence" prefix="fn">
+   <fos:function name="generate" prefix="fn">
       <fos:signatures>
-         <fos:proto name="generate-sequence" return-type="item()*">
-            <fos:arg name="initial-state" type="item()" usage="navigation"/>
-            <fos:arg name="step" type="function(item()) as item()?" usage="inspection"/>
+         <fos:proto name="generate" return-type="item()*">
+            <fos:arg name="init" type="item()" usage="navigation"/>
+            <fos:arg name="step" type="function(item(), xs:integer) as item()?" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -37912,30 +37912,25 @@ return $array/descendant::jnode(*, array(*))[. > 25] =!> jvalue()</eg></fos:expr
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Delivers a potentially unbounded sequence based on a supplied initial state, together
-         with a function for computing the next state.</p>
+         <p>Delivers a potentially unbounded sequence based on a supplied initial value, together
+         with a function for computing the next value.</p>
       </fos:summary>
       <fos:rules>
-         <p>The first item in the returned sequence is <code>$initial-state</code>; the
-         second item is the result of <code>$initial-state => $step()</code>; the third item
-         is the result of <code>$initial-state => $step() => step()</code>, and so on.</p>
+         <p>The first item in the returned sequence is <code>$init</code>; the
+         second item is the result of <code>$initial-state => $step(1)</code>; the third item
+         is the result of <code>$initial-state => $step(1) => step(2)</code>, and so on.</p>
+         
+         <p>The <code>$step</code> function is called with two arguments, the current state, and
+         the sequential position of the current state (starting at 1). The coercion rules allow
+         an arity-1 function to be supplied if the second argument is not required.</p>
          
          <p>If the <code>$step</code> function returns an empty sequence, this marks the end
          of the generated sequence. However, the generated sequence is potentially unbounded,
-         and the specification defines that certain operations on sequences are <termref def="dt-pipelined"/>,
+         and the specification defines that certain operations on sequences are 
+            <termref def="dt-incremental-evaluation">incrementally evaluated</termref>,
          ensuring that unbounded sequences can be processed without exhausting available resources.</p>
          
-         <p>For example, the function call:</p>
-            
-<eg>generate-sequence(random-number-generator($seed), 
-                   fn{?next}) ? number => slice(end=1000)</eg>
-            
-         <p>returns an sequence of one thousand random numbers. The reason this works is that the lookup
-            operator (<code>?</code>) and the <function>slice</function> function are both defined to be
-            pipelined, which guarantees that the operation is capable of handling an unbounded input
-            sequence.
-         </p>   
-            
+         
             
       </fos:rules>
       <fos:notes>
@@ -37946,7 +37941,7 @@ return $array/descendant::jnode(*, array(*))[. > 25] =!> jvalue()</eg></fos:expr
          hardware is free to take advantage of this. This has the practical implication that
          an application cannot assume there will be zero lookahead in the pipeline, nor that
          such lookahead will be error-free.</p>
-         <p>The <function>generate-sequence</function> function delivers a sequence of items
+         <p>The <function>generate</function> function delivers a sequence of items
          representing succesive states. There is no constraint on how states are represented; in many cases it will be useful
          to represent states as records with a method conventionally named <code>next</code> that delivers
          the next state in the sequence (as in the example using <function>fn:random-number-generator</function>).</p>
@@ -37989,22 +37984,104 @@ return $array/descendant::jnode(*, array(*))[. > 25] =!> jvalue()</eg></fos:expr
 
       <fos:examples>
          <fos:example>
-            <fos:test>
-               <fos:expression><eg>generate-sequence(0, fn{.+2})[1 to 10]</eg></fos:expression>
-               <fos:result><eg>0, 2, 4, 6, 8, 10, 12, 14, 16, 18</eg></fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression><eg>generate-sequence(xs:date('2025-03-01'), 
-      fn{.+xs:dayTimeDuration('PT7D')})[1 to 10] => format-date('[D] [MNn]')</eg></fos:expression>
-               <fos:result><eg>"1 March", "8 March", "15 March", "22 March", "29 March", 
-"5 April", "12 April", "19 April", "26 April", "3 May"</eg></fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression><eg>generate-sequence([1,1], fn{[?2, ?1+?2]})?1[1 to 10]</eg></fos:expression>
-               <fos:result><eg>1, 1, 2, 3, 5, 8, 13, 21, 34, 55</eg></fos:result>
-            </fos:test>
-           
+            <p><emph>An infinite sequence of even numbers</emph></p>
+            <p>The expression </p>
+            <eg>generate(0, fn{.+2})</eg>
+            <p>Produces an infinite sequence of even numbers: <code>0, 2, 4, 6, 8, ...</code>.</p>
+            <p>Operations that attempt to process this entire sequence (for example, <code>count</code>
+            or <code>sum</code>) will inevitably fail (either by running out of resources, or by failing
+            to terminate). However, operations that only need access to the start of the sequence, for 
+            example <code>generate(0, fn{.+2})[20]</code> will typically succeed, evaluating
+            the infinite sequence only as far as is needed to deliver a result. Such operations are guaranteed
+            to succeed if the operation in question is guaranteed to perform <termref def="dt-incremental-evaluation"/>
+            of its operand.</p>
+            <p>Some operations, such as:</p>
+            <eg>index-of(generate(0, fn{.+2}), $n)[1]</eg>
+            <p>may or may not succeed, depending on the actual content of the data (in this case, depending on whether
+            <code>$n</code> is odd or even).</p>
          </fos:example>
+         <fos:example>
+            <p><emph>An infinite sequence of random doubles</emph></p>
+            <p>The function call:</p>
+            
+           <eg>generate(random-number-generator($seed), fn{?next}) 
+   [1 to 1000] ? number</eg>
+            
+         <p>returns an sequence of one thousand random numbers. The call to <function>generate</function>
+            supplies as initial value a random number generator with a given seed. The <code>$step</code>
+            function calls the <code>next</code> method of <function>fn:random-number-generator</function>
+            to produce a new random number generator. The result of the call to <function>generate</function> 
+            is thus an unbounded sequence of random number generators. The filter predicate <code>1 to 1000</code>
+            then reduces this sequence to the first 1000 items: this works because a filter expression is
+            guaranteed to perform <termref def="dt-incremental-evaluation"/> of its base expression.
+            The final <code>? number</code> operation then extracts the number delivered by each of the 
+            random number generator objects.
+         </p>   
+         </fos:example>
+         <fos:example>
+            <p><emph>Generating the Fibonnaci sequence</emph></p>
+            <p>The expression:</p>
+            <eg>generate([1,1], fn{[?2, ?1+?2]})?1</eg>
+            <p>delivers an infinite sequence of integers, specifically the Fibonacci sequence:</p>
+            <eg>1, 1, 2, 3, 5, 8, 13, 21, 34, 55...</eg>
+            <p>This example illustrates that <function>generate</function> produces a sequence of states,
+            which in turn can be used to deliver the actual values that are needed. In this case the state
+            is represented by an array containing two consecutive Fibonacci numbers, which is sufficient
+            information to compute the next state. The final <code>?1</code> is used to extract the actual
+            wanted number from the array used to represent the state.</p>
+         </fos:example> 
+         <fos:example>
+            <p><emph>Markov simulation</emph></p>
+            <p>The <function>generate</function> function can be useful in simulations of Markov processes.
+            A trivial example of such a process is the “drunkard's walk”: a sequence of integers in which
+            each integer is either one greater or one less than the previous integer, with equal probability.
+            </p>
+            
+            <eg>
+  generate({'val':0, 'rg':random-number-generator(current-dateTime())},
+           fn{ {'val': ?val + head(?rg?permute((-1, +1))),
+                'rg': ?rg?next() } } )
+            </eg>
+            <p>In one sample run of the simulation, this produced the sequence 
+               <code>0 1 0 -1 -2 -1 0 1 0 -1 -2 -3 -4 -3 -2 -3 ...</code></p>
+            
+         </fos:example>
+         
+         <fos:example>
+            <p><emph>A finite state automaton</emph></p>
+            <p>Validating a text against a grammar often involves production of a finite state automaton.
+            Each state in such an automaton has a set of possible transitions, which is a mapping from the
+            next token in the input to the next state in the automaton. For example, the grammar
+            <code>(ab)*</code> has two states: state <var>S1</var> has a single transition that maps the token
+            <code>"a"</code> to the state <var>S2</var>, while state <var>S2</var> has a single transition that maps the token
+            <code>"b"</code> to state <var>S1</var>. State <var>S1</var> is both the initial state and the required final state,
+            so an input string is valid against the grammar if a sequence of transitions ends with state <var>S1</var>.</p>
+            <p>This finite state automaton might be represented by the data structure:</p>
+            <eg>{
+  "S1": { "final":true(),  "transitions": {"a": "S2" } },
+  "S2": { "final":false(), "transitions": {"b": "S1" } }
+}</eg>
+            <p>If this data structure is bound to the variable <code>$fsa</code>, and the input (as a sequence of string tokens)
+               is bound to the variable <code>$input</code>. The following function call:</p>
+            
+            <eg>
+generate("S1", fn($state, $i) {
+    if ($i le count($input)) {
+       $fsa ? $state ? transitions ? ($input[$i])
+         otherwise error(`Unexpected token "{$input[$i]}"`)
+    }) ? final
+            </eg>
+            <p>returns <code>true</code> if and only if the input matches the grammar corresponding to the automaton.</p>
+            <p>The way this works is that the sequence of states of the generator (which correspond to states of the
+            finite state automaton) advances by matching successive tokens from the input against the valid transitions
+            for that state. If a valid transition is found, the generator moves to the next state; if no transition
+            is found, an error is reported. When the stream of tokens is exhausted, the step function returns an empty
+            sequence to indicate completion. Finally the expression returns true if the last state is marked as a final
+            state, or false otherwise.</p>
+         </fos:example>
+         
+            
+
          
       </fos:examples>
       

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -37990,20 +37990,20 @@ return $array/descendant::jnode(*, array(*))[. > 25] =!> jvalue()</eg></fos:expr
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression><eg>let $array := [1, 3, 4.5, 7, "eight", 10]
-return $array / child::type(xs:integer) =!> jnode-selector()</eg></fos:expression>
-               <fos:result>1, 2, 4, 6</fos:result>
+               <fos:expression><eg>generate-sequence(0, fn{.+2})[1 to 10]</eg></fos:expression>
+               <fos:result><eg>0, 2, 4, 6, 8, 10, 12, 14, 16, 18</eg></fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>let $map := {'Mo': 'Monday', 'Tu': 'Tuesday', 'We': 'Wednesday'}
-return $map / child::get(("Mo", "We", "Fr", "Su")) =!> jnode-selector()</eg></fos:expression>
-               <fos:result>"Mo", "We"</fos:result>
+               <fos:expression><eg>generate-sequence(xs:date('2025-03-01'), 
+      fn{.+xs:dayTimeDuration('PT7D')})[1 to 10] => format-date('[D] [MNn]')</eg></fos:expression>
+               <fos:result><eg>"1 March", "8 March", "15 March", "22 March", "29 March", 
+"5 April", "12 April", "19 April", "26 April", "3 May"</eg></fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>let $array := [[4, 18], [30, 4, 22]]
-return $array / descendant::*[. > 25] / ancestor-or-self::* =!> jnode-selector()</eg></fos:expression>
-               <fos:result>2, 1</fos:result>
+               <fos:expression><eg>generate-sequence([1,1], fn{[?2, ?1+?2]})?1[1 to 10]</eg></fos:expression>
+               <fos:result><eg>1, 1, 2, 3, 5, 8, 13, 21, 34, 55</eg></fos:result>
             </fos:test>
+           
          </fos:example>
          
       </fos:examples>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -38069,14 +38069,14 @@ generate("S1", fn($state, $i) {
     if ($i le count($input)) {
        $fsa ? $state ? transitions ? ($input[$i])
          otherwise error(`Unexpected token "{$input[$i]}"`)
-    }) ? final
+    }) [last()] ? final
             </eg>
             <p>returns <code>true</code> if and only if the input matches the grammar corresponding to the automaton.</p>
             <p>The way this works is that the sequence of states of the generator (which correspond to states of the
             finite state automaton) advances by matching successive tokens from the input against the valid transitions
             for that state. If a valid transition is found, the generator moves to the next state; if no transition
             is found, an error is reported. When the stream of tokens is exhausted, the step function returns an empty
-            sequence to indicate completion. Finally the expression returns true if the last state is marked as a final
+            sequence to indicate completion. Finally the expression returns true if the last state is a final
             state, or false otherwise.</p>
          </fos:example>
          

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -37927,7 +37927,8 @@ return $array/descendant::jnode(*, array(*))[. > 25] =!> jvalue()</eg></fos:expr
          
          <p>For example, the function call:</p>
             
-            <eg>generate-sequence(random-number-generator($seed), fn{?next}) ? number => slice(end=1000)</eg>
+<eg>generate-sequence(random-number-generator($seed), 
+                   fn{?next}) ? number => slice(end=1000)</eg>
             
          <p>returns an sequence of one thousand random numbers. The reason this works is that the lookup
             operator (<code>?</code>) and the <function>slice</function> function are both defined to be
@@ -38008,7 +38009,7 @@ return $array / descendant::*[. > 25] / ancestor-or-self::* =!> jnode-selector()
       </fos:examples>
       
       <fos:changes>
-         <fos:change issue="2025" PR="2031" date="2025-06-12"><p>New in 4.0</p></fos:change>
+         <fos:change issue="708" PR="2350" date="2025-12-17"><p>New in 4.0</p></fos:change>
       </fos:changes>
    </fos:function>
    

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -1651,6 +1651,65 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                <head><?function fn:while-do?></head>
             </div3>
          </div2>
+         <div2 id="pipelining">
+            <head>Pipelining</head>
+            <p>Some operations, most notably the <function>generate-sequence</function> function,
+            may deliver sequences of unbounded length. Other examples include the <function>do-while</function>
+            and <code>until-do</code> functions. In addition, many functions and operators that take
+            an unbounded sequence as input may also deliver an unbounded sequence as their result: example
+            include the functions <function>filter</function>, <function>for-each</function>,
+            <function>index-of</function>, <function>index-where</function>, <function>insert-before</function>,
+            <function>remove</function>, and operations such as <code>A!B</code> and <code>for $x in X return R</code>.
+            </p>
+            <p><termdef id="dt-pipelined" term="pipelined">A function or operation is said to be
+            <term>pipelined</term> with respect to one of its arguments or operands if the implementation
+            is capable of processing an unbounded value for that argument or operand without exhausting 
+            available memory.</termdef></p>
+            
+            <p>Some functions and operators may accept more than one unbounded sequence among their inputs.
+               Examples are the comma operator (which performs <xtermref spec="XP40" ref="dt-sequence-concatenation"/>),
+               and the functions <code>for-each-pair</code> and <code>insert-before</code>.
+            </p>
+            <p>Pipelining applies not only to sequences, but also to arrays. Although there is no
+            equivalent to <function>generate-sequence</function> that directly delivers an unbounded
+            array, the functions <function>array:build</function> and <function>array:of-members</function>
+            produce an unbounded array if supplied with an unbounded sequence as their input.</p>
+            <p>Pipelined operations can be divided into a number of categories:</p>
+            
+            <ulist>
+               <item><p>Bounded input, unbounded output. This category includes <function>generate-sequence</function>,
+               <function>do-until</function>, and <function>while-do</function>.</p></item>
+               <item><p>Unbounded input, unbounded output. This category includes <function>filter</function>,
+               <function>for-each</function>, <code>index-of</code>, <code>index-where</code>, 
+               <code>for</code> expressions, and the <code>!</code> operator.</p></item>
+               <item><p>Unbounded input, guaranteed finite output. This category includes <function>subsequence</function>,
+               and <function>slice</function> (provided an end condition is supplied),
+                     <function>head</function>, <function>exists</function>, <code>empty</code>
+                     <function>starts-with-subsequence</function></p></item>
+               <item><p>Non-terminating: functions that will not terminate until they reach
+               the end of the input sequence. Examples are <function>count</function>, <function>sum</function>
+               <function>string-join</function>, <function>distinct-values</function>.</p></item>
+               <item><p>Potentially non-terminating: functions that may or may not terminate,
+               depending on the content of the input sequence. For example, <function>some</function>.</p></item>
+            </ulist>
+            
+            <p>For a small number of functions and operators, this specification mandates that the implementation
+            <rfc2119>must</rfc2119> be pipelined. To conform with this specification, the implementation of these functions and
+            operators must not be constrained by available memory (though it may have other limits, such as a limit on 
+            the size of integer used to represent the value of <function>position</function>).</p>
+            
+            <p>For a larger class of operations, the processor <rfc2119>may</rfc2119> be able to
+            use a pipelined implementation, but this is not mandated. For example, the specification
+            does not mandate that the <function>partition</function> must be pipelined. Similarly,
+            it does not mandate that a general comparison (such as the <code>=</code> operator)
+            must be pipelined with respect to either or both of the operands.</p>
+            
+            <p>TODO: define which functions and operators are guaranteed to be pipelined.</p>
+            
+            <div3 id="func-generate-sequence">
+               <head><?function fn:generate-sequence?></head>
+            </div3>
+         </div2>
          
          
       </div1>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -1651,9 +1651,9 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                <head><?function fn:while-do?></head>
             </div3>
          </div2>
-         <div2 id="pipelining">
-            <head>Pipelining</head>
-            <p>Some operations, most notably the <function>generate-sequence</function> function,
+         <div2 id="incremental-evaluation">
+            <head>Incremental Evaluation</head>
+            <p>Some operations, most notably the <function>generate</function> function,
             may deliver sequences of unbounded length. Other examples include the <function>do-while</function>
             and <code>until-do</code> functions. In addition, many functions and operators that take
             an unbounded sequence as input may also deliver an unbounded sequence as their result: example
@@ -1661,23 +1661,29 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
             <function>index-of</function>, <function>index-where</function>, <function>insert-before</function>,
             <function>remove</function>, and operations such as <code>A!B</code> and <code>for $x in X return R</code>.
             </p>
-            <p><termdef id="dt-pipelined" term="pipelined">A function or operation is said to be
-            <term>pipelined</term> with respect to one of its arguments or operands if the implementation
+            <p><termdef id="dt-incremental-evaluation" term="incremental evaluation">A function or operation is said to be
+            <term>incrementally evaluated</term> with respect to one of its arguments or operands if the implementation
             is capable of processing an unbounded value for that argument or operand without exhausting 
             available memory.</termdef></p>
+            
+            <note><p>Other terms used for incremental evaluation include <emph>lazy evaluation</emph> and <emph>pipelining</emph>. However,
+            these terms have different meanings in other contexts. Incremental evaluation of sequences (processing the initial items
+            of a sequence without first materializing the entire sequence) is one example of a lazy evaluation
+            strategy, while the term <emph>pipelining</emph> can also be used to refer to a sequence of processing steps in which each
+            step runs to completion before the next one starts.</p></note>
             
             <p>Some functions and operators may accept more than one unbounded sequence among their inputs.
                Examples are the comma operator (which performs <xtermref spec="XP40" ref="dt-sequence-concatenation"/>),
                and the functions <code>for-each-pair</code> and <code>insert-before</code>.
             </p>
-            <p>Pipelining applies not only to sequences, but also to arrays. Although there is no
-            equivalent to <function>generate-sequence</function> that directly delivers an unbounded
+            <p>Incremental evaluation applies not only to sequences, but also to arrays. Although there is no
+            equivalent to <function>generate</function> that directly delivers an unbounded
             array, the functions <function>array:build</function> and <function>array:of-members</function>
             produce an unbounded array if supplied with an unbounded sequence as their input.</p>
-            <p>Pipelined operations can be divided into a number of categories:</p>
+            <p>Incremental operations can be divided into a number of categories:</p>
             
             <ulist>
-               <item><p>Bounded input, unbounded output. This category includes <function>generate-sequence</function>,
+               <item><p>Bounded input, unbounded output. This category includes <function>generate</function>,
                <function>do-until</function>, and <function>while-do</function>.</p></item>
                <item><p>Unbounded input, unbounded output. This category includes <function>filter</function>,
                <function>for-each</function>, <function>index-of</function>, <function>index-where</function>, 
@@ -1694,17 +1700,25 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
             </ulist>
             
             <p>For a small number of functions and operators, this specification mandates that the implementation
-            <rfc2119>must</rfc2119> be pipelined. A conformant implementation of these functions and
+            <rfc2119>must</rfc2119> be incrementally evaluated. A conformant implementation of these functions and
             operators must not be constrained by available memory (though it may have other limits, such as a limit on 
             the size of integer used to represent the value of <function>position</function>).</p>
             
             <p>For a larger class of operations, the processor <rfc2119>may</rfc2119> be able to
-            use a pipelined implementation, but this is not mandated. For example, the specification
+            use incremental evaluation, but this is not mandated. For example, the specification
             does not mandate that the <function>partition</function> function must be pipelined. Similarly,
             it does not mandate that a general comparison (such as the <code>=</code> operator)
-            must be pipelined with respect to either or both of the operands.</p>
+            must be incrementally evaluated with respect to either or both of the operands.</p>
             
-            <p>TODO: define which functions and operators are guaranteed to be pipelined.</p>
+            <p>Some operations may be amenable to incremental evaluation depending on the conditions.
+            For example, the <code>union</code> and <code>intersect</code> operators can be incrementally
+            evaluated provided that the processor is able to determine that the operand sequences will always be
+            in document order (this will be the case, for example, if the operands are path expressions).
+            This analysis is outside the scope of the specification: in consequence it is
+            implementation-dependent whether, and under what circumstances, such operations are incrementally
+            evaluated.</p>
+            
+            <p>TODO: define which functions and operators are guaranteed to be incrementally evaluated.</p>
             
             <div3 id="pipelining-and-optimization">
                <head>Unbounded sequences and optimization</head>
@@ -1733,7 +1747,7 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                <p>This is not a new problem, because previous versions of XQuery and XSLT also allowed constructs (recursive functions,
                for example) that evaluated to unbounded sequences, and applications using such constructs might succeed on 
                some implementations and fail on others. However, the explicit use of generators (via the 
-               <function>generate-sequence</function> function) makes it necessary to address the issues raised.</p>
+               <function>generate</function> function) makes it necessary to address the issues raised.</p>
                
                <p>The specification does not attempt a complete solution to the problem. Rather, it takes a pragmatic
                approach, offering recommendations of good practise both to implementers and users.</p>
@@ -1750,21 +1764,21 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                <p>Recommendations for users:</p>
                
                <ulist>
-                  <item><p>Avoid binding expressions whose result is unbounded to variables.</p></item>
-                  <item><p>Avoid using expressions whose result is unbounded as the argument to a function call,
-                  except where the function explicitly guarantees pipelined evaluation. (Note that these
+                  <item><p>Avoid binding expressions to variables if the value might be unbounded.</p></item>
+                  <item><p>Avoid using an expression whose result might be unbounded as the argument to a function call,
+                  except where the function explicitly guarantees incremental evaluation. (Note that these
                   specifications offer no such guarantee in the case of user-defined functions, though an implementation
                   might do so.)</p></item>
                </ulist>
             </div3>
             
             <div3 id="pipelining-and-streaming">
-               <head>Pipelining and streaming</head>
-               <p>TODO: say something here about the relationship of pipelining to XSLT streaming.</p>
+               <head>Incremental evaluation and streaming</head>
+               <p>TODO: say something here about the relationship of incremental evaluation to XSLT streaming.</p>
             </div3>
             
-            <div3 id="func-generate-sequence">
-               <head><?function fn:generate-sequence?></head>
+            <div3 id="func-generate">
+               <head><?function fn:generate?></head>
             </div3>
          </div2>
          

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -1680,11 +1680,11 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                <item><p>Bounded input, unbounded output. This category includes <function>generate-sequence</function>,
                <function>do-until</function>, and <function>while-do</function>.</p></item>
                <item><p>Unbounded input, unbounded output. This category includes <function>filter</function>,
-               <function>for-each</function>, <code>index-of</code>, <code>index-where</code>, 
+               <function>for-each</function>, <function>index-of</function>, <function>index-where</function>, 
                <code>for</code> expressions, and the <code>!</code> operator.</p></item>
                <item><p>Unbounded input, guaranteed finite output. This category includes <function>subsequence</function>,
                and <function>slice</function> (provided an end condition is supplied),
-                     <function>head</function>, <function>exists</function>, <code>empty</code>
+                     <function>head</function>, <function>exists</function>, <code>empty</code>, and
                      <function>starts-with-subsequence</function></p></item>
                <item><p>Non-terminating: functions that will not terminate until they reach
                the end of the input sequence. Examples are <function>count</function>, <function>sum</function>
@@ -1694,13 +1694,13 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
             </ulist>
             
             <p>For a small number of functions and operators, this specification mandates that the implementation
-            <rfc2119>must</rfc2119> be pipelined. To conform with this specification, the implementation of these functions and
+            <rfc2119>must</rfc2119> be pipelined. A conformant implementation of these functions and
             operators must not be constrained by available memory (though it may have other limits, such as a limit on 
             the size of integer used to represent the value of <function>position</function>).</p>
             
             <p>For a larger class of operations, the processor <rfc2119>may</rfc2119> be able to
             use a pipelined implementation, but this is not mandated. For example, the specification
-            does not mandate that the <function>partition</function> must be pipelined. Similarly,
+            does not mandate that the <function>partition</function> function must be pipelined. Similarly,
             it does not mandate that a general comparison (such as the <code>=</code> operator)
             must be pipelined with respect to either or both of the operands.</p>
             

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -1721,6 +1721,9 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                   avoid evaluating the expression repeatedly;</p></item>
                   <item><p>Common subexpression elimination: recognising where the same expression appears more than
                   once in the code, so that it need only be evaluated once.</p></item>
+                  <item><p>Memoization: caching the results of a function call so that subsequent attempts to
+                        evaluate the same function with the same arguments do not require the value to
+                        be recomputed.</p></item>
                </ulist>
                
                <p>All these optimizations potentially become problematic when expressions evaluate to unbounded sequences.
@@ -1738,10 +1741,10 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                <p>Recommendations for implementers:</p>
                
                <ulist>
-                  <item><p>When implementing constant folding, abandon any attempt to replace an expression by its value
+                  <item><p>When implementing constant folding or memoization, abandon the attempted optimization
                   if the value becomes too large.</p></item>
                   <item><p>When variables are introduced to avoid repeated evaluation of an expression, ensure that the
-                  variable itself is lazily evaluated so that evaluation does not fail if the expression is non-terminating.</p></item>
+                  variable itself is lazily evaluated so that evaluation does not fail when the expression is non-terminating.</p></item>
                </ulist>
                
                <p>Recommendations for users:</p>
@@ -1749,7 +1752,9 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                <ulist>
                   <item><p>Avoid binding expressions whose result is unbounded to variables.</p></item>
                   <item><p>Avoid using expressions whose result is unbounded as the argument to a function call,
-                  other than functions that explicitly guarantee pipelined evaluation.</p></item>
+                  except where the function explicitly guarantees pipelined evaluation. (Note that these
+                  specifications offer no such guarantee in the case of user-defined functions, though an implementation
+                  might do so.)</p></item>
                </ulist>
             </div3>
             

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -1706,6 +1706,58 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
             
             <p>TODO: define which functions and operators are guaranteed to be pipelined.</p>
             
+            <div3 id="pipelining-and-optimization">
+               <head>Unbounded sequences and optimization</head>
+               
+               <p>As declarative expression-based language, XPath, XSLT, and XQuery are designed to have <term>referential transparency</term>.
+                  This essentially means that any subexpression can be replaced by its value, or by a different expression
+                  having the same value. This property enables powerful optimizations through expression rewriting, including,
+                  for example:</p>
+               
+               <ulist>
+                  <item><p>Constant folding: that is, early compile-time evaluation of expressions whose value will 
+                  be the same on every execution of a program;</p></item>
+                  <item><p>Loop lifting: moving an expression out of a loop, and binding its result to a variable, to 
+                  avoid evaluating the expression repeatedly;</p></item>
+                  <item><p>Common subexpression elimination: recognising where the same expression appears more than
+                  once in the code, so that it need only be evaluated once.</p></item>
+               </ulist>
+               
+               <p>All these optimizations potentially become problematic when expressions evaluate to unbounded sequences.
+               The fact that the value of such an expression cannot be held in finite memory effectively undermines the
+               principle that the expression can always be replaced by its value.</p>
+               
+               <p>This is not a new problem, because previous versions of XQuery and XSLT also allowed constructs (recursive functions,
+               for example) that evaluated to unbounded sequences, and applications using such constructs might succeed on 
+               some implementations and fail on others. However, the explicit use of generators (via the 
+               <function>generate-sequence</function> function) makes it necessary to address the issues raised.</p>
+               
+               <p>The specification does not attempt a complete solution to the problem. Rather, it takes a pragmatic
+               approach, offering recommendations of good practise both to implementers and users.</p>
+               
+               <p>Recommendations for implementers:</p>
+               
+               <ulist>
+                  <item><p>When implementing constant folding, abandon any attempt to replace an expression by its value
+                  if the value becomes too large.</p></item>
+                  <item><p>When variables are introduced to avoid repeated evaluation of an expression, ensure that the
+                  variable itself is lazily evaluated so that evaluation does not fail if the expression is non-terminating.</p></item>
+               </ulist>
+               
+               <p>Recommendations for users:</p>
+               
+               <ulist>
+                  <item><p>Avoid binding expressions whose result is unbounded to variables.</p></item>
+                  <item><p>Avoid using expressions whose result is unbounded as the argument to a function call,
+                  other than functions that explicitly guarantee pipelined evaluation.</p></item>
+               </ulist>
+            </div3>
+            
+            <div3 id="pipelining-and-streaming">
+               <head>Pipelining and streaming</head>
+               <p>TODO: say something here about the relationship of pipelining to XSLT streaming.</p>
+            </div3>
+            
             <div3 id="func-generate-sequence">
                <head><?function fn:generate-sequence?></head>
             </div3>


### PR DESCRIPTION
This proposal has two ingredients

(a) a single function generate-sequence() that produces a sequence of states from an initial state and a function that computes one state from the previous state

(b) a definition of pipelining (aka lazy evaluation) and (currently incomplete) rules requiring certain operations to have a pipelined implementation.