### PR TITLE
Add character-maps to the allowed context dependencies

### DIFF
--- a/specifications/xpath-functions-40/src/fos.xsd
+++ b/specifications/xpath-functions-40/src/fos.xsd
@@ -184,6 +184,7 @@
                       <xs:enumeration value="available-documents"/>
                       <xs:enumeration value="available-collections"/>
                       <xs:enumeration value="available-uri-collections"/>
+                      <xs:enumeration value="character-maps"/>
                       <xs:enumeration value="decimal-formats"/>
                       <xs:enumeration value="default-calendar"/>
                       <xs:enumeration value="default-language"/>


### PR DESCRIPTION
Currently function-catalog.xml is invalid against the schema fos.xsd. This PR updates the schema to allow "character-maps" in the enumeration of allowed context dependencies.

(Note, this should probably cause the build to fail. The problem was only spotted when using Oxygen to query the function catalog.)