### PR TITLE
QT4CG-154-02 Revise rules for setting stylesheet parameters

### DIFF
--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -3133,7 +3133,8 @@ Michael Sperberg-McQueen (1954–2024).</p>
             <div3 id="package-dependencies">
                <head>Dependencies between Packages</head>
 
-               <p>When <termref def="dt-component">components</termref> in one <termref def="dt-package"/> reference components in another, the dependency of the first
+               <p>When <termref def="dt-component">components</termref> in one <termref def="dt-package"/> 
+                  reference components in another, the dependency of the first
                   package on the second must be represented by an <elcode>xsl:use-package</elcode>
                   element. This may appear in the <termref def="dt-principal-stylesheet-module"/>
                of the first package (which may be a <termref def="dt-package-manifest"/>), or
@@ -3414,7 +3415,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
                   <elcode>xsl:param</elcode> declarations. This applies both to <termref def="dt-static-parameter">static parameters</termref>,
                and to non-static parameters.</p>
                
-               <p>The actual value of the supplied parameter must be known statically.
+               <p>In the case of a static parameter, the actual value must be known statically.
                   The <elcode>xsl:with-param</elcode> element must therefore have a <code>select</code>
                   attribute, and the value of the <code>select</code> attribute must be
                   a <termref def="dt-static-expression"/>. In other respects it is evaluated in the usual way: 
@@ -3424,12 +3425,17 @@ Michael Sperberg-McQueen (1954–2024).</p>
                   <error spec="XT" type="static" class="SE" code="3012">
                      <p>It is a <termref def="dt-static-error"> static error</termref> if an
                      <elcode>xsl:with-param</elcode> child of an <elcode>xsl:use-package</elcode> 
-                        declaration has no <code>select</code>
+                        declaration that references a <termref def="dt-static-parameter"/> 
+                        in the used package has no <code>select</code>
                         attribute, or if the value of the <code>select</code> attribute
                         is not a <termref def="dt-static-expression"/>.
                      </p>
                   </error>
                </p>
+               
+               <p>If the referenced stylesheet parameter is non-static, a dynamic initializing expression
+               may be used: this is evaluated in the same way as the initializing expression of a global
+               variable in the using package.</p>
                
                <p>It is not an error to supply a value for a parameter which the library package does not declare. Such a value
                is simply ignored.</p>
@@ -3461,10 +3467,18 @@ Michael Sperberg-McQueen (1954–2024).</p>
                   parameter may be supplied either using this mechanism, or using some external mechanism.</p>
                </note>
                <note>
-                  <p>In the case of a non-static <termref def="dt-stylesheet-parameter"/>, it is also possible
-                  (in effect) to supply a value by overriding the parameter with an <elcode>xsl:variable</elcode>
-                  or <elcode>xsl:param</elcode> declaration within the <elcode>xsl:override</elcode> child of
-                  the <elcode>xsl:use-package</elcode> declaration.</p>
+                  <p>XSLT 3.0 processors, depending on the way they interpret the specification, may allow
+                  parameter values to be supplied by using an <elcode>xsl:override</elcode> declaration to
+                  override the parameter value. This is expressly disallowed in 4.0, because stylesheet
+                  parameters always have private visibility.</p>
+               </note>
+               <note>
+                  <p>An <elcode>xsl:with-param</elcode> child of <elcode>xsl:use-package</elcode> can only
+                  set parameter values for that specific package; it cannot be used to set values for other
+                  packages invoked transitively. However, a declaration such as 
+                     <code>&lt;xsl:with-param name="p" select="$p" static="yes"/></code> may be used
+                  to set the value of a parameter in the used package base on the values of
+                  parameters declared in the using package.</p>
                </note>
             </div3>
                
@@ -3796,7 +3810,9 @@ Michael Sperberg-McQueen (1954–2024).</p>
                   
                   <changes>
                      <change issue="272" PR="2474" date="2026-02-18">The rules for the visibility of
-                     stylesheet parameters have changed; this may cause some incompatibility.</change>
+                     stylesheet parameters have changed: it has been clarified that they are
+                     always private (XSLT 3.0 made conflicting statements). This may cause some 
+                     backwards incompatibility.</change>
                   </changes>
 
 
@@ -3818,7 +3834,11 @@ Michael Sperberg-McQueen (1954–2024).</p>
                         <label>private</label>
                         <def><p>The component can be referenced from other components in this
                               package; it cannot be referenced or overridden within a using
-                              package.</p></def>
+                              package. In general, private components cannot be referenced
+                              directly from the calling application (but the design of APIs is
+                              outside the scope of this specification). Stylesheet parameters
+                              are the exception: they are always private, but are expressly
+                              designed to be referenced from the calling application.</p></def>
                      </gitem>
                      <gitem>
                         <label>abstract</label>


### PR DESCRIPTION
Looking at the issues raised by this action I decided to make a couple of changes that are not purely editorial.

* Confirming that an xsl:param in the used package cannot be overridden by an xsl:param or xsl:variable in the using package, because it is private (the 3.0 spec contained conflicting statements here).
* Allowing a non-static xsl:param in the used package to be initialised using a non-static expression in the using package (thus allowing parameter values to be passed through transitively).