### PR TITLE
Fix whitespace changes; (attempt to) improve long type signatures

### DIFF
--- a/specifications/css/qtspecs.css
+++ b/specifications/css/qtspecs.css
@@ -16,11 +16,8 @@ code           { font-family: var(--monospace-font-family);
     background-color: inherit;
     border: inherit;
     border-radius: 0;
-    padding-top: inherit;
-    padding-bottom: inherit;
-    padding-left: inherit;
-    padding-right: inherit;
-    margin: inherit;
+    padding: 0;
+    margin: 0;
 }
 
 div.constraint,
@@ -221,6 +218,12 @@ div.exampleHeader { font-weight: bold;
 div.proto { border: 0;
             border-spacing: 0;
           }
+
+table.proto tr.arg td:nth-child(2) .rt {
+    display: inline-block;
+    text-indent: -2em;
+    margin-left: 2em;
+}
 
 div.issue { border-bottom-color: black;
             border-bottom-style: solid;

--- a/specifications/xpath-functions-40/style/xpath-functions.xsl
+++ b/specifications/xpath-functions-40/style/xpath-functions.xsl
@@ -259,21 +259,23 @@
               </code>
               <xsl:text>(</xsl:text>
               <xsl:text>)</xsl:text>
-              <code class="as">&#160;as&#160;</code>
-              <xsl:choose>
-                <xsl:when test="@returnVaries = 'yes'">
-                  <code class="return-varies">
-                    <xsl:value-of select="@return-type"/>
-                    <xsl:if test="@returnEmptyOk='yes'">?</xsl:if>
-                  </code>
-                </xsl:when>
-                <xsl:otherwise>
-                  <code class="return-type">
-                    <xsl:value-of select="@return-type"/>
-                    <xsl:if test="@returnEmptyOk='yes'">?</xsl:if>
-                  </code>
-                </xsl:otherwise>
-              </xsl:choose>
+              <span class="rt">
+                <code class="as">&#160;as&#160;</code>
+                <xsl:choose>
+                  <xsl:when test="@returnVaries = 'yes'">
+                    <code class="return-varies">
+                      <xsl:value-of select="@return-type"/>
+                      <xsl:if test="@returnEmptyOk='yes'">?</xsl:if>
+                    </code>
+                  </xsl:when>
+                  <xsl:otherwise>
+                    <code class="return-type">
+                      <xsl:value-of select="@return-type"/>
+                      <xsl:if test="@returnEmptyOk='yes'">?</xsl:if>
+                    </code>
+                  </xsl:otherwise>
+                </xsl:choose>
+              </span>
             </td>
           </tr>
         </table>
@@ -299,19 +301,23 @@
               </td>
               <td>
                 <xsl:if test="@type">
-                  <code class="as">as&#160;</code>
-                  <code class="type"><xsl:apply-templates select="@type" mode="render-type"/></code>
-                  <xsl:if test="not (@default) and not($last)">,</xsl:if>
+                  <span class="rt">
+                    <code class="as">as&#160;</code>
+                    <code class="type"><xsl:apply-templates select="@type" mode="render-type"/></code>
+                    <xsl:if test="not (@default) and not($last)">,</xsl:if>
+                  </span>
                 </xsl:if>
                 <xsl:if test="@type-ref">
-                  <code class="as">as&#160;</code>
-                  <code>
-                    <a href="#{@type-ref}">
-                      <xsl:value-of select="@type-ref"/>                
-                    </a>
-                    <xsl:value-of select="@type-ref-occurs"/>    
-                  </code>
-                  <xsl:if test="not (@default) and not($last)">,</xsl:if>
+                  <span class="rt">
+                    <code class="as">as&#160;</code>
+                    <code>
+                      <a href="#{@type-ref}">
+                        <xsl:value-of select="@type-ref"/>                
+                      </a>
+                      <xsl:value-of select="@type-ref-occurs"/>    
+                    </code>
+                    <xsl:if test="not (@default) and not($last)">,</xsl:if>
+                  </span>
                 </xsl:if>
               </td>
               <td>
@@ -327,35 +333,36 @@
           <tr class="return-type">
 	          <td colspan="3">
               <xsl:text>)</xsl:text>
-              <code class="as">&#160;as&#160;</code>
-              <code>
-                <xsl:if test="@returnVaries = 'yes' or @return-type-ref">
-                  <xsl:attribute name="class"
-                                 select="if (@returnVaries = 'yes' and @return-type-ref)
-                                         then 'return-varies return-type-ref'
-                                         else if (@returnVaries = 'yes')
-                                              then 'return-varies'
-                                              else 'return-type-ref'"/>
-                </xsl:if>
-
-                <xsl:choose>
-                  <xsl:when test="@return-type">
-                    <xsl:apply-templates select="@return-type" mode="render-type"/>
-                    <xsl:if test="@returnEmptyOk='yes'">?</xsl:if>
-                  </xsl:when>
-                  <xsl:when test="@return-type-ref">
-                    <a href="#{replace(@return-type-ref, '[*+?]$', '')}">
-                      <xsl:value-of select="@return-type-ref"/>
-                    </a>
-                    <xsl:value-of select="@return-type-ref-occurs"/>
-                    <xsl:if test="@returnEmptyOk='yes'">?</xsl:if>
-                  </xsl:when>
-                  <!--<xsl:otherwise>
-                    <xsl:apply-templates select="@return-type" mode="render-type"/>
-                    <xsl:if test="@returnEmptyOk='yes'">?</xsl:if>
-                  </xsl:otherwise>-->
-                </xsl:choose>
-              </code>
+              <span class="rt">
+                <code class="as">&#160;as&#160;</code>
+                <code>
+                  <xsl:if test="@returnVaries = 'yes' or @return-type-ref">
+                    <xsl:attribute name="class"
+                                   select="if (@returnVaries = 'yes' and @return-type-ref)
+                                           then 'return-varies return-type-ref'
+                                           else if (@returnVaries = 'yes')
+                                                then 'return-varies'
+                                                else 'return-type-ref'"/>
+                  </xsl:if>
+                
+                  <xsl:choose>
+                    <xsl:when test="@return-type">
+                      <xsl:apply-templates select="@return-type" mode="render-type"/>
+                      <xsl:if test="@returnEmptyOk='yes'">?</xsl:if>
+                    </xsl:when>
+                    <xsl:when test="@return-type-ref">
+                      <a href="#{replace(@return-type-ref, '[*+?]$', '')}">
+                        <xsl:value-of select="@return-type-ref"/>
+                      </a>
+                      <xsl:value-of select="@return-type-ref-occurs"/>
+                      <xsl:if test="@returnEmptyOk='yes'">?</xsl:if>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <xsl:message select="'Unexpected return type:', ."/>
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </code>
+              </span>
             </td>
           </tr>
         </table>
@@ -369,7 +376,9 @@
 </xsl:template>
   
 <xsl:template match="@*" mode="render-type" priority="11">
-  <code><xsl:value-of select="."/></code>
+  <code>
+    <xsl:sequence select="replace(string(.), ' as ', ' as ')"/>
+  </code>
 </xsl:template>
 
 <xsl:template match="proto" mode="stringify">


### PR DESCRIPTION
Fix #2494 

The whitespace issue turned out to be in the CSS not related to `fos.scm` directly. I fixed it, but it's not clear what changed. Keep your eyes open for `code` elements that look like they have extra or missing whitespace!

With this PR, we get:

<img width="1560" height="362" alt="image" src="https://github.com/user-attachments/assets/16fd1804-16ca-409c-994c-cde04b0587c8" />
