### PR TITLE
1479 XQuery: Default Namespace Clarifications

### DIFF
--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -16319,7 +16319,7 @@ attribute is processed as follows:</p>
                                 is added both to the <termref def="dt-static-namespaces"
                            >statically known namespaces</termref>
                      of the constructor expression (overriding any existing binding of
-                     the given prefix), and also as to the
+                     the given prefix), and also to the
                      <termref def="dt-in-scope-namespaces"
                            >in-scope namespaces</termref>
                         of the constructed element.</p>


### PR DESCRIPTION
I came to the conclusion that the existing spec was technically sound, but that some editorial clarification was appropriate.

Fix #1479