### PR TITLE
Attempt to resolve action QT4CG-148-01

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -31339,6 +31339,10 @@ return deep-equal(
       </fos:examples>
       <fos:changes>
          <fos:change issue="29 113 314" PR="360 476"><p>New in 4.0</p></fos:change>
+         <fos:change issue="2351">
+            <p>The group may remove this function, it is considered <loc href="#at-risk">at risk</loc>.
+            </p>
+         </fos:change>
       </fos:changes>
    </fos:function>
    
@@ -31468,6 +31472,10 @@ fold-left($input, [], fn($array, $record) {
       </fos:examples>
       <fos:changes>
          <fos:change issue="29 113 314" PR="360 476" date="2023-03-21"><p>New in 4.0</p></fos:change>
+         <fos:change issue="2351">
+            <p>The group may remove this function, it is considered <loc href="#at-risk">at risk</loc>.
+            </p>
+         </fos:change>
       </fos:changes>
    </fos:function>
    

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -204,6 +204,8 @@ for transition to Proposed Recommendation. </p>'>
          
          <p>The community group welcomes comments on the specification. Comments are best submitted
          as issues on the group's <loc href="https://github.com/qt4cg/qtspecs/issues">GitHub repository</loc>.</p>
+
+         <?at-risk?>
          
          <p>The community group maintains two extensive test suites, 
             one oriented to XQuery and XPath, the other to XSLT.

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -22088,6 +22088,10 @@ declare record my:rectangle (
                <change issue="1207" PR="1217" date="2024-05-15">
                   Predicates in filter expressions for maps and arrays can now be numeric.
                </change>
+               <change issue="2351">
+                  The group is considering removing or substantially changing this feature,
+                  it is considered <loc href="#at-risk">at risk</loc>.
+               </change>
             </changes>
 
                <scrap>

--- a/specifications/xquery-40/src/xquery-header.xml
+++ b/specifications/xquery-40/src/xquery-header.xml
@@ -77,6 +77,8 @@
          
          <p>The community group welcomes comments on the specification. Comments are best submitted
          as issues on the group's <loc href="https://github.com/qt4cg/qtspecs/issues">GitHub repository</loc>.</p>
+
+         <?at-risk?>
          
          <p>The community group maintains two extensive test suites, 
             one oriented to XQuery and XPath, the other to XSLT.


### PR DESCRIPTION
Per #2315:

1. Added ‘at-risk’ changes to the fn:insert-separator, array:members, and array:of-members
2. Added ‘at-risk’ changes to the XPath/XQuery section on map and array filtering
3. Added a note about what ‘at risk’ means to the status sections