### PR TITLE
2403 Enhancements to fos.xsd

### DIFF
--- a/specifications/xpath-functions-40/src/fos.xsd
+++ b/specifications/xpath-functions-40/src/fos.xsd
@@ -401,7 +401,7 @@
   <xs:element name="result">
     <xs:complexType mixed="true">
       <xs:sequence>
-        <xs:any namespace="##local" processContents="skip" minOccurs="0"/>
+        <xs:any namespace="##local" processContents="skip" minOccurs="0" maxOccurs="unbounded"/>
       </xs:sequence>
       <xs:attribute name="allow-permutation" type="xs:boolean"/>
       <xs:attribute name="approx" type="xs:boolean"/>


### PR DESCRIPTION
Schema enhancements to the function catalog for

Issue #2403 - allow non-testable results for examples to be labelled narrative="true"
Issue #2177 - allow a fos:see-also element to make links to related functions

Note this PR is purely an enabler, it does not include changes to the function catalog to exploit this features, nor stylesheet enhancements to render them.