### PR TITLE
2448 Change title of XPath 4.0 specification

### DIFF
--- a/etc/xsl-query-bibl.xml
+++ b/etc/xsl-query-bibl.xml
@@ -127,9 +127,9 @@ This version is https://www.w3.org/TR/2017/REC-xpath-31-20170321/.
 The <a href="https://www.w3.org/TR/xpath-31/">latest version</a>
 is available at https://www.w3.org/TR/xpath-31/.</bibl>
 
-<bibl id="xpath-40" key="XML Path Language (XPath) 4.0">
+<bibl id="xpath-40" key="XPath 4.0">
 <titleref href="https://qt4cg.org/specifications/xquery-40/xpath-40.html"
->XML Path Language (XPath) 4.0</titleref>,
+>XPath 4.0</titleref>,
 XSLT Extensions Community Group,
 World Wide Web Consortium.</bibl>
 

--- a/explorer/config.xml
+++ b/explorer/config.xml
@@ -8,7 +8,7 @@
   <specification title="XPath and XQuery Functions and Operators 4.0"
                  href="https://qt4cg.org/specifications/xpath-functions-40/Overview.html"
                  src="../build/www/xpath-functions-40/xpath-functions-40.xml"/>
-  <specification title="XML Path Language (XPath) 4.0"
+  <specification title="XPath 4.0"
                  href="https://qt4cg.org/specifications/xquery-40/xpath-40.html"
                  src="../build/www/xquery-40/xpath-40.xml"/>
   <specification title="XQuery 4.0: An XML Query Language"

--- a/specifications/EXPath/binary/src/binary-functions.xml
+++ b/specifications/EXPath/binary/src/binary-functions.xml
@@ -930,7 +930,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
                     <bibl id="xpath20" key="XML Path Language (XPath) 2.0"/>
 
                     <bibl id="xpath-functions-40" key="XQuery and XPath Functions and Operators 4.0"/>
-                    <bibl id="xpath-40" key="XML Path Language (XPath) 4.0">
+                    <bibl id="xpath-40" key="XPath 4.0">
                         <!--<emph>CITATION: T.B.D.</emph>-->
                     </bibl>
 

--- a/specifications/EXPath/file/src/file-functions.xml
+++ b/specifications/EXPath/file/src/file-functions.xml
@@ -561,7 +561,7 @@ file:resolve-path($path, file:base-dir())
           </bibl>
           <bibl id="xpath20" key="XML Path Language (XPath) 2.0"/>
           <bibl id="xpath-functions-40" key="XQuery and XPath Functions and Operators 4.0"/>
-          <bibl id="xpath-40" key="XML Path Language (XPath) 4.0">
+          <bibl id="xpath-40" key="XPath 4.0">
             <!--<emph>CITATION: T.B.D.</emph>-->
           </bibl>
           <bibl id="xslt-40" key="XSL Transformations (XSLT) Version 4.0">

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -13869,7 +13869,7 @@ Consortium. <emph>XML Information Set (Second Edition).</emph> W3C Recommendatio
                <!--<bibl  id="xpath-30"
                      key="XML Path Language (XPath) 3.0"/>-->
                <bibl  id="xpath-40"
-                      key="XML Path Language (XPath) 4.0">
+                      key="XPath 4.0">
                  <emph>CITATION: T.B.D.</emph>
                </bibl>
                

--- a/specifications/xquery-40/src/xpath.xml
+++ b/specifications/xquery-40/src/xpath.xml
@@ -57,7 +57,7 @@
 <!ENTITY language-tech "XPath">
 <!ENTITY language "XPath &doc.version;">
 <!ENTITY language-major "XPath &doc.major-version;">
-<!ENTITY language-title "XML Path Language (XPath) &doc.version;">
+<!ENTITY language-title "XPath &doc.version;">
 <!-- ************************ THIS MUST BE EITHER 'WG Review Draft' OR '' **************** -->
 <!ENTITY version "WG Review Draft">
 <!-- ************************************************************************************* -->


### PR DESCRIPTION
Drops the appellation "XML Path Language" which no-one ever uses.

Fix #2448