### PR TITLE
Patch grammar explorer

### DIFF
--- a/explorer/grammar-explorer.xsl
+++ b/explorer/grammar-explorer.xsl
@@ -106,11 +106,11 @@
       <body>
         <div class="ribbon">
           <nav>
-            <a href="index.html#{$name}">Grammar</a>
+            <a href="index.html#{$name}">{$display-name} Grammar</a>
           </nav>
         </div>
         <header>
-          <h1>{$display-name} <code><xsl:value-of select="$name"/></code></h1>
+          <h1><code><xsl:value-of select="$name"/></code></h1>
         </header>
         <main>
         <table>

--- a/explorer/grammar.css
+++ b/explorer/grammar.css
@@ -49,15 +49,16 @@ body {
 }
 
 .ribbon {
-    background-color:var(--gr);
-    color:var(--white);
+    background-color: var(--gr);
 }
 
 nav {
+    display: flex;
+    align-items: center;
     margin-block: 0;
-    padding-block-start: var(--s-1);
-    padding-block-end: var(--s-3);
-    min-height: var(--s1);
+    color: var(--lightgrey);
+    font-size: var(--s0);
+    min-height: var(--s2);
 }
 
 nav a,
@@ -67,28 +68,28 @@ nav a:active {
     color: inherit;
     text-decoration: none;
 }
+nav a:active,
+nav a:hover {
+    color: var(--white);
+}
 
 nav a::before {
     content: "⬅︎";
     margin-inline-end: var(--s-2);
 }
 
-h1, h2, h3, h4, h5 {
+h1, h2, h3, h4, h5, h5 {
     font-family: sans-serif;
-    line-height: 1.125;
+    line-height: 1.25;
 }
 h1 {
-    font-size: var(--s3);
-}
-h2 {
     font-size: var(--s2);
 }
-h3 {
+h2 {
     font-size: var(--s1);
 }
-
-h1 code {
-    font-size: .6em;
+h3, h4, h5, h6 {
+    font-size: var(--s0);
 }
 
 /* TOC page */
@@ -150,10 +151,12 @@ a {
 .chars, .choices, .sequenceItems:has(~ .paren) {
     margin-inline: var(--s-2);
 }
+
 /* append caret to opening [ for inverted character class matches */
 .complement > .charClass > .bracket.opening::after {
   content: "^";
 }
+
 /* having occurrence indicators in extra elements causes them to be placed on
    the next line in edge cases
  */


### PR DESCRIPTION
On all pages:
Improve display of Headlines with slightly smaller font-size.

<img width="1984" height="716" alt="Screenshot 2026-02-02 at 11 07 32" src="https://github.com/user-attachments/assets/99756cf9-7ec2-4772-b44d-a29c1e445fd0" />


On rule detail pages:
The Name of the Grammar is now visible in the back button of the ribbon instead of the H1 which only displays the rule name.

<img width="2011" height="1192" alt="Screenshot 2026-02-02 at 11 08 41" src="https://github.com/user-attachments/assets/53c49922-a09e-4a18-b89e-43ca8224cad0" />


On the right hand side:

- Fix complement character class display.
- Sequence and choice items now are indented if they do not fit on one line
- occurrence indicators always stick to the item they belong to
- use spans to group items and mark any character that is displayed
- dashes in character ranges and the pipes in choices are now also recognized as part of EBNF syntax
- literals are never wrapped into the next line

<img width="1988" height="829" alt="Screenshot 2026-02-02 at 11 00 45" src="https://github.com/user-attachments/assets/9ac1658f-0cb3-4393-bc70-785e04d97207" />


