### PR TITLE
1310 Function fn:matching-segments

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -315,7 +315,7 @@
    
    <fos:record-type id="matching-segment-record" extensible="false">
       <fos:summary>
-         <p>This record type represents the a <termref def="dt-segment"/> of an input string 
+         <p>This record type represents a <termref def="dt-segment"/> of an input string 
             that matched a regular expression,
             together with any captured groups found during the matching process.</p>
       </fos:summary>
@@ -8203,6 +8203,29 @@ Tak, tak, tak! - da kommen sie.
       <fos:examples>
          <fos:example>
             <fos:test>
+               <fos:expression><eg>matching-segments("The cat sat on the mat.", "\w+")</eg></fos:expression>
+               <fos:result><eg>
+  { "substring": "The", "position": 1, "groups": {}},
+  { "substring": "cat", "position": 5, "groups": {}},  
+  { "substring": "sat", "position": 9, "groups": {}},  
+  { "substring": "on",  "position": 13, "groups": {}},  
+  { "substring": "the", "position": 16, "groups": {}},  
+  { "substring": "mat", "position": 20, "groups": {}}  
+               </eg></fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>matching-segments("08-12-03", "^(\d+)\-(\d+)\-(\d+)$")</eg></fos:expression>
+               <fos:result><eg>
+  { "substring": "08-12-03",
+    "position": 1,
+    "groups": { 1: {"group": "08", "position": 1},
+                2: {"group": "12", "position": 4},
+                3: {"group": "03", "position": 7}
+              }
+  }
+                </eg></fos:result>
+            </fos:test>
+            <fos:test>
                <fos:expression><eg>matching-segments("A1,C15,,D24, X50,", "([A-Z])([0-9]+)")</eg></fos:expression>
                <fos:result><eg>
   { "substring": "A1",
@@ -8226,6 +8249,34 @@ Tak, tak, tak! - da kommen sie.
                2: { "group": "50", "position": 15 }}
   }</eg>
                </fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>matching-segments("Chapter 5", "(Chapter|Appendix)(?=\s+([0-9]+))")</eg></fos:expression>
+               <fos:result><eg>
+  { "substring": "Chapter",
+    "position": 1,
+    "groups": {1: { "group": "Chapter", "position": 1 },
+               2: { "group": "5", "position": 9 }
+              }
+  }                                               
+               </eg></fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>matching-segments("There we go", "\b(?=(\w+))")</eg></fos:expression>
+               <fos:result><eg>
+  { "substring": "",
+    "position": 1,
+    "groups": {1: { "group": "There", "position": 1 } }
+  },
+  { "substring": "",
+    "position": 7,
+    "groups": {1: { "group": "we", "position": 7 } }
+  }
+  { "substring": "",
+    "position": 10,
+    "groups": {1: { "group": "go", "position": 10 } }
+  }
+               </eg></fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -249,6 +249,98 @@
       </fos:field>-->
    </fos:record-type>
    
