### PR TITLE
Markup: Allow empty nt elements

### DIFF
--- a/style/xmlspec.xsl
+++ b/style/xmlspec.xsl
@@ -1449,7 +1449,14 @@
           <xsl:with-param name="target" select="key('ids', @def)"/>
         </xsl:call-template>
       </xsl:attribute>
-      <xsl:apply-templates/>
+      <xsl:choose>
+        <xsl:when test="exists(child::node())">
+          <xsl:apply-templates/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="@def"/>
+        </xsl:otherwise>
+      </xsl:choose>     
     </a>
   </xsl:template>
 


### PR DESCRIPTION
Stylesheet change to allow empty NT elements, bringing them into line with other referencing elements such as `termref` and `xnt`. The markup `<nt def="AxisStep"/>` is treated as equivalent to `<nt def="AxisStep">AxisStep</nt>`. This removes a common source of error which tends to result in missing text in the spec rather than in any kind of build error.