### PR TITLE
Stylesheet handling of fos:result/@narrative

### DIFF
--- a/specifications/xpath-functions-40/style/generate-qt3-test-set.xsl
+++ b/specifications/xpath-functions-40/style/generate-qt3-test-set.xsl
@@ -130,6 +130,10 @@
               </xsl:otherwise>
             </xsl:choose>           
           </xsl:when>
+          <xsl:when test="fos:result[@narrative]">
+            <!-- In this case the generated test must compile and execute, but the result is not tested -->
+            <assert>true()</assert>
+          </xsl:when>
           <xsl:when test="fos:result[@approx]">
             <assert>abs($result - {fos:result}) lt 1e-5</assert>
           </xsl:when>

--- a/specifications/xpath-functions-40/style/merge-function-specs.xsl
+++ b/specifications/xpath-functions-40/style/merge-function-specs.xsl
@@ -203,8 +203,8 @@
 					  <xsl:if test="fos:use-two-column-format($fspec/fos:examples)">
 					    <thead>
 					      <tr>
-						<th>Expression</th>
-						<th>Result</th>
+								<th>Expression</th>
+								<th>Result</th>
 					      </tr>
 					    </thead>
 					  </xsl:if>
@@ -215,16 +215,6 @@
 				 </def>
 		    </gitem>
 		  </xsl:if>
-			<!--<xsl:if test="$fspec/fos:history">
-				<gitem>
-					<label>History</label>
-					<def role="example">
-						<p>
-							<xsl:apply-templates select="$fspec/fos:history/fos:version/node()"/>
-						</p>
-					</def>
-				</gitem>
-			</xsl:if>-->
 		</glist>
 	</xsl:template>
 	
@@ -553,6 +543,9 @@
 	
 	<xsl:template match="fos:result">
 		<xsl:choose>
+			<xsl:when test="@narrative">
+				<p><xsl:apply-templates/></p>
+			</xsl:when>
 			<xsl:when test="contains(., codepoints-to-string(10)) or ..//eg">
 				<eg><xsl:value-of select="."/></eg>
 			</xsl:when>


### PR DESCRIPTION
Following a schema change that allows the function catalog to contain code examples annotated `<fos:result narrative="true">`, this PR makes stylesheet changes allowing such examples to be rendered.

- In generating the specification documents, narrative results are simply rendered as prose, without containing `<code>` tags
- In generating the QT4 tests, the generated test case ensures that the example can be successfully compiled and run, but the test always succeeds so long as the result is not a static or dynamic error.
