### PR TITLE
QT4CG-156-02 Follow on from 2520, esp re non-XML characters

### DIFF
--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -628,7 +628,7 @@ a reference to a type definition in the Schema Component Model.
   <div3 id="xsd-versions">
     <head>XSD versions</head>
     <changes>
-      <change issue="2520">The type system of XDM 4.0 is based on XSD 1.1 rather than XSD 1.0, 
+      <change issue="2520" PR="2520" date="2026-03-18">The type system of XDM 4.0 is based on XSD 1.1 rather than XSD 1.0, 
       but with concessions to allow a conformant implementation to be make use of an 
       XSD 1.0 processor.</change>
     </changes>
@@ -976,6 +976,10 @@ size and scope of the processing context.</p>
     <change issue="414" PR="546" date="2023-07-25">
       Relaxed the rules regarding use of non-XML characters in instances of <code>xs:string</code>.
     </change>
+    <change issue="2520" date="2025-03-18">
+      Implementations are now required to accept all characters allowed by XML 1.1, even if they
+      do not support an XML 1.1 parser.
+    </change>
   </changes>
 
 <p>Some of the types defined in XML Schema have differing definitions
@@ -1014,11 +1018,18 @@ is a sequence of zero or more
 <termref def="dt-character">characters</termref>.</termdef></p>
 
 <p diff="chg" at="2023-06-12"><termdef term="character" id="dt-character">A
-<term>character</term> is any Unicode character.</termdef>
-Implementations <rfc2119>may</rfc2119> restrict characters
-to those Unicode characters allowed by the <code>Char</code>
-production in <bibref ref="xml"/>. Unpaired surrogates are always forbidden.</p>
-
+<term>character</term> is any Unicode character.</termdef></p>
+  
+<p>Implementations <rfc2119>must</rfc2119> accept all characters
+allowed by the <code>Char</code> production in <bibref ref="xml-11"/>,
+that is, characters whose Unicode codepoints are in the range 
+x0001 to xD7FF, xE000 to xFFFD, x10000 to x10FFFF.</p>
+  
+<p>Implementations <rfc2119>may</rfc2119> additionally accept the control
+  character x0000 and the codepoints (refered to in Unicode 
+  as <term>noncharacters</term>) xFFFE and xFFFF. Unpaired surrogates (xD800 to xDFFF)
+  are always forbidden.</p>
+  
 <p><termdef id="dt-codepoint" term="codepoint">A
 <term>codepoint</term> is a non-negative integer assigned to a
 <termref def="dt-character">character</termref> by the Unicode
@@ -1030,32 +1041,26 @@ character.</termdef></p>
 allow an implementation to accept input that cannot occur in a
 well-formed XML document. For example, an implementation might allow
 the <code>unparsed-text()</code> function to return the content of a
-text file that includes the control character <char>U+0007</char> or might
+text file that includes the control character <char>U+0000</char> or might
 not restrict what <code>codepoints-to-string()</code> can return.</p>
+  
+<p>An implementation <rfc2119>may</rfc2119> reject any attempt to construct
+an <termref def="dt-XNode"/> whose string value contains a character that is
+not permitted in the selected version of XML.</p>  
 
-<p diff="add" at="2023-06-12">An implementation that allows a broader repertoire of characters to
-be consumed by the processor, <rfc2119>must</rfc2119> ensure that</p>
+<p diff="add" at="2023-06-12">An implementation <rfc2119>must</rfc2119> ensure that:</p>
 
 <olist diff="add" at="2023-06-12">
 <item>
-<p>Any characters serialized with the XML or XHTML output methods satisfy the
-well-formedness criteria of the selected version of XML.</p>
+<p>Any characters serialized with the XML, XHTML, HTML, or JSON output methods satisfy the
+well-formedness criteria of the selected output format and version.</p>
 </item>
