### PR TITLE
Updates to schema for xslt

### DIFF
--- a/specifications/xslt-40/src/schema-for-xslt40.rnc
+++ b/specifications/xslt-40/src/schema-for-xslt40.rnc
@@ -305,7 +305,7 @@ use-package.element =
       attribute _name { avt.datatype }?,
       attribute package-version { string.datatype }?,
       attribute _package-version { avt.datatype }?,
-      (accept.element | override.element)*
+      (package-location.element | accept.element | override.element)*
    }
 expose.element =
    element expose {
@@ -319,6 +319,20 @@ expose.element =
       attribute _visibility { avt.datatype }?,
       empty
    }
+package-location.element =
+   element package-location {
+      extension.atts,
+      global.atts,    
+      (attribute path-in-archive { string.datatype } |
+      attribute _path-in-archive { avt.datatype })+,
+      (attribute archive-type { string.datatype } |
+      attribute _archive-type { avt.datatype })+,
+      (attribute is-priority { boolean.datatype } |
+      attribute _is-priority { avt.datatype })+,
+      (attribute format { string.datatype } |
+      attribute _format { avt.datatype })+,
+      empty
+   }   
 accept.element =
    element accept {
       extension.atts,
@@ -1252,6 +1266,8 @@ result-document.element =
       attribute _build-tree { avt.datatype }?,
       attribute byte-order-mark { boolean.datatype | avt.datatype }?,
       attribute _byte-order-mark { avt.datatype }?,
+      attribute canonical { boolean.datatype | avt.datatype }?,
+      attribute _canonical { avt.datatype }?,
       attribute cdata-section-elements { eqnames.datatype | avt.datatype }?,
       attribute _cdata-section-elements { avt.datatype }?,
       attribute doctype-public { string.datatype | avt.datatype }?,
@@ -1306,6 +1322,8 @@ output.element =
       attribute _build-tree { avt.datatype }?,
       attribute byte-order-mark { boolean.datatype }?,
       attribute _byte-order-mark { avt.datatype }?,
+      attribute canonical { boolean.datatype }?,
+      attribute _canonical { avt.datatype }?,
       attribute cdata-section-elements { eqnames.datatype }?,
       attribute _cdata-section-elements { avt.datatype }?,
       attribute doctype-public { string.datatype }?,

--- a/specifications/xslt-40/src/schema-for-xslt40.xsd
+++ b/specifications/xslt-40/src/schema-for-xslt40.xsd
@@ -171,7 +171,8 @@ of problems processing the schema using various tools
                       xsl:output 
                       xsl:output-character 
                       xsl:override 
-                      xsl:package 
+                      xsl:package
+                      xsl:package-location
                       xsl:param 
                       xsl:perform-sort 
                       xsl:preserve-space 
@@ -1461,6 +1462,7 @@ of problems processing the schema using various tools
           <xs:attribute name="allow-duplicate-names" type="xsl:yes-or-no"/>
           <xs:attribute name="build-tree" type="xsl:yes-or-no"/>
           <xs:attribute name="byte-order-mark" type="xsl:yes-or-no"/>
+          <xs:attribute name="canonical" type="xsl:yes-or-no"/>
           <xs:attribute name="cdata-section-elements" type="xsl:EQNames"/>
           <xs:attribute name="doctype-public" type="xs:string"/>
           <xs:attribute name="doctype-system" type="xs:string"/>
@@ -1487,6 +1489,7 @@ of problems processing the schema using various tools
           <xs:attribute name="_allow-duplicate-names" type="xs:string"/>
           <xs:attribute name="_build-tree" type="xs:string"/>
           <xs:attribute name="_byte-order-mark" type="xs:string"/>
+          <xs:attribute name="_canonical" type="xs:string"/>
           <xs:attribute name="_cdata-section-elements" type="xs:string"/>
           <xs:attribute name="_doctype-public" type="xs:string"/>
           <xs:attribute name="_doctype-system" type="xs:string"/>
@@ -1579,7 +1582,26 @@ of problems processing the schema using various tools
       </xs:complexContent>
     </xs:complexType>
   </xs:element>
-
+  
+  <xs:element name="package-location">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:attribute name="href" type="xs:anyURI" use="required"/>
+          <xs:attribute name="path-in-archive" type="xs:string"/>
+          <xs:attribute name="archive-type" type="xs:string"/>
+          <xs:attribute name="is-priority" type="xsl:yes-or-no"/>
+          <xs:attribute name="format" type="xs:string"/>
+          <xs:attribute name="_href" type="xs:string"/>
+          <xs:attribute name="_path-in-archive" type="xs:string"/>
+          <xs:attribute name="_archive-type" type="xs:string"/>
+          <xs:attribute name="_is-priority" type="xs:string"/>
+          <xs:attribute name="_format" type="xs:string"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  
   <xs:element name="param" substitutionGroup="xsl:declaration">
     <xs:annotation>
       <xs:documentation>
@@ -1721,6 +1743,7 @@ of problems processing the schema using various tools
           <xs:attribute name="allow-duplicate-names" type="xsl:avt"/>
           <xs:attribute name="build-tree" type="xsl:avt"/>
           <xs:attribute name="byte-order-mark" type="xsl:avt"/>
+          <xs:attribute name="canonical" type="xsl:avt"/>
           <xs:attribute name="cdata-section-elements" type="xsl:avt"/>
           <xs:attribute name="doctype-public" type="xsl:avt"/>
           <xs:attribute name="doctype-system" type="xsl:avt"/>
@@ -1751,6 +1774,7 @@ of problems processing the schema using various tools
           <xs:attribute name="_allow-duplicate-names" type="xs:string"/>
           <xs:attribute name="_build-tree" type="xs:string"/>
           <xs:attribute name="_byte-order-mark" type="xs:string"/>
+          <xs:attribute name="_canonical" type="xs:string"/>
           <xs:attribute name="_cdata-section-elements" type="xs:string"/>
           <xs:attribute name="_doctype-public" type="xs:string"/>
           <xs:attribute name="_doctype-system" type="xs:string"/>
@@ -2120,6 +2144,7 @@ of problems processing the schema using various tools
       <xs:complexContent mixed="false">
         <xs:extension base="xsl:element-only-versioned-element-type">
           <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="xsl:package-location"/>
             <xs:element ref="xsl:accept"/>
             <xs:element ref="xsl:override"/>
           </xs:choice>


### PR DESCRIPTION
Updates the schema for XSLT 4.0:

* Adds `canonical` to `xsl:output` and `xsl:result-document`
* Adds `xsl:package-location` to content model of `xsl:use-package`.