### PR TITLE
2562 Empty fields in parts-of-dateTime result now absent

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -10909,13 +10909,14 @@ return ($value - unix-dateTime()) div seconds(0.001)</eg>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns all the components of a <termref def="dt-gregorian"/> value.</p>
+         <p>Returns the components of a <termref def="dt-gregorian"/> value.</p>
       </fos:summary>
       
       <fos:rules>
          <p>If <code>$value</code> is the empty sequence, the function returns the empty sequence.</p>
-         <p>Otherwise, the function returns a record whose fields are as follows. All entries will be present,
-         even when the value is an empty sequence.</p>
+         <p>Otherwise, the function returns a record whose fields are as follows. If a particular component
+         is not present in the value, the corresponding entry will be absent from the map (the returned
+         map will never contain any entry whose value is the empty sequence).</p>
          <table>
             <thead>
                <tr>
@@ -10977,9 +10978,7 @@ return ($value - unix-dateTime()) div seconds(0.001)</eg>
                <fos:expression><eg>parts-of-dateTime(
   xs:time("13:30:04.2678")
 )</eg></fos:expression>
-               <fos:result><eg>{ "year": (), "month": (), "day": (), 
-  "hours": 13, "minutes": 30, "seconds": 4.2678, 
-  "timezone": () }</eg></fos:result>
+               <fos:result><eg>{ "hours": 13, "minutes": 30, "seconds": 4.2678 }</eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -10987,9 +10986,7 @@ return ($value - unix-dateTime()) div seconds(0.001)</eg>
                <fos:expression><eg>parts-of-dateTime(
   xs:gYearMonth("2007-05Z")
 )</eg></fos:expression>
-               <fos:result><eg>{ "year": 2007, "month": 5, "day": (), 
-  "hours": (), "minutes": (), "seconds": (), 
-  "timezone": xs:dayTimeDuration("PT0S") }</eg></fos:result>
+               <fos:result><eg>{ "year": 2007, "month": 5, "timezone": xs:dayTimeDuration("PT0S") }</eg></fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>


### PR DESCRIPTION
Fix #2562

Note: this aligns the spec with the existing tests.