### PR TITLE
Stopgap fix to get the status quo drafts built

### DIFF
--- a/specifications/EXPath/file/src/function-catalog.xml
+++ b/specifications/EXPath/file/src/function-catalog.xml
@@ -144,6 +144,7 @@
         </fos:test>
         <fos:test>
           <fos:expression>file:is-absolute('/')</fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Returns <code>true</code> on a UNIX-based system and
              <code>false</code> on a Windows system.</fos:postamble>
         </fos:test>
@@ -182,11 +183,13 @@
       <fos:example>
         <fos:test>
           <fos:expression>file:last-modified('.')</fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Returns the last modification time of the
           <termref def="current-working-dir"/>.</fos:postamble>
         </fos:test>
         <fos:test>
           <fos:expression>file:last-modified(file:base-dir())</fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Returns the last modification time of the
             <termref def="base-dir"/>.</fos:postamble>
         </fos:test>
@@ -282,11 +285,13 @@
       <fos:example>
         <fos:test spec="XQuery">
           <fos:expression><![CDATA[file:append('fragments.xml', <fragment/>)]]></fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Appends a serialized element node to the file
             <code>fragments.xml</code>. The file is created if it does not already exist.</fos:postamble>
         </fos:test>
         <fos:test>
           <fos:expression>file:append('snippets.json', { 'one': 1 }, { 'method': 'json' })</fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Serializes a map as JSON and appends the resulting string to the file
             <code>snippets.json</code>.</fos:postamble>
         </fos:test>
@@ -334,6 +339,7 @@
       <fos:example>
         <fos:test>
           <fos:expression>file:append-binary('data.bin', xs:hexBinary('414243'))</fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Appends the bytes <code>0x44</code>, <code>0x43</code> and <code>0x41</code>
             to the file <code>data.bin</code>.
             The file is created if it does not already exist.</fos:postamble>
@@ -382,6 +388,7 @@
       <fos:example>
         <fos:test>
           <fos:expression>file:append-text('todos.txt', 'clean up')</fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Appends a string to the file <code>todos.txt</code>.
             The file is created if it does not already exist.</fos:postamble>
         </fos:test>
@@ -430,6 +437,7 @@
       <fos:example>
         <fos:test>
           <fos:expression>file:append-text-lines('numbers.txt', (1 to 5) ! string())</fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Appends the string representation of the integers 1 to 5 to the file
             <code>numbers.txt</code>. The file is created if it does not already exist.</fos:postamble>
         </fos:test>
@@ -508,16 +516,19 @@
       <fos:example>
         <fos:test>
           <fos:expression>file:copy('a.txt', 'b.txt')</fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Creates a copy of the file <code>a.txt</code> in the
             same directory, named <code>b.txt</code>.</fos:postamble>
         </fos:test>
         <fos:test>
           <fos:expression>file:copy('a.txt', '../')</fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Creates a copy of the file <code>a.txt</code> with the same name
             in the parent directory.</fos:postamble>
         </fos:test>
         <fos:test>
           <fos:expression>file:copy('dir/', 'dir2/')</fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Creates a recursive copy of the directory <code>dir</code>
             in the <termref def="current-working-dir"/>, named <code>dir2</code>. If
             <code>dir2</code> already exists, the contents of <code>dir</code> will be copied
@@ -557,11 +568,13 @@
       <fos:example>
         <fos:test>
           <fos:expression>file:create-dir('examples')</fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Creates a directory named <code>examples</code> in the
             <termref def="current-working-dir"/>.</fos:postamble>
         </fos:test>
         <fos:test>
           <fos:expression>file:create-dir('/')</fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Will do nothing, as the root directory already exists.</fos:postamble>
         </fos:test>
       </fos:example>
@@ -609,6 +622,7 @@
         </fos:test>
         <fos:test>
           <fos:expression><eg>file:create-temp-dir(dir := file:base-dir())</eg></fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Creates a temporary directory in the <termref def="base-dir"/> or,
             if it is undefined, in the default temporary-file directory.</fos:postamble>
         </fos:test>
