### PR TITLE
More Explorer tweaks

### DIFF
--- a/explorer/grammar-explorer.xsl
+++ b/explorer/grammar-explorer.xsl
@@ -9,7 +9,7 @@
                 expand-text="yes"
                 version="3.0">
 
-<xsl:output method="xml" encoding="utf-8" indent="no"/>
+<xsl:output method="html" version="5.0" encoding="utf-8" indent="no"/>
 <xsl:strip-space elements="*"/>
 
 <xsl:param name="grammar" as="xs:string" select="'xpath40'"/>
@@ -37,9 +37,16 @@
       <link rel="stylesheet" href="grammar.css"/>
     </head>
     <body>
-      <h1>{$display-name} Grammar</h1>
+      <div class="ribbon">
+        <nav>
+          <a href="../index.html">Grammar Explorer</a>
+        </nav>
+      </div>
+      <main>
+        <h1>{$display-name} Grammar</h1>
 
-      <xsl:apply-templates select="$xml-grammar"/>
+        <xsl:apply-templates select="$xml-grammar"/>
+      </main>
     </body>
   </html>
 </xsl:template>
@@ -58,6 +65,7 @@
     <tbody>
       <xsl:apply-templates select="$productions[@name=$name]"/>
       <xsl:for-each select="distinct-values($productions/@name/string())">
+        <!-- Q: group character classes and append to the end of the list? -->
         <xsl:sort select="upper-case(.)"/>
         <xsl:if test=". != $name">
           <xsl:variable name="pname" select="."/>
@@ -72,22 +80,20 @@
   <xsl:variable name="name" select="@name/string()"/>
 
   <tr>
-    <td>
+    <td class="rule">
       <code id="{$name}">
         <a href="{$name}.html">
           <xsl:value-of select="$name"/>
         </a>
       </code>
     </td>
-    <td>
+    <td class="assign">
       <code>::=</code>
     </td>
-    <td>
-      <span class="rhs">
-        <xsl:call-template name="m:sequence">
-          <xsl:with-param name="parens" select="false()"/>
-        </xsl:call-template>
-      </span>
+    <td class="rhs">
+      <xsl:call-template name="m:sequence">
+        <xsl:with-param name="parens" select="false()"/>
+      </xsl:call-template>
     </td>
   </tr>
 
@@ -98,28 +104,29 @@
         <link rel="stylesheet" href="grammar.css"/>
       </head>
       <body>
-        <nav>
-          <a href="index.html#{$name}">Grammar</a>
-        </nav>
+        <div class="ribbon">
+          <nav>
+            <a href="index.html#{$name}">Grammar</a>
+          </nav>
+        </div>
         <header>
           <h1>{$display-name} <code><xsl:value-of select="$name"/></code></h1>
         </header>
+        <main>
         <table>
           <tbody>
             <tr>
-              <td>
+              <td class="rule">
                 <code>
                   <xsl:value-of select="$name"/>
                 </code>
               </td>
-              <td>::=</td>
-              <td>
-                <span class="rhs">
-                  <xsl:call-template name="m:sequence">
-                    <xsl:with-param name="parens" select="false()"/>
-                    <xsl:with-param name="relative" select="false()" tunnel="true"/>
-                  </xsl:call-template>
-                </span>
+              <td class="assign"><code>::=</code></td>
+              <td class="rhs">
+                <xsl:call-template name="m:sequence">
+                  <xsl:with-param name="parens" select="false()"/>
+                  <xsl:with-param name="relative" select="false()" tunnel="true"/>
+                </xsl:call-template>
               </td>
             </tr>
           </tbody>
@@ -154,6 +161,7 @@
             </div>
           </xsl:for-each>
         </xsl:if>
+        </main>
       </body>
     </html>
   </xsl:result-document>
@@ -200,9 +208,9 @@
 
 <xsl:template match="g:choice">
   <span class="choice">
-    <span class="paren oparen">(</span>
+    <span class="paren opening">(</span>
     <xsl:call-template name="m:choice"/>
-    <span class="paren cparen">)</span>
+    <span class="paren closing">)</span>
   </span>
 </xsl:template>
 
@@ -229,7 +237,7 @@
 </xsl:template>
 
 <xsl:template match="g:charClass">
