### PR TITLE
2384 Clarify that fn:xsd-validator can validate attributes

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -20336,12 +20336,12 @@ return { "width": $int16-at($loc + 5),
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Given an XSD schema, delivers a function item that can be invoked to validate a document or element node
+         <p>Given an XSD schema, delivers a function item that can be invoked to validate a document, element, or attribute node
             against this schema.</p>
       </fos:summary>
       <fos:rules>
          <p>The <function>fn:xsd-validator</function> function returns a function item that can be used to validate a
-        document node or an element node with respect to a supplied schema.</p>
+        document node, element node, or attribute node with respect to a supplied schema.</p>
          
          <p>The details of how the schema is assembled, and the way it is used, are defined by the supplied <code>$options</code>.
             If the <code>$options</code> argument is absent or empty the effect is to use the schema components from the
@@ -20523,7 +20523,7 @@ return { "width": $int16-at($loc + 5),
             some processors might allow validation using a schema in which an element declaration
             contains a reference to a type declaration that is not present in the schema, provided
             that the element declaration is never needed in the course of a particular validation
-            episodes.</p></item>
+            episode.</p></item>
          </ulist>
          
          <p>Having assembled a schema, the next task is to validate a supplied node (and the subtree
@@ -20661,8 +20661,6 @@ return { "width": $int16-at($loc + 5),
              The information available for this part of the processing may not be 100% interoperable, though with care it
              should be possible to write the query in such a way that it works with different processors.</p></item>
           </ulist>
-          <p>The validation process is explained in more detail in the XQuery (<xspecref spec="XQ40" ref="id-validate"/>)
-             and XSLT (<xspecref spec="XT40" ref="validation"/>) specifications.</p>
           <p>The function has no effect on the static context. Schemas loaded using this function, either directly or
           via the effect of <code>xsi:schemaLocation</code> and <code>xsi:noNamespaceSchemaLocation</code> attributes, are not
           added to the static context and have no effect on any other validation episodes. A processor may cache schema


### PR DESCRIPTION
Fix #2384