### PR TITLE
Improved use of fos:result

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -14218,7 +14218,7 @@ fn:parse-QName("xmp:person")</eg></fos:expression>
                   
                   <p>TODO: Better handling of the case where the parent is neither a map nor an array,
                   for example where it is a sequence of several maps or several arrays. It's hard to
-                  provide a better path for these when there is no <code>AxisStep</code> for selecting within
+                  provide a better path for these when there is no AxisStep for selecting within
                   such values.</p>
                         
                      
@@ -14240,8 +14240,8 @@ fn:parse-QName("xmp:person")</eg></fos:expression>
                      class="DY" code="0002" type="type"/></p>
             </item>
             <item>
-               <p>If the context value is not an instance of the sequence type <code>gnode()?</code>, 
-                  type error <xerrorref spec="XP" class="TY" code="0004" type="type"/>.</p>
+               <p>If the context value is not an instance of the sequence type <code>node()?</code>, type error <xerrorref spec="XP" class="TY"
+                     code="0004" type="type"/>.</p>
             </item></ulist>
             
                <p>If the value of the <code>origin</code> option is a node that is not an ancestor
@@ -14585,11 +14585,11 @@ let $newi := $o/tool</eg>
                <fos:result>false()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>jtree([1,2,3]) => has-children()</fos:expression>
+               <fos:expression>[1,2,3] => has-children()</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>jtree([]) => has-children()</fos:expression>
+               <fos:expression>[] => has-children()</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
             
@@ -14647,7 +14647,7 @@ return distinct-ordered-nodes(($x//c, $x//b, $x//a, $x//b)) ! name()]]></eg></fo
             <fos:test>
                <fos:expression><eg><![CDATA[let $x := [1, "a", true()]
 return count(distinct-ordered-nodes(
-                ($x/*[1], $x/type(xs:integer)) 
+                ($x/*[1], $x/jnode(*, xs:integer)) 
             )) ]]></eg></fos:expression>
                <fos:result>1</fos:result>
                <fos:postamble>The first array member is selected by two different
@@ -14697,7 +14697,7 @@ return count(distinct-ordered-nodes(
                <fos:result><code>"c"</code></fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg><![CDATA[[[[1,2], [3,4]], [[5,6], [7,8]]]//array(*)
+               <fos:expression><eg><![CDATA[[[[1,2], [3,4]], [[5,6], [7,8]]]//jnode(*, array(*))
    => innermost() =!> jnode-content()]]></eg></fos:expression>
                <fos:result><code>[1,2], [3,4], [5,6], [7,8]</code></fos:result>
             </fos:test>
@@ -14759,7 +14759,7 @@ return count(distinct-ordered-nodes(
                <fos:result><code>"a"</code></fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg><![CDATA[[[[1], [2]], [[3], [4]], [[5], [6]]]//jnode(*, array(*))
+               <fos:expression><eg><![CDATA[[[[1], [2]], [[3], [4]], [[5], [6]]]//self::jnode(*, array(*))
    => outermost() =!> array:size()]]></eg></fos:expression>
                <fos:result><code>3</code></fos:result>
             </fos:test>
@@ -14971,8 +14971,8 @@ return empty($break)
          
       </fos:rules>
       <fos:equivalent style="xpath-expression">
-if ($node intersect $node/parent::gnode()/child::gnode())
-then $node/parent::gnode()/child::gnode()
+if ($node intersect $node/parent::node()/child::node())
+then $node/parent::node()/child::node()
 else $node
       </fos:equivalent>
       <fos:errors>
@@ -14985,8 +14985,8 @@ else $node
                      class="DY" code="0002" type="type"/></p>
             </item>
             <item>
-               <p>If the context value is not an instance of the sequence type <code>gnode()?</code>, 
-                  type error <xerrorref spec="XP" class="TY" code="0004" type="type"/>.</p>
+               <p>If the context value is not an instance of the sequence type <code>node()?</code>, type error <xerrorref spec="XP" class="TY"
+                     code="0004" type="type"/>.</p>
             </item>
          </ulist>
 
@@ -15014,10 +15014,6 @@ else $node
             <fos:test use="v-siblings-e" spec="XQuery">
                <fos:expression>siblings($e//@x) ! string()</fos:expression>
                <fos:result>"X"</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>[[1,2], [11,12], [13,14]]//jnode()[.='12'] => siblings() => sum()</fos:expression>
-               <fos:result>23</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -36165,7 +36161,7 @@ return jtree($data)//languages[. = 'German']/../capital =!> string()</eg></fos:e
          <fos:example>
             <fos:test>
                <fos:expression><eg>let $array := [1, 3, 4.5, 7, "eight", 10]
-return $array / child::type(xs:integer) =!> jnode-selector()</eg></fos:expression>
+return $array / child::jnode(*, xs:integer) =!> jnode-selector()</eg></fos:expression>
                <fos:result>1, 2, 4, 6</fos:result>
             </fos:test>
             <fos:test>
@@ -36376,7 +36372,7 @@ return $input / child::b / *
          <fos:example>
             <fos:test>
                <fos:expression><eg>let $array := [1, 3, 4.5, 7, "eight", 10]
-return $array / child::type(xs:integer) =!> jnode-content()</eg></fos:expression>
+return $array / child::jnode(*, xs:integer) =!> jnode-content()</eg></fos:expression>
                <fos:result>1, 3, 7, 10</fos:result>
             </fos:test>
             <fos:test>


### PR DESCRIPTION
Changes the main function catalog to make improved use of the fos:result element. Specifically:

* Uses fos:error-result for error examples
* Makes greater use of explicit results rather than narrative results where possible
* Uses fos:result narrative="true" to get auto-checking of examples having no definitive result, and improved rendition.