-<item><p>Any schema validation carried out using an XML Schema 1.0 or 1.1 schema rejects
-any nodes or <termref def="dt-atomic-item">atomic items</termref> containing characters that do not satisfy the
+<item><p>Any schema validation carried out using an XSD 1.0 or 1.1 schema rejects
+any <termref def="dt-XNode"/> containing characters that do not satisfy the
 constraints of the selected version of XML.</p></item>
 </olist>
   
-  <note diff="add" at="2023-09-28">
-    <p>The lexical space of type <code>xs:duration</code> is defined in XSD 1.1 part 2 (§3.3.6.2) 
-      in two different ways:
-    with a BNF grammar starting with the production <code>durationLexicalRep</code>, and with a regular 
-    expression. The two definitions are inconsistent: the BNF allows a decimal point at the start or end
-    of the seconds component, while the regular expression requires any decimal point to be preceded and followed
-    by a digit. For the purposes of this specification, the regular expression is considered to be 
-    correct, and the BNF incorrect; this makes the representation identical to that in XSD 1.0, 
-    and is compatible with ISO 8601.</p>
-  </note>
+
 </div3>
 
 </div2>
@@ -1466,6 +1471,25 @@ any representation that is convenient for them, provided that the
 individual properties can be accessed and modified.</p></note>
 
 </div2>
+    
+    <div2 id="durations">
+      <head>Durations</head>
+      
+      <p>The types <code>xs:duration</code>, <code>xs:dayTimeDuration</code>, and <code>xs:yearMonthDuration</code>
+      are as defined in XSD 1.1. The types <code>xs:dayTimeDuration</code> and <code>xs:yearMonthDuration</code>
+      were originally defined in this data model but the definitions were subsequently adopted by XSD 1.1.</p>
+      
+        <note diff="add" at="2023-09-28">
+          <p>The lexical space of type <code>xs:duration</code> is defined in XSD 1.1 part 2 (§3.3.6.2) 
+            in two different ways:
+          with a BNF grammar starting with the production <code>durationLexicalRep</code>, and with a regular 
+          expression. The two definitions are inconsistent: the BNF allows a decimal point at the start or end
+          of the seconds component, while the regular expression requires any decimal point to be preceded and followed
+          by a digit. For the purposes of this specification, the regular expression is considered to be 
+          correct, and the BNF incorrect; this makes the representation identical to that in XSD 1.0, 
+          and is compatible with ISO 8601.</p>
+        </note>
+    </div2>
 
 <div2 id="qnames-and-notations">
 <head>QNames and NOTATIONS</head>
@@ -6792,6 +6816,7 @@ if the data model is constructed from a PSVI:</p>
 <!--FIXME: update ../etc/tr with the latest TR page info! -->
 
 <bibl id="xml"                key="XML"/>
