### PR TITLE
2476 guaranteed streamability

### DIFF
--- a/specifications/xslt-streaming-40/src/xslt-streaming.xml
+++ b/specifications/xslt-streaming-40/src/xslt-streaming.xml
@@ -721,6 +721,13 @@ Michael Sperberg-McQueen (1954–2024).</p>
         
         <div2 id="streamability-guarantees">
             <head>Streamability Guarantees</head>
+           
+           <changes>
+              <change issue="2476">A processor is no longer required to report all cases where constructs
+              are declared streamable but are not guaranteed streamable according to the streamability
+              rules in this specification: that is, processors are free to implement streamability rules
+              that are more liberal than those defined here.</change>
+           </changes>
 
             <p>Certain constructs allow a stylesheet author to declare that a construct is
                streamable. Specifically:</p>
@@ -780,7 +787,8 @@ Michael Sperberg-McQueen (1954–2024).</p>
             </olist>
 
             <p><termdef id="dt-guaranteed-streamable" term="guaranteed-streamable">A
-                     <term>guaranteed-streamable</term> construct is a <termref def="dt-construct">construct</termref> that is declared to be streamable and that follows the
+                     <term>guaranteed-streamable</term> construct is a <termref def="dt-construct">construct</termref> 
+                  that is declared to be streamable and that follows the
                   particular rules for that construct to make streaming possible, as defined by the
                   analysis in this specification.</termdef></p>
 
@@ -794,8 +802,8 @@ Michael Sperberg-McQueen (1954–2024).</p>
                   the input is provided in streamable form, then the input <rfc2119>must</rfc2119> be processed using streaming.</p>
                   <note><p>The requirement to process the input using streaming
                   does not apply if the processor is able to determine that this would convey no benefit:
-                  for example, if the input is supplied as a tree in memory. However, this does not remove
-                  the requirement to verify that the relevant stylesheet constructs are <termref def="dt-guaranteed-streamable"/>.</p></note>
+                  for example, if the input is supplied as a tree in memory, or if it can be established
+                  in advance that the input file is small.</p></note>
                </item>
                <item>
                   <p>If a construct is declared as streamable but is not <termref def="dt-guaranteed-streamable"/> (that is, if it fails to satisfy the
@@ -803,9 +811,9 @@ Michael Sperberg-McQueen (1954–2024).</p>
                         <rfc2119>must</rfc2119> be prepared to do any one of the following at user
                      option:</p>
                   <olist>
-                     <item>
+                     <!--<item>
                         <p>Raise a static error <errorref spec="XT" class="SE" code="3430"/></p>
-                     </item>
+                     </item>-->
                      <item>
                         <p>Process the stylesheet as if it were a non-streaming processor (see
                            below)</p>
@@ -820,12 +828,24 @@ Michael Sperberg-McQueen (1954–2024).</p>
             </olist>
 
             <p><error spec="XT" type="static" class="SE" code="3430">
-                  <p>It is a <xtermref spec="XT40" ref="dt-static-error"/> if a <xtermref spec="XT40" ref="dt-package">package</xtermref> contains a construct that is
-                     declared to be streamable but which is not <termref def="dt-guaranteed-streamable"/>, unless the user has indicated that the
-                     processor is to handle this situation by processing the stylesheet without
-                     streaming or by making use of processor extensions to the streamability rules
-                     where available.</p>
+                  <p>It is a <xtermref spec="XT40" ref="dt-static-error"/> if a 
+                     <xtermref spec="XT40" ref="dt-package">package</xtermref> contains a construct that is
+                     declared to be streamable but which is not <termref def="dt-guaranteed-streamable"/>.
+                  A processor is not required to report this error if it is capable of processing
+                  the stylesheet using streaming.</p>
                </error></p>
+           
+             <note>
+                <p>In XSLT 3.0, processors were required to have the capability to report an error in all cases
+                   where a construct was <termref def="dt-declared-streamable"/> but not 
+                   <termref def="dt-guaranteed-streamable"/>, thus effectively
+                   inhibiting a processor from implementing extensions to the streamability rules (for example,
+                   extensions to take advantage of schema knowledge). This requirement has been dropped in 4.0.
+                   All conformant streaming processors are required to evaluate a <termref def="dt-guaranteed-streamable"/>
+                   stylesheet in streaming mode, but they are no longer required to detect all stylesheets that are
+                   not <termref def="dt-guaranteed-streamable"/>.
+                </p>
+             </note>
 
             <p>For a non-streaming processor, the processor <rfc2119>must</rfc2119> evaluate the construct
                delivering the same results as if execution used streaming, but with no constraints


### PR DESCRIPTION
Fix #2476

Removes the requirement for a conformant streaming XSLT processor to report an error when streaming is possible according to the processor's own rules, but not according to the rules in the specification.