### PR TITLE
Add namespace declaration to environment for generated tests

### DIFF
--- a/specifications/xpath-functions-40/style/generate-keyword-test-set.xsl
+++ b/specifications/xpath-functions-40/style/generate-keyword-test-set.xsl
@@ -37,6 +37,7 @@
          <xsl:comment>Generated using generate-keyword-test-set.xsl from function-catalog.xml at {current-dateTime()}</xsl:comment>
          <environment name="ka">
             <namespace prefix="math" uri="http://www.w3.org/2005/xpath-functions/math"/>
+            <namespace prefix="output" uri="http://www.w3.org/2010/xslt-xquery-serialization"/>
             <decimal-format name="data" decimal-separator="." grouping-separator=","/>
             <source role="." file="BuiltInKeywords/simple-doc.xml"/>
          </environment>


### PR DESCRIPTION
Changes the stylesheet for generating keyword and function signature tests so that the namespace prefix "output" is explicitly declared in the test environment. This prefix is used in one of the tests and it needs to be declared if the test is to work in XPath.