+   <fos:record-type id="compiled-regex-record" extensible="false">
+      <fos:summary>
+         <p>This record type represents the results of processing a regular expression,
+            together with a set of flags, It contains function items that can be used
+            to evaluate the regular expression in various ways.</p>
+      </fos:summary>
+      <fos:field name="regex" type="xs:string" required="true">
+         <fos:meaning>
+            <p>The supplied regular expression, as a string.</p>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="flags" type="xs:string" required="true">
+         <fos:meaning>
+            <p>The supplied flags, as a string; or the zero-length string if no flags were supplied.</p>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="matches" type="fn($s as xs:string) as xs:boolean" required="true">
+         <fos:meaning>
+            <p>An arity-one function that can be used to test whether the supplied string <var>$s</var> matches
+            the regular expression. If <var>R</var> is a <code>compiled-regex-record</code> 
+               produced by the function <function>fn:regex</function>, then the effect
+               of the expression <code>R?matches($s)</code> is defined
+               to be the same as the result of <code>fn:matches($s, R?regex, R?flags)</code>.</p>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="tokenize" type="fn($s as xs:string) as xs:string*" required="true">
+         <fos:meaning>
+            <p>An arity-one function that can be used to split the supplied string <var>$s</var> on
+               separators that match
+            the regular expression. If <var>R</var> is a <code>compiled-regex-record</code> 
+               produced by the function <function>fn:regex</function>, then the effect
+               of the expression <code>R?tokenize($s)</code> is defined
+               to be the same as the result of <code>fn:tokenize($s, R?regex, R?flags)</code>.</p>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="replace" type="fn($s as xs:string, $replacement as (xs:string | fn(xs:untypedAtomic, xs:untypedAtomic*) as item()?)?) as xs:string*" required="true">
+         <fos:meaning>
+            <p>An arity-two function that can be used to replace parts of the supplied string <var>$s</var> that match
+            the regular expression. If <var>R</var> is a <code>compiled-regex-record</code> 
+               produced by the function <function>fn:regex</function>, then the effect
+               of the expression <code>R?replace($s, $rep)</code> is defined
+               to be the same as the result of <code>fn:replace($s, R?regex, $rep, R?flags)</code>.</p>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="analyze-string" type="fn($s as xs:string) as element(fn:analyze-string-result)" required="true">
+         <fos:meaning>
+            <p>An arity-one function that can be used to process a string against the regular expression
+               and return all the matching and non-matching substrings, plus matching groups, in an XML structure. 
+               If <var>R</var> is a <code>compiled-regex-record</code> 
+               produced by the function <function>fn:regex</function>, then the effect
+               of the expression <code>R?analyze-string($s)</code> is defined
+               to be the same as the result of <code>fn:analyze-string($s, R?regex, R?flags)</code>.</p>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="matching-segments" type="fn($s as xs:string) as fn:matching-segment-record*" required="true">
+         <fos:meaning>
+            <p>An arity-one function that can be used to process a string against the regular expression
+               and return details of all the matching substrings, together with their captured groups.
+               The result is returned as a sequence of records of type <code>fn:matching-segment-record</code>.
+            </p>
+         </fos:meaning>
+      </fos:field>
+   </fos:record-type>
+   
+   <fos:record-type id="matching-segment-record" extensible="false">
+      <fos:summary>
+         <p>This record type represents the a segment of an input string that matched a regular expression,
+            together with any captured groups found during the matching process.</p>
+      </fos:summary>
+      <fos:field name="substring" type="xs:string" required="true">
+         <fos:meaning>
+            <p>The substring of the original input that matched the regular expression. May be zero-length.</p>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="position" type="xs:integer" required="true">
+         <fos:meaning>
+            <p>The 1-based position of the matching segment within the original input string.</p>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="groups" type="map(xs:integer, record($group as xs:string, $position as xs:integer))" required="true">
+         <fos:meaning>
+            <p>The captured groups for this matching segment. This is represented as a map from the group number
+            (corresponding to the sequence of left parentheses introducing capturing subexpressions of the
+            regular expression) to details of the captured group: specifically, the 1-based start position of the
+            captured group within the original input string, and the string content of the capture. Note that
+            where groups are captured within a lookahead, the captured group is not necessarily a substring
+            of the matching segment.</p>
+         </fos:meaning>
+      </fos:field>
+   </fos:record-type>
+   
+   
    <fos:record-type id="load-xquery-module-record" extensible="false">
       <fos:summary>
          <p>This record type is used to hold the result of the <function>fn:load-xquery-module</function> function.</p>
@@ -8056,6 +8148,86 @@ Tak, tak, tak! - da kommen sie.
          </fos:change>
       </fos:changes>
    </fos:function>