-  <code>
+  <code class="bracket opening">
     <xsl:text>[</xsl:text>
     <xsl:if test="../g:complement">
       <xsl:text>^</xsl:text>
@@ -238,7 +246,7 @@
   <span class="charClass">
     <xsl:apply-templates/>
   </span>
-  <code>]</code>
+  <code class="bracket closing">]</code>
 </xsl:template>
 
 <xsl:template match="g:char">
@@ -267,15 +275,15 @@
       <xsl:text>&amp;#x</xsl:text>
       <xsl:value-of select="@minValue"/>
       <xsl:text>;</xsl:text>
+      <xsl:sequence select="f:show-char(@minValue)"/>
     </code>
-    <xsl:sequence select="f:show-char(@minValue)"/>
     <xsl:text>-</xsl:text>
     <code>
       <xsl:text>&amp;#x</xsl:text>
       <xsl:value-of select="@maxValue"/>
       <xsl:text>;</xsl:text>
+      <xsl:sequence select="f:show-char(@maxValue)"/>
     </code>
-    <xsl:sequence select="f:show-char(@maxValue)"/>
   </span>
   <xsl:text> </xsl:text>
 </xsl:template>
@@ -309,7 +317,7 @@
   <xsl:param name="parens" as="xs:boolean" select="true()"/>
 
   <xsl:if test="$parens and count(*) gt 1">
-    <span class="paren oparen">(</span>
+    <span class="paren opening">(</span>
   </xsl:if>
 
   <xsl:for-each select="*">
@@ -320,7 +328,7 @@
   </xsl:for-each>
 
   <xsl:if test="$parens and count(*) gt 1">
-    <span class="paren cparen">)</span>
+    <span class="paren closing">)</span>
   </xsl:if>
 </xsl:template>
 
@@ -352,8 +360,8 @@
   <xsl:param name="spechref" as="xs:string" tunnel="yes"/>
 
   <!-- The XSLT spec has an un-headed div2; so special case... -->
-  <xsl:variable name="current" select="(scrap/prod[lhs=$name]
-                                       |scrap/prodgroup/prod[lhs=$name]
+  <xsl:variable name="current" select="( scrap/prod[lhs=$name]
+                                       | scrap/prodgroup/prod[lhs=$name]
                                        | div1[not(head)]//prod[lhs=$name]
                                        | div2[not(head)]//prod[lhs=$name]
                                        | div3[not(head)]//prod[lhs=$name]

--- a/explorer/grammar.css
+++ b/explorer/grammar.css
@@ -1,80 +1,184 @@
-/* Grammar */
+/* Grammar styles */
+:root {
+    /* sizes */
+    --ratio: 1.5;
+    --s-5: calc(var(--s-4) / var(--ratio));    /* 0.131rem */
+    --s-4: calc(var(--s-3) / var(--ratio));    /* 0.198rem */
+    --s-3: calc(var(--s-2) / var(--ratio));    /* 0.296rem */
+    --s-2: calc(var(--s-1) / var(--ratio));    /* 0.444rem */
+    --s-1: calc(var(--s0) / var(--ratio));     /* 0.667rem */
+    --s0: 1rem;                                /* 1.000rem */
+    --s1: calc(var(--s0) * var(--ratio));      /* 1.500rem */
+    --s2: calc(var(--s1) * var(--ratio));      /* 2.250rem */
+    --s3: calc(var(--s2) * var(--ratio));      /* 3.375rem */
+    --s4: calc(var(--s3) * var(--ratio));      /* 5.063rem */
+    --s5: calc(var(--s4) * var(--ratio));      /* 7.594rem */
+
+    /* colors */
+    --black: #161622;
+    --white: #fefefe;
+    --lightgrey: #f4f1fa;
+ 
+    --ch: #d3daf9;
+    --gr: #131462;
+}
+
 html {
-    font-size: 14pt;
+    font-size: 16px;
     line-height: 1.5;
+    color: var(--black);
+}
+
+/* centered blocks */
+header, main, nav {
+    box-sizing: content-box;
+    max-width: 60rem;
+    margin-inline: auto;
+    padding-inline: var(--s0);
 }
 
 body {
-    max-width: 50rem;
-    margin-left: auto;
-    margin-right: auto;
+    padding-inline: 0;
+    margin-inline: 0;
+    margin-block-start: 0;
+    margin-block-end: var(--s5);
+
+    background-color: var(--white);
+    color: var(--black);
+    font-family: sans-serif;
+}
+
+.ribbon {
+    background-color:var(--gr);
+    color:var(--white);
+}
+
+nav {
+    margin-block: 0;
+    padding-inline: var(--s-2);
+    padding-block-start: var(--s-1);
+    padding-block-end: var(--s-3);
+    min-height: var(--s1);
+}
+
+nav a,
+nav a:hover,
+nav a:visited,
+nav a:active {
+    color: inherit;
+    text-decoration: none;
+}
+
+nav a::before {
+    content: "⬅︎";
+    margin-inline-end: var(--s-2);
 }
 
 h1, h2, h3, h4, h5 {
     font-family: sans-serif;
+    line-height: 1.125;
+}
+h1 {
+    font-size: var(--s3);
+}
+h2 {
+    font-size: var(--s2);
+}
+h3 {
+    font-size: var(--s1);
 }
 
