### PR TITLE
Harmonize functions that read text (supersedes #2467)

### DIFF
--- a/specifications/EXPath/file/src/function-catalog.xml
+++ b/specifications/EXPath/file/src/function-catalog.xml
@@ -1064,6 +1064,7 @@ return file:read-text($path)
                   with the value false, any such character is an error.
                </fos:meaning>
                <fos:type>xs:boolean</fos:type>
+               <fos:default>false</fos:default>
             </fos:option>
          </fos:options>
     </fos:rules>
@@ -1147,15 +1148,14 @@ return file:read-text($path)
             </fos:option>
             <fos:option key="fallback">
                <fos:meaning>
-                  Provides a function which is called when the input contains a character
-                  that is not a <xtermref spec="FO40" ref="dt-permitted-character"/>.
-                  It is called once for each non-permitted character, passing in the
-                  Unicode codepoint of the character.
-                  If the function returns the empty
-                  sequence, the character is simply removed from the input.
+                  If <code>$fallback</code> is true, any character
+                  that is not a <xtermref spec="FO40" ref="dt-permitted-character"/>
+                  is replaced by the Unicode replacement character
+                  (<code>char(0xFFFD)</code>). If it is not provided or is provided
+                  with the value false, any such character is an error.
                </fos:meaning>
-               <fos:type>(fn(xs:string) as xs:string)?</fos:type>
-               <fos:default>fn { char(0xFFFD) }</fos:default>
+               <fos:type>xs:boolean</fos:type>
+               <fos:default>false</fos:default>
             </fos:option>
          </fos:options>
 

--- a/specifications/EXPath/file/src/function-catalog.xml
+++ b/specifications/EXPath/file/src/function-catalog.xml
@@ -1025,8 +1025,7 @@ return file:read-text($path)
     <fos:signatures>
       <fos:proto name="read-text" return-type="xs:string">
         <fos:arg type="xs:string" name="file"/>
-        <fos:arg type="xs:string?" default="'UTF-8'" name="encoding"/>
-        <fos:arg type="xs:boolean?" default="false()" name="fallback"/>
+        <fos:arg name="options" type="(xs:string | map(*))?" default="()"/>
       </fos:proto>
     </fos:signatures>
     <fos:properties>
@@ -1041,10 +1040,32 @@ return file:read-text($path)
       <p>Returns the content of a file in its string representation.
         Newlines are normalized: Any <char>U+000D</char> character, optionally followed by
         a <char>U+000A</char> character, is converted to a single <char>U+000A</char> character.</p>
-      <p>If no encoding is supplied, <code>UTF-8</code> is used as input encoding.
-        By default, invalid XML characters will be rejected. If <code>$fallback</code> is
-        <code>true</code>, the characters will be replaced with the Unicode replacement character
-        <char>U+FFFD</char>.</p>
+
+         <p>The <code>$options</code> argument, for backwards compatibility reasons, may be supplied
+         either as a map, or as a string. Supplying a value <code>$S</code> that is not a map
+         is equivalent to supplying the map <code>{ "encoding": $S }</code>.
+         After that substitution, the <xtermref spec="FO40" ref="option-parameter-conventions"/> apply.</p>
+
+         <p>The entries that may appear in the <code>$options</code> map are as follows:</p>
+         
+         <fos:options>
+            <fos:option key="encoding">
+               <fos:meaning>Defines the encoding of the resource, as described below.
+               </fos:meaning>
+               <fos:type>xs:string?</fos:type>
+               <fos:default>"UTF-8"</fos:default>
+            </fos:option>
+            <fos:option key="fallback">
+               <fos:meaning>
+                  If <code>$fallback</code> is true, any character
+                  that is not a <xtermref spec="FO40" ref="dt-permitted-character"/>
+                  is replaced by the Unicode replacement character
+                  (<code>char(0xFFFD)</code>). If it is not provided or is provided
+                  with the value false, any such character is an error.
+               </fos:meaning>
+               <fos:type>xs:boolean</fos:type>
+            </fos:option>
+         </fos:options>
     </fos:rules>
     <fos:errors>
       <p>
@@ -1080,7 +1101,7 @@ return file:read-text($path)
     </fos:examples>
     <fos:changes>
       <fos:change issue="2016" PR="2077" date="2024-07-02">
-        <p><code>$fallback</code> parameter added.</p>
+        <p><code>$options</code> parameter added.</p>
       </fos:change>
       <fos:change issue="2016" PR="2077" date="2024-07-02">
         <p>The normalization of newlines has been made explicit.</p>
@@ -1092,8 +1113,7 @@ return file:read-text($path)
     <fos:signatures>
       <fos:proto name="read-text-lines" return-type="xs:string*">
         <fos:arg type="xs:string" name="file"/>
-        <fos:arg type="xs:string?" default="'UTF-8'" name="encoding"/>
-        <fos:arg type="xs:boolean?" default="false()" name="fallback"/>
+        <fos:arg name="options" type="(xs:string | map(*))?" default="()"/>
       </fos:proto>
     </fos:signatures>
     <fos:properties>
@@ -1110,10 +1130,41 @@ return file:read-text($path)
         boundaries.</p>
       <p>Any of the character sequences <char>U+000A</char>, <char>U+000D</char>, or
          <char>U+000D</char> followed by <char>U+000A</char> is interpreted as newline.</p>
-      <p>If no encoding is supplied, <code>UTF-8</code> is used as input encoding.
-        By default, invalid XML characters will be rejected. If <code>$fallback</code> is enabled,
-        the characters will be replaced with the Unicode replacement character
-        <char>U+FFFD</char>.</p>
+
+         <p>The <code>$options</code> argument, for backwards compatibility reasons, may be supplied
+         either as a map, or as a string. Supplying a value <code>$S</code> that is not a map
+         is equivalent to supplying the map <code>{ "encoding": $S }</code>.
+         After that substitution, the <xtermref spec="FO40" ref="option-parameter-conventions"/> apply.</p>
+
+         <p>The entries that may appear in the <code>$options</code> map are as follows:</p>
+         
+         <fos:options>
+            <fos:option key="encoding">
+               <fos:meaning>Defines the encoding of the resource, as described below.
+               </fos:meaning>
+               <fos:type>xs:string?</fos:type>
+               <fos:default>"UTF-8"</fos:default>
+            </fos:option>
+            <fos:option key="fallback">
+               <fos:meaning>
+                  Provides a function which is called when the input contains a character
+                  that is not a <xtermref spec="FO40" ref="dt-permitted-character"/>.
+                  It is called once for each non-permitted character, passing in the
+                  Unicode codepoint of the character.
+                  If the function returns the empty
+                  sequence, the character is simply removed from the input.
+               </fos:meaning>
+               <fos:type>(fn(xs:string) as xs:string)?</fos:type>
+               <fos:default>fn { char(0xFFFD) }</fos:default>
+            </fos:option>
+         </fos:options>
+
+      <p>By default, characters that are not
+      <xtermref spec="FO40" ref="dt-permitted-character"/> will be rejected.
+      A fallback function can be provided in the <code>$options</code> to remap non-permitted characters.
+      One such function, <code>fn { char(0xFFFD) }</code>, replaces all non-permitted
+      characters with the Unicode replacement character.
+      </p>
     </fos:rules>
     <fos:errors>
       <p>

--- a/specifications/EXPath/file/src/function-catalog.xml
+++ b/specifications/EXPath/file/src/function-catalog.xml
@@ -1057,11 +1057,10 @@ return file:read-text($path)
             </fos:option>
             <fos:option key="fallback">
                <fos:meaning>
-                  If <code>$fallback</code> is true, any character
-                  that is not a <xtermref spec="FO40" ref="dt-permitted-character"/>
+                  If <code>$fallback</code> is true, any character that 
+                  cannot be decoded or that is not a <xtermref spec="FO40" ref="dt-permitted-character"/>
                   is replaced by the Unicode replacement character
-                  (<code>char(0xFFFD)</code>). If it is not provided or is provided
-                  with the value false, any such character raises an error.
+                  (<char>U+FFFD</char>).
                </fos:meaning>
                <fos:type>xs:boolean</fos:type>
                <fos:default>false</fos:default>
@@ -1107,6 +1106,10 @@ return file:read-text($path)
       <fos:change issue="2016" PR="2077" date="2024-07-02">
         <p>The normalization of newlines has been made explicit.</p>
       </fos:change>
+      <fos:change issue="2460" PR="2510" date="2026-03-11">
+         <p>A fallback option is now provided to address characters that cannot be
+         decoded or are not permitted.</p>
+      </fos:change>
     </fos:changes>
   </fos:function>
 
@@ -1148,11 +1151,10 @@ return file:read-text($path)
             </fos:option>
             <fos:option key="fallback">
                <fos:meaning>
-                  If <code>$fallback</code> is true, any character
-                  that is not a <xtermref spec="FO40" ref="dt-permitted-character"/>
+                  If <code>$fallback</code> is true, any character that 
+                  cannot be decoded or that is not a <xtermref spec="FO40" ref="dt-permitted-character"/>
                   is replaced by the Unicode replacement character
-                  (<code>char(0xFFFD)</code>). If it is not provided or is provided
-                  with the value false, any such character raises an error.
+                  (<char>U+FFFD</char>).
                </fos:meaning>
                <fos:type>xs:boolean</fos:type>
                <fos:default>false</fos:default>
@@ -1190,6 +1192,9 @@ return (
     <fos:changes>
       <fos:change issue="2016" PR="2077" date="2024-07-02">
         <p><code>$fallback</code> parameter added.</p>
+      </fos:change>
+      <fos:change issue="2460" PR="2510" date="2026-03-11">
+         <p>The <code>$fallback</code> parameter has been integrated into the options map.</p>
       </fos:change>
     </fos:changes>
   </fos:function>

--- a/specifications/EXPath/file/src/function-catalog.xml
+++ b/specifications/EXPath/file/src/function-catalog.xml
@@ -1061,7 +1061,7 @@ return file:read-text($path)
                   that is not a <xtermref spec="FO40" ref="dt-permitted-character"/>
                   is replaced by the Unicode replacement character
                   (<code>char(0xFFFD)</code>). If it is not provided or is provided
-                  with the value false, any such character is an error.
+                  with the value false, any such character raises an error.
                </fos:meaning>
                <fos:type>xs:boolean</fos:type>
                <fos:default>false</fos:default>
@@ -1152,19 +1152,12 @@ return file:read-text($path)
                   that is not a <xtermref spec="FO40" ref="dt-permitted-character"/>
                   is replaced by the Unicode replacement character
                   (<code>char(0xFFFD)</code>). If it is not provided or is provided
-                  with the value false, any such character is an error.
+                  with the value false, any such character raises an error.
                </fos:meaning>
                <fos:type>xs:boolean</fos:type>
                <fos:default>false</fos:default>
             </fos:option>
          </fos:options>
-
-      <p>By default, characters that are not
-      <xtermref spec="FO40" ref="dt-permitted-character"/> will be rejected.
-      A fallback function can be provided in the <code>$options</code> to remap non-permitted characters.
-      One such function, <code>fn { char(0xFFFD) }</code>, replaces all non-permitted
-      characters with the Unicode replacement character.
-      </p>
     </fos:rules>
     <fos:errors>
       <p>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19547,6 +19547,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                   with the value false, any such character is an error.
                </fos:meaning>
                <fos:type>xs:boolean</fos:type>
+               <fos:default>false</fos:default>
             </fos:option>
          </fos:options>
                 
@@ -19757,6 +19758,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                   with the value false, any such character is an error.
                </fos:meaning>
                <fos:type>xs:boolean</fos:type>
+               <fos:default>false</fos:default>
             </fos:option>
          </fos:options>
         

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19540,11 +19540,10 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             </fos:option>
             <fos:option key="fallback">
                <fos:meaning>
-                  If <code>$fallback</code> is true, any character
-                  that is not a <xtermref spec="FO40" ref="dt-permitted-character"/>
+                  If <code>$fallback</code> is true, any character that 
+                  cannot be decoded or that is not a <termref def="dt-permitted-character"/>
                   is replaced by the Unicode replacement character
-                  (<code>char(0xFFFD)</code>). If it is not provided or is provided
-                  with the value false, any such character is an error.
+                  (<char>U+FFFD</char>).
                </fos:meaning>
                <fos:type>xs:boolean</fos:type>
                <fos:default>false</fos:default>
@@ -19712,6 +19711,10 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             <p>The specification now describes in more detail how to determine the effective
                encoding value.</p>
          </fos:change>
+         <fos:change issue="2460" PR="2510" date="2026-03-11">
+            <p>A fallback option is now provided to address characters that cannot be
+            decoded or are not permitted.</p>
+         </fos:change>
       </fos:changes>
    </fos:function>
    <fos:function name="unparsed-text-lines" prefix="fn">
@@ -19751,11 +19754,10 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             </fos:option>
             <fos:option key="fallback">
                <fos:meaning>
-                  If <code>$fallback</code> is true, any character
-                  that is not a <xtermref spec="FO40" ref="dt-permitted-character"/>
+                  If <code>$fallback</code> is true, any character that 
+                  cannot be decoded or that is not a <termref def="dt-permitted-character"/>
                   is replaced by the Unicode replacement character
-                  (<code>char(0xFFFD)</code>). If it is not provided or is provided
-                  with the value false, any such character is an error.
+                  (<char>U+FFFD</char>).
                </fos:meaning>
                <fos:type>xs:boolean</fos:type>
                <fos:default>false</fos:default>
@@ -19793,6 +19795,10 @@ return $lines[not(position() = last() and . = '')]
       <fos:changes>
          <fos:change issue="1116 1278" PR="1117 1279" date="2024-05-21">
             <p>The <code>$options</code> parameter has been added.</p>
+         </fos:change>
+         <fos:change issue="2460" PR="2510" date="2026-03-11">
+            <p>A fallback option is now provided to address characters that cannot be
+            decoded or are not permitted.</p>
          </fos:change>
       </fos:changes>
    </fos:function>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19538,6 +19538,16 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                   </fos:value>
                </fos:values>
             </fos:option>
+            <fos:option key="fallback">
+               <fos:meaning>
+                  If <code>$fallback</code> is true, any character
+                  that is not a <xtermref spec="FO40" ref="dt-permitted-character"/>
+                  is replaced by the Unicode replacement character
+                  (<code>char(0xFFFD)</code>). If it is not provided or is provided
+                  with the value false, any such character is an error.
+               </fos:meaning>
+               <fos:type>xs:boolean</fos:type>
+            </fos:option>
          </fos:options>
                 
          <p>The way in which an absolute URI is dereferenced to obtain an external resource is 
@@ -19738,8 +19748,17 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                <fos:type>xs:string?</fos:type>
                <fos:default>()</fos:default>
             </fos:option>
+            <fos:option key="fallback">
+               <fos:meaning>
+                  If <code>$fallback</code> is true, any character
+                  that is not a <xtermref spec="FO40" ref="dt-permitted-character"/>
+                  is replaced by the Unicode replacement character
+                  (<code>char(0xFFFD)</code>). If it is not provided or is provided
+                  with the value false, any such character is an error.
+               </fos:meaning>
+               <fos:type>xs:boolean</fos:type>
+            </fos:option>
          </fos:options>
-         
         
          <p>The result of the function is the same as the result of the expression:</p>
          


### PR DESCRIPTION
Just make the fallback option a boolean.

I propose this as an alternative to #2467 