+   
+   <fos:function name="regex" prefix="fn">
+      <fos:signatures>
+         <fos:proto name="regex" return-type="fn:compiled-regex-record">
+            <fos:arg name="pattern" type="xs:string"/>
+            <fos:arg name="flags" type="xs:string?" default='""'/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:summary>
+         <p>Processes a regular expression, plus flags, into a form suitable for repeated use.</p>
+      </fos:summary>
+      <fos:rules>
+         <p>The value of <code>$regex</code> must be a regular expression as defined
+         in <specref ref="regex-syntax"/>.</p>
+         <p>The value of <code>$flags</code> (if supplied) must be a string representing
+         a set of flags as defined in <specref ref="flags"/>.</p>
+         <p>The function returns a record, whose fields are function items that can
+         be used to evaluate the regular expression in various ways. The structure
+         of this record is described in <specref ref="compiled-regex-record"/></p>
+      </fos:rules>
+      <fos:errors>
+         <p>A dynamic error is raised <errorref class="RX" code="0002"
+               /> if the value of
+               <code>$pattern</code> is invalid according to the rules described in section <specref
+               ref="regex-syntax"/>.</p>
+         <p>A dynamic error is raised <errorref class="RX" code="0001"
+               /> if the value of
+               <code>$flags</code> is invalid according to the rules described in section <specref
+               ref="flags"/>.</p>
+      </fos:errors>
+      <fos:notes>
+         <p>The function is designed to allow an implementation to process the regular expression
+         into an internal compiled form, which may yield performance benefits if it is used repeatedly.</p>
+      </fos:notes>
+      <fos:examples>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>let $regex := regex('^[a-z]+$')
+return tokenize("A group of 10 students")[$regex ? matches(.)]</eg></fos:expression>
+               <fos:result><eg>"group", "of", "students"</eg></fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>let $regex := regex('^(a-z).*')
+return tokenize("A group of 10 students")!$regex ? replace(., '$1', upper-case#1)]</eg></fos:expression>
+               <fos:result><eg>"A", "Group", "Of", "10", "Students"</eg></fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>regex("([A-Z])([0-9]+)") ? matching-segments("A1,C15,,D24, X50,")</eg></fos:expression>
+               <fos:result><eg>
+  { "substring": "A1",
+    "position": 1,
+    "groups": {1: { "group": "A", "position": 1 },
+               2: { "group": "1", "position": 2 }}
+  },
+  { "substring": "C15",
+    "position": 4,
+    "groups": {1: { "group": "C", "position": 4 },
+               2: { "group": "15", "position": 5 }}
+  },
+  { "substring": "D24",
+    "position": 9,
+    "groups": {1: { "group": "D", "position": 9 },
+               2: { "group": "24", "position": 10 }}
+  },
+  { "substring": "X50",
+    "position": 14,
+    "groups": {1: { "group": "X", "position": 14 },
+               2: { "group": "50", "position": 15 }}
+  }</eg>
+               </fos:result>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
+   </fos:function>
+   
    <fos:function name="analyze-string" prefix="fn">
       <fos:signatures>
          <fos:proto name="analyze-string" return-type="element(fn:analyze-string-result)">
@@ -8076,8 +8248,10 @@ Tak, tak, tak! - da kommen sie.
             regular expression.</p>
       </fos:summary>
       <fos:rules>
+
          <p>Flags are defined in <specref ref="flags"/>.</p>
          <p>If <code>$value</code> is the empty sequence, the function behaves as if
+
             <code>$value</code> were the zero-length string.</p>
          <p>The function returns an element node whose local name is
                <code>analyze-string-result</code>. This element and all its descendant elements have

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -329,7 +329,7 @@
             <p>The 1-based position of the matching segment within the original input string.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="groups" type="map(xs:integer, record($group as xs:string, $position as xs:integer))" required="true">
+      <fos:field name="groups" type="map(xs:integer, record(group as xs:string, position as xs:integer))" required="true">
          <fos:meaning>
             <p>The captured groups for this matching segment. This is represented as a map from the group number
             (corresponding to the sequence of left parentheses introducing capturing subexpressions of the

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -249,7 +249,7 @@
       </fos:field>-->
    </fos:record-type>
    
-   <fos:record-type id="compiled-regex-record" extensible="false">
+   <!--<fos:record-type id="compiled-regex-record" extensible="false">
       <fos:summary>
          <p>This record type represents the results of processing a regular expression,
             together with a set of flags, It contains function items that can be used
@@ -311,11 +311,12 @@
             </p>
          </fos:meaning>
       </fos:field>
-   </fos:record-type>
+   </fos:record-type>-->
    
    <fos:record-type id="matching-segment-record" extensible="false">
       <fos:summary>
-         <p>This record type represents the a segment of an input string that matched a regular expression,
+         <p>This record type represents the a <termref def="dt-segment"/> of an input string 
+            that matched a regular expression,
             together with any captured groups found during the matching process.</p>
       </fos:summary>
       <fos:field name="substring" type="xs:string" required="true">
@@ -8137,6 +8138,7 @@ Tak, tak, tak! - da kommen sie.
          </fos:example>
       </fos:examples>
       <fos:see-also prefix="fn" name="analyze-string"/>
+      <fos:see-also prefix="fn" name="matching-segments"/>
       <fos:see-also prefix="fn" name="substring-before"/>
       <fos:see-also prefix="fn" name="substring-after"/>
       <fos:changes>
@@ -8149,7 +8151,91 @@ Tak, tak, tak! - da kommen sie.
       </fos:changes>
    </fos:function>
    
-   <fos:function name="regex" prefix="fn">
+   <fos:function name="matching-segments" prefix="fn">
+      <fos:signatures>
+         <fos:proto name="matching-segments" return-type="fn:matching-segment-record*">
+            <fos:arg name="value" type="xs:string?"/>
+            <fos:arg name="pattern" type="xs:string"/>
+            <fos:arg name="flags" type="xs:string?" default='""' note="default-on-empty"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:summary>
+         <p>Applies a regular expression (with flags) to an input string, returning details
+         of all the matches that were found.</p>
+      </fos:summary>
+      <fos:rules>
+         
+         <p>If <code>$value</code> is the empty sequence then the function returns the empty sequence.</p>
+         
+         <p>The value of <code>$regex</code> must be a regular expression as defined
+         in <specref ref="regex-syntax"/>.</p>
+         
+         <p>The value of <code>$flags</code> (if supplied) must be a string representing
+         a set of flags as defined in <specref ref="flags"/>.</p>
+         
+         <p>The function returns a sequence of records of type <loc href="#matching-segment-record">matching-segment-record</loc>,
+         one for each of the <termref def="dt-disjoint-matching-segments"/> of <code>$value</code> that matches the regular expression.</p>
+         
+         <p>The way in which the disjoint matching segments are identified is described in <specref ref="id-regex-processing-model"/>.</p>
+         
+         <p>The sequence of matching segments in the result will be sorted in order of ascending 
+            position within the input string.</p>
+      </fos:rules>
+      <fos:errors>
+         <p>A dynamic error is raised <errorref class="RX" code="0002"
+               /> if the value of
+               <code>$pattern</code> is invalid according to the rules described in section <specref
+               ref="regex-syntax"/>.</p>
+         <p>A dynamic error is raised <errorref class="RX" code="0001"
+               /> if the value of
+               <code>$flags</code> is invalid according to the rules described in section <specref
+               ref="flags"/>.</p>
+      </fos:errors>
+      <fos:notes>
+         <p>The information returned by this function is similar to that returned by <function>fn:analyze-string</function>.
+         But because it is returned as a map, it may be easier to process.</p>
+      </fos:notes>
+      <fos:examples>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>matching-segments("A1,C15,,D24, X50,", "([A-Z])([0-9]+)")</eg></fos:expression>
+               <fos:result><eg>
+  { "substring": "A1",
+    "position": 1,
+    "groups": {1: { "group": "A", "position": 1 },
+               2: { "group": "1", "position": 2 }}
+  },
+  { "substring": "C15",
+    "position": 4,
+    "groups": {1: { "group": "C", "position": 4 },
+               2: { "group": "15", "position": 5 }}
+  },
+  { "substring": "D24",
+    "position": 9,
+    "groups": {1: { "group": "D", "position": 9 },
+               2: { "group": "24", "position": 10 }}
+  },
+  { "substring": "X50",
+    "position": 14,
+    "groups": {1: { "group": "X", "position": 14 },
+               2: { "group": "50", "position": 15 }}
+  }</eg>
+               </fos:result>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
+      <fos:see-also prefix="fn" name="analyze-string"/>
+      <fos:changes>
+         <fos:change issue="1310" PR="2470" date="2026-04-20"><p>New in 4.0</p></fos:change>
+      </fos:changes>
+   </fos:function>
+   
+   <!--<fos:function name="regex" prefix="fn">
       <fos:signatures>
          <fos:proto name="regex" return-type="fn:compiled-regex-record">
             <fos:arg name="pattern" type="xs:string"/>
@@ -8226,7 +8312,7 @@ return tokenize("A group of 10 students")!$regex ? replace(., '$1', upper-case#1
             </fos:test>
          </fos:example>
       </fos:examples>
-   </fos:function>
+   </fos:function>-->
    
    <fos:function name="analyze-string" prefix="fn">
       <fos:signatures>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -4094,12 +4094,15 @@ WildcardEsc         ::= '.'
             <div3 id="func-analyze-string">
                <head><?function fn:analyze-string?></head>
             </div3>
-            <div3 id="func-regex">
+            <div3 id="func-matching-segments">
+               <head><?function fn:matching-segments?></head>
+            </div3>
+            <!--<div3 id="func-regex">
                <head><?function fn:regex?></head>
             </div3>
             <div3 id="compiled-regex-record">
               <head><?record-description compiled-regex-record?></head>
-            </div3>
+            </div3>-->
             <div3 id="matching-segment-record">
               <head><?record-description matching-segment-record?></head>
             </div3>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -4094,6 +4094,15 @@ WildcardEsc         ::= '.'
             <div3 id="func-analyze-string">
                <head><?function fn:analyze-string?></head>
             </div3>
+            <div3 id="func-regex">
+               <head><?function fn:regex?></head>
+            </div3>
+            <div3 id="compiled-regex-record">
+              <head><?record-description compiled-regex-record?></head>
+            </div3>
+            <div3 id="matching-segment-record">
+              <head><?record-description matching-segment-record?></head>
+            </div3>
  
 
           </div2>


### PR DESCRIPTION
Fix #1310

This proposal meets the requirement expressed in the cited issue, but goes some way beyond it.

First, it proposes a new function fn:regex which effectively compiles a regular expression and returns a number of function items using that regular expression, so you can do for example 

```
let $regex := regex("[A-Z][0-9]")
return //e[$regex?matches(@att)]
```
to give imlementations a better chance of optimising repeated use of the same regex.

Secondly, it proposes a new sub-function `regex()?matching-segments()` which returns similar information to `analyze-string()`, but as a map rather than as XML.

The proposal needs a bit more editorial work (more notes and examples) but I'm interested at this stage to get feedback on whether the general direction is sound.