-table tbody tr td {
-    font-size: 14pt;
+h1 code {
+    font-size: .6em;
 }
 
-code {
-    font-size: 90%;
-}
-
+/* TOC page */
 ul.toc {
     list-style: none;
     font-family: sans-serif;
 }
 
 div > ul.toc {
-    padding-left: 1rem;
-}
-
-.paren, .occur {
-    font-weight: bold;
-}
-
-.oparen::after {
-    content: " ";
-}
-
-.cparen::before {
-    content: " ";
-}
-
-td {
-    vertical-align: top;
-    padding: 4px;
+    padding-left: 0;
 }
 
 table {
-    background-color: #eeeeee;
     border-spacing: 0;
     border-collapse: collapse;
+    width: 100%;
 }
 
-table.grammar tbody tr:nth-child(odd) {
-    background-color: inherit;
+tr:nth-child(odd) {
+    background-color: var(--lightgrey);
 }
 
-table.grammar tbody tr:nth-child(even) {
-    background-color: white;
+tr:nth-child(even) {
+    background-color: var(--white);
 }
 
-.ch {
-    background-color: #ddddff;
-    padding-left: 0.25rem;
-    padding-right: 0.25rem;
-    border-radius: 2px;
-    user-select: none;
-    -webkit-user-select: none;
+td.rule {
+    max-width: 26ch; /* the longest rule is 26 characters long */
+}
+td.assign {
+    width: 3ch; /* ::= */
+}
+td.rhs {
+    width: 100%; /* the rest is the right hand side */
 }
 
-.grammar .ch {
-    display: none;
+td {
+    vertical-align: baseline;
+    font-family: monospace;
+    padding-inline: var(--s-2);
+    padding-block: var(--s-3);
+    font-size: var(--s0);
+}
+
+a {
+    font-weight: normal;
+}
+
+/* EBNF syntax */
+.bracket, .paren, .occur, .choice,
+.assign code {
+    font-weight: bold;
+    color: var(--gr);
+}
+
+/* reset font styles for literals */
+.string, .char {
+    font-weight: normal;
+    color: var(--black);
+}
+
+/* only apply margin to parens */
+.paren.opening {
+    margin-inline-end: var(--s-2);
+}
+.paren.closing {
+    margin-inline-start: var(--s-2);
+}
+/* for brackets the margin is applied from their content */
+.charClass {
+    display: inline-block;
+    margin-inline: var(--s-2);
 }
 
 .charCodeRange {
     white-space: nowrap;
 }
+
+/* display character codes as characters */
+.ch {
+    background-color: var(--ch);
+    padding-inline: var(--s-2);
+    padding-block: var(--s-4);
+    border-radius: var(--s-4);
+    user-select: none;
+    -webkit-user-select: none;
+}
+/* hide them on grammar listings */
+.grammar .ch {
+    display: none;
+}
+

--- a/explorer/index.html
+++ b/explorer/index.html
@@ -1,42 +1,50 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
-  <head>
-    <title>Grammar Explorer</title>
-    <link rel="stylesheet" href="grammar.css"/>
-  </head>
+
+<head>
+  <title>Grammar Explorer</title>
+  <link rel="stylesheet" href="grammar.css" />
+</head>
+
 <body>
-<h1>Grammar Explorer</h1>
+  <div class="ribbon">
+    <nav></nav>
+  </div>
+  <main>
 
-<p>These pages present the various QT grammars as a navigable web
-of pages with links back to the occurrences in the spec where productions
-are referenced.</p>
+    <h1>Grammar Explorer</h1>
 
-<p>On each grammar page, clicking on links on the “right hand side” side a
-production will navigate within the grammar page. Clicking on the production
-name on the left hand side will take you to a detail page about that production.
-The detail pages show where the nonterminal occurs in the grammar and where it
-is referenced in the specifications.</p>
+    <p>These pages present the various QT grammars as a navigable web
+      of pages with links back to the occurrences in the spec where productions
+      are referenced.</p>
 
-<h2>Current grammars</h2>
+    <p>On each grammar page, clicking on links on the “right hand side” side a
+      production will navigate within the grammar page. Clicking on the production
+      name on the left hand side will take you to a detail page about that production.
+      The detail pages show where the nonterminal occurs in the grammar and where it
+      is referenced in the specifications.</p>
 
-<ul>
-  <li><a href="xpath40/index.html">XPath 4.0</a></li>
-  <li><a href="xquery40/index.html">XQuery 4.0</a></li>
-  <li><a href="xslt40-patterns/index.html">XSLT 4.0 patterns</a></li>
-</ul>
+    <h2>Current grammars</h2>
 
-<h2>Old grammars</h2>
+    <ul>
+      <li><a href="xpath40/index.html">XPath 4.0</a></li>
+      <li><a href="xquery40/index.html">XQuery 4.0</a></li>
+      <li><a href="xslt40-patterns/index.html">XSLT 4.0 patterns</a></li>
+    </ul>
 
-<p>These pages are constructed from the grammars and documents associated with
-XPath 3.1, XQuery 3.1, and XSLT 3.0. They’re imperfect because the grammar file
-uses some features that Norm hasn’t reverse engineered. And might never.</p>
+    <h2>Old grammars</h2>
 
-<ul>
-<li><a href="xpath31/index.html">XPath 3.1</a></li>
-<li><a href="xquery31/index.html">XQuery 3.1</a></li>
-<li><a href="xpath30/index.html">XPath 3.0</a></li>
-<li><a href="xquery30",>XQuery 3.0</a></li>
-<li><a href="xslt30-patterns/index.html">XSLT 3.0 patterns</a></li>
-</ul>
+    <p>These pages are constructed from the grammars and documents associated with
+      XPath 3.1, XQuery 3.1, and XSLT 3.0. They’re imperfect because the grammar file
+      uses some features that Norm hasn’t reverse engineered. And might never.</p>
 
+    <ul>
+      <li><a href="xpath31/index.html">XPath 3.1</a></li>
+      <li><a href="xquery31/index.html">XQuery 3.1</a></li>
+      <li><a href="xpath30/index.html">XPath 3.0</a></li>
+      <li><a href="xquery30" ,>XQuery 3.0</a></li>
+      <li><a href="xslt30-patterns/index.html">XSLT 3.0 patterns</a></li>
+    </ul>
+  </main>
 </body>
+
 </html>


### PR DESCRIPTION
Building on the awesome work from @ndw I just tweaked the grammar explorer layout a little more

- layout works better on bigger and smaller screens
- consistent navigation between all screens with back button alwasy on the navigation at the top
- consistent sizes, paddings, colors set by CSS variables
- output as html5 which fixes small issues with whitespace in inline elements
- additional, minor layout improvmements


<img width="400" alt="Screenshot 2026-01-29 at 22 25 40" src="https://github.com/user-attachments/assets/1ec721f8-fde8-490e-ad31-442891874c7c" />
<img width="400" alt="Screenshot 2026-01-29 at 22 25 58" src="https://github.com/user-attachments/assets/e01953dd-10e1-4b68-9b17-4bbe82de0ac8" />
<img width="364" alt="Screenshot 2026-01-29 at 22 26 11" src="https://github.com/user-attachments/assets/2d816271-ee5c-4b49-aea8-e3e094b88f15" />

## Before 
<img width="400" alt="Screenshot 2026-01-29 at 22 41 33" src="https://github.com/user-attachments/assets/4d3ef049-7666-4ed7-9e6b-9201ca63c66f" />

## After
<img width="400" alt="Screenshot 2026-01-29 at 22 41 20" src="https://github.com/user-attachments/assets/ae790d26-0c8e-4fcd-b6c4-81653c577c93" />