### PR TITLE
2520 Atomic Data Types based on XSD 1.1

### DIFF
--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -259,8 +259,8 @@ the <bibref ref="xml-infoset"/>
 <ulist>
   <item>
     <p>Support for XML Schema types. The XML Schema recommendations
-    define features, such as structures (<bibref ref="xmlschema-1"/>)
-    and simple data types (<bibref ref="xmlschema-2"/>), that extend
+    define features, such as structures (<bibref ref="xmlschema11-1"/>)
+    and simple data types (<bibref ref="xmlschema11-2"/>), that extend
     the Infoset with precise type information.</p>
   </item>
   <item>
@@ -399,7 +399,7 @@ they relate to values in the Infoset and PSVI.</p>
     <xspecref spec="FO40" ref="func-signatures"/>.</p>
     
     <p>This document relies on the <bibref ref="xml-infoset"/> and
-    <loc href="https://www.w3.org/TR/xmlschema-1/#key-psvi">Post-Schema-Validation
+    <loc href="https://www.w3.org/TR/xmlschema11-1/#key-psvi">Post-Schema-Validation
     Infoset</loc> (PSVI). Information items
     and properties are indicated by the styles <emph role="info-item">information
     item</emph> and <emph role="infoset-property">infoset property</emph>, respectively.</p>
@@ -559,6 +559,18 @@ therefore can also be contained within sequences.</p>
     
   </div3>
 </div2>
+    
+    <div2 id="limits">
+      <head>Limits</head>
+      
+      <p>Implementations may impose limits on the size, range, or precision of values
+        (for example, on the maximum length of a sequence, or the maximum depth of nesting
+        of nodes).
+      In general all such limits are <termref def="implementation-defined"/>.</p>
+      
+      <p>In the case of atomic items, the specification requires implementations
+      to support some minimum limits: see <specref ref="atomic-type-limits"/>.</p>
+    </div2>
 
   
   </div1>
@@ -570,9 +582,9 @@ therefore can also be contained within sequences.</p>
 
 <p>The data model supports strongly typed languages such as
 <bibref ref="xpath-40"/> and <bibref ref="xquery-40"/>
-that have a type system based on <bibref ref="xmlschema-1"/>. To achieve this,
+that have a type system based on <bibref ref="xmlschema11-1"/>. To achieve this,
 the data model includes (by reference) the Schema Component Model described in
-<bibref ref="xmlschema-1"/>.
+<bibref ref="xmlschema11-1"/>.
 </p>
 
 <note>
@@ -613,6 +625,70 @@ a reference to a type definition in the Schema Component Model.
   
   &common-anyType.xml;
   
+  <div3 id="xsd-versions">
+    <head>XSD versions</head>
+    <changes>
+      <change issue="2520">The type system of XDM 4.0 is based on XSD 1.1 rather than XSD 1.0, 
+      but with concessions to allow a conformant implementation to be make use of an 
+      XSD 1.0 processor.</change>
+    </changes>
+    <p>The atomic types of XDM 4.0 are based on the definitions in XSD 1.1 (<bibref ref="xmlschema11-2"/>)
+      rather than XSD 1.0 (<bibref ref="xmlschema-2"/>). The differences between XSD versions are minor, 
+      and include the following:</p>
+    
+    <ulist>
+      <item><p>In XSD 1.1, instances of <code>xs:string</code> can include all Unicode characters
+      other than <char>U+0000</char>.</p>
+      <p>Note: implementations of XDM 4.0 may extend the set of permitted characters to include <char>U+0000</char>.</p></item>    
+      <item><p>XSD 1.1 allows instances of <code>xs:anyURI</code> to be arbitrary character strings. XSD 1.0
+      suggests that the type should only allow valid URIs, but does not define precise rules.</p></item>
+      <item><p>In XSD 1.1, the value space for <code>xs:float</code> and <code>xs:double</code> includes
+      positive and negative zero as distinct values.</p></item>
+      <item><p>In XSD 1.1, the lexical representation of an <code>xs:float</code> or <code>xs:double</code>
+      allows the form <code>+INF</code> to represent positive infinity (XSD 1.0 does not allow the leading sign).</p></item>
+      <item><p>In XSD 1.1, the definition of <code>xs:date</code>, <code>xs:dateTime</code>, <code>xs:gYear</code>,
+      and <code>xs:gYearMonth</code> includes year 0 as the year preceding 0001 CE, bringing it into line with
+      ISO 8601. XSD 1.0 allows negative years but does not allow year zero.</p></item>
+      <item><p>XSD 1.1 includes a new data type <code>xs:dateTimeStamp</code>, being a restriction of
+      <code>xs:dateTime</code> in which the timezone offset is required to be present.</p></item>
+      <item><p>XSD 1.1 includes the types <code>xs:anyAtomicType</code>, <code>xs:dayTimeDuration</code>,
+      and <code>xs:yearMonthDuration</code>, having adopted these from an earlier version of XDM.</p></item>
+    </ulist>
+    
+    <p>In addition, XSD 1.1 clarifies the rules and corrects errors in the XSD 1.0 specification.</p>
+    
+    <p>The value space of these data types in XDM 4.0 corresponds to the value space as defined in XSD 1.1.
+    Conversions to and from string representations also follow the lexical representations as defined in XSD 1.1.</p>
+   
+    
+    <p>However, because XSD 1.1 processors are not available in all environments, operations that require the use
+    of a schema processor allow a conformant implementation to be constructed using an XSD 1.0
+    processor. Specifically:</p>
+    
+    <ulist>
+      <item><p>A schema-aware processor may restrict the schemas that it can process to XSD 1.0 schemas.</p></item>
+      <item><p>Validation of XML documents against a schema may follow the XSD 1.0 rules (for example,
+      values such as <code>+INF</code> and <code>0000-01-01</code> may be deemed invalid).</p></item>
+    </ulist>
+    
+    <p>In the case of dates and times earlier than <code>0001-01-01</code>, 
+      the result of processing such dates using an XSD 1.0
+    processor is implementation-defined.</p>
+    
+    <p>XDM 4.0 implementations may impose limits on the range and precision of atomic items. XSD 1.1, with a few
+      exceptions, does not define such limits.</p>
+    
+    <note><p>The value of <code>fn:year-from-date(xs:date('-0001-01-01'))</code> is -1 (minus one)
+    in all implementations, provided that the value is within the implementation-defined range limits for dates. 
+    However, the value of <code>fn:year-from-date(@date)</code>, where
+    <code>@date</code> is an attribute node <code>date="-0001-01-01"</code>
+        validated against a schema-defined type of <code>xs:date</code>,
+    is implementation-defined: different schema processors may produce different results.</p></note>
+    
+    <note><p>Since this rule is stricter than the rule in earlier versions of the specification,
+    implementations may provide options to retain backwards-compatible behavior.</p></note>
+  </div3>
+  
 <div3 id="xs-types">
 <head>Types adopted from XML Schema</head>
   
