### PR TITLE
2316 Add fn-prefix to record type names

### DIFF
--- a/specifications/xpath-functions-40/style/xpath-functions.xsl
+++ b/specifications/xpath-functions-40/style/xpath-functions.xsl
@@ -312,7 +312,7 @@
                     <code class="as">as&#160;</code>
                     <code>
                       <a href="#{@type-ref}">
-                        <xsl:value-of select="@type-ref"/>                
+                        <xsl:value-of select="if (contains(@type-ref, ':')) then @type-ref else 'fn:' || @type-ref"/>                
                       </a>
                       <xsl:value-of select="@type-ref-occurs"/>    
                     </code>
@@ -352,7 +352,7 @@
                     </xsl:when>
                     <xsl:when test="@return-type-ref">
                       <a href="#{replace(@return-type-ref, '[*+?]$', '')}">
-                        <xsl:value-of select="@return-type-ref"/>
+                        <xsl:value-of select="if (contains(@return-type-ref, ':')) then @return-type-ref else 'fn:' || @return-type-ref"/>
                       </a>
                       <xsl:value-of select="@return-type-ref-occurs"/>
                       <xsl:if test="@returnEmptyOk='yes'">?</xsl:if>


### PR DESCRIPTION
Stylesheet change to add the 'fn:' prefix to names of built-in-record types in function signatures

Fix #2316