### PR TITLE
2444 Make match="*" and match="N" match element nodes only

### DIFF
--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -12664,8 +12664,7 @@ return $tree =?> depth()]]></eg>
                
             <div5 id="pattern-semantics">
                <head>The Meaning of a GNode Pattern</head>
-               <p>This section defines the formal meaning of a <nt def="GNodePattern">GNodePattern</nt>.
-                  In this section, “if” is to be read as “if and only if”.</p>
+               <p>This section defines the formal meaning of a <nt def="GNodePattern">GNodePattern</nt>.</p>
 
                
   
@@ -12788,7 +12787,7 @@ return $tree =?> depth()]]></eg>
                      equivalent expression, denoted below as <code>EE</code>.</p>
    
                   <p>Specifically, an item <var>N</var> matches a <nt def="GNodePattern">GNodePattern</nt>
-                      <var>P</var> if  the following applies, where
+                      <var>P</var> if and only if the following applies, where
                         <code>EE</code> is the <term>equivalent expression</term> to <var>P</var>:</p>
                   <ulist>
    
@@ -12820,7 +12819,7 @@ return $tree =?> depth()]]></eg>
                      <code>p</code> matches any <code>p</code> element. The equivalent expression,
                      after adjustment, is <code>child-or-top::element(p)</code>, and the pattern matches because a <code>p</code>
                      element will always be present in the result of evaluating the 
-                     eqivalent <termref def="dt-expression">expression</termref>
+                     equivalent <termref def="dt-expression">expression</termref>
                      <code>root(.)//(child-or-top::element(p))</code>.</p>
                   <p>Similarly, <code>/</code> matches a
                      document node, and only a document node. The equivalent expression, after adjustment,


### PR DESCRIPTION
Fix #2444

The effect of the change is that simple patterns like `match="*"` and `match="order"` will only match element nodes, they will no longer match JNodes.

This is motivated firstly by implementation experience: the current rules cause a performance regression compared with XSLT 3.0 because it's harder to do precise static type inferencing, and some streaming use cases are no longer streamable for the same reason.

However, I think there is also a usability benefit. These simple match patterns are instinctively understood by the entire XSLT user population, and extending their meaning so they match things unexpectedly could be a debugging nightmare. Consider the case of a mature stylesheet with hundreds of template rules designed to process XML elements, which is then extended with a new module to handle a JSON representation of the same data; it's very unlikely the user will actually want or intend the same template rules to process both, and if this is what they want, it's clearer to make this explicit by using a union pattern.