@@ -627,7 +703,7 @@ a reference to a type definition in the Schema Component Model.
 <item>
 <p>The 19 <phrase diff="add" at="2022-11-05">primitive atomic</phrase> types defined in
 <xspecref spec="XS2" ref="built-in-primitive-datatypes"/>
-of <bibref ref="xmlschema-2"/>.</p>
+of <bibref ref="xmlschema11-2"/>.</p>
 </item>
 <item>
 <p>Three built-in list types:
@@ -798,7 +874,7 @@ the specifications do not speculate on what happens if they are not.</p>
 <p>The data model uses
 <termref def="dt-expanded-qname">expanded QNames</termref> to
 represent the names of schema types, which include the built-in
-types defined by <bibref ref="xmlschema-2"/> and the five additional types
+types defined by <bibref ref="xmlschema11-2"/> and some additional types
 defined by this specification, and may include other user- or
 implementation-defined types.</p>
 
@@ -1086,7 +1162,7 @@ model.</p>
 <p id="hier_anyAtomicType">The next diagram shows all of the
 atomic types, including the primitive simple types and the built-in
 types derived from the primitive simple types. This includes all the
-built-in datatypes defined in <bibref ref="xmlschema-2"/>. Atomic types
+built-in datatypes defined in <bibref ref="xmlschema11-2"/>. Atomic types
 act both as <termref def="dt-item-type">item types</termref> (meaning
 they can be used to declare the types of variables and function arguments),
 and as <termref def="dt-schema-type">schema types</termref> (meaning they
@@ -1175,6 +1251,60 @@ in <specref ref="xs-types"/>.</termdef></p>
   possibly <phrase diff="chg" at="2022-11-05">absent</phrase> prefix, a possibly 
   <phrase diff="chg" at="2022-11-05">absent</phrase> namespace URI, and a local
 name.</termdef> See <specref ref="qnames-and-notations"/>.</p>
+    
+    <div2 id="atomic-type-limits">
+      <head>Atomic Type Limits</head>
+      
+      <p>For some data types, implementations are required to support a minimum
+        range or precision of values. Where not otherwise stated the limits are
+                        <termref def="dt-implementation-defined"/>:</p>
+                <olist>
+                    <item>
+                        <p>For the <code>xs:decimal</code> type, the maximum number of decimal
+                            digits (<code>totalDigits</code> facet) <rfc2119>must</rfc2119> be at least 18.
+                            This limit <rfc2119>should</rfc2119> be at least 20 digits in order to 
+                            accommodate the full range of values of built-in subtypes of <code>xs:integer</code>, such as 
+                            <code>xs:long</code> and <code>xs:unsignedLong</code>.
+                        </p>
+                    </item>
+                    <item>
+                        
+
+                        <p>For the types <code>xs:date</code>, <code>xs:dateTime</code>, 
+                          <code>xs:gYear</code>, and <code>xs:gYearMonth</code> 
+                          the range of the year component must be at least 1 to 9999.</p>
+
+                        <p>For the types <code>xs:time</code>, <code>xs:dateTime</code>, and <code>xs:duration</code>: 
+                          implementations must support millisecond precision (three fractional digits)
+                          or greater.</p>
+
+                    </item>
+                    <item>
+                        <p>For the <code>xs:duration type</code>: the maximum absolute values of the
+                            years, months, days, hours, minutes, and seconds components.</p>
+                    </item>
+                    <item>
+                        <p>For the <code>xs:yearMonthDuration</code> type: the maximum absolute
+                            value, expressed as an integer number of months.</p>
+                    </item>
+                    <item>
+                        <p>For the <code>xs:dayTimeDuration</code> type: the maximum absolute value,
+                            expressed as a decimal number of seconds.</p>
+                    </item>
+                    <item>
+                        <p>For the types <code>xs:string</code>, <code>xs:hexBinary</code>,
+                                <code>xs:base64Binary</code>, <code>xs:QName</code>,
+                                <code>xs:anyURI</code>, <code>xs:NOTATION</code>, and types derived
+                            from them: limitations (if any) imposed by the implementation on lengths
+                            of values.</p>
+                    </item>
+                </olist>
+                <p>Limits imposed by an implementation need not be fixed, but 
+                  <rfc2119>may</rfc2119>  depend on environmental
+                    factors such as system resources. For example, the length of a value of type
+                        <code>xs:string</code> might be limited by available memory.</p>
+                
+    </div2>
 
 
 <div2 id="StringValue">
@@ -2159,11 +2289,11 @@ a value onto the value itself.</p>
 <note>
 <p>For atomic and list types, the mapping is the “lexical mapping”
 defined for <code>T</code> in
-<bibref ref="xmlschema-2"/>; for union types, the mapping is the
+<bibref ref="xmlschema11-2"/>; for union types, the mapping is the
 lexical mapping defined in
-<bibref ref="xmlschema-2"/> modified
+<bibref ref="xmlschema11-2"/> modified
 as appropriate by any applicable rules in
-<bibref ref="xmlschema-1"/>. The mapping, so modified, is a function
+<bibref ref="xmlschema11-1"/>. The mapping, so modified, is a function
 (in the mathematical sense) which maps to a single value even
 in cases where the lexical mapping proper maps to multiple values.
 </p>
@@ -6672,10 +6802,10 @@ if the data model is constructed from a PSVI:</p>
 <bibl id="xpath-40"           key="XPath 4.0"/>
 <bibl id="xpath-functions-40" key="Functions and Operators 4.0"/>
 
-<bibl id="xmlschema-1"        key="Schema Part 1"/>
-<bibl id="xmlschema-2"        key="Schema Part 2"/>
-<bibl id="xmlschema11-1"      key="Schema 1.1 Part 1"/>
-<bibl id="xmlschema11-2"      key="Schema 1.1 Part 2"/>
+<bibl id="xmlschema-1"        key="XML Schema (XSD) 1.0 Part 1"/>
+<bibl id="xmlschema-2"        key="XML Schema (XSD) 1.0 Part 2"/>
+<bibl id="xmlschema11-1"      key="XML Schema (XSD) 1.1 Part 1"/>
+<bibl id="xmlschema11-2"      key="XML Schema (XSD) 1.1 Part 2"/>
 
 <bibl id="xslt-xquery-serialization-40" key="Serialization 4.0"/>
 

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -244,7 +244,9 @@
       </fos:summary>
       <fos:field name="year" type="xs:integer" required="false">
          <fos:meaning>
-            <p>The value of the <code>year</code> component. Range is implementation-defined.</p>
+            <p>The value of the <code>year</code> component. Range is implementation-defined.
+            If years less than one are supported, then the integer zero represents the year
+            before year one, and the integer -1 represents the year before year zero.</p>
          </fos:meaning>        
       </fos:field>
       <fos:field name="month" type="xs:integer" required="false">
@@ -10423,10 +10425,9 @@ return ($value - unix-dateTime()) div seconds(0.001)</eg>
             component in <code>$value</code>. The result may be negative.</p>
       </fos:rules>
       <fos:notes>
-         <p>Ignoring complications that arise with midnight on the last day
-            of the year, the year returned is the same numeric value that appears in the lexical
-         representation, which for negative years means the meaning may vary depending on whether
-         XSD 1.0 or XSD 1.1 conventions are in use.</p>
+         <p>The value space for <code>xs:dateTime</code> allows year zero. XSD 1.0, however, does not
+            allow year zero, so if a date earlier that 0001 CE was produced by validating
+            an XML document using an XSD 1.0 processor, the results may be unpredictable.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -10934,7 +10935,8 @@ return ($value - unix-dateTime()) div seconds(0.001)</eg>
             <tbody>
                <tr>
                   <td><code>year</code></td>
-                  <td>The value of <code>fn:year-from-dateTime($value)</code></td>
+                  <td>Generally, the value of <code>fn:year-from-dateTime($value)</code>: but
+                  see the notes below regarding negative years.</td>
                </tr>
                <tr>
                   <td><code>month</code></td>
@@ -10962,6 +10964,11 @@ return ($value - unix-dateTime()) div seconds(0.001)</eg>
                </tr>              
             </tbody>
          </table>
+         <p>The range of years supported is <termref def="implementation-defined"/>. If years earlier than
+         0001 CE are supported, however, the year number returned by this function 
+         follows the proleptic Gregorian calendar as defined
+         in ISO 8601. This means that the year before 0001 CE is numbered zero, and the year before that
+         is numbered -1.</p>
       </fos:rules>
       <fos:examples>
          <fos:example>
@@ -11026,6 +11033,10 @@ return ($value - unix-dateTime()) div seconds(0.001)</eg>
          with key <code>"timezone"</code>.</p>
          <p>If all seven components are present (year, month, day, hours, minutes, seconds, and timezone)
          then the result will be of type <code>xs:dateTimeStamp</code>.</p>
+         <p>The range of years supported is <termref def="implementation-defined"/>. If years earlier than
+         0001 CE are supported then the numbering follows the proleptic Gregorian calendar as defined
+         in ISO 8601. This means that the year before 0001 CE is numbered zero, and the year before that
+         is numbered -1.</p>
       </fos:rules>
       <fos:errors>
          <p>A dynamic error is raised <errorref class="DT" code="0005"/> if the set of fields
@@ -11114,9 +11125,9 @@ build-dateTime({ "year": 2007, "month": 5, "timezone": xs:dayTimeDuration("PT0S"
             local value of <code>$value</code>. The value may be negative. </p>
       </fos:rules>
       <fos:notes>
-         <p>The year returned is the same numeric value that appears in the lexical
-            representation, which for negative years means the meaning may vary depending on whether
-            XSD 1.0 or XSD 1.1 conventions are in use.</p>
+         <p>The value space for <code>xs:date</code> allows year zero. XSD 1.0, however, does not
+            allow year zero, so if a date earlier that 0001 CE was produced by validating
+            an XML document using an XSD 1.0 processor, the results may be unpredictable.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -13837,11 +13848,9 @@ fn:parse-QName("xmp:person")</eg></fos:expression>
          <!-- bug 16745 -->
       </fos:errors>
       <fos:notes>
-         <p>XSD 1.1 allows the string <code>+INF</code> as a representation of positive infinity;
-            XSD 1.0 does not. It is <termref
-               def="implementation-defined"
-            >implementation-defined</termref> whether XSD 1.1 is
-            supported.</p>
+         <p>The string <code>+INF</code> is permitted as a representation of positive infinity,
+            whether or not XSD 1.1 is supported. Similarly, <code>-0</code> and <code>0</code>
+            produce negative zero and positive zero respectively.</p>
          <p>Generally <function>fn:number</function> returns <code>NaN</code> rather than raising a dynamic
             error if the argument cannot be converted to <code>xs:double</code>. However, a type
             error is raised in the usual way if the supplied argument cannot be atomized or if the

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding='utf-8'?>
-<!-- Changes for maps and JSON labeled at="MAP" and commented out -->
-<!-- Current changes labeled at="A": first 4.0 Working Draft -->
 
 <!DOCTYPE spec SYSTEM "../../../schema/xsl-query.dtd" [ 
 
@@ -304,14 +302,15 @@ Michael Sperberg-McQueen (1954–2024).</p>
             it modifies the value space of <code>xs:Name</code>
          to permit additional Unicode characters; it allows year zero and disallows leap seconds in <code>xs:dateTime</code>
          values; and it allows any character string to appear as the value of an <code>xs:anyURI</code> item.
-         Implementations of this specification <rfc2119>may</rfc2119> support either XSD 1.0 or XSD 1.1 or both.</p>
+         Implementations of this specification <rfc2119>may</rfc2119> support either XSD 1.0 or XSD 1.1 when
+            performing schema-based validation, but in all other respects, the type system follows XSD 1.1.</p>
          
-         <p>In some cases, this specification references XSD for the semantics of operations such as the effect of matching
+         <!--<p>In some cases, this specification references XSD for the semantics of operations such as the effect of matching
          using regular expressions, or conversion of atomic items to strings. In most such cases there is no intended
          technical difference between the XSD 1.0 and XSD 1.1 specifications, but the 1.1 version often provides clearer
          explanations and sometimes also corrects technical errors. In such cases this specification
          often chooses to reference the XSD 1.1 specification. This should not be taken as implying that it is necessary
-         to invoke an XSD 1.1 processor.</p>
+         to invoke an XSD 1.1 processor.</p>-->
          
          <p>References to specific sections of some of the above documents are indicated by
                 cross-document links in this document. Each such link consists of a pointer to a
@@ -1620,8 +1619,12 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
 	  
       <div1 id="numeric-functions">
          <head>Processing numerics</head>
+         <changes>
+            <change issue="2520">Some operations must now be carried out following
+            XSD 1.1 rules, where previously use of XSD 1.0 was permitted.</change>
+         </changes>
          <p>This section specifies arithmetic operators on the numeric datatypes defined in
-                    <bibref ref="xmlschema-2"/>.</p>
+                    <bibref ref="xmlschema11-2"/>.</p>
          <div2 id="numeric-types">
             <head>Numeric types</head>
             <p>The operators described in this section are defined on the following atomic
@@ -1662,9 +1665,11 @@ This differs from <bibref ref="xmlschema-2"/>, which defines
  in the interest of alignment with <bibref ref="ieee754-2019"/>. A conformant implementation must
  respect these semantics. In consequence, the expression <code>-0.0e0</code> (which is actually a unary minus operator 
     applied to an <code>xs:double</code> value) will always return negative zero: see <specref ref="func-numeric-unary-minus"/>. 
-    As a concession to implementations that rely on implementations of XSD 1.0, however, when casting from string to double
- the lexical form <code>-0</code> <rfc2119>may</rfc2119> be converted to positive zero, though negative zero
- is <rfc2119>recommended</rfc2119>.
+    As a concession to implementations that rely on implementations of XSD 1.0, 
+ the lexical form <code>-0</code> <rfc2119>may</rfc2119> be converted to positive zero when validating
+                  a node against the type <code>xs:float</code> or <code>xs:double</code>,
+                  but casting from <code>xs:string</code>
+                  to <code>xs:float</code> or <code>xs:double</code> will always produce negative zero.
 </p>
                <p>XML Schema 1.1 introduces support for positive and negative zero as distinct values, and also uses the <bibref ref="ieee754-2019"/>
                semantics for comparisons involving <code>NaN</code>.</p>
@@ -3986,9 +3991,8 @@ WildcardEsc         ::= '.'
                            </item>
                            <item>
                               <p>
-                                    A character range (production <code>charRange</code>
-                                    in the XSD 1.0 grammar, replaced by productions <code>charRange</code> and <code>singleChar</code>
-                                    in XSD 1.1) represents the set 
+                                    A character range (productions <code>charRange</code> and <code>singleChar</code>
+                                    in the XSD 1.1 grammar) represents the set 
                                     containing all the characters that it would match in the absence 
                                     of the <code>i</code> flag, together with their case-variants. 
                                     For example, 
@@ -4395,6 +4399,11 @@ See <bibref ref="Working-With-Timezones"/> for a disquisition on working with da
          <div2 id="date-time-types">
             <head>Date and time types</head>
             
+            <changes>
+               <change issue="2520">The semantics of date/time operations are now based on the definitions
+               in XSD 1.1, although validation may still use an XSD 1.0 schema processor.</change>
+            </changes>
+            
             <p><termdef id="dt-gregorian" term="Gregorian">The eight primitive types 
             <code>xs:dateTime</code>, <code>xs:date</code>, <code>xs:time</code>, <code>xs:gYearMonth</code>, 
                <code>xs:gYear</code>, <code>xs:gMonthDay</code>, <code>xs:gMonth</code>, <code>xs:gDay</code>
@@ -4409,23 +4418,36 @@ See <bibref ref="Working-With-Timezones"/> for a disquisition on working with da
             <p>The only operations defined on					
                     <code>xs:gYearMonth</code>, <code>xs:gYear</code>,
                     <code>xs:gMonthDay</code>, <code>xs:gMonth</code>, and <code>xs:gDay</code> values are 
-               equality comparison and component extraction.
+               equality comparison, ordering, and component extraction.
                For other types, further operations are provided, including  
-               order comparisons, arithmetic, formatted display, and timezone
+               arithmetic, formatted display, and timezone
 					adjustment.</p>
 
             <div3 id="date-time-duration-conformance">
                <head>Limits and precision</head>
                
                <p>All conforming processors
-                        <rfc2119>must</rfc2119> support year values in the range 1 to 9999,
+                        <rfc2119>must</rfc2119> support
                         and a minimum fractional second precision of 1 millisecond or three
                         digits (that is, <code>s.sss</code>). However, processors
-                        <rfc2119>may</rfc2119>  set larger <termref def="implementation-defined"/> limits
-                        on the maximum number of digits they support in these two situations.  
-                        Processors <rfc2119>may</rfc2119> also choose to support the year 0 and 
-                        years with negative values.  The results of operations on dates that cross the year 
-                        0 are <termref def="implementation-defined"/>.</p>
+                        <rfc2119>may</rfc2119> support a higher <termref def="implementation-defined"/> precision.</p>
+                        
+               <p>All conforming processors
+                        <rfc2119>must</rfc2119> support year values in the range 1 to 9999.
+                        Processors <rfc2119>may</rfc2119> support a larger range than this.
+                  If the supported range includes negative years, then it must also include the year zero.
+                  Arithmetic on dates works on the basis of the proleptic Gregorian calendar, as defined
+                  in ISO 8601, in which the year preceding 0001 CE is numbered zero.</p>
+                  
+               <p>In XSD 1.0, dates can include a negative year, but cannot include the year zero.
+               In the 4.0 version of this specification, the value space includes values with year zero,
+               and casting from <code>xs:string</code> accepts year zero in the lexical representation.
+               If an XSD 1.0 processor is used to validate source documents containing dates with negative
+               years, then it is <termref def="implementation-defined"/> whether the lexical
+               form <code>-0001</code> translates to year zero or year -1 in the value space.</p>   
+                  
+                  
+
                <p>A processor that limits the number of digits in date and time datatype
                         representations may encounter overflow and underflow conditions when it
                         tries to execute the functions in <specref ref="dateTime-arithmetic"/>. In
@@ -4451,22 +4473,29 @@ See <bibref ref="Working-With-Timezones"/> for a disquisition on working with da
 			<code>xs:date</code>, <code>xs:time</code>,  <code>xs:gYearMonth</code>, <code>xs:gYear</code>, 
 			<code>xs:gMonthDay</code>, <code>xs:gMonth</code>, <code>xs:gDay</code> values, 
 			referred to collectively as <termref def="dt-gregorian"/> values, are represented as seven components or properties: 
-			<code>year</code>, <code>month</code>, <code>day</code>, <code>hour</code>, <code>minute</code>, 
-			<code>second</code> and <code>timezone</code>.  The first five components are 
-			<code>xs:integer</code> values.  The value of the <code>second</code> component is an <code>xs:decimal</code> 
+
+			<code>year</code>, <code>month</code>, <code>day</code>, <code>hours</code>, <code>minutes</code>, 
+			<code>seconds</code> and <code>timezone</code>.  The first five components are 
+			<code>xs:integer</code> values.  The value of the <code>seconds</code> component is an <code>xs:decimal</code>
 			and the value of the <code>timezone</code> component is an <code>xs:dayTimeDuration</code>.  
 			For all the primitive date/time datatypes, the <code>timezone</code> property is optional and may or may not 
 			be present. Depending on the datatype, some of the remaining six properties must be present and 
 			some must be <xtermref ref="dt-absent" spec="DM31">absent</xtermref>.   
-               Absent, or missing, properties are represented by the empty sequence.  
-			This value is referred to as the <emph>local</emph> value in that the value retains its original timezone.  
-			Before comparing or subtracting <code>xs:dateTime</code> values, this local value <rfc2119>must</rfc2119>  
-			be translated or <emph>normalized</emph> to UTC.</p>
+               Absent, or missing, properties are represented by the empty sequence.</p>
+            
+         <p><termdef id="dt-local-gregorian" term="local gregorian">A <termref def="dt-gregorian"/> value that includes
+         a timezone component is referred to as a <term>local gregorian</term> value.</termdef></p>
+            
+         <p><termdef id="dt-normalized-gregorian" term="normalized-gregorian">A <termref def="dt-gregorian"/>
+         value in which the timezone offset is zero (that is, UTC) is referred to as a <term>normalized gregorian</term>
+         value.</termdef>. For every <termref def="dt-local-gregorian"/> value, there is an equivalent
+         normalized gregorian value representing the same point in time, but in the UTC timezone. Operations
+         that compare or subtract <termref def="dt-gregorian"/> values always work on normalized values.</p>
 
             <p>For <code>xs:time</code>, <code>00:00:00</code> and <code>24:00:00</code> are alternate lexical forms 
 			for the same value, whose canonical representation is <code>00:00:00</code>.  For <code>xs:dateTime</code>,
 		    a time component <code>24:00:00</code> translates to <code>00:00:00</code> of the following day.</p>
-
+         
             <div3 id="date-time-lexical-mapping">
                <head>Examples</head>
                <ulist>
@@ -13243,6 +13272,11 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
                   digits in the fractional seconds than the implementation is able to retain, excess digits are truncated.
                   Rounding upwards (which could affect the number of minutes or hours in the value) is not permitted. 
                </change>
+               <change issue="2520">
+                  Casting from a string is now defined to follow the rules of XSD 1.1 in all cases, even if the processor
+                  uses XSD 1.0 rules for validation of XML documents. In edge cases this means that casting from string
+                  might succeed when validation fails.
+               </change>
             </changes>
             <p>This section applies when the supplied value <var>SV</var>
                is an instance of <code>xs:string</code> or <code>xs:untypedAtomic</code>,
@@ -13250,13 +13284,21 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
                <code>xs:untypedAtomic</code>, it is treated in exactly the same way as a
                string containing the same sequence of characters.</p>
             
-            <p>The supplied string is mapped to a typed value of the target type as defined in <bibref ref="xmlschema-2"/>. 
+            <p>The supplied string is mapped to a typed value of the target type as defined in <bibref ref="xmlschema11-2"/>. 
                Whitespace normalization is applied as indicated by the
                <code>whiteSpace</code> facet for the datatype. The resulting whitespace-normalized string 
                must be a valid lexical form for the datatype.  The semantics of casting follow the rules of
-               XML Schema validation.  For example, <code>"13" cast as xs:unsignedInt</code> returns 
+               XSD 1.1 validation (even for processors where validation would follow XSD 1.0 rules).  
+               For example, <code>"13" cast as xs:unsignedInt</code> returns 
                the <code>xs:unsignedInt</code> typed 
                value <code>13</code>. This could also be written <code>xs:unsignedInt("13")</code>.</p>
+            
+            <note><p>In the 4.0 version of this specification, casting from <code>xs:string</code>
+            is defined to follow XSD 1.1. This means that some lexical forms not permitted by
+            XSD 1.0 must be accepted: for example dates with the year zero, and <code>+INF</code>
+            as a representation of positive infinity. Casting to <code>xs:anyURI</code> will
+            never fail, because XSD 1.1 allows any sequence of characters in an <code>xs:anyURI</code>
+            value.</p></note>
             
             <p>The target type can be any simple type other than an
                abstract type. Specifically, it can be a type whose variety is atomic, union, or list.
@@ -13327,8 +13369,7 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
                <errorref class="DT" code="0001" type="dynamic"/> is raised.</p>
             <p>In casting to a duration value, if the value is too large or too small to be represented by the 
                implementation, a dynamic error <errorref class="DT" code="0002" type="dynamic"/> is raised.</p>
-            <p> For <code>xs:anyURI</code>, the extent to which an implementation validates the
-               lexical form of <code>xs:anyURI</code> is <termref def="implementation-dependent"/>.</p>
+            
             <p>If the cast fails for any other reason, a dynamic error
                <errorref class="RG" code="0001" type="dynamic"/> is raised.</p>
             

--- a/specifications/xquery-40/src/conformance.xml
+++ b/specifications/xquery-40/src/conformance.xml
@@ -272,10 +272,11 @@
                 <p>
                     <emph>Support for versions of XML and XSD.</emph> As stated in <bibref
                         ref="xpath-datamodel-40"/>, the
-                    definitions of primitives such as strings, characters, and names <termref def="should">SHOULD</termref> be taken
-                    from the latest applicable version of the base specifications in which they are
-                    defined; it is implementation-defined which definitions are used in cases where
-                    these differ. </p>
+                    definitions of primitives such as strings, characters, and names 
+                    are based on the definitions in XSD 1.1, though operations that require
+                    use of an XML Schema processor <rfc2119>may</rfc2119> use an XSD 1.0 processor.
+                    If new versions, editions, or errata are published for XML, XSD, or related specifications,
+                    then implementations <rfc2119>may</rfc2119> adopt any changes.</p>
                 <note>
                     <p>For suggestions on processing XML 1.1 documents with XSD 1.0, see <bibref
                             ref="xml11schema10"/>.</p>
@@ -283,48 +284,9 @@
             </item>
 
             <item>
-                <p><emph>Ranges of data values.</emph> In XQuery, the following limits are <termref
-                        def="dt-implementation-defined">implementation-defined</termref>:</p>
-                <olist>
-                    <item>
-                        <p>For the <code>xs:decimal</code> type, the maximum number of decimal
-                            digits (<code>totalDigits</code> facet) <termref def="must">MUST</termref> be at least 18.
-                            This limit <termref def="should">SHOULD</termref> be at least 20 digits in order to 
-                            accommodate the full range of values of built-in subtypes of <code>xs:integer</code>, such as 
-                            <code>xs:long</code> and <code>xs:unsignedLong</code>.
-                        </p>
-                    </item>
-                    <item>
-                        
-
-                        <p>For the types <code>xs:date</code>, <code>xs:dateTime</code>, <code>xs:gYear</code>, and <code>xs:gYearMonth</code>: the minimum and maximum value of the year component (must be at least 1 to 9999).</p>
-
-                        <p>For the types <code>xs:time</code> and <code>xs:dateTime</code>: the maximum number of fractional second digits (must be at least 3).</p>
-
-                    </item>
-                    <item>
-                        <p>For the <code>xs:duration type</code>: the maximum absolute values of the
-                            years, months, days, hours, minutes, and seconds components.</p>
-                    </item>
-                    <item>
-                        <p>For the <code>xs:yearMonthDuration</code> type: the maximum absolute
-                            value, expressed as an integer number of months.</p>
-                    </item>
-                    <item>
-                        <p>For the <code>xs:dayTimeDuration</code> type: the maximum absolute value,
-                            expressed as a decimal number of seconds.</p>
-                    </item>
-                    <item>
-                        <p>For the types <code>xs:string</code>, <code>xs:hexBinary</code>,
-                                <code>xs:base64Binary</code>, <code>xs:QName</code>,
-                                <code>xs:anyURI</code>, <code>xs:NOTATION</code>, and types derived
-                            from them: limitations (if any) imposed by the implementation on lengths
-                            of values.</p>
-                    </item>
-                </olist>
-                <p>The limits listed above need not be fixed, but <termref def="may">MAY</termref>  depend on environmental
-                    factors such as system resources. For example, the length of a value of type
-                        <code>xs:string</code> might be limited by available memory.</p>
+                <p><emph>Ranges of data values.</emph> 
+                    Limits are defined in <xspecref spec="DM40" ref="atomic-type-limits"/>.</p>
+                
                 <note>
                     <p>For discussion of errors due to <termref def="dt-implementation-dependent"
                             >implementation-dependent</termref> limits, see <specref

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -8445,12 +8445,27 @@ and <code>version="1.0"</code> otherwise.</p>
             </note>
             <imp-def-feature id="idf-spec-xml">It is implementation-defined which versions and
                editions of XML and XML Namespaces (1.0 and/or 1.1) are supported.</imp-def-feature>
-            <p>The current version of <bibref ref="xmlschema11-2"/> references the XML 1.1 specifications, but the previous version (<bibref ref="xmlschema-2"/>) (that is, XSD 1.0) remains in widespread use, and only
-                  references XML 1.0. With processors lacking support for XSD 1.1,
-               therefore, datatypes such as <code>xs:NCName</code> and <code>xs:ID</code> may be
-               constrained by the XML 1.0 rules, and not allow the full range of values permitted by
-               XML 1.1. It is <rfc2119>recommended</rfc2119> that implementers wishing to support
-               XML 1.1 should consult <bibref ref="SCHEMA-AND-XML-1.1"/> for guidance.</p>
+            
+            <p>Atomic types such as <code>xs:string</code> and <code>xs:dateTime</code> are defined
+            in <bibref ref="xpath-datamodel-40"/> by reference to <bibref ref="xmlschema11-2"/>.
+            This means for example, that:</p>
+            
+            <ulist>
+               <item><p>The value space of <code>xs:string</code> includes all Unicode characters
+               other than <code>U+0000</code> (but not non-characters such as unpaired surrogates).</p></item>
+               <item><p>The type <code>xs:anyURI</code> imposes no constraints on the form of the value.</p></item>
+               <item><p>If the range of dates supports negative years, then it must also support year zero.</p></item>
+               <item><p>The value space for <code>xs:double</code> and <code>xs:float</code> includes
+               negative zero and positive zero as distinct values.</p></item>
+            </ulist>
+            
+            <p>However, for operations that necessarily involve use of a schema processor (such as
+            <elcode>xsl:import-schema</elcode> and schema validation), it is acceptable to use
+            a processor that supports only XSD 1.0.</p>
+            
+            
+            
+            
          </div2>
          
          <div2 id="preprocessing-source-docs">
@@ -8821,52 +8836,14 @@ and <code>version="1.0"</code> otherwise.</p>
             
          <div2 id="limits">
             <head>Limits</head>
-            <p>The XDM data model (see <bibref ref="xpath-datamodel-40"/>) leaves it to the host
-               language to define limits. This section describes the limits that apply to XSLT.</p>
-            <p>Limits on some primitive datatypes are defined in <bibref ref="xmlschema-2"/>. Other
-               limits, listed below, are <termref def="dt-implementation-defined">implementation-defined</termref>. Note that this does not necessarily mean that
-               each limit must be a simple constant: it may vary depending on environmental factors
-               such as available resources.</p>
+            <p>The XDM data model (see <bibref ref="xpath-datamodel-40"/>) generally leaves
+               limits on the ranges and precision of values as <termref def="dt-implementation-defined"/>,
+               though some minimum limits are defined: see <xspecref spec="DM40" ref="limits"/>.</p>
+            
             <imp-def-feature id="idf-defaults-limits">Limits on the value space of primitive
-               datatypes, where not fixed by <bibref ref="xmlschema-2"/>, are
+               datatypes, where not fixed by <bibref ref="xmlschema-2"/> or <bibref ref="xpath-datamodel-40"/>, are
                implementation-defined.</imp-def-feature>
-            <p>The following limits are <termref def="dt-implementation-defined">implementation-defined</termref>:</p>
-            <olist>
-               <item>
-                  <p>For the <code>xs:decimal</code> type, the maximum number of decimal digits (the
-                        <code>totalDigits</code> facet). This must be at least 18 digits. (Note,
-                     however, that support for the full value range of <code>xs:unsignedLong</code>
-                     requires 20 digits.) </p>
-               </item>
-               <item>
-                  <p>For the types <code>xs:date</code>, <code>xs:time</code>,
-                        <code>xs:dateTime</code>, <code>xs:gYear</code>, and
-                        <code>xs:gYearMonth</code>: the range of values of the year component, which
-                     must be at least +0001 to +9999; and the maximum number of fractional second
-                     digits, which must be at least 3.</p>
-               </item>
-               <item>
-                  <p>For the <code>xs:duration</code> type: the maximum absolute values of the
-                     years, months, days, hours, minutes, and seconds components. </p>
-               </item>
-               <item>
-                  <p>For the <code>xs:yearMonthDuration</code> type: the maximum absolute value,
-                     expressed as an integer number of months.</p>
-               </item>
-               <item>
-                  <p>For the <code>xs:dayTimeDuration</code> type: the maximum absolute value,
-                     expressed as a decimal number of seconds.</p>
-               </item>
-               <item>
-                  <p>For the types <code>xs:string</code>, <code>xs:hexBinary</code>,
-                        <code>xs:base64Binary</code>, <code>xs:QName</code>, <code>xs:anyURI</code>,
-                        <code>xs:NOTATION</code>, and types derived from them: the maximum length of
-                     the value. </p>
-               </item>
-               <item>
-                  <p>For sequences, the maximum number of items in a sequence.</p>
-               </item>
-            </olist>
+            
          </div2>
          <div2 id="d-o-e-in-data-model">
             <head>Disable Output Escaping</head>


### PR DESCRIPTION
This PR started as a fairly local change to resolve issue #2520 (year zero in build-dateTime and parts-of-dateTime) but it gradually became more ambitious.

The data model now states that the definitions of atomic types are taken from XSD 1.1. This means, for example, that `xs:date` includes year zero, and `xs:double` includes negative zero. It is still permitted to use an XSD 1.0 processor for schema processing and validation, but other operations (including casting from string) must follow the XSD 1.1 rules.

In the course of this some rules (including the rules on limits) have migrated from the XQuery and XSLT specs into the XDM specification.

Fix #2520