### PR TITLE
Correct narrative examples in F+O

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -1377,9 +1377,9 @@
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression><eg>fn:trace($v, 'the value of $v is: ')</eg></fos:expression>
-               <fos:result narrative="true">Supposing that <code>$v</code> is an <code>xs:decimal</code>
-               with the value <code>124.84</code>, the function returns the value <code>124.84</code>,
+               <fos:expression><eg>let $v := 124.84
+return fn:trace($v, 'the value of $v is: ')</eg></fos:expression>
+               <fos:result narrative="true">The function returns the <code>xs:decimal</code> value <code>124.84</code>,
                while outputting a message such as "the value of $v is: 124.84" to 
                an <termref def="implementation-defined"/> destination. The format of the message
                is also <termref def="implementation-defined"/>.</fos:result>
@@ -1392,6 +1392,11 @@
                <fos:result narrative="true">The result of the expression is the same as the result of
                <code>//book[xs:decimal(@price) gt 100]</code>, but evaluation has the side-effect of
                providing diagnostic feedback to the user.</fos:result>
+               <fos:test-assertion>
+                  <result xmlns="http://www.w3.org/2010/09/qt-fots-catalog">
+                     <error code="XPDY0002"/>
+                  </result>
+               </fos:test-assertion>
             </fos:test>
             
             
@@ -1448,6 +1453,11 @@
                <fos:result narrative="true">The result of the expression is the same as the result of
                <code>//book[xs:decimal(@price) lt 1000]</code>, but evaluation has the side-effect of
                providing diagnostic feedback to the user relating to books above this price threshold.</fos:result>
+               <fos:test-assertion>
+                  <result xmlns="http://www.w3.org/2010/09/qt-fots-catalog">
+                     <error code="XPDY0002"/>
+                  </result>
+               </fos:test-assertion>
             </fos:test>
             
             
@@ -3047,17 +3057,17 @@ compare($N * $arg2, 0) eq compare($arg1, 0).</eg>
          <fos:example>
             <fos:test>
                <fos:expression>format-integer(14, 'Ww;o(-e)', 'de')</fos:expression>
-               <fos:result>If supported, might return the string <code>"Vierzehnte"</code>.</fos:result>
+               <fos:result narrative="true">If supported, might return the string <code>"Vierzehnte"</code>.</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>1 to 10 ! format-integer(., "1;o(-º)", language:="it")</fos:expression>
+               <fos:expression>(1 to 10) ! format-integer(., "1;o(-º)", language:="it")</fos:expression>
                <fos:result narrative="true">This requests ordinal numbering in Italian: if supported, 
                   this should produce the sequence: <code>1º 2º 3º 4º ...</code></fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>1 to 10 ! format-integer(., "Ww;o", language:="it")</fos:expression>
+               <fos:expression>(1 to 10) ! format-integer(., "Ww;o", language:="it")</fos:expression>
                <fos:result narrative="true">This requests ordinal numbering in Italian, spelled out
                   as words: if supported, 
                   this should produce the sequence: <code>Primo Secondo Terzo Quarto Quinto ...</code></fos:result>
@@ -13159,7 +13169,7 @@ else QName("", $value)</eg>
             <fos:test>
                <fos:expression><eg>declare namespace xmp = "http://www.example.com/ns";
 fn:parse-QName("xmp:person")</eg></fos:expression>
-               <fos:result>fn:QName("http://www.example.com/ns", "xmp:person")</fos:result>
+               <fos:result>#Q{http://www.example.com/ns}xmp:person</fos:result>
             </fos:test>
          </fos:example>
 