@@ -621,6 +635,7 @@ return try {
   file:delete($dir, true())
 }
           </eg></fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Creates a temporary directory, writes a file into that directory, and
             deletes it again.</fos:postamble>
         </fos:test>
@@ -670,6 +685,7 @@ return try {
       <fos:example>
         <fos:test>
           <fos:expression>file:create-temp-file(suffix := '.txt')</fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Creates a file with the suffix <code>.txt</code> in the
             temporary-file directory.</fos:postamble>
         </fos:test>
@@ -715,11 +731,13 @@ return try {
       <fos:example>
         <fos:test>
           <fos:expression>file:delete('list.txt')</fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Deletes the file <code>list.txt</code> from the
             <termref def="current-working-dir"/>.</fos:postamble>
         </fos:test>
         <fos:test>
           <fos:expression>file:delete('examples', true())</fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Deletes the file or directory <code>example</code> and (if available)
             all subdirectories.</fos:postamble>
         </fos:test>
@@ -782,6 +800,7 @@ return try {
       <fos:example>
         <fos:test>
           <fos:expression>file:list('.')</fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Returns the names of all files in the
             <termref def="current-working-dir"/>.</fos:postamble>
         </fos:test>
@@ -789,6 +808,7 @@ return try {
       <fos:example>
         <fos:test>
           <fos:expression>file:list('.', pattern := '*.zip')</fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Returns the names of archive files in the
             <termref def="current-working-dir"/>.</fos:postamble>
         </fos:test>
@@ -802,6 +822,7 @@ let $path := file:resolve-path($file, $root)
 where file:size($path) > 1000000
 return file:read-text($path)
           </eg></fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Returns the contents of large text files found in a specific
             directory and its subdirectories.</fos:postamble>
         </fos:test>
@@ -846,6 +867,7 @@ return file:read-text($path)
       <fos:example>
         <fos:test>
           <fos:expression>file:list-roots('/')</fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>A single slash as result indicates a UNIX-based system.</fos:postamble>
         </fos:test>
       </fos:example>
@@ -924,14 +946,17 @@ return file:read-text($path)
       <fos:example>
         <fos:test>
           <fos:expression>file:move('a.txt', 'b.txt')</fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Renames <code>a.txt</code> to <code>b.txt</code>.</fos:postamble>
         </fos:test>
         <fos:test>
           <fos:expression>file:move('a.txt', '../')</fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Moves the file <code>a.txt</code> to the parent directory.</fos:postamble>
         </fos:test>
         <fos:test>
           <fos:expression>file:move('dir/', 'dir2/')</fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Renames <code>dir</code> to <code>dir2</code>. If <code>dir2</code>
           already exists, moves the source directory into that directory.</fos:postamble>
         </fos:test>
@@ -978,11 +1003,13 @@ return file:read-text($path)
       <fos:example>
         <fos:test>
           <fos:expression>file:read-binary('data.bin') eq xs:hexBinary('41')</fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Returns <code>true</code> if the file <code>data.bin</code>
             contains the single byte <code>0x41</code>.</fos:postamble>
         </fos:test>
         <fos:test>
           <fos:expression>file:read-binary('data.bin', file:size($path) - 1, 1)</fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Returns the last byte of the file <code>data.bin</code>.</fos:postamble>
         </fos:test>
       </fos:example>
@@ -1035,6 +1062,7 @@ return file:read-text($path)
       <fos:example>
         <fos:test>
           <fos:expression>contains(file:read-text('todos.txt'), 'push forward')</fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Returns <code>true</code> if the file <code>todos.txt</code>
             contains the specified string.</fos:postamble>
         </fos:test>
@@ -1163,6 +1191,7 @@ return (
       <fos:example>
         <fos:test>
           <fos:expression>file:write('numbers.txt', 1 to 10)</fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Writes 10 numbers to the file <code>numbers.txt</code>.</fos:postamble>
         </fos:test>
         <fos:test spec="XQuery">
@@ -1173,6 +1202,7 @@ file:write(
   { 'encoding': 'us-ascii', 'indent': true() }
 )
           ]]></eg></fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Serializes an indented element node as <code>US-ASCII</code> and
             writes it to the file <code>result.xml</code>.</fos:postamble>
         </fos:test>
@@ -1184,6 +1214,7 @@ file:write(
   { 'method': 'json' }
 )
           </eg></fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Writes a map, serialized as JSON, to a specified file.</fos:postamble>
         </fos:test>
       </fos:example>
@@ -1240,11 +1271,13 @@ file:write(
       <fos:example>
         <fos:test>
           <fos:expression>file:write-binary('data.bin', xs:hexBinary('414243'))</fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Writes the bytes <code>0x44</code>, <code>0x43</code> and <code>0x41</code>
             to the file <code>data.bin</code>.</fos:postamble>
         </fos:test>
         <fos:test>
           <fos:expression>file:write-binary('data.bin', xs:hexBinary('44', 2))</fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>If this expression is called after the previous one, overwrites the last
             byte with <code>0x44</code>.</fos:postamble>
         </fos:test>
@@ -1291,6 +1324,7 @@ file:write(
       <fos:example>
         <fos:test>
           <fos:expression>file:write-text('todos.txt', 'get organized')</fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Writes a string to the file <code>todos.txt</code>.
             The file is created if it does not already exist.</fos:postamble>
         </fos:test>
@@ -1338,6 +1372,7 @@ file:write(
       <fos:example>
         <fos:test>
           <fos:expression>file:write-text-lines('numbers.txt', (1 to 5) ! string())</fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Writes the string representation of the integers 1 to 5 to the file
             <code>numbers.txt</code>.</fos:postamble>
         </fos:test>
@@ -1476,6 +1511,7 @@ file:write(
       <fos:example>
         <fos:test>
           <fos:expression>count(file:children('.'))</fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>
             Counts the files and directories in the <termref def="current-working-dir"/>.
           </fos:postamble>
@@ -1484,6 +1520,7 @@ file:write(
           <fos:expression>
             file:children('path/to/media/')[matches(., '\.(avi|mpg|mp4)$', 'i')]
           </fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>
             Returns the paths to large videos found in a specific directory.
           </fos:postamble>
@@ -1527,6 +1564,7 @@ file:write(
       <fos:example>
         <fos:test>
           <fos:expression>count(file:descendants('.')[file:is-directory(.)])</fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>
             Counts the subdirectories in the <termref def="current-working-dir"/>.
           </fos:postamble>
@@ -1537,6 +1575,7 @@ for $file in file:descendants('.')
 where file:last-modified($file) > current-dateTime() - xs:dayTimeDuration('PT1H')
 return $file
           </eg></fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>
             Returns the paths to all files that have been modified in the last hour.
           </fos:postamble>
@@ -1580,6 +1619,7 @@ return $file
       <fos:example>
         <fos:test>
           <fos:expression>file:path-to-native('/')</fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Returns <code>/</code> on a UNIX-based system.</fos:postamble>
         </fos:test>
       </fos:example>
@@ -1610,6 +1650,7 @@ return $file
       <fos:example>
         <fos:test>
           <fos:expression>file:path-to-uri('/temp')</fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Returns <code>file:///temp</code> on a UNIX-based system</fos:postamble>
         </fos:test>
         <fos:test>
@@ -1785,6 +1826,7 @@ return $file
       <fos:example>
         <fos:test>
           <fos:expression>file:write-text(file:temp-dir() || 'todos.txt', 'get on going')</fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Write a text string to a file in the temporary-file directory.</fos:postamble>
         </fos:test>
       </fos:example>
@@ -1815,6 +1857,7 @@ return $file
 let $dir := file:base-dir() otherwise file:create-temp-dir()
 return file:write-text($dir || 'todos.txt', 'get up')
           </eg></fos:expression>
+          <fos:result>FIXME:</fos:result>
           <fos:postamble>Writes <code>todos.txt</code> to the <termref def="base-dir"/> or,
 if it is not defined, to a temporary directory.</fos:postamble>
         </fos:test>


### PR DESCRIPTION
The content model of fos:test requires an fos:result or fos:error-result. For the EXPath File module, we have to work out what those should be or change the markup or change the schema.

In the short term, I’ve made bogus fos:results of FIXME: