### PR TITLE
2475 Unification of type syntax

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -2700,10 +2700,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
       </g:choice>
       <g:optional>
         <g:string>,</g:string>
-        <g:choice>
-          <g:string>*</g:string>
-          <g:ref name="SequenceType"/>
-        </g:choice>
+        <g:ref name="SequenceType"/>
       </g:optional>
     </g:optional>
     <g:string>)</g:string>   

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -121,7 +121,7 @@ apply.
   <!--<g:production name="TypePattern" if="xslt40-patterns">
     <g:choice name="TypePatternChoices">
       <g:ref name="WrappedItemTest" lookahead="2"/>
-      <g:ref name="AnyItemTest" lookahead="2"/>
+      <g:ref name="AnyItemType" lookahead="2"/>
       <g:ref name="FunctionType" lookahead="2" if="xpath40 xquery40  xslt40-patterns"/>
       <g:ref name="MapType" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
       <g:ref name="ArrayType" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
@@ -1947,7 +1947,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   <g:production name="TypeTest">
     <g:choice>
       <g:ref name="GNodeType"/>
-      <g:ref name="NodeKindTest"/>
+      <g:ref name="XNodeType"/>
       <g:ref name="JNodeType"/>
     </g:choice>
   </g:production>
@@ -2665,8 +2665,8 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   
   <g:production name="RegularItemType">
     <g:choice>
-      <g:ref name="AnyItemTest" lookahead="2"/>
-      <g:ref name="NodeKindTest" lookahead="2"/>
+      <g:ref name="AnyItemType" lookahead="2"/>
+      <g:ref name="XNodeType" lookahead="2"/>
       <g:ref name="GNodeType"/>
       <g:ref name="JNodeType"/>
       <g:ref name="MapType" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
@@ -2676,7 +2676,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     </g:choice>
   </g:production>
   
-  <g:production name="AnyItemTest" >
+  <g:production name="AnyItemType" >
     <g:string process-value="yes">item</g:string>
     <g:string>(</g:string>
     <g:string>)</g:string>   
@@ -2715,62 +2715,62 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   </g:production>
 
  
-  <g:production name="NodeKindTest" node-type="void">
-    <g:choice break="true" name="NodeKindTestChoice">
-      <g:ref name="DocumentTest" />
-      <g:ref name="ElementTest" />
-      <g:ref name="AttributeTest" />
-      <g:ref name="SchemaElementTest" />
-      <g:ref name="SchemaAttributeTest" />
-      <g:ref name="PITest"/>
-      <g:ref name="CommentTest"/>
-      <g:ref name="TextTest"/>
-      <g:ref name="NamespaceNodeTest" if="xpath40 xquery40  xslt40-patterns"/>
-      <g:ref name="AnyNodeKindTest"/>
+  <g:production name="XNodeType" node-type="void">
+    <g:choice break="true" name="XNodeTypeChoice">
+      <g:ref name="DocumentNodeType" />
+      <g:ref name="ElementNodeType" />
+      <g:ref name="AttributeNodeType" />
+      <g:ref name="SchemaElementNodeType" />
+      <g:ref name="SchemaAttributeNodeType" />
+      <g:ref name="ProcessingInstructionNodeType"/>
+      <g:ref name="CommentNodeType"/>
+      <g:ref name="TextNodeType"/>
+      <g:ref name="NamespaceNodeType" if="xpath40 xquery40  xslt40-patterns"/>
+      <g:ref name="AnyXNodeType"/>
     </g:choice>
   </g:production>
 
-  <g:production name="AnyNodeKindTest">
+  <g:production name="AnyXNodeType">
     <g:string>node</g:string>
     <g:string>(</g:string>
     <g:string>)</g:string>
   </g:production>
 
-  <g:production name="DocumentTest" >
+  <g:production name="DocumentNodeType" >
     <g:string>document-node</g:string>
     <g:string>(</g:string>
-    <g:optional name="OptionalDocumentTestBody">
-      <g:choice name="DocumentTestBodyChoice">
-        <g:ref name="ElementTest"/>
-        <g:ref name="SchemaElementTest"/>
+    <g:optional name="OptionalDocumentNodeTypeBody">
+      <g:choice name="DocumentNodeTypeBodyChoice">
+        <g:ref name="ElementNodeType"/>
+        <g:ref name="SchemaElementNodeType"/>
         <g:ref name="NameTestUnion"/>
       </g:choice>
     </g:optional>
     <g:string>)</g:string>
   </g:production>
 
-  <g:production name="TextTest">
+  <g:production name="TextNodeType">
     <g:string>text</g:string>
     <g:string>(</g:string>
     <g:string>)</g:string>
   </g:production>
 
-  <g:production name="CommentTest">
+  <g:production name="CommentNodeType">
     <g:string>comment</g:string>
     <g:string>(</g:string>
     <g:string>)</g:string>
   </g:production>
 
-  <g:production name="NamespaceNodeTest" if="xpath40 xquery40  xslt40-patterns">
+  <g:production name="NamespaceNodeType" if="xpath40 xquery40  xslt40-patterns">
     <g:string>namespace-node</g:string>
     <g:string>(</g:string>
     <g:string>)</g:string>
   </g:production>
 
-  <g:production name="PITest">
+  <g:production name="ProcessingInstructionNodeType">
     <g:string>processing-instruction</g:string>
     <g:string>(</g:string>
-    <g:optional name="OptionalPITestBody">
+    <g:optional name="OptionalProcessingInstructionNodeTypeBody">
       <g:choice name="NCNameForPIOrStringLit">
         <g:ref name="NCName" />
         <g:ref name="StringLiteral"/>
@@ -2779,12 +2779,12 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:string>)</g:string>
   </g:production>
 
-  <g:production name="AttributeTest" >
+  <g:production name="AttributeNodeType" >
     <g:string>attribute</g:string>
     <g:string>(</g:string>
-    <g:optional name="OptionalAttributeTestBody">
+    <g:optional name="OptionalAttributeNodeTypeBody">
       <g:ref name="NameTestUnion"/>
-      <g:optional name="AttributeTestBodyOptionalParam">
+      <g:optional name="AttributeNodeTypeBodyOptionalParam">
         <g:string>,</g:string>
         <g:ref name="TypeName"/>
       </g:optional>
@@ -2792,19 +2792,19 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:string>)</g:string>
   </g:production>
 
-  <g:production name="SchemaAttributeTest" >
+  <g:production name="SchemaAttributeNodeType" >
     <g:string>schema-attribute</g:string>
     <g:string>(</g:string>
     <g:ref name="AttributeName"/>
     <g:string>)</g:string>
   </g:production>
 
-  <g:production name="ElementTest" >
+  <g:production name="ElementNodeType" >
     <g:string>element</g:string>
     <g:string>(</g:string>
-    <g:optional name="OptionalElementTestBody">
+    <g:optional name="OptionalElementNodeTypeBody">
       <g:ref name="NameTestUnion"/>
-      <g:optional name="ElementTestBodyOptionalParam">
+      <g:optional name="ElementNodeTypeBodyOptionalParam">
         <g:string>,</g:string>
         <g:ref name="TypeName"/>
         <g:optional name="Nillable">
@@ -2815,7 +2815,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:string>)</g:string>
   </g:production>
 
-  <g:production name="SchemaElementTest" >
+  <g:production name="SchemaElementNodeType" >
     <g:string>schema-element</g:string>
     <g:string>(</g:string>
     <g:ref name="ElementName"/>

--- a/specifications/xquery-40/src/ebnf.xml
+++ b/specifications/xquery-40/src/ebnf.xml
@@ -317,8 +317,8 @@
         <head>reserved-function-names</head>
         <p>Unprefixed function names spelled the same way as language keywords could make the
           language impossible to parse. For instance, <code>element(foo)</code> could be taken either as
-          a <nt def="FunctionCall">FunctionCall</nt> or as an <nt def="ElementTest"
-            >ElementTest</nt>. Therefore, an unprefixed function name must not be any of the names in
+          a <nt def="FunctionCall">FunctionCall</nt> or as an <nt def="ElementNodeType"/>. 
+          Therefore, an unprefixed function name must not be any of the names in
             <specref ref="id-reserved-fn-names"/>.</p>
 
         <p>A function named <code>if</code> can be called by binding its namespace to a prefix and using the

--- a/specifications/xquery-40/src/errors.xml
+++ b/specifications/xquery-40/src/errors.xml
@@ -66,8 +66,8 @@
          <p> It is a <termref def="dt-static-error">static error</termref> if an expression refers
             to an element name, attribute name, schema type name, or variable name
             that is not defined in the <termref def="dt-static-context">static context</termref>,
-            except for an ElementName in an <nt def="ElementTest">ElementTest</nt> or an
-            AttributeName in an <nt def="AttributeTest">AttributeTest</nt>.</p>
+            except for an ElementName in an <nt def="ElementNodeType"/> or an
+            AttributeName in an <nt def="AttributeNodeType"/>.</p>
       </error>
 
 

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -2667,9 +2667,8 @@ or more of these constraints is not satisfied.</p>
                         def="dt-in-scope-variables"/> or <termref def="dt-statically-known-function-definitions"/>
                          must be in the <termref def="dt-issd"
                         >in-scope schema definitions</termref>, unless it is an element name referenced as part of an <nt
-                        def="ElementTest"
-                        >ElementTest</nt> or an attribute name referenced as part of an <nt
-                        def="AttributeTest">AttributeTest</nt>.</p>
+                        def="ElementNodeType"/> or an attribute name referenced as part of an <nt
+                        def="AttributeNodeType"/>.</p>
                </item>
 
                <item>
@@ -4961,8 +4960,7 @@ declare variable $orange-fruit as my:fruit := "orange";
                         <code>document-node(</code>
                         <emph>E</emph>
                         <code>)</code>, where <var>E</var> is an <nt
-                           def="ElementTest">ElementTest</nt> or <nt def="SchemaElementTest"
-                           >SchemaElementTest</nt> (see <specref
+                           def="ElementNodeType"/> or <nt def="SchemaElementNodeType"/> (see <specref
                            ref="id-element-test"/> and <specref ref="id-schema-element-test"/>)
     matches any document node whose children comprise (in any order) zero or more
     comment and processing instruction nodes, zero text nodes, and exactly one element node,
@@ -4971,9 +4969,8 @@ declare variable $orange-fruit as my:fruit := "orange";
     <code role="parse-test"
                            >document-node(element(book))</code> matches a document node
     containing
-    exactly one element node that is matched by the ElementTest
-    <code
-                           role="parse-test">element(book)</code>.</p>
+    exactly one element node that is matched by the <nt def="ElementNodeType"/>
+    <code role="parse-test">element(book)</code>.</p>
                   </item>
                   
                   <item><p>The construct <code>document-node(<var>NTU</var>)</code>, where
@@ -4988,17 +4985,12 @@ declare variable $orange-fruit as my:fruit := "orange";
  
                   <item>
                      <p>An <nt def="ItemType">ItemType</nt> that is an
-    <nt def="ElementTest"
-                           >ElementTest</nt>, <nt def="SchemaElementTest"
-                           >SchemaElementTest</nt>, <nt def="AttributeTest"
-                           >AttributeTest</nt>,
-    <nt def="SchemaAttributeTest"
-                           >SchemaAttributeTest</nt>, or <nt def="FunctionType"
-                        >FunctionType</nt> matches an item as described in the following sections.
-    </p>
-                  </item>
-
-                  
+                     <nt def="ElementNodeType"/>, <nt def="SchemaElementNodeType"/>, 
+                        <nt def="AttributeNodeType"/>,
+                     <nt def="SchemaAttributeNodeType"/>, or <nt def="FunctionType"/> 
+                        matches an item as described in the following sections.
+                     </p>
+                  </item>                  
                </ulist>
             </div4>
                   
@@ -5024,13 +5016,12 @@ declare variable $orange-fruit as my:fruit := "orange";
                </changes>
 
                <scrap>
-                  <prodrecap ref="ElementTest"/>
+                  <prodrecap ref="ElementNodeType"/>
                </scrap>
 
 
                <p>
-    An <nt def="ElementTest"
-                     >ElementTest</nt> is used to match an
+    An <nt def="ElementNodeType"/> is used to match an
     element node by its name and/or <termref
                      def="dt-type-annotation">type annotation</termref>.
   </p>
@@ -5064,10 +5055,10 @@ declare variable $orange-fruit as my:fruit := "orange";
                <note><p><termref
                      def="dt-substitution-group"
                      >Substitution groups</termref> do not affect the semantics of <nt
-                        def="ElementTest">ElementTest</nt>.</p></note>
+                        def="ElementNodeType"/>.</p></note>
          
          
-               <p diff="chg" at="Issue23">An <nt def="ElementTest">ElementTest</nt>
+               <p diff="chg" at="Issue23">An <nt def="ElementNodeType"/>
                   <var>ET</var> matches an item <var>E</var> if the following conditions
                   are satisfied:</p>
                      
@@ -5098,7 +5089,7 @@ declare variable $orange-fruit as my:fruit := "orange";
                            or includes a <nt def="TypeName">TypeName</nt> followed by the symbol <code>?</code>.</p></item>
                      </olist>
 
-               <p>Here are some examples of <nt def="ElementTest">ElementTests</nt>:</p>
+               <p>Here are some examples of <nt def="ElementNodeType">ElementNodeTypes</nt>:</p>
 
 
                <olist>
@@ -5218,11 +5209,11 @@ matches any nilled or non-nilled element node whose type annotation is
                <p diff="add" at="Issue451">
                   Where a <nt def="TypeName">TypeName</nt> <var>T</var> (other than 
                   <code>xs:anyType</code> or <code>xs:untyped</code>) is included in an 
-                  <nt def="ElementTest">ElementTest</nt> <var>T</var>, an element node will only
+                  <nt def="ElementNodeType"/> <var>T</var>, an element node will only
                   match the test if it has been validated against a schema that 
                   defines type <var>T</var>; furthermore, <var>T</var> must be
                   present in the <termref def="dt-issd"/> of the static context of the
-                  <nt def="ElementTest">ElementTest</nt>. Although it is guaranteed that
+                  <nt def="ElementNodeType"/>. Although it is guaranteed that
                   type <var>T</var> will have 
                   <xtermref spec="DM40" ref="dt-schema-compatible">compatible</xtermref>
                   definitions in the schema that was used for validation and in the
@@ -5246,19 +5237,17 @@ matches any nilled or non-nilled element node whose type annotation is
                <head>Schema Element Types</head>
 
                <scrap>
-                  <prodrecap ref="SchemaElementTest"/>
+                  <prodrecap ref="SchemaElementNodeType"/>
                </scrap>
 
                <p>
-    A <nt def="SchemaElementTest"
-                     >SchemaElementTest</nt> matches an element node against a corresponding
+    A <nt def="SchemaElementNodeType"/> matches an element node against a corresponding
     element declaration found in the <termref
                      def="dt-is-elems">in-scope element declarations</termref>.
   </p>
 
                <p>
-    The <nt def="ElementName">ElementName</nt> of a <nt def="SchemaElementTest"
-                     >SchemaElementTest</nt>
+    The <nt def="ElementName">ElementName</nt> of a <nt def="SchemaElementNodeType"/>
     has its prefixes expanded to a namespace URI by means of the
     <termref
                      def="dt-static-namespaces"
@@ -5268,8 +5257,7 @@ matches any nilled or non-nilled element node whose type annotation is
                   value <code>"##any"</code>, an unprefixed name represents a name in no namespace.
 
     If the <nt
-                     def="ElementName">ElementName</nt> specified in the <nt def="SchemaElementTest"
-                     >SchemaElementTest</nt>
+                     def="ElementName">ElementName</nt> specified in the <nt def="SchemaElementNodeType"/>
     is not found in the <termref def="dt-is-elems"
                      >in-scope element declarations</termref>, a
     <termref def="dt-static-error"
@@ -5277,8 +5265,7 @@ matches any nilled or non-nilled element node whose type annotation is
   </p>
 
                <p>
-    A <nt def="SchemaElementTest"
-                  >SchemaElementTest</nt> matches a candidate element node if all of the following conditions are satisfied:
+    A <nt def="SchemaElementNodeType"/> matches a candidate element node if all of the following conditions are satisfied:
   </p>
 
                <olist>
@@ -5351,7 +5338,7 @@ matches any nilled or non-nilled element node whose type annotation is
                   that was used for validation.</p>
                </note>
 
-               <p>Example: The <nt def="SchemaElementTest">SchemaElementTest</nt>
+               <p>Example: The <nt def="SchemaElementNodeType"/>
                   <code role="parse-test">schema-element(customer)</code> matches a candidate element node 
                   in the following two situations (among others):
 <olist>
@@ -5379,7 +5366,7 @@ matches any nilled or non-nilled element node whose type annotation is
                   <var>E</var> (whose name is <var>N</var>)
                   differs from the schema <var>Y</var> represented by the
                   <termref def="dt-issd"/> in the static context of the 
-                  <nt def="SchemaElementTest">SchemaElementTest</nt>, the following
+                  <nt def="SchemaElementNodeType"/>, the following
                   considerations apply:</p>
                
                <ulist>
@@ -5417,13 +5404,12 @@ matches any nilled or non-nilled element node whose type annotation is
                </changes>
 
                <scrap>
-                  <prodrecap id="AttributeTest" ref="AttributeTest"/>
+                  <prodrecap id="AttributeNodeType" ref="AttributeNodeType"/>
                </scrap>
 
 
                <p>
-    An <nt def="AttributeTest"
-                     >AttributeTest</nt> is used to match an
+    An <nt def="AttributeNodeType"/> is used to match an
     attribute node by its name and/or <termref
                      def="dt-type-annotation">type annotation</termref>.
   </p>
@@ -5444,7 +5430,7 @@ matches any nilled or non-nilled element node whose type annotation is
  
                
                   
-                  <p diff="chg" at="Issue23">An <nt def="AttributeTest">AttributeTest</nt>
+                  <p diff="chg" at="Issue23">An <nt def="AttributeNodeType"/>
                      <var>AT</var> matches an item <var>A</var> if the following conditions
                      are satisfied:</p>
                   
@@ -5471,8 +5457,7 @@ matches any nilled or non-nilled element node whose type annotation is
                         then the <termref def="dt-type-annotation"/> of the attribute node <var>A</var>
                         <termref def="dt-derives-from"/> <var>T</var>.</p></item>
                   </olist>
-    <p>Here are some examples of <nt def="AttributeTest"
-                  >AttributeTests</nt>:
+    <p>Here are some examples of <nt def="AttributeNodeType"/>s:
   </p>
                <ulist>
                   <item>
@@ -5551,7 +5536,7 @@ name.</p>
 
                </ulist>
                <p diff="add" at="Issue451">
-                  Unlike the situation with an <nt def="ElementTest">ElementTest</nt>,
+                  Unlike the situation with an <nt def="ElementNodeType"/>,
                   few problems arise if the attribute was validated using a different
                   schema. This is because simple types can never be derived by extension,
                   and attributes do not have substitution groups.</p>
@@ -5566,19 +5551,17 @@ name.</p>
                <head>Schema Attribute Types</head>
 
                <scrap>
-                  <prodrecap ref="SchemaAttributeTest"/>
+                  <prodrecap ref="SchemaAttributeNodeType"/>
                </scrap>
 
                <p>
-    A <nt def="SchemaAttributeTest"
-                     >SchemaAttributeTest</nt> matches an attribute node against a corresponding
+    A <nt def="SchemaAttributeNodeType"/> matches an attribute node against a corresponding
     attribute declaration found in the <termref
                      def="dt-is-attrs">in-scope attribute declarations</termref>.
   </p>
                <p>
     The <nt def="AttributeName">AttributeName</nt> of a <nt
-                     def="SchemaAttributeTest"
-                     >SchemaAttributeTest</nt>
+                     def="SchemaAttributeNodeType"/>
     has its prefixes expanded to a namespace URI by means of the
     <termref
                      def="dt-static-namespaces"
@@ -5588,8 +5571,7 @@ name.</p>
 
     If the <nt
                      def="AttributeName">AttributeName</nt> specified in the <nt
-                     def="SchemaAttributeTest"
-                     >SchemaAttributeTest</nt>
+                     def="SchemaAttributeNodeType"/>
     is not found in the <termref def="dt-is-attrs"
                      >in-scope attribute declarations</termref>, a
     <termref
@@ -5597,8 +5579,7 @@ name.</p>
                      code="0008"/>.
   </p>
                <p>
-    A <nt def="SchemaAttributeTest"
-                  >SchemaAttributeTest</nt> matches a candidate attribute node if both of the
+    A <nt def="SchemaAttributeNodeType"/> matches a candidate attribute node if both of the
   following conditions are satisfied:
   </p>
                <olist>
@@ -5618,13 +5599,13 @@ name.</p>
                            >in-scope attribute declarations</termref>.</p>
                   </item>
                </olist>
-               <p>Example: The <nt def="SchemaAttributeTest">SchemaAttributeTest</nt>
+               <p>Example: The <nt def="SchemaAttributeNodeType"/>
                   <code role="parse-test"
                      >schema-attribute(color)</code> matches a candidate attribute node if <code>color</code> is a top-level attribute declaration in the <termref
                      def="dt-is-attrs"
                      >in-scope attribute declarations</termref>, the name of the candidate node is <code>color</code>, and the type annotation of the candidate node  is the same as or derived from the schema type declared for the <code>color</code> attribute.</p>
                <p diff="add" at="Issue451">
-                  Unlike the situation with a <nt def="SchemaElementTest">SchemaElementTest</nt>,
+                  Unlike the situation with a <nt def="SchemaElementNodeType"/>,
                   few problems arise if the attribute was validated using a different
                   schema. This is because attributes do not have substitution groups.</p>
             </div5>
@@ -6990,7 +6971,7 @@ declare record Particle (
                   
                      <olist>
                         <item>
-                           <p><var>A</var> is a <nt def="NodeKindTest">NodeKindTest</nt> and <var>B</var> is <code>node()</code>.</p>
+                           <p><var>A</var> is an <nt def="XNodeType"/> and <var>B</var> is <code>node()</code>.</p>
                            <example>
                               <head>Example:</head>
                               <p><code>comment() ⊆ node()</code></p>
@@ -7099,8 +7080,8 @@ declare record Particle (
                   
                   <olist>
                      <item>
-                        <p><var>A</var> is an <nt def="ElementTest">ElementTest</nt> 
-                           or <nt def="SchemaElementTest">SchemaElementTest</nt> and
+                        <p><var>A</var> is an <nt def="ElementNodeType"/> 
+                           or <nt def="SchemaElementNodeType"/> and
                            <var>B</var> is either <code>element()</code> or <code>element(*)</code>
                         </p>
                      </item>
@@ -7242,8 +7223,7 @@ declare record Particle (
                   <p>Given item types <var>A</var> and <var>B</var>, <code><var>A</var> ⊆ <var>B</var></code> is true if any of the following apply:</p>
                     <olist>
                         <item>
-                           <p><var>A</var> is an <nt
-                                 def="AttributeTest">AttributeTest</nt> 
+                           <p><var>A</var> is an <nt def="AttributeNodeType"/> 
                               and
                               <var>B</var> is either <code>attribute()</code> or <code>attribute(*)</code>
                            </p>
@@ -12939,7 +12919,7 @@ return <var>Axis</var>::*[some($selector, atomic-equal(?, jkey()))]
         </note>       -->
                
         <p>The syntax
-		  and semantics of <nt def="NodeKindTest">NodeKindTest</nt> and <nt def="JNodeType">JNodeType</nt>
+		  and semantics of <nt def="XNodeType"/> and <nt def="JNodeType"/>
            are described in <specref ref="id-sequencetype-syntax"/> and <specref ref="id-sequencetype-matching"/>.</p>
         <p>Shown below are further examples of type tests that might
 		  be used in path expressions selecting within an XTree:</p>
@@ -13082,7 +13062,7 @@ return <var>Axis</var>::*[some($selector, atomic-equal(?, jkey()))]
                         <code role="parse-test"
                            >document-node(element(book))</code>
                   matches any document node whose children consist of
-                  a single element node that satisfies the <nt def="ElementTest">ElementTest</nt>
+                  a single element node that satisfies the <nt def="ElementNodeType"/>
                         <code role="parse-test"
                         >element(book)</code>, interleaved with zero or more
                   comments and processing
@@ -13621,13 +13601,12 @@ last <code>chapter</code> or <code>appendix</code> child of the context node.</p
     <code>child</code>, with two exceptions:
 
     (1) if the <nt
-                        def="NodeTest">NodeTest</nt> in an axis step contains an <nt
-                        def="AttributeTest">AttributeTest</nt> or <nt def="SchemaAttributeTest"
-                        >SchemaAttributeTest</nt> then the
+                        def="NodeTest">NodeTest</nt> in an axis step contains an 
+                     <nt def="AttributeNodeType"/> or <nt def="SchemaAttributeNodeType"/> then the
     default axis is <code>attribute</code>;     
     (2) if the <nt
                         def="NodeTest">NodeTest</nt> in an axis step is a <nt
-                        def="NamespaceNodeTest">NamespaceNodeTest</nt>
+                        def="NamespaceNodeType"/>
                      <phrase role="xquery">then a static error
     is raised <errorref class="ST"
                            code="0134"/>.</phrase>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -6424,7 +6424,7 @@ declare record Particle (
                <p>Specifically:</p>
                
                <ulist>
-                  <item><p>The forms <code>jnode()</code>, <code>jnode(*)</code>, and <code>jnode(*, *)</code> are
+                  <item><p>The forms <code>jnode()</code> and <code>jnode(*)</code> are
                   equivalent, and match any JNode.</p></item>
                   <item><p>The first argument constrains the value of the <term>·jkey·</term> property:</p>
                      <ulist>
@@ -6445,7 +6445,7 @@ declare record Particle (
                   <item>
                      <p>The second argument, if present, constrains the <term>·jvalue·</term> property of the JNode:</p>
                      <ulist>
-                        <item><p>If the argument is omitted, or is <code>*</code>, then there are no constraints on the 
+                        <item><p>If the argument is omitted then there are no constraints on the 
                         <term>·jvalue·</term> property</p></item>
                         <item><p>If the argument is a sequence type, then the value of the <term>·jvalue·</term> 
                               property of the JNode must match this sequence type.</p></item>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -12501,11 +12501,11 @@ return $tree =?> depth()]]></eg>
                         <p><emph>Patterns matching JNodes</emph></p>
                         <olist>
                            <item>
-                              <p>The patterns <code>jnode()</code>, <code>jnode(*)</code>, and <code>jnode(*, *)</code> 
+                              <p>The patterns <code>jnode()</code>, <code>jnode(*)</code>, and <code>jnode(*, item()*)</code> 
                                  are equivalent, and match any JNode.</p>
                            </item>
                            <item>
-                              <p><code>jnode("date of birth", *)</code> matches any JNode representing a map
+                              <p><code>jnode("date of birth")</code> matches any JNode representing a map
                                  entry with key <code>"date of birth"</code>.</p>
                            </item>
                            <item>
@@ -13003,7 +13003,7 @@ return $tree =?> depth()]]></eg>
                      JNode whose ·jvalue· is a map having an <code>Author</code> entry with the value
                      <code>"Dickens"</code>, a <code>Title</code> entry with any value, and optionally
                      other entries.</p></item>
-                  <item><p>The pattern <code>jnode(*, *)[jkey() = current-date()]</code> matches any
+                  <item><p>The pattern <code>jnode(*)[jkey() = current-date()]</code> matches any
                      JNode whose ·jkey· property is an <code>xs:date</code> value equal to the current date.
                      The comparison uses the implicit timezone from the dynamic context. The rules for error
                   handling in patterns ensure that any JNode whose ·jkey· value is of a type other
@@ -13464,18 +13464,18 @@ return $tree =?> depth()]]></eg>
                </item>
                   
                   <item>
-                     <p>The default priority of the pattern <code>jnode(*, *)</code> is −0.5.</p>
+                     <p>The default priority of the pattern <code>jnode(*)</code> is −0.5.</p>
                      <p>The default priority of the equivalent pattern 
                         <code>jnode(*, item()*)</code> is also −0.5.</p>
                   </item>
                   <item>
-                     <p>The default priority of the pattern <code>jnode(<var>S</var>, *)</code>,
+                     <p>The default priority of the pattern <code>jnode(<var>S</var>)</code>,
                         where <var>S</var> is any constant, is 0 (zero).</p>
                      <p>The default priority of the equivalent pattern <code>jnode(<var>S</var>, item()*)</code>,
                         where <var>S</var> is any constant, is also 0 (zero).</p>
                   </item>
                   <item>
-                     <p>The default priority of the pattern <code>jnode((), *)</code> is 0 (zero).</p>
+                     <p>The default priority of the pattern <code>jnode(())</code> is 0 (zero).</p>
                      <p>The default priority of the equivalent pattern <code>jnode((), item()*)</code> is also 0 (zero).</p>
                   </item>
                   <item>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -12815,7 +12815,7 @@ return $tree =?> depth()]]></eg>
                         <p>The <code>NodeTest</code> is adjusted to ensure that the pattern will (in most cases) match
                            XNodes or JNodes but not both. Specifically, if the principal node kind of the
                            axis is <code>element</code>, then any <code>Selector</code> within the <code>NodeTest</code>
-                           that takes the form of an <code>EQName</code> or <code>Wildcard</code> is wrapped in an <code>ElementTest</code> 
+                           that takes the form of an <code>EQName</code> or <code>Wildcard</code> is wrapped in an <nt def="ElementNodeType"/> 
                            so it only selects element nodes. For example, <code>match="*"</code> is interpreted as
                            <code>match="element(*)"</code>, and <code>match="employee"</code> is interpreted
                            as <code>match="element(employee)"</code>.</p>
@@ -13102,7 +13102,7 @@ return $tree =?> depth()]]></eg>
             <head>Default Priority for Patterns</head>
             <changes>
                <change issue="1394" PR="1442" date="2024-09-15">
-                  Default priorities are added for new forms of <code>ElementTest</code> and <code>AttributeTest</code>,
+                  Default priorities are added for new forms of <nt def="ElementNodeType"/> and <nt def="AttributeNodeType"/>,
                   for example <code>element(p:*)</code> and <code>element(a|b)</code>.
                </change>
                <change issue="1770" PR="1772" date="2025-02-11">
@@ -13151,8 +13151,8 @@ return $tree =?> depth()]]></eg>
                   <item><p>For the item type <code>item()</code>, the default priority is -1 (minus one).</p></item>
                                    
                   <item><p>For any item type that is a 
-                        <xnt spec="XP40" ref="GNodeType"/>, <xnt spec="XP40" ref="NodeKindTest"/>
-                        or <xnt spec="XP40" ref="JNodeType"/>
+                        <nt def="GNodeType"/>, <nt def="XNodeType"/>
+                        or <nt def="JNodeType"/>
                   (for example <code>jnode(*)</code>, <code>element()</code> or <code>element(N)</code>), the default
                   priority is the same as that of the corresponding GNode Pattern: 
                   see <specref ref="default-priority-for-gnode-patterns"/>.</p></item>
@@ -13275,8 +13275,8 @@ return $tree =?> depth()]]></eg>
                </item>
                <item>
                   <p>If the pattern is a <nt def="PathExprP">PathExprP</nt> taking the form of an
-                        <xnt spec="XP40" ref="prod-xpath40-ElementTest">ElementTest</xnt> 
-                     or <xnt spec="XP40" ref="prod-xpath40-AttributeTest">AttributeTest</xnt>, optionally
+                        <xnt spec="XP40" ref="prod-xpath40-ElementNodeType">ElementNodeType</xnt> 
+                     or <xnt spec="XP40" ref="prod-xpath40-AttributeNodeType">AttributeNodeType</xnt>, optionally
                      preceded by a <nt def="ForwardAxisP">ForwardAxisP</nt>, then the priority is as
                      shown in the table below. In this table:</p>
                      <ulist>
