### PR TITLE
2477 Get current date in streaming spec

### DIFF
--- a/specifications/xslt-streaming-40/src/xslt-streaming.xml
+++ b/specifications/xslt-streaming-40/src/xslt-streaming.xml
@@ -9,10 +9,10 @@
       <w3c-designation>REC-xslt-streaming-40</w3c-designation>
       <w3c-doctype>W3C Editor's Draft</w3c-doctype>
       <pubdate>
-         <!-- The value from the build.xml file is used in preference -->
-         <day>5</day>
-         <month>Sept</month>
-         <year>2025</year>
+         <!-- The stylesheet xmlspec-2016.xsl recognizes this as a trigger to insert the current date -->
+         <day>01</day>
+         <month>January</month>
+         <year>2000</year>
       </pubdate> 
       <publoc>
          <loc href="https://qt4cg.org/specifications/xslt-streaming-40/"


### PR DESCRIPTION
Use of the magic date 01 January 2000 triggers the stylesheet xmlspec-2016 to insert the current date in its place.