### PR TITLE
Harmonize the fn: and file: functions that read text

### DIFF
--- a/specifications/EXPath/file/src/function-catalog.xml
+++ b/specifications/EXPath/file/src/function-catalog.xml
@@ -1025,8 +1025,7 @@ return file:read-text($path)
     <fos:signatures>
       <fos:proto name="read-text" return-type="xs:string">
         <fos:arg type="xs:string" name="file"/>
-        <fos:arg type="xs:string?" default="'UTF-8'" name="encoding"/>
-        <fos:arg type="xs:boolean?" default="false()" name="fallback"/>
+        <fos:arg name="options" type="(xs:string | map(*))?" default="()"/>
       </fos:proto>
     </fos:signatures>
     <fos:properties>
@@ -1041,10 +1040,41 @@ return file:read-text($path)
       <p>Returns the content of a file in its string representation.
         Newlines are normalized: Any <char>U+000D</char> character, optionally followed by
         a <char>U+000A</char> character, is converted to a single <char>U+000A</char> character.</p>
-      <p>If no encoding is supplied, <code>UTF-8</code> is used as input encoding.
-        By default, invalid XML characters will be rejected. If <code>$fallback</code> is
-        <code>true</code>, the characters will be replaced with the Unicode replacement character
-        <char>U+FFFD</char>.</p>
+
+         <p>The <code>$options</code> argument, for backwards compatibility reasons, may be supplied
+         either as a map, or as a string. Supplying a value <code>$S</code> that is not a map
+         is equivalent to supplying the map <code>{ "encoding": $S }</code>.
+         After that substitution, the <xtermref spec="FO40" ref="option-parameter-conventions"/> apply.</p>
+
+         <p>The entries that may appear in the <code>$options</code> map are as follows:</p>
+         
+         <fos:options>
+            <fos:option key="encoding">
+               <fos:meaning>Defines the encoding of the resource, as described below.
+               </fos:meaning>
+               <fos:type>xs:string?</fos:type>
+               <fos:default>"UTF-8"</fos:default>
+            </fos:option>
+            <fos:option key="fallback">
+               <fos:meaning>
+                  Provides a function which is called when the input contains a character
+                  that is not a <xtermref spec="FO40" ref="dt-permitted-character"/>.
+                  It is called once for each non-permitted character, passing in the
+                  Unicode codepoint of the character.
+                  If the function returns the empty
+                  sequence, the character is simply removed from the input.
+               </fos:meaning>
+               <fos:type>(fn(xs:integer) as xs:anyAtomicType?)?</fos:type>
+            </fos:option>
+         </fos:options>
+
+      <p>By default, characters that are not
+      <xtermref spec="FO40" ref="dt-permitted-character"/> will be rejected.
+      A fallback function can be provided in the <code>$options</code> to remap non-permitted characters.
+      One such function, <code>fn { char(0xFFFD) }</code>, replaces all non-permitted
+      characters with the Unicode replacement character.
+      </p>
+
     </fos:rules>
     <fos:errors>
       <p>
@@ -1080,7 +1110,7 @@ return file:read-text($path)
     </fos:examples>
     <fos:changes>
       <fos:change issue="2016" PR="2077" date="2024-07-02">
-        <p><code>$fallback</code> parameter added.</p>
+        <p><code>$options</code> parameter added.</p>
       </fos:change>
       <fos:change issue="2016" PR="2077" date="2024-07-02">
         <p>The normalization of newlines has been made explicit.</p>
@@ -1092,8 +1122,7 @@ return file:read-text($path)
     <fos:signatures>
       <fos:proto name="read-text-lines" return-type="xs:string*">
         <fos:arg type="xs:string" name="file"/>
-        <fos:arg type="xs:string?" default="'UTF-8'" name="encoding"/>
-        <fos:arg type="xs:boolean?" default="false()" name="fallback"/>
+        <fos:arg name="options" type="(xs:string | map(*))?" default="()"/>
       </fos:proto>
     </fos:signatures>
     <fos:properties>
@@ -1110,10 +1139,41 @@ return file:read-text($path)
         boundaries.</p>
       <p>Any of the character sequences <char>U+000A</char>, <char>U+000D</char>, or
          <char>U+000D</char> followed by <char>U+000A</char> is interpreted as newline.</p>