@@ -13424,8 +13424,8 @@ return $tree =?> depth()]]></eg>
                   </table>
                </item>
                <item><p>For a pattern such as <code>element(A|B)</code> or <code>attribute(A|B)</code>
-               (more specifically, for any <nt def="ElementTest">ElementTest</nt> or
-               <nt def="AttributeTest">AttributeTest</nt> whose <nt def="NameTestUnion">NameTestUnion</nt>
+               (more specifically, for any <nt def="ElementNodeType"/> or
+               <nt def="AttributeNodeType"/> whose <nt def="NameTestUnion">NameTestUnion</nt>
                contains more than one <nt def="NameTest">NameTest</nt>) the default priority is the
                highest of the priorities obtained by considering each of the <nt def="NameTest">NameTests</nt>
                individually.</p>
@@ -13438,10 +13438,10 @@ return $tree =?> depth()]]></eg>
                </item>
                <item>
                   <p>If the pattern is a <nt def="PathExprP">PathExprP</nt> taking the form of a
-                        <xnt spec="XP40" ref="prod-xpath40-DocumentTest">DocumentTest</xnt>, then if
-                     it includes no <xnt spec="XP40" ref="prod-xpath40-ElementTest">ElementTest</xnt> or <xnt spec="XP40" ref="prod-xpath40-SchemaElementTest">SchemaElementTest</xnt> the priority is −0.5. If it does include an
-                        <xnt spec="XP40" ref="prod-xpath40-ElementTest">ElementTest</xnt> or <xnt spec="XP40" ref="prod-xpath40-SchemaElementTest">SchemaElementTest</xnt>,
-                     then the priority is the same as the priority of that <xnt spec="XP40" ref="prod-xpath40-ElementTest">ElementTest</xnt> or <xnt spec="XP40" ref="prod-xpath40-SchemaElementTest">SchemaElementTest</xnt>, computed
+                        <nt def="DocumentNodeType"/>, then if
+                     it includes no <nt def="ElementNodeType"/> or <nt def="SchemaElementNodeType"/> the priority is −0.5. If it does include an
+                        <nt def="ElementNodeType"/> or <nt def="SchemaElementNodeType"/>,
+                     then the priority is the same as the priority of that <nt def="ElementNodeType"/> or <nt def="SchemaElementNodeType"/>, computed
                      according to the table above.</p>
                </item>
                <item>If the default namespace for elements and types is <code>#any</code>, and the pattern includes


### PR DESCRIPTION
Fix #2475 

1. Rename a number of productions, for example `ElementTest` becomes `ElementNodeType`
2. Drop the syntax `jnode(X, *)`, it is now written `jnode(X)`

I didn't implement the suggestion of extending `jnode(X)` to allow alternative key values.