### PR TITLE
2388 Adaptive serialization of anonymous functions

### DIFF
--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -3997,13 +3997,16 @@ according to the <bibref ref="JSON-LINES"/> format, as described in <specref ref
     <change issue="1651" PR="1703" date="2025-01-14">
       The serialization of maps retains the order of entries.
     </change>
-    <change issue="2059" PR="TODO" date="2025-06-23">
+    <change issue="2059" PR="2060" date="2025-06-23">
       The output of QNames reflects the new syntax for QName literals.
     </change>
     <change issue="2087 2186" PR="2114 2226" date="2025-06-22">
       A JNode is represented as <code>jnode(<var>K</var>: <var>V</var>)</code> where 
       <var>K</var> is its <code>·selector·</code> property and
       <var>V</var> is its <code>·content·</code> property.
+    </change>
+    <change issue="2388" PR="2485" date="2026-02-20">
+      The adaptive serialization of anonymous functions is now implementation-dependent.
     </change>
   </changes>
 
@@ -4167,7 +4170,7 @@ for serializing an atomic item. The values are serialized in the same way as the
 </item>
 
 <item><p>A <termref def="dt-function-item">function item</termref> that has a name is
-serialized to the representation <code>name#A</code> where 
+serialized to the representation <code>name#<var>A</var></code> where 
 <var>fn:name</var> is a representation of
 the function name and <var>A</var> is the arity. 
 If the function name is in one of the namespaces
@@ -4181,14 +4184,19 @@ then the name is output as a lexical QName using the conventional prefix
 as appropriate; if it is in any other namespace or in no namespace, then the name is 
 output as a URI-qualified name (that is, <code>Q{uri}local</code>).</p>
  
-<p>The serialization of an anonymous function item is <termref def="impdep">implementation-dependent</termref>.</p>
+<p>The serialization of an anonymous function item (other than a map or array) 
+  is <termref def="impdep">implementation-dependent</termref>.</p>
 <note><p>
 The following examples illustrate this rule:</p>
 <ulist>
 <item><p><code>fn:exists#1</code> is serialized as <code>fn:exists#1</code></p></item>
 <item><p><code>Q{http://www.w3.org/2005/xpath-functions}exists#1</code> is serialized as <code>fn:exists#1</code></p></item>
-<item><p><code>function($a) { $a }</code> is serialized as <code>(anonymous-function)#1</code></p></item>
 <item><p><code>math:pi#0</code> is serialized as <code>math:pi#0</code></p></item>
+<item><p>The serialization of <code>function($a) { $a }</code> is 
+  is <termref def="impdep">implementation-dependent</termref></p></item>
+<item><p>The serialization of <code>fn:contains(?, "e")</code> is 
+  is <termref def="impdep">implementation-dependent</termref></p></item>  
+
 </ulist>
 </note>
 </item>


### PR DESCRIPTION
The adaptive serialization of anonymous functions becomes implementation-dependent.

(Some implementation might be able to do better than the current spec suggests, e.g. by displaying the source code of the function).

Fix #2388