### PR TITLE
2550 Shadow attributes in RelaxNG schema

### DIFF
--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -32317,7 +32317,11 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
             caveats apply as for the XSD 1.1 version.</p>
             <p>A copy of this schema is available at <loc href="schema-for-xslt30.rnc">schema-for-xslt30.rnc</loc>
             </p>
-            <p diff="add" at="2023-04-18">TODO: Needs updating for 4.0.</p>
+            <p>In this schema, shadow attributes and their corresponding non-shadow versions (for example,
+               <code>_select</code> and <code>select</code>) are defined as being mutually exclusive. Although
+            a stylesheet can validly contain both, this is allowed solely to support forwards compatibility 
+            from older XSLT versions, whereas this schema is designed principally for stylesheets
+            that target XSLT 4.0.</p>
             <?rng-schema-for-xslt?>
          </div2>
       </inform-div1>


### PR DESCRIPTION
Adds a justification (excuse?) for making shadow attributes and their targets mutually exclusive in the RelaxNG schema.

Fix #2550