### PR TITLE
641 NaN/Infinity in JSON

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -29363,6 +29363,10 @@ return document {
          <fos:change issue="973 1037" PR="975 1058 1246" date="2024-03-12">
             <p>An option is provided to control how JSON numbers should be formatted.</p>
          </fos:change>
+         <fos:change issue="641" PR="2387" date="2026-01-16">
+            <p>It is now recommended that out-of-range <code>xs:double</code> values should translate
+               to positive or negative infinity.</p>
+         </fos:change>
          <fos:change issue="1555" PR="1565" date="2024-11-11">
             <p>The default for the <code>escape</code> option has been changed to <code>false</code>. The 3.1
             specification gave the default value as <code>true</code>, but this appears to have been an error,

--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -3513,7 +3513,7 @@ is described in <specref ref="serdm"/>.</p>
     <change issue="938" PR="TODO" date="2025-10-20">
       JSON canonicalization is supported by the <code>·canonical·</code> property.
     </change>
-    <change issue="641">
+    <change issue="641" PR="2387" date="2026-01-16">
       The JSON output method now produces fallback representation of NaN and infinity, rather
       than reporting an error for such values.
     </change>


### PR DESCRIPTION
Addresses part of issue #641 

In the JSON serialization method, NaN is output as `null`, and infinity is output as `±1e9999`.

The parse-json function adds recommendations on how to achieve round-tripping of these values.