### PR TITLE
2434 Fix inconsistencies with GNode tests in axis steps

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1946,6 +1946,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   
   <g:production name="TypeTest">
     <g:choice>
+      <g:ref name="GNodeType"/>
       <g:ref name="NodeKindTest"/>
       <g:ref name="JNodeType"/>
     </g:choice>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -14200,7 +14200,7 @@ fn:parse-QName("xmp:person")</eg></fos:expression>
                   
                   <p>TODO: Better handling of the case where the parent is neither a map nor an array,
                   for example where it is a sequence of several maps or several arrays. It's hard to
-                  provide a better path for these when there is no AxisStep for selecting within
+                  provide a better path for these when there is no <code>AxisStep</code> for selecting within
                   such values.</p>
                         
                      
@@ -14222,8 +14222,8 @@ fn:parse-QName("xmp:person")</eg></fos:expression>
                      class="DY" code="0002" type="type"/></p>
             </item>
             <item>
-               <p>If the context value is not an instance of the sequence type <code>node()?</code>, type error <xerrorref spec="XP" class="TY"
-                     code="0004" type="type"/>.</p>
+               <p>If the context value is not an instance of the sequence type <code>gnode()?</code>, 
+                  type error <xerrorref spec="XP" class="TY" code="0004" type="type"/>.</p>
             </item></ulist>
             
                <p>If the value of the <code>origin</code> option is a node that is not an ancestor
@@ -14567,11 +14567,11 @@ let $newi := $o/tool</eg>
                <fos:result>false()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>[1,2,3] => has-children()</fos:expression>
+               <fos:expression>jtree([1,2,3]) => has-children()</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>[] => has-children()</fos:expression>
+               <fos:expression>jtree([]) => has-children()</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
             
@@ -14741,7 +14741,7 @@ return count(distinct-ordered-nodes(
                <fos:result><code>"a"</code></fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg><![CDATA[[[[1], [2]], [[3], [4]], [[5], [6]]]//self::array(*)
+               <fos:expression><eg><![CDATA[[[[1], [2]], [[3], [4]], [[5], [6]]]//jnode(*, array(*))
    => outermost() =!> array:size()]]></eg></fos:expression>
                <fos:result><code>3</code></fos:result>
             </fos:test>
@@ -14953,8 +14953,8 @@ return empty($break)
          
       </fos:rules>
       <fos:equivalent style="xpath-expression">
-if ($node intersect $node/parent::node()/child::node())
-then $node/parent::node()/child::node()
+if ($node intersect $node/parent::gnode()/child::gnode())
+then $node/parent::gnode()/child::gnode()
 else $node
       </fos:equivalent>
       <fos:errors>
@@ -14967,8 +14967,8 @@ else $node
                      class="DY" code="0002" type="type"/></p>
             </item>
             <item>
-               <p>If the context value is not an instance of the sequence type <code>node()?</code>, type error <xerrorref spec="XP" class="TY"
-                     code="0004" type="type"/>.</p>
+               <p>If the context value is not an instance of the sequence type <code>gnode()?</code>, 
+                  type error <xerrorref spec="XP" class="TY" code="0004" type="type"/>.</p>
             </item>
          </ulist>
 
@@ -14996,6 +14996,10 @@ else $node
             <fos:test use="v-siblings-e" spec="XQuery">
                <fos:expression>siblings($e//@x) ! string()</fos:expression>
                <fos:result>"X"</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>[[1,2], [11,12], [13,14]]//jnode()[.='12'] => siblings() => sum()</fos:expression>
+               <fos:result>23</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>


### PR DESCRIPTION
Fix #2434
Fix #2437

1. The axis step `child::gnode()` should be allowed.
2. The axis step `self::array(*)` is used in an example but is invalid syntax and makes no sense
3. Functions with an argument of type `gnode()`  that accept the context item as a default should allow the context item to be any gnode, not just an XNode.