@@ -13296,9 +13306,7 @@ fn:parse-QName("xmp:person")</eg></fos:expression>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression><eg>local-name-from-QName(
-  QName("http://www.example.com/example", "person")
-)</eg></fos:expression>
+               <fos:expression><eg>local-name-from-QName(#Q{http://www.example.com/ns}person)</eg></fos:expression>
                <fos:result>"person"</fos:result>
             </fos:test>
          </fos:example>
@@ -13328,10 +13336,8 @@ fn:parse-QName("xmp:person")</eg></fos:expression>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression><eg>namespace-uri-from-QName(
-  QName("http://www.example.com/example", "person")
-)</eg></fos:expression>
-               <fos:result>xs:anyURI("http://www.example.com/example")</fos:result>
+               <fos:expression><eg>namespace-uri-from-QName(#Q{http://www.example.com/ns}person)</eg></fos:expression>
+               <fos:result>xs:anyURI("http://www.example.com/ns")</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -16826,7 +16832,7 @@ return for-each(1 to 10, $mapping otherwise void#0)</eg></fos:expression>
       <fos:equivalent style="xpath-expression" covers-error-cases="false">
 if (count($input) le 1) 
 then $input 
-else error(parse-QName('Q{http://www.w3.org/2005/xqt-errors}FORG0003'))
+else error(#Q{http://www.w3.org/2005/xqt-errors}FORG0003))
       </fos:equivalent>
       <fos:errors>
          <p>A dynamic error is raised <errorref class="RG" code="0003"
@@ -16857,7 +16863,7 @@ else error(parse-QName('Q{http://www.w3.org/2005/xqt-errors}FORG0003'))
       <fos:equivalent style="xpath-expression" covers-error-cases="false">
 if (count($input) ge 1) 
 then $input 
-else error(parse-QName('Q{http://www.w3.org/2005/xqt-errors}FORG0004'))
+else error(#Q{http://www.w3.org/2005/xqt-errors}FORG0004))
       </fos:equivalent>
       <fos:errors>
          <p>A dynamic error is raised <errorref class="RG" code="0004"
@@ -16886,7 +16892,7 @@ else error(parse-QName('Q{http://www.w3.org/2005/xqt-errors}FORG0004'))
       <fos:equivalent style="xpath-expression" covers-error-cases="false">
 if (count($input) eq 1) 
 then $input 
-else error(parse-QName('Q{http://www.w3.org/2005/xqt-errors}FORG0005'))
+else error(#Q{http://www.w3.org/2005/xqt-errors}FORG0005))
       </fos:equivalent>
       <fos:errors>
          <p>A dynamic error is raised <errorref class="RG" code="0005"
@@ -22096,10 +22102,11 @@ serialize(
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression><eg>let $f := function-lookup( #zip:binary-entry, 2 )
-return if (exists($f)) then $f($source, $entry) else ()</eg></fos:expression>
-               <fos:result>The result of
-               calling <code>zip:binary-entry($source, $entry)</code> if the function is available, or
+               <fos:expression><eg>declare namespace zip = "http://expath.org/ns/zip";
+let $f := function-lookup( #zip:binary-entry, 2 )
+return if (exists($f)) then $f("file:///temp.zip", "index.xml") else ()</eg></fos:expression>
+               <fos:result narrative="true">The result of
+               calling <code>zip:binary-entry("file:///temp.zip", "index.xml")</code> if the function is available, or
                the empty sequence otherwise.</fos:result>
             </fos:test>
          </fos:example>
@@ -22132,7 +22139,7 @@ return if (exists($f)) then $f($source, $entry) else ()</eg></fos:expression>
          <fos:example>
             <fos:test>
                <fos:expression>function-name(substring#2)</fos:expression>
-               <fos:result><eg>QName("http://www.w3.org/2005/xpath-functions", "fn:substring")</eg></fos:result>
+               <fos:result><eg>#Q{http://www.w3.org/2005/xpath-functions}substring</eg></fos:result>
                <fos:postamble>The namespace prefix of the returned QName is not predictable.</fos:postamble>
             </fos:test>
             <fos:test>
@@ -23489,6 +23496,11 @@ for-each-pair(
                <fos:expression><eg>let $SWEDISH := collation({ 'lang': 'se' })
 return sort(//name!string(), $SWEDISH)</eg></fos:expression>
                <fos:result narrative="true">The names in <code>//name</code> sorted using Swedish collation.</fos:result>
+               <fos:test-assertion>
+                  <result xmlns="http://www.w3.org/2010/09/qt-fots-catalog">
+                     <error code="XPDY0002"/>
+                  </result>
+               </fos:test-assertion>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -23496,7 +23508,12 @@ return sort(//name!string(), $SWEDISH)</eg></fos:expression>
                <fos:expression><eg>sort(//employee, (), fn { name ! (last, first) })</eg></fos:expression>
                <fos:result narrative="true">A sorted sequence of employees by last name as the major sort key and first name as the minor sort key,
                using the default collation.</fos:result>
-            </fos:test>
+               <fos:test-assertion>
+               <result xmlns="http://www.w3.org/2010/09/qt-fots-catalog">
+                  <error code="XPDY0002"/>
+               </result>
+            </fos:test-assertion>
+            </fos:test>           
          </fos:example>
       </fos:examples>
    </fos:function>
@@ -23655,27 +23672,39 @@ else +1</eg>
                <fos:expression>sort-by((1, -2, 5, 10, -10, 10, 8), { 'key': abs#1 })</fos:expression>
                <fos:result>1, -2, 5, 8, 10, -10, 10</fos:result>
             </fos:test>
-         </fos:example>
-         
-         <fos:example>
             <fos:test>
                <fos:expression><eg>let $SWEDISH := collation({ 'lang': 'se' })
-return sort-by($in, { 'collation': $SWEDISH })</eg></fos:expression>
+return sort-by(//name, { 'collation': $SWEDISH })</eg></fos:expression>
                <fos:result narrative="true">The names in <code>//name</code> sorted using Swedish collation.</fos:result>
+               <fos:test-assertion>
+                  <result xmlns="http://www.w3.org/2010/09/qt-fots-catalog">
+                     <error code="XPDY0002"/>
+                  </result>
+               </fos:test-assertion>
             </fos:test>
             <fos:test>
                <fos:expression><eg>sort-by(//employee, { 'key': fn { name ! (last, first) } })</eg></fos:expression>
                <fos:result narrative="true">Sorts a sequence of employees by last name as the major sort key 
                   and first name as the minor sort key,
                using the default collation</fos:result>
+               <fos:test-assertion>
+                  <result xmlns="http://www.w3.org/2010/09/qt-fots-catalog">
+                     <error code="XPDY0002"/>
+                  </result>
+               </fos:test-assertion>
             </fos:test>
             <fos:test>
                <fos:expression><eg>sort-by(
-  $employees, 
+  //employee, 
   ({ 'key': fn { name/last }, 'collation': collation({ 'lang': 'se' }) },
    { 'key': fn { xs:decimal(salary) }, 'order': 'descending' }))</eg></fos:expression>
                <fos:result narrative="true">Sorts a sequence of employees first by increasing last name (using Swedish collation order)
                and then by decreasing salary</fos:result>
+               <fos:test-assertion>
+                  <result xmlns="http://www.w3.org/2010/09/qt-fots-catalog">
+                     <error code="XPDY0002"/>
+                  </result>
+               </fos:test-assertion>
             </fos:test>
          </fos:example>
          
@@ -26496,6 +26525,11 @@ return map:build($titles/title, fn($title) { $title/ix })
                <fos:expression><eg>map:build(//employee, fn { @ssn })</eg></fos:expression>
                <fos:result narrative="true">A map whose keys are employee <code>@ssn</code> values, and whose
                corresponding values are the employee nodes</fos:result>
+               <fos:test-assertion>
+                  <result xmlns="http://www.w3.org/2010/09/qt-fots-catalog">
+                     <error code="XPDY0002"/>
+                  </result>
+               </fos:test-assertion>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -26504,6 +26538,11 @@ return map:build($titles/title, fn($title) { $title/ix })
                <fos:result narrative="true">A map whose keys are employee <code>@location</code> values, and whose
                corresponding values represent the number of employees at each distinct location. Any employees that
                lack an <code>@location</code> attribute will be excluded from the result.</fos:result>
+               <fos:test-assertion>
+                  <result xmlns="http://www.w3.org/2010/09/qt-fots-catalog">
+                     <error code="XPDY0002"/>
+                  </result>
+               </fos:test-assertion>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -26511,10 +26550,15 @@ return map:build($titles/title, fn($title) { $title/ix })
                <fos:expression><eg>map:build(
   //employee,
   key := fn { @location }, 
-  combine := fn($a, $b) { highest(($a, $b), fn { xs:decimal(@salary) }) }
+  options := {"combine" : fn($a, $b) { highest(($a, $b), (), fn { xs:decimal(@salary) }) } }
 )</eg></fos:expression>
                <fos:result narrative="true">A map whose keys are employee <code>@location</code> values, and whose
                corresponding values contain the employee node for the highest-paid employee at each distinct location</fos:result>
+               <fos:test-assertion>
+                  <result xmlns="http://www.w3.org/2010/09/qt-fots-catalog">
+                     <error code="XPDY0002"/>
+                  </result>
+               </fos:test-assertion>
             </fos:test>
             
          </fos:example>
@@ -26523,6 +26567,11 @@ return map:build($titles/title, fn($title) { $title/ix })
                <fos:expression><eg>map:build(//*, generate-id#1)</eg></fos:expression>
                <fos:result narrative="true">A map allowing efficient access to every element in a document by means
                of its <function>fn:generate-id</function> value.</fos:result>
+               <fos:test-assertion>
+                  <result xmlns="http://www.w3.org/2010/09/qt-fots-catalog">
+                     <error code="XPDY0002"/>
+                  </result>
+               </fos:test-assertion>
             </fos:test>
  
          </fos:example>
@@ -26533,8 +26582,8 @@ return map:build($titles/title, fn($title) { $title/ix })
   "name": "org",
   "content": [
       { "type": "package",
-        "name": "xml,
-        "content: [
+        "name": "xml",
+        "content": [
             { "type": "package",
               "name": "sax",
               "content": [
@@ -26548,11 +26597,14 @@ return map:build($titles/title, fn($title) { $title/ix })
             }]
        }]
    }')
-   return map:build($tree ? descendant::~[record(type, name, content?)],
-                    fn{?ancestor-or-self::name => reverse() => string-join(,)},
+   return map:build($tree/descendant-or-self::jnode(*, record(type, name, content?)),
+                    fn{./ancestor-or-self::jnode()?name => string-join(".")},
                     fn{`{?type} {?name}`})
             </eg></fos:expression>
-               <fos:result><eg>{ "org.xml.sax.Attributes": "class Attributes",
+               <fos:result><eg>{ "org":"package org",
+  "org.xml":"package xml",
+  "org.xml.sax":"package sax",
+  "org.xml.sax.Attributes": "class Attributes",
   "org.xml.sax.ContentHandler": "class ContentHandler",
   "org.xml.sax.XMLReader": "class XMLReader" }</eg></fos:result>
                <fos:postamble>Constructs a map allowing efficient access to values in a recursive JSON structure
@@ -33387,6 +33439,11 @@ return $result?output//body
             <fos:test>
                <fos:expression>random-number-generator()?permute($seq)[1 to (count($seq) idiv 10)]</fos:expression>
                <fos:result narrative="true">A 10% sample of the items in an input sequence <code>$seq</code>, chosen at random</fos:result>
+               <fos:test-assertion>
+                  <result xmlns="http://www.w3.org/2010/09/qt-fots-catalog">
+                     <error code="XPST0008"/>
+                  </result>
+               </fos:test-assertion>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -33909,6 +33966,11 @@ return every($dl/*, fn($elem, $pos) {
             <fos:test>
                <fos:expression>highest(//employee, (), fn { xs:decimal(salary) })</fos:expression>
                <fos:result narrative="true">The employees having the highest salary.</fos:result>
+               <fos:test-assertion>
+                  <result xmlns="http://www.w3.org/2010/09/qt-fots-catalog">
+                     <error code="XPDY0002"/>
+                  </result>
+               </fos:test-assertion>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -34268,6 +34330,11 @@ return $item
             <fos:test>
                <fos:expression>lowest(//employee, (), fn { xs:decimal(salary) })</fos:expression>
                <fos:result narrative="true">The employees having the lowest salary.</fos:result>
+               <fos:test-assertion>
+                  <result xmlns="http://www.w3.org/2010/09/qt-fots-catalog">
+                     <error code="XPDY0002"/>
+                  </result>
+               </fos:test-assertion>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -34454,11 +34521,21 @@ exists(filter($input, $predicate))
                <fos:expression>all-equal(//p/@class)</fos:expression>
                <fos:result narrative="true">Returns <code>true</code> if all
                 <code>p</code> elements have the same value for <code>@class</code>.</fos:result>
+               <fos:test-assertion>
+                  <result xmlns="http://www.w3.org/2010/09/qt-fots-catalog">
+                     <error code="XPDY0002"/>
+                  </result>
+               </fos:test-assertion>
             </fos:test>
             <fos:test>
                <fos:expression>all-equal(* ! node-name())</fos:expression>
                <fos:result narrative="true">Returns <code>true</code> if all
                element children of the context node have the same name.</fos:result>
+               <fos:test-assertion>
+                  <result xmlns="http://www.w3.org/2010/09/qt-fots-catalog">
+                     <error code="XPDY0002"/>
+                  </result>
+               </fos:test-assertion>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -34541,13 +34618,23 @@ exists(filter($input, $predicate))
                <fos:expression>fn:all-different(//employee/@ssn)</fos:expression>
                <fos:result narrative="true">Returns <code>true</code> if no two employees have the same value for their
             <code>@ssn</code> attribute.</fos:result>
+               <fos:test-assertion>
+                  <result xmlns="http://www.w3.org/2010/09/qt-fots-catalog">
+                     <error code="XPDY0002"/>
+                  </result>
+               </fos:test-assertion>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test> 
                <fos:expression>fn:all-different(* ! fn:node-name())</fos:expression>
-                  <fos:result narrative="true">Returns <code>true</code> if all
+               <fos:result narrative="true">Returns <code>true</code> if all
                   element children of the context node have distinct names.</fos:result>
+               <fos:test-assertion>
+                  <result xmlns="http://www.w3.org/2010/09/qt-fots-catalog">
+                     <error code="XPDY0002"/>
+                  </result>
+               </fos:test-assertion>
             </fos:test>
          </fos:example>
       </fos:examples>

--- a/specifications/xpath-functions-40/style/generate-qt3-test-set.xsl
+++ b/specifications/xpath-functions-40/style/generate-qt3-test-set.xsl
@@ -108,6 +108,10 @@
           <xsl:when test="exists(fos:test-assertion)">
             <xsl:copy-of select="fos:test-assertion/*:result/*"/>           
           </xsl:when>
+          <xsl:when test="fos:result[@narrative]">
+            <!-- In this case the generated test must compile and execute, but the result is not tested -->
+            <assert>true()</assert>
+          </xsl:when>
           <xsl:when test="fos:result[matches(., '^\s*&lt;')] and not(contains(fos:expression, 'serialize'))">
             <!-- Drop leading whitespace to keep the XML parser happy -->
             <xsl:variable name="trimmed" select="replace(fos:result, '^\s+&lt;', '&lt;')"/>
@@ -129,10 +133,6 @@
                 <assert-xml ignore-prefixes="{(fos:result/@ignore-prefixes, false())[1]}">{$trimmed}</assert-xml>
               </xsl:otherwise>
             </xsl:choose>           
-          </xsl:when>
-          <xsl:when test="fos:result[@narrative]">
-            <!-- In this case the generated test must compile and execute, but the result is not tested -->
-            <assert>true()</assert>
           </xsl:when>
           <xsl:when test="fos:result[@approx]">
             <assert>abs($result - {fos:result}) lt 1e-5</assert>


### PR DESCRIPTION
A change to the test-generation stylesheet to correctly handle narrative results where there is an explicit test assertion.

Corrections to many of the narrative examples to make them pass the tests.