### PR TITLE
2443 Naming: JNodes, selectors and contents

### DIFF
--- a/specifications/xpath-datamodel-40/image-sources/jgraph.n3
+++ b/specifications/xpath-datamodel-40/image-sources/jgraph.n3
@@ -5,13 +5,13 @@ digraph jnodes {
     R [label=<
 <table border="0" cellborder="1" cellspacing="0">
   <tr><td colspan="2">R</td></tr>
-  <tr><td>content:</td><td balign="left"><font face="monospace">[{"a": 1, "b": "XXX", "c": true(), "d": ()},<br align="left"/> {"a": 2, "b": "YYY", "c": false(), "d": ()}]  </font></td></tr>
+  <tr><td>content:</td><td balign="left"><font face="monospace">[ { "a": 1, "b": "XXX", "c": true(), "d": () },<br align="left"/>{ "a": 2, "b": "YYY", "c": false(), "d": () } ]</font></td></tr>
 </table>>];
 
     M1 [label=<
 <table border="0" cellborder="1" cellspacing="0">
   <tr><td colspan="6">M1</td></tr>
-  <tr><td>content:</td><td colspan="5"><font face="monospace">{"a": 1, "b": "XXX", "c": true(), "d": ()}  </font></td></tr>
+  <tr><td>content:</td><td colspan="5"><font face="monospace">{ "a": 1, "b": "XXX", "c": true(), "d": () }</font></td></tr>
   <tr><td>parent:</td><td><font face="monospace">R</font></td>
       <td>position:</td><td><font face="monospace">1</font></td>
       <td>selector:</td><td><font face="monospace">1</font></td></tr>
@@ -52,7 +52,7 @@ digraph jnodes {
     M2 [label=<
 <table border="0" cellborder="1" cellspacing="0">
   <tr><td colspan="6">M2</td></tr>
-  <tr><td>content:</td><td colspan="5"><font face="monospace">{"a": 2, "b": "YYY", "c": false(), "d": ()}  </font></td></tr>
+  <tr><td>content:</td><td colspan="5"><font face="monospace">{ "a": 2, "b": "YYY", "c": false(), "d": () }</font></td></tr>
   <tr><td>parent:</td><td><font face="monospace">R</font></td>
       <td>position:</td><td><font face="monospace">1</font></td>
      <td>selector:</td><td><font face="monospace">2</font></td></tr>

--- a/specifications/xpath-datamodel-40/image-sources/xgraph.n3
+++ b/specifications/xpath-datamodel-40/image-sources/xgraph.n3
@@ -8,8 +8,8 @@ digraph xnodes {
   <tr><td>content</td><td balign="right"><font face="monospace">{<br align="left"/>
    "a": 1,<br align="left"/>
    "b": ("x", "y"),<br align="left"/>
-   "c": [(10, 20), 30],<br align="left"/>
-   "d": (10, [20, 30]),<br align="left"/>
+   "c": [ (4, 5), 6 ],<br align="left"/>
+   "d": (7, [ 8, 9 ]),<br align="left"/>
    "e": (&lt;p/&gt;, &lt;q/&gt;)<br align="left"/>
 }<br align="left"/></font></td></tr>
 </table>>];
@@ -43,7 +43,7 @@ digraph xnodes {
    J3 [label=<
 <table border="0" cellborder="1" cellspacing="0">
   <tr><td colspan="2">J3</td></tr>
-  <tr><td>content</td><td><font face="monospace">[(10, 20), 30]</font></td></tr>
+  <tr><td>content</td><td><font face="monospace">[ (4, 5), 6 ]</font></td></tr>
   <tr><td>parent</td><td><font face="monospace">R</font></td></tr>
   <tr><td>position</td><td><font face="monospace">1</font></td></tr>
   <tr><td>selector</td><td><font face="monospace">"c"</font></td></tr>
@@ -51,7 +51,7 @@ digraph xnodes {
 
    J3_1 [label=<
 <table border="0" cellborder="1" cellspacing="0">
-  <tr><td>content</td><td><font face="monospace">(10, 20)</font></td></tr>
+  <tr><td>content</td><td><font face="monospace">(4, 5)</font></td></tr>
   <tr><td>parent</td><td><font face="monospace">J3</font></td></tr>
   <tr><td>position</td><td><font face="monospace">1</font></td></tr>
   <tr><td>selector</td><td><font face="monospace">1</font></td></tr>
@@ -61,7 +61,7 @@ digraph xnodes {
 
    J3_2 [label=<
 <table border="0" cellborder="1" cellspacing="0">
-  <tr><td>content</td><td><font face="monospace">30</font></td></tr>
+  <tr><td>content</td><td><font face="monospace">6</font></td></tr>
   <tr><td>parent</td><td><font face="monospace">J3</font></td></tr>
   <tr><td>position</td><td><font face="monospace">1</font></td></tr>
   <tr><td>selector</td><td><font face="monospace">2</font></td></tr>
@@ -78,7 +78,7 @@ digraph xnodes {
    J4 [label=<
 <table border="0" cellborder="1" cellspacing="0">
   <tr><td colspan="2">J4</td></tr>
-  <tr><td>content</td><td><font face="monospace">(10, [20, 30])</font></td></tr>
+  <tr><td>content</td><td><font face="monospace">(7, [ 8, 9 ])</font></td></tr>
   <tr><td>parent</td><td><font face="monospace">R</font></td></tr>
   <tr><td>position</td><td><font face="monospace">1</font></td></tr>
   <tr><td>selector</td><td><font face="monospace">"d"</font></td></tr>
@@ -86,7 +86,7 @@ digraph xnodes {
 
    J4_1 [label=<
 <table border="0" cellborder="1" cellspacing="0">
-  <tr><td>content</td><td><font face="monospace">20</font></td></tr>
+  <tr><td>content</td><td><font face="monospace">8</font></td></tr>
   <tr><td>parent</td><td><font face="monospace">J4</font></td></tr>
   <tr><td>position</td><td><font face="monospace">2</font></td></tr>
   <tr><td>selector</td><td><font face="monospace">1</font></td></tr>
@@ -96,7 +96,7 @@ digraph xnodes {
 
    J4_2 [label=<
 <table border="0" cellborder="1" cellspacing="0">
-  <tr><td>content</td><td><font face="monospace">30</font></td></tr>
+  <tr><td>content</td><td><font face="monospace">9</font></td></tr>
   <tr><td>parent</td><td><font face="monospace">J4</font></td></tr>
   <tr><td>position</td><td><font face="monospace">2</font></td></tr>
   <tr><td>selector</td><td><font face="monospace">2</font></td></tr>

--- a/specifications/xpath-datamodel-40/images/jgraph.svg
+++ b/specifications/xpath-datamodel-40/images/jgraph.svg
@@ -16,8 +16,8 @@
 <polygon fill="none" stroke="black" points="216.38,-328.75 216.38,-369.25 265.88,-369.25 265.88,-328.75 216.38,-328.75"/>
 <text xml:space="preserve" text-anchor="start" x="219.38" y="-343.95" font-family="Times,serif" font-size="14.00">content:</text>
 <polygon fill="none" stroke="black" points="265.88,-328.75 265.88,-369.25 659.62,-369.25 659.62,-328.75 265.88,-328.75"/>
-<text xml:space="preserve" text-anchor="start" x="268.88" y="-352.95" font-family="monospace" font-size="14.00">[{&quot;a&quot;: 1, &quot;b&quot;: &quot;XXX&quot;, &quot;c&quot;: true(), &quot;d&quot;: ()},</text>
-<text xml:space="preserve" text-anchor="start" x="268.88" y="-335.7" font-family="monospace" font-size="14.00"> {&quot;a&quot;: 2, &quot;b&quot;: &quot;YYY&quot;, &quot;c&quot;: false(), &quot;d&quot;: ()}]  </text>
+<text xml:space="preserve" text-anchor="start" x="268.88" y="-352.95" font-family="monospace" font-size="14.00"> [ { &quot;a&quot;: 1, &quot;b&quot;: &quot;XXX&quot;, &quot;c&quot;: true(), &quot;d&quot;: () },</text>
+<text xml:space="preserve" text-anchor="start" x="268.88" y="-335.7" font-family="monospace" font-size="14.00"> { &quot;a&quot;: 2, &quot;b&quot;: &quot;YYY&quot;, &quot;c&quot;: false(), &quot;d&quot;: () } ]</text>
 </g>
 <!-- M1 -->
 <g id="node2" class="node">
@@ -27,7 +27,7 @@
 <polygon fill="none" stroke="black" points="8.75,-226.75 8.75,-250 58.25,-250 58.25,-226.75 8.75,-226.75"/>
 <text xml:space="preserve" text-anchor="start" x="11.75" y="-233.32" font-family="Times,serif" font-size="14.00">content:</text>
 <polygon fill="none" stroke="black" points="58.25,-226.75 58.25,-250 427.25,-250 427.25,-226.75 58.25,-226.75"/>
-<text xml:space="preserve" text-anchor="start" x="61.25" y="-233.7" font-family="monospace" font-size="14.00">{&quot;a&quot;: 1, &quot;b&quot;: &quot;XXX&quot;, &quot;c&quot;: true(), &quot;d&quot;: ()}  </text>
+<text xml:space="preserve" text-anchor="start" x="61.25" y="-233.7" font-family="monospace" font-size="14.00"> { &quot;a&quot;: 1, &quot;b&quot;: &quot;XXX&quot;, &quot;c&quot;: true(), &quot;d&quot;: () }</text>
 <polygon fill="none" stroke="black" points="8.75,-203.5 8.75,-226.75 58.25,-226.75 58.25,-203.5 8.75,-203.5"/>
 <text xml:space="preserve" text-anchor="start" x="14.75" y="-210.07" font-family="Times,serif" font-size="14.00">parent:</text>
 <polygon fill="none" stroke="black" points="58.25,-203.5 58.25,-226.75 116.75,-226.75 116.75,-203.5 58.25,-203.5"/>
@@ -56,7 +56,7 @@
 <polygon fill="none" stroke="black" points="445.62,-226.75 445.62,-250 495.12,-250 495.12,-226.75 445.62,-226.75"/>
 <text xml:space="preserve" text-anchor="start" x="448.62" y="-233.32" font-family="Times,serif" font-size="14.00">content:</text>
 <polygon fill="none" stroke="black" points="495.12,-226.75 495.12,-250 872.38,-250 872.38,-226.75 495.12,-226.75"/>
-<text xml:space="preserve" text-anchor="start" x="498.12" y="-233.7" font-family="monospace" font-size="14.00">{&quot;a&quot;: 2, &quot;b&quot;: &quot;YYY&quot;, &quot;c&quot;: false(), &quot;d&quot;: ()}  </text>
+<text xml:space="preserve" text-anchor="start" x="498.12" y="-233.7" font-family="monospace" font-size="14.00"> { &quot;a&quot;: 2, &quot;b&quot;: &quot;YYY&quot;, &quot;c&quot;: false(), &quot;d&quot;: () }</text>
 <polygon fill="none" stroke="black" points="445.62,-203.5 445.62,-226.75 495.12,-226.75 495.12,-203.5 445.62,-203.5"/>
 <text xml:space="preserve" text-anchor="start" x="451.62" y="-210.07" font-family="Times,serif" font-size="14.00">parent:</text>
 <polygon fill="none" stroke="black" points="495.12,-203.5 495.12,-226.75 555.27,-226.75 555.27,-203.5 495.12,-203.5"/>

--- a/specifications/xpath-datamodel-40/images/xgraph.svg
+++ b/specifications/xpath-datamodel-40/images/xgraph.svg
@@ -16,13 +16,13 @@
 <polygon fill="none" stroke="black" points="210.38,-375.25 210.38,-502 256.12,-502 256.12,-375.25 210.38,-375.25"/>
 <text xml:space="preserve" text-anchor="start" x="213.38" y="-433.57" font-family="Times,serif" font-size="14.00">content</text>
 <polygon fill="none" stroke="black" points="256.12,-375.25 256.12,-502 451.88,-502 451.88,-375.25 256.12,-375.25"/>
-<text xml:space="preserve" text-anchor="start" x="259.12" y="-485.7" font-family="monospace" font-size="14.00">{</text>
-<text xml:space="preserve" text-anchor="start" x="259.12" y="-468.45" font-family="monospace" font-size="14.00"> &#160;&#160;&quot;a&quot;: 1,</text>
-<text xml:space="preserve" text-anchor="start" x="259.12" y="-451.2" font-family="monospace" font-size="14.00"> &#160;&#160;&quot;b&quot;: (&quot;x&quot;, &quot;y&quot;),</text>
-<text xml:space="preserve" text-anchor="start" x="259.12" y="-433.95" font-family="monospace" font-size="14.00"> &#160;&#160;&quot;c&quot;: [(10, 20), 30],</text>
-<text xml:space="preserve" text-anchor="start" x="259.12" y="-416.7" font-family="monospace" font-size="14.00"> &#160;&#160;&quot;d&quot;: (10, [20, 30]),</text>
-<text xml:space="preserve" text-anchor="start" x="259.12" y="-399.45" font-family="monospace" font-size="14.00"> &#160;&#160;&quot;e&quot;: (&lt;p/&gt;, &lt;q/&gt;)</text>
-<text xml:space="preserve" text-anchor="start" x="259.12" y="-382.2" font-family="monospace" font-size="14.00">}</text>
+<text xml:space="preserve" text-anchor="start" x="259.12" y="-485.7" font-family="monospace" font-size="14.00"> {</text>
+<text xml:space="preserve" text-anchor="start" x="259.12" y="-468.45" font-family="monospace" font-size="14.00">  &#160;&#160;&quot;a&quot;: 1,</text>
+<text xml:space="preserve" text-anchor="start" x="259.12" y="-451.2" font-family="monospace" font-size="14.00">  &#160;&#160;&quot;b&quot;: (&quot;x&quot;, &quot;y&quot;),</text>
+<text xml:space="preserve" text-anchor="start" x="259.12" y="-433.95" font-family="monospace" font-size="14.00">  &#160;&#160;&quot;c&quot;: [ (4, 5), 6 ],</text>
+<text xml:space="preserve" text-anchor="start" x="259.12" y="-416.7" font-family="monospace" font-size="14.00">  &#160;&#160;&quot;d&quot;: (7, [ 8, 9 ]),</text>
+<text xml:space="preserve" text-anchor="start" x="259.12" y="-399.45" font-family="monospace" font-size="14.00">  &#160;&#160;&quot;e&quot;: (&lt;p/&gt;, &lt;q/&gt;)</text>
+<text xml:space="preserve" text-anchor="start" x="259.12" y="-382.2" font-family="monospace" font-size="14.00"> }</text>
 </g>
 <!-- J1 -->
 <g id="node2" class="node">
@@ -90,7 +90,7 @@
 <polygon fill="none" stroke="black" points="245.62,-273.25 245.62,-296.5 295.12,-296.5 295.12,-273.25 245.62,-273.25"/>
 <text xml:space="preserve" text-anchor="start" x="250.5" y="-279.82" font-family="Times,serif" font-size="14.00">content</text>
 <polygon fill="none" stroke="black" points="295.12,-273.25 295.12,-296.5 416.62,-296.5 416.62,-273.25 295.12,-273.25"/>
-<text xml:space="preserve" text-anchor="start" x="298.12" y="-280.2" font-family="monospace" font-size="14.00">[(10, 20), 30]</text>
+<text xml:space="preserve" text-anchor="start" x="298.12" y="-280.2" font-family="monospace" font-size="14.00"> [ (4, 5), 6 ]</text>
 <polygon fill="none" stroke="black" points="245.62,-250 245.62,-273.25 295.12,-273.25 295.12,-250 245.62,-250"/>
 <text xml:space="preserve" text-anchor="start" x="253.5" y="-256.57" font-family="Times,serif" font-size="14.00">parent</text>
 <polygon fill="none" stroke="black" points="295.12,-250 295.12,-273.25 416.62,-273.25 416.62,-250 295.12,-250"/>
@@ -119,7 +119,7 @@
 <polygon fill="none" stroke="black" points="434.62,-273.25 434.62,-296.5 484.12,-296.5 484.12,-273.25 434.62,-273.25"/>
 <text xml:space="preserve" text-anchor="start" x="439.5" y="-279.82" font-family="Times,serif" font-size="14.00">content</text>
 <polygon fill="none" stroke="black" points="484.12,-273.25 484.12,-296.5 605.62,-296.5 605.62,-273.25 484.12,-273.25"/>
-<text xml:space="preserve" text-anchor="start" x="487.12" y="-280.2" font-family="monospace" font-size="14.00">(10, [20, 30])</text>
+<text xml:space="preserve" text-anchor="start" x="487.12" y="-280.2" font-family="monospace" font-size="14.00"> (7, [ 8, 9 ])</text>
 <polygon fill="none" stroke="black" points="434.62,-250 434.62,-273.25 484.12,-273.25 484.12,-250 434.62,-250"/>
 <text xml:space="preserve" text-anchor="start" x="442.5" y="-256.57" font-family="Times,serif" font-size="14.00">parent</text>
 <polygon fill="none" stroke="black" points="484.12,-250 484.12,-273.25 605.62,-273.25 605.62,-250 484.12,-250"/>
@@ -197,7 +197,7 @@
 <polygon fill="none" stroke="black" points="205.38,-124 205.38,-147.25 254.88,-147.25 254.88,-124 205.38,-124"/>
 <text xml:space="preserve" text-anchor="start" x="210.25" y="-130.57" font-family="Times,serif" font-size="14.00">content</text>
 <polygon fill="none" stroke="black" points="254.88,-124 254.88,-147.25 326.88,-147.25 326.88,-124 254.88,-124"/>
-<text xml:space="preserve" text-anchor="start" x="257.88" y="-130.95" font-family="monospace" font-size="14.00">(10, 20)</text>
+<text xml:space="preserve" text-anchor="start" x="257.88" y="-130.95" font-family="monospace" font-size="14.00"> (4, 5)</text>
 <polygon fill="none" stroke="black" points="205.38,-100.75 205.38,-124 254.88,-124 254.88,-100.75 205.38,-100.75"/>
 <text xml:space="preserve" text-anchor="start" x="213.25" y="-107.33" font-family="Times,serif" font-size="14.00">parent</text>
 <polygon fill="none" stroke="black" points="254.88,-100.75 254.88,-124 326.88,-124 326.88,-100.75 254.88,-100.75"/>
@@ -224,7 +224,7 @@
 <polygon fill="none" stroke="black" points="345.12,-124 345.12,-147.25 394.62,-147.25 394.62,-124 345.12,-124"/>
 <text xml:space="preserve" text-anchor="start" x="350" y="-130.57" font-family="Times,serif" font-size="14.00">content</text>
 <polygon fill="none" stroke="black" points="394.62,-124 394.62,-147.25 417.12,-147.25 417.12,-124 394.62,-124"/>
-<text xml:space="preserve" text-anchor="start" x="397.62" y="-130.95" font-family="monospace" font-size="14.00">30</text>
+<text xml:space="preserve" text-anchor="start" x="401.75" y="-130.95" font-family="monospace" font-size="14.00">6</text>
 <polygon fill="none" stroke="black" points="345.12,-100.75 345.12,-124 394.62,-124 394.62,-100.75 345.12,-100.75"/>
 <text xml:space="preserve" text-anchor="start" x="353" y="-107.33" font-family="Times,serif" font-size="14.00">parent</text>
 <polygon fill="none" stroke="black" points="394.62,-100.75 394.62,-124 417.12,-124 417.12,-100.75 394.62,-100.75"/>
@@ -273,7 +273,7 @@
 <polygon fill="none" stroke="black" points="442.12,-124 442.12,-147.25 491.62,-147.25 491.62,-124 442.12,-124"/>
 <text xml:space="preserve" text-anchor="start" x="447" y="-130.57" font-family="Times,serif" font-size="14.00">content</text>
 <polygon fill="none" stroke="black" points="491.62,-124 491.62,-147.25 514.12,-147.25 514.12,-124 491.62,-124"/>
-<text xml:space="preserve" text-anchor="start" x="494.62" y="-130.95" font-family="monospace" font-size="14.00">20</text>
+<text xml:space="preserve" text-anchor="start" x="498.75" y="-130.95" font-family="monospace" font-size="14.00">8</text>
 <polygon fill="none" stroke="black" points="442.12,-100.75 442.12,-124 491.62,-124 491.62,-100.75 442.12,-100.75"/>
 <text xml:space="preserve" text-anchor="start" x="450" y="-107.33" font-family="Times,serif" font-size="14.00">parent</text>
 <polygon fill="none" stroke="black" points="491.62,-100.75 491.62,-124 514.12,-124 514.12,-100.75 491.62,-100.75"/>
@@ -300,7 +300,7 @@
 <polygon fill="none" stroke="black" points="532.12,-124 532.12,-147.25 581.62,-147.25 581.62,-124 532.12,-124"/>
 <text xml:space="preserve" text-anchor="start" x="537" y="-130.57" font-family="Times,serif" font-size="14.00">content</text>
 <polygon fill="none" stroke="black" points="581.62,-124 581.62,-147.25 604.12,-147.25 604.12,-124 581.62,-124"/>
-<text xml:space="preserve" text-anchor="start" x="584.62" y="-130.95" font-family="monospace" font-size="14.00">30</text>
+<text xml:space="preserve" text-anchor="start" x="588.75" y="-130.95" font-family="monospace" font-size="14.00">9</text>
 <polygon fill="none" stroke="black" points="532.12,-100.75 532.12,-124 581.62,-124 581.62,-100.75 532.12,-100.75"/>
 <text xml:space="preserve" text-anchor="start" x="540" y="-107.33" font-family="Times,serif" font-size="14.00">parent</text>
 <polygon fill="none" stroke="black" points="581.62,-100.75 581.62,-124 604.12,-124 604.12,-100.75 581.62,-100.75"/>

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -6203,15 +6203,15 @@ position, in the range 1 to the size of the array.</p>
       <termref def="dt-GNode"/> (a generic node).
     JNodes have identity, and are organized into trees called <termref def="dt-JTree">JTrees</termref>.
     </p>
-      <p><termdef id="prop-jnode-value" term="value">Every <termref def="dt-JNode"/> has a property <term>·content·</term> which is an 
+      <p><termdef id="prop-jnode-value" term="value">Every <termref def="dt-JNode"/> has a property <term>·jvalue·</term> which is an 
         arbitrary <termref def="dt-value"/> (that is, in general, a <termref def="dt-sequence"/>).</termdef></p>
       
       <p>In addition a JNode that is not a root JNode has the following properties:</p>
       
       <slist>
-        <sitem><term>·parent·</term>: a JNode</sitem>
-        <sitem><term>·position·</term>: a positive integer</sitem>
-        <sitem><term>·selector·</term>: an atomic item</sitem>
+        <sitem><term>·jparent·</term>: a JNode</sitem>
+        <sitem><term>·jposition·</term>: a positive integer</sitem>
+        <sitem><term>·jkey·</term>: an atomic item</sitem>
       </slist>
       
       <p>In effect, there are four kinds of JNode (though they are not distinguished
@@ -6224,23 +6224,21 @@ position, in the range 1 to the size of the array.</p>
         <item><p>A non-root JNode that represents a member of an array.</p></item>
       </ulist>
       
-      <p><termdef id="dt-j-children" term="j-children">The accessor <code>j-children</code>, applied to a JNode <var>$P</var>, returns a sequence
-      of non-root JNodes representing the children of <var>$P</var>.</termdef></p>
-      
-
-      
+      <p><termdef id="dt-j-children" term="j-children">The accessor <code>j-children</code>,
+         applied to a JNode <var>$PARENT</var>, returns a sequence of non-root JNodes
+         representing the children of <var>$PARENT</var>.</termdef></p>
       
       <p>Values are classified as <term>leaf</term> or <term>non-leaf</term>. A value is classified
         as <term>non-leaf</term> if and only if at least one item in the value
-      is a non-empty map or array. If the ·content· property of a JNode is classified as <term>leaf</term>, then
+      is a non-empty map or array. If the ·jvalue· property of a JNode is classified as <term>leaf</term>, then
       the <code>j-children</code> accessor returns an empty sequence.</p>
       
       <note><p>If the <code>j-children</code> accessor of a JNode returns an empty sequence,
-      then it is necessary to examine the ·content· property in order to distinguish whether
+      then it is necessary to examine the ·jvalue· property in order to distinguish whether
       the value is (for example) an empty sequence, an atomic item, an empty map,
       or an empty array.</p></note>
       
-      <p>If the ·content· property of a JNode <var>P</var> is classified as <term>non-leaf</term>, then
+      <p>If the ·jvalue· property of a JNode <var>P</var> is classified as <term>non-leaf</term>, then
       the <code>j-children</code> accessor returns a sequence of JNodes that includes
         one JNode for each member of an array in <var>J</var> and one JNode for each entry
         of a map in <var>J</var>. More specifically, the result is determined
@@ -6249,27 +6247,30 @@ position, in the range 1 to the size of the array.</p>
       
       <ulist>
         <item><p>The function
-        <code>dm:j-value</code> is used to access the ·content· property of a JNode</p></item>
+        <code>dm:j-value</code> is used to access the ·jvalue· property of a JNode</p></item>
         <item><p>The function <code>dm:JNode</code> is used to construct (or obtain)
         a JNode whose properties correspond to the names of the argument keywords.</p></item>
       </ulist>
       
-      <eg>         
-for $item at $pos in dm:j-value($P)
-return
-  if ($item instance of array(*))
-  then for member $member at $index in $item
-       return dm:JNode(parent := $P,
-                       position := $pos,
-                       selector := $index,
-                       value := $member)
-  else if ($item instance of map(*))
-  then for key $key value $value in $item
-       return dm:JNode(parent := $P,
-                       position := $pos,
-                       selector := $key
-                       value := $value)
-  else ()
+      <eg>
+for $item at $pos in dm:j-value($PARENT)
+return if ($item instance of array(*)) then (
+  for member $member at $index in $item
+  return dm:JNode(
+    jparent   := $PARENT,
+    jposition := $pos,
+    jkey      := $index,
+    jvalue    := $member
+  )
+) else if ($item instance of map(*)) then (
+  for key $key value $value in $item
+  return dm:JNode(
+    jparent   := $PARENT,
+    jposition := $pos,
+    jkey      := $key,
+    jvalue    := $value
+  )
+) else ()
 </eg> 
       
       <p>The order of JNodes returned by the <code>j-children</code> accessor is significant, and is
@@ -6286,13 +6287,13 @@ return
         <p>Consider a tree constructed by parsing the following JSON input:</p>
         
         <eg role="json">[
-  {"a": 1, "b": "XXX", "c": true, "d": null},
-  {"a": 2, "b": "YYY", "c": false, "d": null}
+  { "a": 1, "b": "XXX", "c": true, "d": null },
+  { "a": 2, "b": "YYY", "c": false, "d": null }
 ]
   </eg>
         <p>Then:</p>
         <ulist>
-          <item><p>The root JNode <var>R</var> has a ·content· property that is an 
+          <item><p>The root JNode <var>R</var> has a ·jvalue· property that is an 
             array of two maps.</p></item>
           <item><p>The 
             result of the <code>dm:j-children</code> accessor applied to <var>R</var> is a sequence of two 
@@ -6300,18 +6301,18 @@ return
             representing one of the two maps.</p></item>
           <item><p>For <var>M1</var>:</p>
             <ulist>
-              <item><p><term>·parent·</term> is <var>R</var>.</p></item>
-              <item><p><term>·content·</term> is the first map.</p></item>
-              <item><p><term>·position·</term> is 1.</p></item>
-              <item><p><term>·selector·</term> is 1.</p></item>
+              <item><p><term>·jparent·</term> is <var>R</var>.</p></item>
+              <item><p><term>·jvalue·</term> is the first map.</p></item>
+              <item><p><term>·jposition·</term> is 1.</p></item>
+              <item><p><term>·jkey·</term> is 1.</p></item>
               <item><p>The <emph>dm:j-children</emph> accessor returns a sequence of four
               JNodes, as follows:</p>
               <ulist>
-                <item><p>All four have <term>·parent·</term> set to <var>M1</var>.</p></item>
-                <item><p>The <term>·content·</term> properties are respectively <code>1</code>,
+                <item><p>All four have <term>·jparent·</term> set to <var>M1</var>.</p></item>
+                <item><p>The <term>·jvalue·</term> properties are respectively <code>1</code>,
                   <code>"XXX"</code>, <code>true()</code>, and <code>()</code>.</p></item>
-                <item><p>The <term>·position·</term> properties are all set to 1.</p></item>
-                <item><p>The <term>·selector·</term> properties are respectively <code>"a"</code>
+                <item><p>The <term>·jposition·</term> properties are all set to 1.</p></item>
+                <item><p>The <term>·jkey·</term> properties are respectively <code>"a"</code>
                 <code>"b"</code>, <code>"c"</code>, and <code>"d"</code>.</p></item>
                 <item><p>For each of these JNodes, the <emph>dm:j-children</emph> accessor returns
                 an empty sequence.</p></item>
@@ -6320,18 +6321,18 @@ return
           </item>
           <item><p>For <var>M2</var>:</p>
             <ulist>
-              <item><p><term>·parent·</term> is <var>R</var>.</p></item>
-              <item><p><term>·content·</term> is the second map.</p></item>
-              <item><p><term>·position·</term> is 1.</p></item>
-              <item><p><term>·selector·</term> is 2.</p></item>
+              <item><p><term>·jparent·</term> is <var>R</var>.</p></item>
+              <item><p><term>·jvalue·</term> is the second map.</p></item>
+              <item><p><term>·jposition·</term> is 1.</p></item>
+              <item><p><term>·jkey·</term> is 2.</p></item>
               <item><p>The <emph>dm:j-children</emph> accessor returns a sequence of four
               JNodes, as follows:</p>
               <ulist>
-                <item><p>All four have <term>·parent·</term> set to <var>M2</var>.</p></item>
-                <item><p>The <term>·content·</term> properties are respectively <code>2</code>,
+                <item><p>All four have <term>·jparent·</term> set to <var>M2</var>.</p></item>
+                <item><p>The <term>·jvalue·</term> properties are respectively <code>2</code>,
                   <code>"YYY"</code>, <code>false()</code>, and <code>()</code>.</p></item>
-                <item><p>The <term>·position·</term> properties are all set to 1.</p></item>
-                <item><p>The <term>·selector·</term> properties are respectively <code>"a"</code>
+                <item><p>The <term>·jposition·</term> properties are all set to 1.</p></item>
+                <item><p>The <term>·jkey·</term> properties are respectively <code>"a"</code>
                 <code>"b"</code>, <code>"c"</code>, and <code>"d"</code>.</p></item>
                 <item><p>For each of these JNodes, the <emph>dm:j-children</emph> accessor returns
                 an empty sequence.</p></item>
@@ -6340,7 +6341,7 @@ return
           </item>
         </ulist>
         <p>Note that all JNodes in a JTree that represents parsed JSON input will have the
-        <term>·position·</term> property set to 1. This is because every construct in JSON 
+        <term>·jposition·</term> property set to 1. This is because every construct in JSON 
         (arrays, objects, strings, number, booleans, and <code>null</code>) maps to an XDM sequence
         of length 0 or 1.</p>
 
@@ -6371,49 +6372,73 @@ order of the children.</p>
         <eg><![CDATA[{
    "a": 1,
    "b": ("x", "y"),
-   "c": [(10, 20), 30],
-   "d": (10, [20, 30]),
+   "c": [ (4, 5), 6 ],
+   "d": (7, [ 8, 9 ]),
    "e": (<p/>, <q/>)
 }]]></eg>
         
         <p>Then:</p>
         <ulist>
-          <item><p>The root JNode <var>R</var> has a ·content· property that is a 
+          <item><p>The root JNode <var>R</var> has a ·jvalue· property that is a 
             map with five entries.</p></item>
           <item><p>The result of the <code>dm:j-children</code> accessor applied to <var>R</var>
           is a sequence of five JNodes <var>J1</var>, <var>J2</var>, <var>J3</var>, <var>J4</var>, and <var>J5</var>,
           as follows:</p>
           <ulist>
-            <item><p><var>J1</var> is a leaf node. It has <term>·parent·</term>=<var>R</var>, <term>·content·</term>=1, <term>·position·</term>=1, and
-            <term>·selector·</term>="a". Its <code>dm:j-children</code> accessor returns an empty sequence.</p></item>
-            <item><p><var>J2</var> is a leaf node. It has <term>·parent·</term>=<var>R</var>, <term>·content·</term>=("x", "y"), <term>·position·</term>=1, and
-            <term>·selector·</term>="b". Its <code>dm:j-children</code> accessor returns an empty sequence.</p></item>
-            <item><p><var>J3</var> has <term>·parent·</term>=<var>R</var>, <term>·content·</term>=[(10, 20), 30], <term>·position·</term>=1, and
-            <term>·selector·</term>="c". Its <code>dm:j-children</code> accessor returns a sequence of two
-              JNodes <var>J/31</var> and <var>J/32</var>, representing the two members of the contained
-              array, as follows:</p>
+            <item>
+              <p><var>J1</var> is a leaf node. It has <term>·jparent·</term>=<var>R</var>,
+              <term>·jvalue·</term>=1, <term>·jposition·</term>=1, and
+              <term>·jkey·</term>="a". Its <code>dm:j-children</code> accessor returns an empty sequence.</p>
+            </item>
+            <item>
+              <p><var>J2</var> is a leaf node. It has <term>·jparent·</term>=<var>R</var>,
+              <term>·jvalue·</term>=("x", "y"), <term>·jposition·</term>=1, and
+              <term>·jkey·</term>="b". Its <code>dm:j-children</code> accessor returns an empty sequence.</p>
+            </item>
+            <item>
+              <p><var>J3</var> has <term>·jparent·</term>=<var>R</var>,
+              <term>·jvalue·</term>=[ (4, 5), 6 ], <term>·jposition·</term>=1, and
+              <term>·jkey·</term>="c". Its <code>dm:j-children</code> accessor returns a sequence of two
+                JNodes <var>J/31</var> and <var>J/32</var>, representing the two members of the contained
+                array, as follows:</p>
               <ulist>
-                <item><p><var>J/31</var> is a leaf node. It has <term>·parent·</term>=<var>J3</var>, <term>·content·</term>=(10, 20), <term>·position·</term>=1, and
-                 <term>·selector·</term>="1". Its <code>dm:j-children</code> accessor returns an empty sequence.</p></item>
-                <item><p><var>J/32</var> is a leaf node. It has <term>·parent·</term>=<var>J3</var>, <term>·content·</term>=30, <term>·position·</term>=1, and
-                 <term>·selector·</term>="2". Its <code>dm:j-children</code> accessor returns an empty sequence.</p></item>
+                <item>
+                  <p><var>J/31</var> is a leaf node. It has <term>·jparent·</term>=<var>J3</var>,
+                  <term>·jvalue·</term>=(4, 5), <term>·jposition·</term>=1, and <term>·jkey·</term>="1".
+                  Its <code>dm:j-children</code> accessor returns an empty sequence.</p>
+                </item>
+                <item>
+                  <p><var>J/32</var> is a leaf node. It has <term>·jparent·</term>=<var>J3</var>,
+                  <term>·jvalue·</term>=6, <term>·jposition·</term>=1, and <term>·jkey·</term>="2".
+                  Its <code>dm:j-children</code> accessor returns an empty sequence.</p>
+                </item>
               </ulist>
             </item>
-            <item><p><var>J4</var> has <term>·parent·</term>=<var>R</var>, 
-              <term>·content·</term>=(10, [20, 30]), <term>·position·</term>=1, and
-            <term>·selector·</term>="d". Its <code>dm:j-children</code> accessor returns a sequence of two
+            <item>
+              <p><var>J4</var> has <term>·jparent·</term>=<var>R</var>, 
+              <term>·jvalue·</term>=(7, [ 8, 9 ]), <term>·jposition·</term>=1, and
+              <term>·jkey·</term>="d". Its <code>dm:j-children</code> accessor returns a sequence of two
               JNodes <var>J/41</var> and <var>J/42</var>, representing the two members of the
               contained array, as follows:</p>
               <ulist>
-                <item><p><var>J/41</var> is a leaf node. It has <term>·parent·</term>=<var>J4</var>, <term>·content·</term>=20, <term>·position·</term>=2, and
-                 <term>·selector·</term>="1". Its <code>dm:j-children</code> accessor returns an empty sequence.</p></item>
-                <item><p><var>J/42</var> is a leaf node. It has ·parent·=<var>J4</var>, <term>·content·</term>=30, <term>·position·</term>=2, and
-                 <term>·selector·</term>="2". Its <code>dm:j-children</code> accessor returns an empty sequence.</p></item>
+                <item>
+                  <p><var>J/41</var> is a leaf node. It has <term>·jparent·</term>=<var>J4</var>,
+                  <term>·jvalue·</term>=8, <term>·jposition·</term>=2, and <term>·jkey·</term>="1".
+                  Its <code>dm:j-children</code> accessor returns an empty sequence.</p>
+                </item>
+                <item>
+                  <p><var>J/42</var> is a leaf node. It has ·jparent·=<var>J4</var>,
+                  <term>·jvalue·</term>=9, <term>·jposition·</term>=2, and <term>·jkey·</term>="2".
+                  Its <code>dm:j-children</code> accessor returns an empty sequence.</p>
+                </item>
               </ulist>
             </item>
-            <item><p><var>J5</var> is a leaf node. It has ·parent·=<var>R</var>, a <term>·content·</term> that is a sequence
-              of two element nodes named <code>p</code> and <code>q</code>, <term>·position·</term>=1, and
-            <term>·selector·</term>="e". Its <code>dm:j-children</code> accessor returns an empty sequence.</p></item>
+            <item>
+              <p><var>J5</var> is a leaf node. It has ·jparent·=<var>R</var>,
+              a <term>·jvalue·</term> that is a sequence of two element nodes named
+              <code>p</code> and <code>q</code>, <term>·jposition·</term>=1, and <term>·jkey·</term>="e".
+              Its <code>dm:j-children</code> accessor returns an empty sequence.</p>
+            </item>
           </ulist>
           </item>
         </ulist>
@@ -6449,15 +6474,15 @@ order of the children.</p>
       
       
         
-          <p>For a JNode representing the root of a JTree, the <term>·parent·</term>, <term>·position·</term>,
-            and <term>·selector·</term>
+          <p>For a JNode representing the root of a JTree, the <term>·jparent·</term>, <term>·jposition·</term>,
+            and <term>·jkey·</term>
           properties will always be absent. For a non-root JNode, these properties will always be present.</p>
           
           <p>The identity of a root JNode is established when the root JNode is constructed, so that
           every operation that constructs a root JNode returns a JNode with distinct identity. The
-          identity of a non-root JNode is a function of its <term>·parent·</term>, <term>·position·</term>, and <term>·selector·</term>
+          identity of a non-root JNode is a function of its <term>·jparent·</term>, <term>·jposition·</term>, and <term>·jkey·</term>
           properties: two non-root JNodes are identical by definition if and only if their
-            <term>·parent·</term>s are identical and their <term>·position·</term> and <term>·selector·</term>
+            <term>·jparent·</term>s are identical and their <term>·jposition·</term> and <term>·jkey·</term>
             properties are equal as determined by the <function>atomic-equal</function> function.</p>
           
           <p>A root JNode is constructed, wrapping a map or array, by a call on the <function>jnode</function>
@@ -6479,7 +6504,7 @@ order of the children.</p>
       parent to child), an operation that navigates the data structure can retain additional information
       about the path that was followed, effectively allowing access to nodes of the structure
       that were visited <emph>en route</emph>. This additional information is reified in the
-      <term>·parent·</term>, <term>·position·</term>, and <term>·selector·</term> properties
+      <term>·jparent·</term>, <term>·jposition·</term>, and <term>·jkey·</term> properties
       of a non-root JNode.</p></note>
       
       

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -668,7 +668,7 @@
             </item>
             <item><p>If <var>J</var> is a <xtermref spec="DM40" ref="dt-JNode"/>, the result is in
             the form <code>jnode(<var>T</var>)</code>, where <var>T</var> is the result of
-            applying the <function>type-of</function> function to the <term>·content·</term> property of <var>J</var>.</p>
+            applying the <function>type-of</function> function to the <term>·jvalue·</term> property of <var>J</var>.</p>
             </item>
             <item>
                <p>If <var>J</var> is an atomic item, the result is a string chosen as follows:</p>
@@ -876,8 +876,8 @@
                ref="xpath-datamodel-31"/> (see <xspecref spec="DM40" ref="dm-string-value"/>).</p>
          
          <p>If <code>$value</code> is a <xtermref spec="DM40" ref="dt-JNode"/>, 
-            the function returns the result of <code>string(jnode-content($value))</code>.
-         This will fail in the case where <code>jnode-content($value)</code> is a map or an array.</p>
+            the function returns the result of <code>string(jvalue($value))</code>.
+         This will fail in the case where <code>jvalue($value)</code> is a map or an array.</p>
 
          <p>If <code>$value</code> is an atomic item, the function returns the result of the expression <code>$value cast
                      as xs:string</code> (see <specref
@@ -942,7 +942,7 @@
                <fos:error-result error-code="FOTY0014"/>
             </fos:test>
             <fos:test>
-               <fos:expression>string({"x": [10, 20, 30]} / x / *[3])</fos:expression>
+               <fos:expression>string({ "x": [10, 20, 30] }/x/*[3])</fos:expression>
                <fos:result>"30"</fos:result>
             </fos:test>
          </fos:example>
@@ -998,7 +998,7 @@
             </item>
             <item>
                <p>If the item is a <xtermref spec="DM40" ref="dt-JNode"/>,
-               the atomized value of its <term>·content·</term> property is appended to
+               the atomized value of its <term>·jvalue·</term> property is appended to
                the result sequence.</p>
             </item>
             <item>
@@ -11055,22 +11055,29 @@ return ($value - unix-dateTime()) div seconds(0.001)</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression><eg>build-dateTime({ "year": 1999, "month": 5, "day": 31, 
-  "hours": 13, "minutes": 20, "seconds": 0, 
-  "timezone": xs:dayTimeDuration("-PT5H")})</eg></fos:expression>
+               <fos:expression><eg>
+build-dateTime({
+  "year": 1999,
+  "month": 5,
+  "day": 31, 
+  "hours": 13,
+  "minutes": 20,
+  "seconds": 0, 
+  "timezone": xs:dayTimeDuration("-PT5H")
+})</eg></fos:expression>
                <fos:result><eg>xs:dateTime("1999-05-31T13:20:00-05:00")</eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression><eg>build-dateTime({"hours": 13, "minutes": 30, "seconds": 4.2678})</eg></fos:expression>
+               <fos:expression><eg>build-dateTime({ "hours": 13, "minutes": 30, "seconds": 4.2678 })</eg></fos:expression>
                <fos:result><eg>xs:time("13:30:04.2678")</eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression><eg>build-dateTime({ "year": 2007, "month": 5, 
-                     "timezone": xs:dayTimeDuration("PT0S")})</eg></fos:expression>
+               <fos:expression><eg>
+build-dateTime({ "year": 2007, "month": 5, "timezone": xs:dayTimeDuration("PT0S") })</eg></fos:expression>
                <fos:result><eg>xs:gYearMonth("2007-05Z")</eg></fos:result>
             </fos:test>
          </fos:example>
@@ -14193,11 +14200,11 @@ fn:parse-QName("xmp:person")</eg></fos:expression>
                </olist>
             </item>
                <item>
-                  <p>For a JNode where the ·content· property of the parent
+                  <p>For a JNode where the ·jvalue· property of the parent
                      is an array, then as the string <code>*[<var>N</var>]</code> where <var>N</var>
-                     is the value of the ·selector· property.</p>
+                     is the value of the ·jkey· property.</p>
                </item>
-               <item><p>For any other JNode (including the case where the ·content· property of the parent
+               <item><p>For any other JNode (including the case where the ·jvalue· property of the parent
                      is a map):</p>
                   <olist>
                      <item><p>If the value is an <code>xs:string</code>, <code>xs:untypedAtomic</code>,
@@ -14366,12 +14373,12 @@ Himmlische, dein Heiligtum.
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression><eg>let $in := [{"b":[3,4]}]
+               <fos:expression><eg>let $in := [ { "b": [ 3, 4 ] } ]
 return path($in/*[1]/b/*[2])</eg></fos:expression>
                <fos:result>"/*[1]/b/*[2]"</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>let $in := [[{'a':1}], [{'a':2}]]
+               <fos:expression><eg>let $in := [ [ { 'a': 1 } ], [ { 'a': 2 } ] ]
 return path($in//a[. = 2])</eg></fos:expression>
                <fos:result>"/*[2]/*[1]/a"</fos:result>
             </fos:test>
@@ -14643,18 +14650,22 @@ let $newi := $o/tool</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression><eg><![CDATA[let $x := parse-xml('<doc><a/><b/><c/><d/><c/><e/></doc>')
-return distinct-ordered-nodes(($x//c, $x//b, $x//a, $x//b)) ! name()]]></eg></fos:expression>
+               <fos:expression><eg><![CDATA[
+let $x := parse-xml('<doc><a/><b/><c/><d/><c/><e/></doc>')
+return distinct-ordered-nodes(($x//c, $x//b, $x//a, $x//b)) ! name()
+               ]]></eg></fos:expression>
                <fos:result>"a", "b", "c", "c"</fos:result>
                <fos:postamble>The two <code>$x//b</code> expressions select the same node; one of these
                is eliminated as a duplicate. The <code>$x//c</code> expression selects two nodes
                that have distinct identity, so both are retained.</fos:postamble>
             </fos:test>
             <fos:test>
-               <fos:expression><eg><![CDATA[let $x := [1, "a", true()]
+               <fos:expression><eg><![CDATA[
+let $x := [ 1, "a", true() ]
 return count(distinct-ordered-nodes(
-                ($x/*[1], $x/jnode(*, xs:integer)) 
-            )) ]]></eg></fos:expression>
+  ($x/*[1], $x/jnode(*, xs:integer)) 
+)) 
+               ]]></eg></fos:expression>
                <fos:result>1</fos:result>
                <fos:postamble>The first array member is selected by two different
                   routes; duplicate JNodes are eliminated.</fos:postamble>
@@ -14696,16 +14707,21 @@ return count(distinct-ordered-nodes(
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression><eg><![CDATA[parse-xml("<doc>
-    <div id='a'><div id='b'><div id='c'/></div></div>
-  </doc>")//div
-   => innermost() => for-each(fn{string(@id)})]]></eg></fos:expression>
+               <fos:expression><eg><![CDATA[
+"<doc><div id='a'><div id='b'><div id='c'/></div></div></doc>"
+-> parse-xml(.)//div
+-> innermost(.)
+-> for-each(., fn { string(@id) })
+               ]]></eg></fos:expression>
                <fos:result><code>"c"</code></fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg><![CDATA[[[[1,2], [3,4]], [[5,6], [7,8]]]//jnode(*, array(*))
-   => innermost() =!> jnode-content()]]></eg></fos:expression>
-               <fos:result><code>[1,2], [3,4], [5,6], [7,8]</code></fos:result>
+               <fos:expression><eg><![CDATA[
+[ [ [ 1, 2 ], [ 3, 4 ] ], [ [ 5, 6 ], [ 7, 8 ] ] ]
+  //jnode(*, array(*))
+=> innermost() =!> jvalue()
+               ]]></eg></fos:expression>
+               <fos:result><code>[ 1, 2 ], [ 3, 4 ], [ 5, 6 ], [ 7, 8 ]</code></fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -14758,15 +14774,20 @@ return count(distinct-ordered-nodes(
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression><eg><![CDATA[parse-xml("<doc>
-     <div id='a'><div id='b'><div id='c'/></div></div>
-  </doc>")//div
-   => outermost() => for-each(fn{string(@id)})]]></eg></fos:expression>
+               <fos:expression><eg><![CDATA[
+"<doc><div id='a'><div id='b'><div id='c'/></div></div></doc>"
+-> parse-xml(.)//div
+-> outermost(.)
+-> for-each(., fn { string(@id) })
+               ]]></eg></fos:expression>
                <fos:result><code>"a"</code></fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg><![CDATA[[[[1], [2]], [[3], [4]], [[5], [6]]]//self::jnode(*, array(*))
-   => outermost() =!> array:size()]]></eg></fos:expression>
+               <fos:expression><eg><![CDATA[
+[ [ [ 1 ], [ 2 ] ], [ [ 3 ], [ 4 ] ], [ [ 5 ], [ 6 ] ] ]
+  //self::jnode(*, array(*))
+=> outermost() =!> array:size()
+               ]]></eg></fos:expression>
                <fos:result><code>3</code></fos:result>
             </fos:test>
          </fos:example>
@@ -17489,10 +17510,10 @@ declare function equal-strings(
                <olist>
                   <item><p><code>$i1</code> is a JNode.</p></item>
                   <item><p><code>$i2</code> is a JNode.</p></item>
-                  <item><p>The <term>·content·</term> property of <code>$i1</code>
-                  is deep-equal to the <term>·content·</term> property of <code>$i2</code>.</p>
-                  <note><p>The other properties of the two JNodes, such as <term>·parent·</term>
-                  and <term>·selector·</term>, are ignored. As with XNodes, deep equality
+                  <item><p>The <term>·jvalue·</term> property of <code>$i1</code>
+                  is deep-equal to the <term>·jvalue·</term> property of <code>$i2</code>.</p>
+                  <note><p>The other properties of the two JNodes, such as <term>·jparent·</term>
+                  and <term>·jkey·</term>, are ignored. As with XNodes, deep equality
                   considers only the subtree rooted at the node, and not its position within
                   a containing tree.</p></note>
                   </item>
@@ -26550,7 +26571,7 @@ return map:build($titles/title, fn($title) { $title/ix })
                <fos:expression><eg>map:build(
   //employee,
   key := fn { @location }, 
-  options := {"duplicates" : fn($a, $b) { highest(($a, $b), (), fn { xs:decimal(@salary) }) } }
+  options := { "duplicates": fn($a, $b) { highest(($a, $b), (), fn { xs:decimal(@salary) }) } }
 )</eg></fos:expression>
                <fos:result narrative="true">A map whose keys are employee <code>@location</code> values, and whose
                corresponding values contain the employee node for the highest-paid employee at each distinct location</fos:result>
@@ -32097,11 +32118,11 @@ $array
             </fos:test>
             <fos:test>
                <fos:expression><eg>array:sort-with(
-  [{"a":1, "b":20}, {"a":5, "b":12}, {"a":1, "b":3}],
-   ( fn($x, $y){ compare($x?a, $y?a) },
-     fn($x, $y){ compare($x?b, $y?b) })  
+  [ { "a": 1, "b": 20 }, { "a": 5, "b": 12 }, { "a": 1, "b": 3 } ],
+   ( fn($x, $y) { compare($x?a, $y?a) },
+     fn($x, $y) { compare($x?b, $y?b) })  
 )</eg></fos:expression>
-               <fos:result>[{"a":1, "b":3}, {"a":1, "b":20}, {"a":5, "b":12}]</fos:result>
+               <fos:result>[ { "a": 1, "b": 3 }, { "a": 1, "b": 20 }, { "a": 5, "b": 12 } ]</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -36070,8 +36091,8 @@ return $result
       <fos:rules>
          <p>The function creates a <xtermref spec="DM40" ref="dt-JNode"/>
             that wraps the supplied map or array. Specifically, it creates a root JNode
-            whose <term>·content·</term> property is <code>$input</code>, and whose
-            <term>·parent·</term>, <term>·position·</term>, and <term>·selector·</term> 
+            whose <term>·jvalue·</term> property is <code>$input</code>, and whose
+            <term>·jparent·</term>, <term>·jposition·</term>, and <term>·jkey·</term> 
             properties are absent.</p>
          
          <p>This has the effect that lookup expressions starting from this JNode retain
@@ -36112,14 +36133,14 @@ return $result
          each of these JNodes contains not only the value of the relevant <code>"name"</code> entry,
             but also the key (which in this simple example is always <code>"name"</code>
             and the containing map. This means, for example, if <code>$result</code>
-            is the result of the expression <code>json-doc($source) // name</code>, then:</p>
+            is the result of the expression <code>json-doc($source)//name</code>, then:</p>
          
          <ulist>
-            <item><p><code>$result / .. / ssn</code> locates the map that contained each
+            <item><p><code>$result/../ssn</code> locates the map that contained each
                <code>name</code>, and returns the value of the <code>ssn</code> entry in that map.</p></item>
-            <item><p><code>$result / ancestor::course</code> returns any
+            <item><p><code>$result/ancestor::course</code> returns any
             <code>course</code> entries in containing maps.</p></item>
-            <item><p><code>$result / ancestor::* => jnode-selector() </code> returns a sequence of map keys and array index
+            <item><p><code>$result/ancestor::* => jkey() </code> returns a sequence of map keys and array index
             values representing the location of the found entries within the JSON structure.</p></item>
   
          </ulist>
@@ -36143,12 +36164,12 @@ return $result
             <fos:test>
                <fos:expression>jtree([ "a", "b", "c" ])/*[1]/../*[last()] => string()</fos:expression>
                <fos:result>"c"</fos:result>
-               <fos:postamble>The call on <code>fn:jnode</code> would happen automatically</fos:postamble>
+               <fos:postamble>The call on <code>fn:tree</code> would happen automatically</fos:postamble>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>jtree([ "a", "b", "c", "d" ])/* =!> jnode-selector()</fos:expression>
+               <fos:expression>jtree([ "a", "b", "c", "d" ])/* =!> jkey()</fos:expression>
                <fos:result>1, 2, 3, 4</fos:result>
             </fos:test>
          </fos:example>
@@ -36169,9 +36190,9 @@ return jtree($data)//languages[. = 'German']/../capital =!> string()</eg></fos:e
       </fos:changes>
    </fos:function>
    
-   <fos:function name="jnode-selector" prefix="fn">
+   <fos:function name="jkey" prefix="fn">
       <fos:signatures>
-         <fos:proto name="jnode-selector" return-type="xs:anyAtomicType?">
+         <fos:proto name="jkey" return-type="xs:anyAtomicType?">
             <fos:arg name="input" type="jnode()?" default="." usage="inspection"/>
          </fos:proto>
       </fos:signatures>
@@ -36181,14 +36202,14 @@ return jtree($data)//languages[. = 'German']/../capital =!> string()</eg></fos:e
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns the <term>·selector·</term> property of a JNode.</p>
+         <p>Returns the <term>·jkey·</term> property of a JNode.</p>
       </fos:summary>
       <fos:rules>
          <p>If the argument is omitted, it defaults to the context value (<code>.</code>).</p>
          <p>If <code>$input</code> is the empty sequence, the function returns the empty sequence.</p>
-         <p>If <code>$input</code> is a root JNode (one in which the <term>·selector·</term> property is
+         <p>If <code>$input</code> is a root JNode (one in which the <term>·jkey·</term> property is
             absent), the function returns the empty sequence.</p>
-         <p>Otherwise, the function returns the <term>·selector·</term> property of <code>$input</code>.
+         <p>Otherwise, the function returns the <term>·jkey·</term> property of <code>$input</code>.
          In the case where the parent JNode wraps a map, this will be the key of the relevant entry
          within that map; in the case where the parent JNode wraps an array, it will be the 1-based
          index of the relevant member of the array.</p>
@@ -36212,18 +36233,24 @@ return jtree($data)//languages[. = 'German']/../capital =!> string()</eg></fos:e
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression><eg>let $array := [1, 3, 4.5, 7, "eight", 10]
-return $array / child::jnode(*, xs:integer) =!> jnode-selector()</eg></fos:expression>
+               <fos:expression><eg>
+let $array := [ 1, 3, 4.5, 7, "eight", 10 ]
+return $array/jnode(*, xs:integer) =!> jkey()
+               </eg></fos:expression>
                <fos:result>1, 2, 4, 6</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>let $map := {'Mo': 'Monday', 'Tu': 'Tuesday', 'We': 'Wednesday'}
-return $map / child::get(("Mo", "We", "Fr", "Su")) =!> jnode-selector()</eg></fos:expression>
+               <fos:expression><eg>
+let $map := { 'Mo': 'Monday', 'Tu': 'Tuesday', 'We': 'Wednesday' }
+return $map/child::get(("Mo", "We", "Fr", "Su")) =!> jkey()
+               </eg></fos:expression>
                <fos:result>"Mo", "We"</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>let $array := [[4, 18], [30, 4, 22]]
-return $array / descendant::*[. > 25] / ancestor-or-self::* =!> jnode-selector()</eg></fos:expression>
+               <fos:expression><eg>
+let $array := [ [ 4, 18 ], [ 30, 4, 22 ] ]
+return $array/descendant::*[. > 25]/ancestor-or-self::* =!> jkey()
+               </eg></fos:expression>
                <fos:result>2, 1</fos:result>
             </fos:test>
          </fos:example>
@@ -36235,9 +36262,9 @@ return $array / descendant::*[. > 25] / ancestor-or-self::* =!> jnode-selector()
       </fos:changes>
    </fos:function>
    
-   <fos:function name="jnode-position" prefix="fn">
+   <fos:function name="jposition" prefix="fn">
       <fos:signatures>
-         <fos:proto name="jnode-position" return-type="xs:integer?">
+         <fos:proto name="jposition" return-type="xs:integer?">
             <fos:arg name="input" type="jnode()?" default="." usage="inspection"/>
          </fos:proto>
       </fos:signatures>
@@ -36247,14 +36274,14 @@ return $array / descendant::*[. > 25] / ancestor-or-self::* =!> jnode-selector()
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns the <term>·position·</term> property of a JNode.</p>
+         <p>Returns the <term>·jposition·</term> property of a JNode.</p>
       </fos:summary>
       <fos:rules>
          <p>If the argument is omitted, it defaults to the context value (<code>.</code>).</p>
          <p>If <code>$input</code> is the empty sequence, the function returns the empty sequence.</p>
-         <p>If <code>$input</code> is a root JNode (one in which the <term>·position·</term> property is
+         <p>If <code>$input</code> is a root JNode (one in which the <term>·jposition·</term> property is
             absent), the function returns the empty sequence.</p>
-         <p>Otherwise, the function returns the <term>·position·</term> property of <code>$input</code>.
+         <p>Otherwise, the function returns the <term>·jposition·</term> property of <code>$input</code>.
             The value of this property will be 1 (one) except in cases where 
             the value of an entry in a map, or a member in an array, is a sequence that contains
             multiple items including maps and/or arrays; in such cases
@@ -36294,15 +36321,13 @@ return $array / descendant::*[. > 25] / ancestor-or-self::* =!> jnode-selector()
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression><eg>let $input := {
-   "a": [10, 20, 30], 
-   "b": ([40, 50, 60], [], 0, [70, 80, (90, 100)])
+               <fos:expression><eg>
+let $input := {
+   "a": [ 10, 20, 30 ], 
+   "b": ([ 40, 50, 60 ], [], 0, [ 70, 80, (90, 100) ])
 }
-return $input / child::b / * 
-       ! { "position": jnode-position(),
-           "index": jnode-selector(),
-           "value": jnode-content()
-         }</eg></fos:expression>
+return $input/b/* ! { "position": jposition(), "index": jkey(), "value": jvalue() }
+               </eg></fos:expression>
                <fos:result><eg>
 { "position": 1, "index": 1, "value": 40 },
 { "position": 1, "index": 2, "value": 50 },
@@ -36312,17 +36337,13 @@ return $input / child::b / *
 { "position": 4, "index": 3, "value": (90, 100) }</eg></fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>let $input := {
-   "a": {"x": 10, "y": 20, "z": 30}, 
-   "b": ( {"x": 40, "y": 50, "z": 60},
-          {},
-          {"x": 70, "y": 80, "z": (90, 100)})
+               <fos:expression><eg>
+let $input := {
+   "a": { "x": 10, "y": 20, "z": 30 }, 
+   "b": ({ "x": 40, "y": 50, "z": 60 }, {}, { "x": 70, "y": 80, "z": (90, 100) })
 }
-return $input / child::b / * 
-       ! { "position": jnode-position(),
-           "key": jnode-selector(),
-           "value": jnode-content()
-         }</eg></fos:expression>
+return $input/b/* ! { "position": jposition(), "key": jkey(), "value": jvalue() }
+               </eg></fos:expression>
                <fos:result><eg>
 { "position": 1, "key": "x", "value": 40 },
 { "position": 1, "key": "y", "value": 50 },
@@ -36342,9 +36363,9 @@ return $input / child::b / *
       </fos:changes>
    </fos:function>
    
-   <fos:function name="jnode-content" prefix="fn">
+   <fos:function name="jvalue" prefix="fn">
       <fos:signatures>
-         <fos:proto name="jnode-content" return-type="item()*">
+         <fos:proto name="jvalue" return-type="item()*">
             <fos:arg name="input" type="jnode()?" default="."/>
          </fos:proto>
       </fos:signatures>
@@ -36354,12 +36375,12 @@ return $input / child::b / *
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns the <term>·content·</term> property of a JNode.</p>
+         <p>Returns the <term>·jvalue·</term> property of a JNode.</p>
       </fos:summary>
       <fos:rules>
          <p>If the argument is omitted, it defaults to the context value (<code>.</code>).</p>
          <p>If <code>$input</code> is the empty sequence, the function returns the empty sequence.</p>
-         <p>Otherwise, the function returns the <term>·content·</term> property of <code>$input</code>.</p>
+         <p>Otherwise, the function returns the <term>·jvalue·</term> property of <code>$input</code>.</p>
       </fos:rules>
       <fos:errors>
          <p>The following errors may be raised when <code>$node</code> is omitted:</p>
@@ -36378,14 +36399,14 @@ return $input / child::b / *
          </ulist>
       </fos:errors>
       <fos:notes>
-         <p>In many cases it is unnecessary to make an explicit call on <code>jnode-content</code>, because
+         <p>In many cases it is unnecessary to make an explicit call on <code>jvalue</code>, because
          the coercion rules will take care of this automatically. For example, in an expression
          such as <code>$X / descendant::name [matches(., '^J')]</code>, the call on
          <function>matches</function> is supplied with a JNode as its first argument; atomization
          ensures that the actual value being passed to the first argument of <function>matches</function>
             is the atomized value of the 
-          <term>·content·</term> property.</p>
-         <p>Other examples where the <term>·content·</term> of a JNode is extracted automatically
+          <term>·jvalue·</term> property.</p>
+         <p>Other examples where the <term>·jvalue·</term> of a JNode is extracted automatically
          include:</p>
          
          <ulist>
@@ -36401,41 +36422,47 @@ return $input / child::b / *
             in the case of a unary lookup operator), and the operand of a map/array
             filter expression <code>$jnode?[predicate]</code>.</p></item>
          </ulist>
-         <p>Notable places where the <term>·content·</term> is <emph>not</emph>
+         <p>Notable places where the <term>·jvalue·</term> is <emph>not</emph>
          automatically extracted include:</p>
          <ulist>
             <item><p>When computing the effective boolean
          value. As with XNodes, writing <code>if ($array/child::*[1]) ...</code> tests for the existence
-         of a child, it does not test its value. To test its value, write <code>if (jnode-content($array/child::*[1])) ...</code>,
+         of a child, it does not test its value. To test its value, write
+         <code>if (jvalue($array/child::*[1])) ...</code>,
          or equivalently <code>if (xs:boolean($array/child::*[1])) ...</code>.</p></item>
             <item><p>When calling functions that accept arbitrary sequences, such as
             <function>count</function> or <function>deep-equal</function>.</p></item>
          </ulist>
-         <p>It is possible (though probably unwise) to construct a JNode whose <term>·content·</term>
+         <p>It is possible (though probably unwise) to construct a JNode whose <term>·jvalue·</term>
          property itself contains another JNode. For example, the expression 
-         <code>jtree([jtree([]), jtree([])])</code> creates a JNode whose <term>·content·</term>
+         <code>jtree([jtree([]), jtree([])])</code> creates a JNode whose <term>·jvalue·</term>
          is an array of JNodes, and applying the <code>child</code> axis to this JNode will
          return a sequence of two JNodes that themselves have further JNodes as their content.
-         The <function>jnode-content</function> returns these contained JNodes, it does not
+         The <function>jvalue</function> returns these contained JNodes, it does not
          recursively extract their content.</p>
          
       </fos:notes>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression><eg>let $array := [1, 3, 4.5, 7, "eight", 10]
-return $array / child::jnode(*, xs:integer) =!> jnode-content()</eg></fos:expression>
+               <fos:expression><eg>
+let $array := [ 1, 3, 4.5, 7, "eight", 10 ]
+return $array/jnode(*, xs:integer) =!> jvalue()
+               </eg></fos:expression>
                <fos:result>1, 3, 7, 10</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>let $map := {'Mo': 'Monday', 'Tu': 'Tuesday', 'We': 'Wednesday'}
-return $map / child::get(("Mo", "We", "Fr", "Su")) =!> jnode-content()</eg></fos:expression>
+               <fos:expression><eg>
+let $map := { 'Mo': 'Monday', 'Tu': 'Tuesday', 'We': 'Wednesday' }
+return $map/child::get(("Mo", "We", "Fr", "Su")) =!> jvalue()
+               </eg></fos:expression>
                <fos:result>"Monday", "Wednesday"</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>let $array := [[4, 18], [30, 4, 22]]
-return $array / descendant::*[. > 25][1] / ancestor-or-self::* =!> jnode-content()</eg></fos:expression>
-               <fos:result>[[4, 18], [30, 4, 22]], [30, 4, 22]</fos:result>
+               <fos:expression><eg>
+let $array := [ [ 4, 18 ], [ 30, 4, 22 ] ], [ 30, 4, 22 ]
+return $array/descendant::*[. > 25][1]/ancestor-or-self::* =!> jvalue()</eg></fos:expression>
+               <fos:result>[ [ 4, 18 ], [ 30, 4, 22 ] ], [ 30, 4, 22 ]</fos:result>
             </fos:test>
          </fos:example>
          

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -6424,8 +6424,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             
             <item>
                <p>A map can be represented as a sequence of JNodes.</p>
-               <p>A JNode holds the map key in its <term>·selector·</term> property and the corresponding
-            value in its <term>·content·</term> property.</p></item>
+               <p>A JNode holds the map key in its <term>·jkey·</term> property and the corresponding
+            value in its <term>·jvalue·</term> property.</p></item>
          </olist>
          
          <p diff="add" at="2023-04-03">The following table summarizes the way in which these two representations 
@@ -6448,7 +6448,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                <tr>
                   <td><p>Compose a map</p></td>
                   <td><p><code>map:merge($entries)</code></p></td>
-                  <td><p><code>map:build($jnodes, jnode-selector#1, jnode-content#1)</code></p></td>
+                  <td><p><code>map:build($jnodes, jkey#1, jvalue#1)</code></p></td>
                </tr>
                <tr>
                   <td><p>Create a single entry</p></td>
@@ -6458,12 +6458,12 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                <tr>
                   <td><p>Extract the key part of a single entry</p></td>
                   <td><p><code>map:keys($entry)</code></p></td>
-                  <td><p><code>jnode-selector($jnode)</code></p></td>
+                  <td><p><code>jkey($jnode)</code></p></td>
                </tr>
                <tr>
                   <td><p>Extract the value part of a single entry</p></td>
                   <td><p><code>map:items($entry)</code></p></td>
-                  <td><p><code>jnode-content($jnode)</code></p></td>
+                  <td><p><code>jvalue($jnode)</code></p></td>
                </tr>
             </tbody>
          </table>
@@ -6489,7 +6489,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                   <item>
                      <p>Using JNodes:</p>
                      
-                     <eg>$map/* => sort-by({'key': jnode-selector#1}) => map:build(jnode-selector#1, jnode-content#1)</eg>
+                     <eg>$map/* => sort-by({'key': jkey#1}) => map:build(jkey#1, jvalue#1)</eg>
                   </item>
                   <item>
                      <p>Using <code>map:for-each</code>:</p>
@@ -6554,8 +6554,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             
             <p>Note that when the required type of an argument to a function such as <function>map:build</function>
             is a map type, then the coercion rules ensure that a JNode can be supplied in the function call:
-            if the <term>·content·</term> property of the JNode is a map, then the map is automatically
-            extracted as if by the <function>jnode-content</function> function.</p>
+            if the <term>·jvalue·</term> property of the JNode is a map, then the map is automatically
+            extracted as if by the <function>jvalue</function> function.</p>
             
             
             
@@ -8326,8 +8326,8 @@ map( xs:string,
  
             <p>Note that when the required type of an argument to a function such as <function>array:build</function>
             is an array type, then the coercion rules ensure that a JNode can be supplied in the function call:
-            if the <term>·content·</term> property of the JNode is an array, then the array is automatically
-            extracted as if by the <function>jnode-content</function> function.</p>
+            if the <term>·jvalue·</term> property of the JNode is an array, then the array is automatically
+            extracted as if by the <function>jvalue</function> function.</p>
      
             
             <?local-function-index?>
@@ -8504,14 +8504,14 @@ map( xs:string,
             <div3 id="func-jtree">
                <head><?function fn:jtree?></head>
             </div3>
-            <div3 id="func-jnode-content">
-               <head><?function fn:jnode-content?></head>
+            <div3 id="func-jkey">
+               <head><?function fn:jkey?></head>
             </div3>
-            <div3 id="func-jnode-selector">
-               <head><?function fn:jnode-selector?></head>
+            <div3 id="func-jvalue">
+               <head><?function fn:jvalue?></head>
             </div3>
-            <div3 id="func-jnode-position">
-               <head><?function fn:jnode-position?></head>
+            <div3 id="func-jposition">
+               <head><?function fn:jposition?></head>
             </div3>
          </div2>
          

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -3721,7 +3721,7 @@ its <termref def="dt-typed-value"
                
                <item>
                   <p>If the item is a <xtermref spec="DM40" ref="dt-JNode"/>,
-                  its <term>·content·</term> property is atomized and the result is returned.</p>
+                  its <term>·jvalue·</term> property is atomized and the result is returned.</p>
                </item>
 
                <item>
@@ -6445,28 +6445,28 @@ declare record Particle (
                <ulist>
                   <item><p>The forms <code>jnode()</code>, <code>jnode(*)</code>, and <code>jnode(*, *)</code> are
                   equivalent, and match any JNode.</p></item>
-                  <item><p>The first argument constrains the value of the <term>·selector·</term> property:</p>
+                  <item><p>The first argument constrains the value of the <term>·jkey·</term> property:</p>
                      <ulist>
                         <item><p>If there are no arguments, the default for the first argument is <code>*</code>.</p></item>
                         <item><p>If the first argument is an NCName, this is equivalent to writing the NCName as a string
                      literal by adding quotation marks. For example, <code>jnode(Status)</code> is simply an abbreviation
                      for <code>jnode("Status")</code>.</p></item>
                         <item><p>If the first argument is a <nt def="Constant">Constant</nt>, then it specifies
-                     a value that must match the value of the <term>·selector·</term> property of the JNode,
+                     a value that must match the value of the <term>·jkey·</term> property of the JNode,
                      according to the rules of the <function>fn:atomic-equal</function> function.</p></item>
-                        <item><p>If the first argument is <code>()</code>, then the <term>·selector·</term> property
+                        <item><p>If the first argument is <code>()</code>, then the <term>·jkey·</term> property
                         must be absent: that is, the JNode must be the root of a JTree.</p></item>
-                        <item><p>If the first argument is <code>*</code>, then the <term>·selector·</term> property
+                        <item><p>If the first argument is <code>*</code>, then the <term>·jkey·</term> property
                         may take any value, or may be absent.</p></item>                      
                      </ulist>
                   </item>
                   
                   <item>
-                     <p>The second argument, if present, constrains the <term>·content·</term> property of the JNode:</p>
+                     <p>The second argument, if present, constrains the <term>·jvalue·</term> property of the JNode:</p>
                      <ulist>
                         <item><p>If the argument is omitted, or is <code>*</code>, then there are no constraints on the 
-                        <term>·content·</term> property</p></item>
-                        <item><p>If the argument is a sequence type, then the value of the <term>·content·</term> 
+                        <term>·jvalue·</term> property</p></item>
+                        <item><p>If the argument is a sequence type, then the value of the <term>·jvalue·</term> 
                               property of the JNode must match this sequence type.</p></item>
                      </ulist>
                   </item>
@@ -6478,16 +6478,16 @@ declare record Particle (
                   <item><p><code>jnode(*)</code> matches any JNode.</p></item>
                   <item><p><code>jnode(())</code> matches a JNode that is the root of a JTree.</p></item>
                   <item><p><code>jnode((), map(*))</code> matches a JNode that is the root of a JTree 
-                        and whose <term>·content·</term> property is an instance of <code>map(*)</code>.</p></item>
-                  <item><p><code>jnode("first name")</code> matches any JNode whose <term>·selector·</term> property
+                        and whose <term>·jvalue·</term> property is an instance of <code>map(*)</code>.</p></item>
+                  <item><p><code>jnode("first name")</code> matches any JNode whose <term>·jkey·</term> property
                      is the string <code>"first name"</code>.</p></item>
-                  <item><p><code>jnode(surname)</code> matches any JNode whose <term>·selector·</term> property
+                  <item><p><code>jnode(surname)</code> matches any JNode whose <term>·jkey·</term> property
                      is the string <code>"surname"</code>.</p></item>
-                  <item><p><code>jnode("first name", xs:string)</code> matches any JNode whose <term>·selector·</term> property
-                     is the string <code>"first name"</code> and whose <term>·content·</term> property is an instance of
+                  <item><p><code>jnode("first name", xs:string)</code> matches any JNode whose <term>·jkey·</term> property
+                     is the string <code>"first name"</code> and whose <term>·jvalue·</term> property is an instance of
                      <code>xs:string</code>.</p></item>
                   <item><p><code>jnode(*, array(xs:integer))</code> matches any JNode whose 
-                        <term>·content·</term> property is an array of integers.</p></item>
+                        <term>·jvalue·</term> property is an array of integers.</p></item>
                </ulist>
                
             </div3>
@@ -8132,7 +8132,7 @@ declare record Particle (
                            <item><p>An array with zero or more members each of which 
                               is codepoint-equal to one of <code>"red"</code>, <code>"green"</code>,
                               or <code>"blue"</code>.</p></item>
-                           <item><p>A JNode whose <term>·content·</term> property is any of the above.</p></item>
+                           <item><p>A JNode whose <term>·jvalue·</term> property is any of the above.</p></item>
                         </ulist>
                      </note>
                   </item>
@@ -8196,7 +8196,7 @@ declare record Particle (
                   <item>
                      <p>If <var>J</var> is a <xtermref spec="DM40" ref="dt-JNode"/> and does not
                         match <var>R</var>,
-                     then each item in the <term>·content·</term> of <var>J</var> is coerced to type <var>R</var>
+                     then each item in the <term>·jvalue·</term> of <var>J</var> is coerced to type <var>R</var>
                      by applying the coercion rules recursively.</p>
                      
                      <note><p>For example, if <code>$A</code> is an array and the members
@@ -12324,9 +12324,9 @@ return if (every $r in $R satisfies $r instance of gnode())
 
                      <p>The <code>parent</code> axis returns the parent of the origin.</p>
                      <p>If the origin is an XNode, this is the result of the 
-				          <xspecref spec="DM40" ref="dm-parent"/> accessor.</p>
+                        <xspecref spec="DM40" ref="dm-parent"/> accessor.</p>
                      <p>If the origin is a JNode, this is the value of the
-                     <term>·parent·</term> property of the origin.</p>
+                        <term>·jparent·</term> property of the origin.</p>
                      <p>If the GNode has no parent, the axis returns the empty sequence.</p>
 
                      <note>
@@ -12772,23 +12772,23 @@ return <var>Axis</var>::*[some($selector, atomic-equal(?, node-name()))]</eg>
                <head>Selectors for JNodes</head>
                
                <p>When the origin is a JNode, the selector filters the JNodes returned
-               by the axis according to the JNode's <term>·selector·</term> property.
+               by the axis according to the JNode's <term>·jkey·</term> property.
                In the case of a JNode that wraps an entry in a map, this can be any
                atomic item; for a JNode that wraps a member of an array, it will
                be a non-negative integer.</p>
                
                <p>If the selector takes the form <code>*</code>, then it matches
-               every JNode (including one whose <term>·selector·</term> property
+               every JNode (including one whose <term>·jkey·</term> property
                is absent).</p>
                
                <p>If the selector takes the form of an <code>NCName</code>, then it matches
-               every JNode whose <term>·selector·</term> property is an atomic item
+               every JNode whose <term>·jkey·</term> property is an atomic item
                   (necessarily an <code>xs:string</code>, <code>xs:anyURI</code>
                   or <code>xs:untypedAtomic</code> value) that is equal to this <code>NCName</code>
                   under the rules of the <function>fn:atomic-equal</function> function.</p>
                
                <p>If the selector takes the form of any other <code>EQName</code> or wildcard,
-               then it matches every JNode whose <term>·selector·</term> property is a matching 
+               then it matches every JNode whose <term>·jkey·</term> property is a matching 
                   <code>xs:QName</code>, using the same rules as for wildcards in XNode steps
                (see <specref ref="id-selectors-for-xnodes"/>).</p>
                
@@ -12797,7 +12797,7 @@ return <var>Axis</var>::*[some($selector, atomic-equal(?, node-name()))]</eg>
                the contained expression <var>E</var> is evaluated with an
                   <xtermref ref="dt-absent" spec="DM40"/> <termref def="dt-focus"/>. 
                   A JNode satisfies the selector if the value of its 
-                  <term>·selector·</term> property is equal to one of the values
+                  <term>·jkey·</term> property is equal to one of the values
                   present in the atomized value of the selector expression <var>E</var>, under the rules
                   of the <function>atomic-equal</function> function.</p>
                
@@ -12806,8 +12806,8 @@ return <var>Axis</var>::*[some($selector, atomic-equal(?, node-name()))]</eg>
                   <code><var>Axis</var>::get(<var>E</var>)</code> returns the result
                of the expression:</p>
                
-               <eg><![CDATA[let $selector := fn(){ data(<var>E</var>) }()
-return <var>Axis</var>::*[some($selector, atomic-equal(?, jnode-selector()))]
+               <eg><![CDATA[let $selector := fn() { data(<var>E</var>) }()
+return <var>Axis</var>::*[some($selector, atomic-equal(?, jkey()))]
 ]]></eg>
                
                <note>
@@ -12866,7 +12866,7 @@ return <var>Axis</var>::*[some($selector, atomic-equal(?, jnode-selector()))]
                
         <ulist>
            <item><p>XNodes that are instances of the supplied <var>SequenceType</var>;</p></item>
-           <item><p>JNodes whose <term>·content·</term> property is an instance of the 
+           <item><p>JNodes whose <term>·jvalue·</term> property is an instance of the 
               supplied <var>SequenceType</var>.</p></item>
         </ulist>-->
                
@@ -12877,8 +12877,8 @@ return <var>Axis</var>::*[some($selector, atomic-equal(?, jnode-selector()))]
                <item><p><code>attribute(*, xs:integer)</code>selects
                attribute nodes whose type annotation is <code>xs:integer</code>.</p></item>
                <item><p><code>text()</code> selects text nodes.</p></item>
-               <item><p><code>jnode("id")</code> selects JNodes having the <term>·selector·</term> property <code>"id"</code>.</p></item>
-               <item><p><code>jnode(*, map(*))</code> selects JNodes whose <term>·content·</term> property is an instance
+               <item><p><code>jnode("id")</code> selects JNodes having the <term>·jkey·</term> property <code>"id"</code>.</p></item>
+               <item><p><code>jnode(*, map(*))</code> selects JNodes whose <term>·jvalue·</term> property is an instance
                of the type <code>map(*)</code>.</p></item>
         </ulist>
                
@@ -12902,14 +12902,14 @@ return <var>Axis</var>::*[some($selector, atomic-equal(?, jnode-selector()))]
         are XNodes: the expressions <code>$array/type(element(*))</code> and <code>$array/type(attribute(*))</code>
         can be used to select the members of an array that are element nodes or attribute nodes
         respectively.</p>
-        <p>Such expressions return a sequence of JNodes, whose <term>·content·</term> property is 
+        <p>Such expressions return a sequence of JNodes, whose <term>·jvalue·</term> property is 
         an XNode. Note that it is not directly possible to start with a JNode, select
         a contained XNode, and then navigate from the XNode: a path such as <code>$array/type(element(p))/@id</code>
         will not work. This is because the first step, <code>$array/type(element(p))</code>, does not select
-        an element node, it selects a JNode whose <term>·content·</term> property is that element node, and use of the
+        an element node, it selects a JNode whose <term>·jvalue·</term> property is that element node, and use of the
         attribute axis starting from a JNode has no effect.</p>
         <p>Instead, the required effect can be achieved by adding a step that explicitly 
-           extracts the content of the JNode: <code>$array/type(element(p))/jnode-content()/@id</code>.</p>   
+           extracts the content of the JNode: <code>$array/type(element(p))/jvalue()/@id</code>.</p>   
         </note>       -->
                
         <p>The syntax
@@ -13073,14 +13073,14 @@ return <var>Axis</var>::*[some($selector, atomic-equal(?, jnode-selector()))]
 
                   <item>
                      <p><code role="parse-test">jnode(*, array(*))</code> matches any JNode
-                        whose <term>·content·</term> is an array.</p></item>
+                        whose <term>·jvalue·</term> is an array.</p></item>
                   <item><p><code role="parse-test">jnode(*, record(longitude, latitude, *))</code> matches any JNode
-                     whose <term>·content·</term> is a map having entries with keys
+                     whose <term>·jvalue·</term> is a map having entries with keys
                      <code>"longitude"</code> and <code>"latitude"</code>.</p></item>
                   <item><p><code role="parse-test">jnode(*, empty-sequence())</code> matches any JNode
-                     whose <term>·content·</term> is the empty sequence.</p></item>
+                     whose <term>·jvalue·</term> is the empty sequence.</p></item>
                   <item><p><code role="parse-test">jnode(*, xs:date)</code> matches any JNode
-                     whose <term>·content·</term> is an instance of <code>xs:date</code>.</p>
+                     whose <term>·jvalue·</term> is an instance of <code>xs:date</code>.</p>
                   </item>
                </ulist>
                
@@ -13889,11 +13889,11 @@ every <code>section</code> element that has a parent that is either a <code>chap
 ]</eg>
             
             <ulist>
-               <item><p><code>get(1)/first</code> returns a JNode whose <term>·content·</term>
+               <item><p><code>get(1)/first</code> returns a JNode whose <term>·jvalue·</term>
                is the string <code>"John"</code>.</p></item>
-               <item><p><code>//first[. = "Mary"]/../last</code> returns a JNode whose <term>·content·</term>
+               <item><p><code>//first[. = "Mary"]/../last</code> returns a JNode whose <term>·jvalue·</term>
                is the string <code>"Smith"</code>.</p></item>
-               <item><p><code>//first[. = "Mary"]/../get("date of birth")</code> returns a JNode whose <term>·content·</term>
+               <item><p><code>//first[. = "Mary"]/../get("date of birth")</code> returns a JNode whose <term>·jvalue·</term>
                is the string <code>"2006-08-12"</code>.</p></item>
                <item><p><code>//*[occupation = "cook"]!`{first} {last}`</code> returns the
                string <code>"John Baker"</code>.</p></item>
@@ -18675,7 +18675,7 @@ let $z := g($x, $y)]]></eg>
                   <p>In this case the corresponding <code>ExprSingle</code>
                   must evaluate to a single array, otherwise a type error is raised <errorref
                   class="TY" code="0141"/>. However, the coercion rules also allow a JNode
-                  whose <term>·content·</term> is an array to be supplied.</p></item>
+                  whose <term>·jvalue·</term> is an array to be supplied.</p></item>
                <item><p>When a <nt def="ForItemBinding">ForEntryBinding</nt> is used (that is, when either
                   or both of the keywords <code>key</code> and <code>value</code> are used), 
                   the <code>key</code> range variable (if present) is bound in turn to each key in the map 
@@ -18684,7 +18684,7 @@ let $z := g($x, $y)]]></eg>
                   <p>In this case the corresponding <code>ExprSingle</code>
                   must evaluate to a single map, otherwise a type error is raised <errorref
                   class="TY" code="0141"/>. However, the coercion rules also allow a JNode
-                  whose <term>·content·</term> is a map to be supplied.</p>
+                  whose <term>·jvalue·</term> is a map to be supplied.</p>
                <p>If both the <code>key</code> and <code>value</code> variables are declared,
                their <termref def="dt-expanded-qname">expanded
 			        QNames</termref> must be distinct <errorref
@@ -20775,7 +20775,7 @@ return ($i, $j)]]></eg>
                   <olist>
                      <item><p>The value of the <termref def="dt-binding-collection-xp"/> must be a single array.
                         Otherwise, a <termref def="dt-type-error">type error</termref> is raised: <errorref class="TY" code="0141"/>.
-                        However, the coercion rules also allow a JNode whose <term>·content·</term> is an array to be supplied.
+                        However, the coercion rules also allow a JNode whose <term>·jvalue·</term> is an array to be supplied.
                      </p></item>
                      <item><p>If a <nt def="TypeDeclaration">TypeDeclaration</nt>
                         is present then each member of the <termref def="dt-binding-collection-xp"/> array
@@ -20805,7 +20805,7 @@ return ($i, $j)]]></eg>
                      <item><p>The value of the <termref def="dt-binding-collection-xp"/> must be a single map.
                         Otherwise, a <termref def="dt-type-error">type error</termref> is raised: 
                         <errorref class="TY" code="0141"/>. However, the coercion rules also allow a JNode
-                        whose <term>·content·</term> is a map to be supplied.
+                        whose <term>·jvalue·</term> is a map to be supplied.
                         The map is treated as a sequence of key/value
                         pairs, in <termref def="dt-implementation-dependent"/> order.
                      </p></item>
@@ -21385,7 +21385,7 @@ processing with JSON processing.</p>
                single instance of <nt def="ExprSingle">ExprSingle</nt> with no colon, it must evaluate
                to a sequence of zero or more map items (<errorref class="TY" code="0004"/>).
                   However, the coercion rules also allow a JNode
-                  whose <term>·content·</term> is a map (or a sequence of maps) to be supplied.
+                  whose <term>·jvalue·</term> is a map (or a sequence of maps) to be supplied.
                   These map items will be merged into the constructed map, as described below.</p>
                
                <p>Each contained <nt def="MapConstructorEntry">MapConstructorEntry</nt> thus
@@ -21877,7 +21877,7 @@ processing with JSON processing.</p>
                   (specifically, <code>(map(*) | array(*))*</code>), and the <termref def="dt-coercion-rules"/>
                   are applied with this required type: this means that if the supplied value
                   includes JNodes, these will be coerced to maps or arrays
-               by extracting the <term>·content·</term> property of the JNode. The lookup
+               by extracting the <term>·jvalue·</term> property of the JNode. The lookup
                operation is applied independently to each of these maps or arrays,
                and the final expression result is the <termref def="dt-sequence-concatenation"/>
                of the individual results.</p>
@@ -22117,9 +22117,10 @@ processing with JSON processing.</p>
                   <code>$m?code = 3</code> and <code>$m/code = 3</code> have the same effect.
                   Path expressions, however, have more power, and with it, more complexity.
                   The expression <code>$m/code = 3</code> (unless simplified by an optimizer)
-                  effectively expands the expression to <code>(jtree($m)/child::get("code") => jnode-content()) = 3</code>:
+                  effectively expands the expression to
+                  <code>(jtree($m)/child::get("code") => jvalue()) = 3</code>:
                   that is, the supplied map is wrapped in a JNode, the child axis returns a sequence of JNodes,
-                  and the <term>·content·</term> properties of these JNodes are compared with the
+                  and the <term>·jvalue·</term> properties of these JNodes are compared with the
                   supplied value <code>3</code>.</p>
                   
                   <p>Whereas simple lookups of specific entries in maps and arrays work well,
@@ -22129,19 +22130,19 @@ processing with JSON processing.</p>
                   <code>$A?*</code> is the sequence <code>(1, 2, 3, 4, 5)</code> which loses information
                   that might be needed for further processing. By contrast, the path expression
                   <code>$A/*</code> (or <code>$A/child::*</code>) returns a sequence of four
-                  JNodes, whose <term>·content·</term> properties are respectively <code>(1,2)</code>, 
+                  JNodes, whose <term>·jvalue·</term> properties are respectively <code>(1,2)</code>, 
                      <code>(3,4)</code>, <code>()</code>, and <code>5</code>.</p>
                   
                   <p>The result of a lookup expression is a simple value (the value of an entry in a map
                   or a member of an array, or the <termref def="dt-sequence-concatenation"/> of 
                   several such values). By contrast, the result of a path expression applied to maps
                   or arrays is always a sequence of JNodes. These JNodes can be used for further
-                  navigation. If only the <term>·content·</term> properties of the JNodes are 
+                  navigation. If only the <term>·jvalue·</term> properties of the JNodes are 
                   needed, these will usually be extracted automatically by virtue of the
                   <termref def="dt-coercion-rules"/>: for example if the value is used in an
                   arithmetic expression or a value comparison, atomization of the JNode
-                  automatically extracts its <term>·content·</term>. In other cases the value can
-                  be extracted explicitly by a call of the <function>jnode-content</function> function.</p>
+                  automatically extracts its <term>·jvalue·</term>. In other cases the value can
+                  be extracted explicitly by a call of the <function>jvalue</function> function.</p>
                   
 
                   <p>Lookup expressions on arrays result in a dynamic error if the subscript is out
@@ -22411,7 +22412,7 @@ declare record my:rectangle (
                <code>(map(*)|array(*))?</code>: that is, it must be either the empty sequence, a single
             map, or a single array <errorref class="TY" code="0004"/>. 
                However, the coercion rules also allow a JNode
-                  whose <term>·content·</term> is a map or array to be supplied.
+                  whose <term>·jvalue·</term> is a map or array to be supplied.
                If the value is the empty sequence, 
                the result of the expression is the empty sequence.</p>
             

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -12527,11 +12527,11 @@ return $tree =?> depth()]]></eg>
                                  entries also allowed).</p>
                            </item>
                            <item>
-                              <p><code>jnode(())</code> matches any root JNode (that is, a JNode whose <term>·selector·</term> property
+                              <p><code>jnode(())</code> matches any root JNode (that is, a JNode whose <term>·jkey·</term> property
                               is absent).</p>
                            </item>
                            <item>
-                              <p><code>jnode((), array(map(*)))</code> matches any root JNode whose <term>·content·</term> property
+                              <p><code>jnode((), array(map(*)))</code> matches any root JNode whose <term>·jvalue·</term> property
                                  is an array of maps.</p>
                            </item>
                         </olist>
@@ -12572,10 +12572,10 @@ return $tree =?> depth()]]></eg>
                   <item><p>An <code>GNodePattern</code> matches GNodes in a GTree (for example, a tree
                      representing the contents of an XML or JSON document), by specifying a path that
                   can be used to locate the nodes: for example <code>order</code> matches an element node
-                  named <code>order</code> within an XTree, or a JNode with ·selector· <code>"order"</code>
+                  named <code>order</code> within an XTree, or a JNode with ·jkey· <code>"order"</code>
                         within a JTree; similarly, <code>billing-address/city</code> matches an element node named <code>city</code>
-                  whose parent node is an element named <code>billing-address</code>, or a JNode with ·selector· <code>"city"</code>
-                  whose parent is a JNode with ·selector· <code>"billing-address"</code>.</p>
+                  whose parent node is an element named <code>billing-address</code>, or a JNode with ·jkey· <code>"city"</code>
+                  whose parent is a JNode with ·jkey· <code>"billing-address"</code>.</p>
                   <!--<p>The grammar for <code>XNodePattern</code> also allows a
                   <code>ParenthesizedPattern</code>, which can be used to match items other than
                   XNodes. This allows patterns such as <code><var>P</var> except (<var>Q</var> union <var>R</var>)</code>,
@@ -12583,7 +12583,7 @@ return $tree =?> depth()]]></eg>
                   </item>
                   <item><p>A <code>JNodePattern</code> matches JNodes in a JTree (a tree of maps and arrays,
                      often representing the contents of a JSON document), by specifying constraints on
-                     the properties of the JNode, notably its ·selector· and ·content· properties.
+                     the properties of the JNode, notably its ·jkey· and ·jvalue· properties.
                    For example the pattern <code>jnode(order, *)</code> matches a JNode corresponding
                      to a map entry with the key <code>"order"</code>.</p>--></item>
                </ulist>
@@ -12685,7 +12685,7 @@ return $tree =?> depth()]]></eg>
                         matches any map having entries with the string-valued keys <code>"first"</code> and <code>"last"</code>,
                         where the entry for the key <code>"first"</code> is equal to the string <code>"Sharon"</code></p></item>
                      <item><p><code>~jnode(address, record(address-line-1, address-line-2))</code> matches a JNode whose
-                     ·selector· property is the string <code>"address"</code>, and whose content matches the given record type.</p></item>
+                     ·jkey· property is the string <code>"address"</code>, and whose content matches the given record type.</p></item>
                   </ulist>
                   
                   
@@ -12889,7 +12889,7 @@ return $tree =?> depth()]]></eg>
                               XSLT 4.0 allows the pattern <code>~node()</code> to be
                               used.</p>
                         <p>The adjustment is not necessary in the case of JNodes, because a JNode
-                        with ·selector· value <code>"person"</code> will necessarily have a parent JNode.</p>
+                        with ·jkey· value <code>"person"</code> will necessarily have a parent JNode.</p>
                      </note>
    
                   </item>
@@ -12989,24 +12989,24 @@ return $tree =?> depth()]]></eg>
                   <head>Matching JNodes</head>
                   <ulist>
                   <item><p>The pattern <code>jnode(code, xs:string)</code> matches any
-                     JNode whose ·selector· is the string <code>"code"</code> and whose ·content·
+                     JNode whose ·jkey· is the string <code>"code"</code> and whose ·jvalue·
                      is an instance of <code>xs:string</code>.</p></item>
                   <item><p>The pattern <code>jnode("date of birth", xs:date)</code> matches any
-                     JNode whose ·selector· is the string <code>"date of birth"</code> and whose ·content·
+                     JNode whose ·jkey· is the string <code>"date of birth"</code> and whose ·jvalue·
                      is an instance of <code>xs:date</code>.</p></item>
                   <item><p>The pattern <code>jnode(*, array(*))</code> matches any
-                     JNode whose ·content· is an array, regardless of its ·selector· property.</p></item>
+                     JNode whose ·jvalue· is an array, regardless of its ·jkey· property.</p></item>
                   <item><p>The pattern <code>jnode(*, record(Author, Title))[ancestor::books]</code> matches any
-                     JNode whose ·content· is an instance of the type <code>record(Author, Title)</code>, 
-                     provided it has an ancestor with the ·selector· value <code>"books"</code>.</p></item>
+                     JNode whose ·jvalue· is an instance of the type <code>record(Author, Title)</code>, 
+                     provided it has an ancestor with the ·jkey· value <code>"books"</code>.</p></item>
                   <item><p>The pattern <code>jnode(*, record(Author as enum("Dickens"), Title))</code> matches any
-                     JNode whose ·content· is a map having an <code>Author</code> entry with the value
+                     JNode whose ·jvalue· is a map having an <code>Author</code> entry with the value
                      <code>"Dickens"</code>, a <code>Title</code> entry with any value, and optionally
                      other entries.</p></item>
-                  <item><p>The pattern <code>jnode(*, *)[jnode-selector() = current-date()]</code> matches any
-                     JNode whose ·selector· property is an <code>xs:date</code> value equal to the current date.
+                  <item><p>The pattern <code>jnode(*, *)[jkey() = current-date()]</code> matches any
+                     JNode whose ·jkey· property is an <code>xs:date</code> value equal to the current date.
                      The comparison uses the implicit timezone from the dynamic context. The rules for error
-                  handling in patterns ensure that any JNode whose ·selector· value is of a type other
+                  handling in patterns ensure that any JNode whose ·jkey· value is of a type other
                   than <code>xs:date</code> does not match, because evaluation of the predicate raises an error.</p></item>
                </ulist>
                   
@@ -13060,9 +13060,9 @@ return $tree =?> depth()]]></eg>
                <p>A <nt def="JNodePattern">JNodePattern</nt> matches JNodes. It has three parts:</p>
                <ulist>
                   <item><p>The <nt def="JNodePatternSelector">JNodePatternSelector</nt> defines
-                  the required value of the ·selector· property of the JNode.</p></item>
+                  the required value of the ·jkey· property of the JNode.</p></item>
                   <item><p>The <nt def="JNodePatternSelector">JNodePatternContent</nt> defines
-                  the required type of the ·content· property of the JNode.</p></item>
+                  the required type of the ·jvalue· property of the JNode.</p></item>
                   <item><p>An optional list of zero or more predicates that the JNode
                   must satisfy.</p></item>
                </ulist>
@@ -13075,11 +13075,11 @@ return $tree =?> depth()]]></eg>
                      <olist>
                         <item>The <nt def="JNodePatternSelector">JNodePatternSelector</nt> is <code>*</code>;</item>
                         <item>The <nt def="JNodePatternSelector">JNodePatternSelector</nt> is an <code>NCName</code>.
-                        and <var>J</var> has a ·selector· property that is an instance of <code>xs:string</code> 
+                        and <var>J</var> has a ·jkey· property that is an instance of <code>xs:string</code> 
                         whose value is equal to the <code>NCName</code> under the rules of the <function>fn:atomic-equal</function>
                         function.</item>
                         <item>The <nt def="JNodePatternSelector">JNodePatternSelector</nt> is a <code>Constant</code>.
-                        and <var>J</var> has a ·selector· property that is equal to the value
+                        and <var>J</var> has a ·jkey· property that is equal to the value
                            of the constant (evaluated as an XPath expression) under the rules of the 
                               <function>fn:atomic-equal</function> function.</item>
                      </olist>
@@ -13087,7 +13087,7 @@ return $tree =?> depth()]]></eg>
                   <item><p>One of the following conditions is satisfied:</p>
                      <olist>
                         <item>The <nt def="JNodePatternContent">JNodePatternContent</nt> is <code>*</code>;</item>
-                        <item>The ·content· property of <var>J</var> is an instance of the sequence type
+                        <item>The ·jvalue· property of <var>J</var> is an instance of the sequence type
                         designated by <nt def="JNodePatternContent">JNodePatternContent</nt>.</item>
                      </olist>
                   </item>

--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -531,7 +531,7 @@ The steps in computing the normalized sequence are:
       <!--End of text replaced by erratum E6-->
 <olist>
   <item><p>Create a new sequence <var>S1</var> from <var>S0</var> as follows. For
-each item in <var>S0</var>, if the item is a JNode, copy the <code>·content·</code>
+each item in <var>S0</var>, if the item is a JNode, copy the <code>·jvalue·</code>
     property of the item; otherwise, copy the item itself.</p></item>
   
 <item><p>Create a new sequence <var>S2</var> from <var>S1</var> as follows. For
@@ -3537,7 +3537,7 @@ is described in <specref ref="serdm"/>.</p>
       The serialization of maps retains the order of entries.
     </change>
     <change issue="2025" PR="2031" date="2025-05-29">
-      A JNode is replaced by its <code>·content·</code> property.
+      A JNode is replaced by its <code>·jvalue·</code> property.
     </change>
     <change issue="938" PR="TODO" date="2025-10-20">
       JSON canonicalization is supported by the <code>·canonical·</code> property.
@@ -3575,7 +3575,7 @@ is described in <specref ref="serdm"/>.</p>
   <p>An individual item is serialized as follows:</p>
 
     <ulist>
-      <item><p>A JNode is serialized by serializing its <code>·content·</code> property.</p></item>
+      <item><p>A JNode is serialized by serializing its <code>·jvalue·</code> property.</p></item>
     <item><p>An <termref def="dt-array-item">array item</termref> in the
       <termref diff="chg" at="2023-11-01" def="dt-input-tree"/> is
     serialized to a JSON array by outputting the serialized JSON value of
@@ -4002,8 +4002,8 @@ according to the <bibref ref="JSON-LINES"/> format, as described in <specref ref
     </change>
     <change issue="2087 2186" PR="2114 2226" date="2025-06-22">
       A JNode is represented as <code>jnode(<var>K</var>: <var>V</var>)</code> where 
-      <var>K</var> is its <code>·selector·</code> property and
-      <var>V</var> is its <code>·content·</code> property.
+      <var>K</var> is its <code>·jkey·</code> property and
+      <var>V</var> is its <code>·jvalue·</code> property.
     </change>
     <change issue="2388" PR="2485" date="2026-02-20">
       The adaptive serialization of anonymous functions is now implementation-dependent.
@@ -4026,16 +4026,16 @@ between successive items.</p>
   
   <item><p>A JNode is serialized as follows:</p>
     <ulist>
-      <item><p>If the <code>·selector·</code> property is absent (that is, for a parentless JNode),
+      <item><p>If the <code>·jkey·</code> property is absent (that is, for a parentless JNode),
       in the format <code>jtree(<var>V</var>)</code> where <var>V</var> is the adaptive 
-        serialization of the value of its <code>·content·</code> property.</p>
+        serialization of the value of its <code>·jvalue·</code> property.</p>
         <p>For example, the JNode selected by the expression <code>jtree({ "a": [4, 5] })</code> is serialized
      as <code>jtree({"a":[4,5]})</code>.</p>
     </item>
-      <item><p>If the <code>·selector·</code> property is present,
+      <item><p>If the <code>·jkey·</code> property is present,
         then in the format <code>jnode(<var>K</var>: <var>V</var>)</code> where 
-    <var>K</var> is the adaptive serialization of the value of its <code>·selector·</code> property
-      and <var>V</var> is the adaptive serialization of the value of its <code>·content·</code> property.</p>
+    <var>K</var> is the adaptive serialization of the value of its <code>·jkey·</code> property
+      and <var>V</var> is the adaptive serialization of the value of its <code>·jvalue·</code> property.</p>
      <p>For example, the JNode selected by the expression <code>jtree({ "a": [4, 5] })/a</code> is serialized
      as <code>jnode("a":[4,5])</code>.</p></item>
       


### PR DESCRIPTION
Closes #2443.

I have also renamed ·parent· and ·position· (maybe we get rid of the position? related: #2073), and the PR includes minor editorial cleanups.