-      <p>If no encoding is supplied, <code>UTF-8</code> is used as input encoding.
-        By default, invalid XML characters will be rejected. If <code>$fallback</code> is enabled,
-        the characters will be replaced with the Unicode replacement character
-        <char>U+FFFD</char>.</p>
+
+         <p>The <code>$options</code> argument, for backwards compatibility reasons, may be supplied
+         either as a map, or as a string. Supplying a value <code>$S</code> that is not a map
+         is equivalent to supplying the map <code>{ "encoding": $S }</code>.
+         After that substitution, the <xtermref spec="FO40" ref="option-parameter-conventions"/> apply.</p>
+
+         <p>The entries that may appear in the <code>$options</code> map are as follows:</p>
+         
+         <fos:options>
+            <fos:option key="encoding">
+               <fos:meaning>Defines the encoding of the resource, as described below.
+               </fos:meaning>
+               <fos:type>xs:string?</fos:type>
+               <fos:default>"UTF-8"</fos:default>
+            </fos:option>
+            <fos:option key="fallback">
+               <fos:meaning>
+                  Provides a function which is called when the input contains a character
+                  that is not a <xtermref spec="FO40" ref="dt-permitted-character"/>.
+                  It is called once for each non-permitted character, passing in the
+                  Unicode codepoint of the character.
+                  If the function returns the empty
+                  sequence, the character is simply removed from the input.
+               </fos:meaning>
+               <fos:type>(fn(xs:string) as xs:string)?</fos:type>
+               <fos:default>fn { char(0xFFFD) }</fos:default>
+            </fos:option>
+         </fos:options>
+
+      <p>By default, characters that are not
+      <xtermref spec="FO40" ref="dt-permitted-character"/> will be rejected.
+      A fallback function can be provided in the <code>$options</code> to remap non-permitted characters.
+      One such function, <code>fn { char(0xFFFD) }</code>, replaces all non-permitted
+      characters with the Unicode replacement character.
+      </p>
     </fos:rules>
     <fos:errors>
       <p>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19489,6 +19489,20 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                   </fos:value>
                </fos:values>
             </fos:option>
+            <fos:option key="fallback">
+               <fos:meaning>
+                  Provides a function which is called when the input contains a character
+                  that is not a <termref def="dt-permitted-character"/>. It is called once for
+                  each non-permitted character, passing in the Unicode codepoint of the
+                  character. For backwards compatibility,
+                  this option has no default. If no fallback function is
+                  provided, a dynamic error is raised <errorref class="UT" code="1190"/>
+                  if the input contains a non-permitted character.
+                  If the function returns the empty
+                  sequence, the character is simply removed from the input.
+               </fos:meaning>
+               <fos:type>(fn(xs:integer) as xs:anyAtomicType?)?</fos:type>
+            </fos:option>
          </fos:options>
                 
          <p>The way in which an absolute URI is dereferenced to obtain an external resource is 
@@ -19689,8 +19703,21 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                <fos:type>xs:string?</fos:type>
                <fos:default>()</fos:default>
             </fos:option>
+            <fos:option key="fallback">
+               <fos:meaning>
+                  Provides a function which is called when the input contains a character
+                  that is not a <termref def="dt-permitted-character"/>. It is called once for
+                  each non-permitted character, passing in the Unicode codepoint of the
+                  character. For backwards compatibility,
+                  this option has no default. If no fallback function is
+                  provided, a dynamic error is raised <errorref class="UT" code="1190"/>
+                  if the input contains a non-permitted character.
+                  If the function returns the empty
+                  sequence, the character is simply removed from the input.
+               </fos:meaning>
+               <fos:type>(fn(xs:integer) as xs:anyAtomicType?)?</fos:type>
+            </fos:option>
          </fos:options>
-         
         
          <p>The result of the function is the same as the result of the expression:</p>
          


### PR DESCRIPTION
Close #2460 

This PR harmonizes the functions fn:unparsed-text, fn:unparsed-text-lines, file:read-text, and file:read-text-lines with respect to handling non-permitted characters. Each function has an options parameter and that parameter may contain a fallback function to remap non-permitted characters.

This leaves unresolved the question of what to do about permitted characters not allowed in XML, but that’s orthogonal. Strings containing such characters might arise from any of these functions, but equally, might arise from other operations.