+<bibl id="xml-11"             key="XML-11"/>
 <bibl id="xml-infoset"        key="Infoset"/>
 <bibl id="xml-names"          key="Namespaces in XML"/>
 <bibl id="xml-names11"        key="Namespaces in XML 1.1"/>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -4958,7 +4958,7 @@ translate(value := '٢٠٢٣', replace := '٠١٢٣٤٥٦٧٨٩', with := '01234
          <p diff="chg" at="2023-06-12">A dynamic error is raised <errorref class="CH" code="0001"
                /> if any of the codepoints in
                <code>$values</code> is not a
-               <termref def="dt-permitted-character">permitted character</termref>.</p>
+               <termref def="dt-permitted-character"/>.</p>
       </fos:errors>
       <fos:examples>
          <fos:example>
@@ -4976,7 +4976,8 @@ translate(value := '٢٠٢٣', replace := '٠١٢٣٤٥٦٧٨٩', with := '01234
             </fos:test>
             <fos:test>
                <fos:expression>codepoints-to-string(0)</fos:expression>
-               <fos:error-result error-code="FOCH0001"/>
+               <fos:result narrative="true">If <char>U+0000</char> is a <termref def="dt-permitted-character"/>,
+               returns a string containing this character. Otherwise raises <errorref code="FOCH0001"/>.</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -280,37 +280,24 @@ Michael Sperberg-McQueen (1954–2024).</p>
             datatype. These functions are also available for general use; they are named after the datatype that they return,
             and they always take a single argument.</p></item>
             <item><p>Functions that specify the semantics of operators defined in <bibref ref="xpath-40"/> and <bibref ref="xquery-40"/>.
-            These exist for specification purposes only, and are not intended for direct calling from user-written code.</p></item>
+            These exist for specification purposes only, and are not intended for direct calling from user-written code.</p>
+            <note><p>In 4.0, there are fewer functions in this category: see <specref ref="operators"/>.</p></note>
+            </item>
          </ulist>
          
-         <p>
-                <bibref ref="xmlschema-2"/> defines a number of primitive and derived datatypes,
+         <p><bibref ref="xmlschema11-2"/> defines a number of primitive and derived datatypes,
                 collectively known as built-in datatypes. This document defines functions and
                 operations on these datatypes as well as the other types 
-                (for example, nodes and sequences of nodes) defined in <xspecref spec="DM31" ref="types"/> of 
-            the <bibref ref="xpath-datamodel-40"/>.
+                (for example, nodes and sequences of nodes) defined in <xspecref spec="DM40" ref="types"/> of 
+                the <bibref ref="xpath-datamodel-40"/>.
                 These functions and operations are available for use in <bibref ref="xpath-40"/>,
-                    <bibref ref="xquery-40"/> and any other host language that chooses to reference them.
-                In particular, they may be referenced in future versions of XSLT and related XML standards. </p>
+                    <bibref ref="xquery-40"/>, <bibref ref="xslt-40"/>, 
+                and any other host language that chooses to reference them.</p>
          
-         <p><bibref ref="xmlschema11-2"/> adds to the datatypes defined
-            in <bibref ref="xmlschema-2"/>. It introduces a new derived type <code>xs:dateTimeStamp</code>, and it
-         incorporates as built-in types the two types <code>xs:yearMonthDuration</code> and <code>xs:dayTimeDuration</code>
-         which were previously XDM additions to the type system. In addition, XSD 1.1 clarifies and updates many
-         aspects of the definitions of the existing datatypes: for example, it extends the value space of
-         <code>xs:double</code> to allow both positive and negative zero, and extends the lexical space to allow <code>+INF</code>;
-            it modifies the value space of <code>xs:Name</code>
-         to permit additional Unicode characters; it allows year zero and disallows leap seconds in <code>xs:dateTime</code>
-         values; and it allows any character string to appear as the value of an <code>xs:anyURI</code> item.
-         Implementations of this specification <rfc2119>may</rfc2119> support either XSD 1.0 or XSD 1.1 when
+         <p>Implementations of this specification <rfc2119>may</rfc2119> support either XSD 1.0 or XSD 1.1 when
             performing schema-based validation, but in all other respects, the type system follows XSD 1.1.</p>
          
-         <!--<p>In some cases, this specification references XSD for the semantics of operations such as the effect of matching
-         using regular expressions, or conversion of atomic items to strings. In most such cases there is no intended
-         technical difference between the XSD 1.0 and XSD 1.1 specifications, but the 1.1 version often provides clearer
-         explanations and sometimes also corrects technical errors. In such cases this specification
-         often chooses to reference the XSD 1.1 specification. This should not be taken as implying that it is necessary
-         to invoke an XSD 1.1 processor.</p>-->
+         
          
          <p>References to specific sections of some of the above documents are indicated by
                 cross-document links in this document. Each such link consists of a pointer to a
@@ -353,6 +340,9 @@ Michael Sperberg-McQueen (1954–2024).</p>
             <head>Conformance</head>
             <changes>
                <change issue="205" PR="326" date="2023-02-01">Higher-order functions are no longer an optional feature.</change>
+               <change issue="2520" PR="2520" date="2026-03-18">The type system of XDM 4.0 is based on XSD 1.1 rather than XSD 1.0, 
+      but with concessions to allow a conformant implementation to be make use of an 
+      XSD 1.0 processor.</change>
             </changes>
             <p>
                This recommendation contains a set of function specifications. 
@@ -392,10 +382,6 @@ Michael Sperberg-McQueen (1954–2024).</p>
                <item>
                   <p>It is <termref def="implementation-defined"/> which version of Unicode is supported, 
                      but it is recommended that the most recent version of Unicode be used.  </p>
-               </item>
-               <item>
-                  <p>It is <termref def="implementation-defined"/> whether the type system is based
-                     on XML Schema 1.0 or XML Schema 1.1.  </p>
                </item>
                <item>
                   <p>It is <termref def="implementation-defined"/> whether definitions that rely on

--- a/specifications/xquery-40/src/ebnf.xml
+++ b/specifications/xquery-40/src/ebnf.xml
@@ -503,6 +503,10 @@
     
     <p diff="add" at="2023-05-22">This section describes how an &language; text is tokenized prior to parsing.</p>
     
+    <p>An &language; text is a sequence of <xtermref spec="DM40" ref="dt-character">characters</xtermref>.
+    Characters appearing without escaping in source text <rfc2119>must</rfc2119> satisfy the <code>Char</code> production
+    in XML 1.0 (specifically, #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]).</p>
+    
     <p>All keywords are case sensitive. Keywords are not reserved&#8212;that is, any <termref
       def="dt-qname">lexical QName</termref> may duplicate a keyword except as noted in <specref
         ref="id-reserved-fn-names"/>.</p>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -13,11 +13,10 @@
          </changes>
      
       <p>The basic building block of &language; is the
-	 <term>expression</term>, which is a string of <bibref
-            ref="Unicode"/> characters; the version of Unicode to be used is <termref
-            def="dt-implementation-defined"
-            >implementation-defined</termref>.
-	 The language provides several kinds of expressions which may be constructed
+	 <term>expression</term>, which is a <xtermref spec="DM40" ref="dt-string"/> of 
+         <xtermref spec="DM40" ref="dt-character">characters</xtermref>.</p>
+         
+	 <p>The language provides several kinds of expressions which may be constructed
 	 from keywords, symbols, and operands. In general, the operands of an expression
 	 are other expressions. &language; allows expressions to be nested with full
 generality. <phrase
@@ -26,12 +25,7 @@ generality. <phrase
 language, it does not allow variable substitution if the variable
 declaration contains construction of new nodes.)</phrase>
       </p>
-      <note>
-         <p>This specification contains no
-assumptions or requirements regarding the character set encoding of strings
-of <bibref
-               ref="Unicode"/> characters.</p>
-      </note>
+ 
       <p>Like XML, &language; is a case-sensitive language. Keywords in
 	 &language; use lower-case characters and are not reserved&mdash;that is, names in &language; expressions are allowed to be the same as language keywords, except for certain unprefixed function-names listed in <specref
             ref="id-reserved-fn-names"/>.</p>
@@ -4023,6 +4017,12 @@ of applying the <function>fn:boolean</function> function to the value.</termdef>
    <div1 id="id-types">
       <head>Types</head>
       
+      <changes>
+         <change issue="2520" PR="2522" date="2026-03-17">Atomic types are now defined in terms 
+         of XSD 1.1; using the XSD 1.0 definitions is no longer an option, even in a processor
+         that uses XSD 1.0 for validation.</change>
+      </changes>
+      
       <p>As noted in <specref ref="id-values"/>, every value in &language; is regarded
       as a <termref def="dt-sequence"/> of zero, one, or more <termref def="dt-item">items</termref>.
       The type system of &language;, described in this section, classifies the
@@ -4033,10 +4033,18 @@ of applying the <function>fn:boolean</function> function to the value.</termdef>
 		<bibref ref="XMLSchema10"/> or <bibref ref="XMLSchema11"/> in two ways:</p>
       
          <ulist>
-            <item><p>atomic items in &language; (which are one kind of <termref def="dt-item"/>)
+            <item><p>Atomic items in &language; (which are one kind of <termref def="dt-item"/>)
                have <termref def="dt-atomic-type">atomic types</termref> such as <code>xs:string</code>,
                <code>xs:boolean</code>, and <code>xs:integer</code>. These types are taken directly
-               from their definitions in <bibref ref="XMLSchema10"/> or <bibref ref="XMLSchema11"/>.</p></item>
+               from their definitions in <bibref ref="XMLSchema11"/>.</p>
+               <note><p>Using the definitions from XSD 1.0 is no longer an option. For a summary
+               of the main differences between atomic types in XSD 1.0 and XSD 1.1, see
+               <xspecref spec="DM40" ref="xsd-versions"/>.</p>
+               <p>Although the value space and lexical space of atomic types is defined by reference
+               to XSD 1.1, processors may continue to use an XSD 1.0 processor for schema validation.</p>
+               </note>
+               
+            </item>
             <item><p><termref def="dt-XNode">XNodes</termref> 
                (which are another kind of <termref def="dt-item"/>) have a property
             called a <termref def="dt-type-annotation"/> which determines the type of their content.
@@ -4496,8 +4504,14 @@ types</term> (such as <code>xs:integer</code>) and function types
             <div3 id="id-atomic-types">
                <head>Atomic Types</head>
                
+               <changes>
+                  <change issue="2520" PR="2522" date="2026-03-17">Atomic types are now defined in terms 
+                  of XSD 1.1; using the XSD 1.0 definitions is no longer an option, even in a processor
+                  that uses XSD 1.0 for validation.</change>
+               </changes>
+               
                <p>Atomic types in the &language; type system correspond directly to atomic types
-                  as defined in the <bibref ref="XMLSchema10"/> or <bibref ref="XMLSchema11"/>
+                  as defined in the <bibref ref="XMLSchema11"/>
                  type system.</p>
                
                <p>Atomic types are either built-in atomic types such as <code>xs:integer</code>,
@@ -4646,8 +4660,9 @@ types</term> (such as <code>xs:integer</code>) and function types
                </p>
                
                
-               <p>It is not possible to preserve the type of a <termref def="dt-namespace-sensitive"
-                  >namespace-sensitive</termref> value without also preserving the <termref def="dt-namespace-binding"/> 
+               <p>It is not possible to convert between the lexical space and the value space 
+                  of a <termref def="dt-namespace-sensitive"/> type without knowledge of 
+                  the <termref def="dt-namespace-binding"/> 
                   that defines the meaning of each namespace prefix used in the value. Therefore, &language; defines 
                   some error conditions that occur only with <termref
                      def="dt-namespace-sensitive"
@@ -23596,7 +23611,7 @@ If <code>?</code> is not specified after the target type, a <termref
 atomic item, the result of the cast expression is determined by
 casting to the target type as described in <xspecref
                         spec="FO40" ref="casting"
-                        />. When casting, an
+                        />.</p> <!--When casting, an
 implementation may need to determine whether one type is derived by
 restriction from another. An implementation can determine this either
 by examining the <termref
@@ -23604,9 +23619,9 @@ by examining the <termref
                         >in-scope schema
 definitions</termref> or by using an alternative, <termref
                         def="dt-implementation-dependent">implementation-dependent</termref>
-mechanism such as a data dictionary.
+mechanism such as a data dictionary.-->
 
-The result of a cast expression is one of the following: 
+<p>The result of a cast expression is one of the following:</p> 
 
 <olist>
                         <item>
@@ -23631,7 +23646,7 @@ The result of a cast expression is one of the following:
   </p>
                         </item>
                      </olist>
-                  </p>
+                  
 
                   <note diff="add" at="issue688"><p>Casting to an enumeration type relies on the fact that an enumeration type
                   is a generalized atomic type. So the expression <code>cast $x as enum("red", "green")</code> 


### PR DESCRIPTION
With atomic types being based on XSD 1.1, this affects text that concerns the definition of strings and characters