### PR TITLE
1979 Records with type annotations

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -2945,37 +2945,31 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:string>)</g:string>
   </g:production>
   
-  <!--<g:production name="RecordType" if="xpath40 xquery40 xslt40-patterns">
+  <g:production name="RecordType" if="xpath40 xquery40 xslt40-patterns">
     <g:choice>
       <g:ref name="AnyRecordType"/>
       <g:ref name="TypedRecordType"/>
     </g:choice>
-  </g:production>-->
+  </g:production>
   
-  <!--<g:production name="AnyRecordType" if="xpath40 xquery40 xslt40-patterns">
+  <g:production name="AnyRecordType" if="xpath40 xquery40 xslt40-patterns">
     <g:string>record</g:string>
     <g:string>(</g:string>
     <g:string>*</g:string>
     <g:string>)</g:string>
-  </g:production>-->
+  </g:production>
   
-  <g:production name="RecordType" if="xpath40 xquery40 xslt40-patterns">
+  <g:production name="TypedRecordType" if="xpath40 xquery40 xslt40-patterns">
     <g:string>record</g:string>
     <g:string>(</g:string>
     <g:zeroOrMore separator=",">
       <g:ref name="FieldDeclaration"/>
     </g:zeroOrMore>
-    <!--<g:optional>
-      <g:ref name="ExtensibleFlag"/>
-    </g:optional>-->
     <g:string>)</g:string>
   </g:production>
   
   <g:production name="FieldDeclaration" if="xpath40 xquery40 xslt40-patterns">
     <g:ref name="FieldName"/>
-    <!--<g:optional>
-      <g:string>?</g:string>
-    </g:optional>-->
     <g:optional>
       <g:string>as</g:string>
       <g:ref name="SequenceType"/>

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1659,6 +1659,14 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     </g:zeroOrMore>
   </g:production>
   
+  <g:production name="WithExpr">
+    <g:ref name="InstanceofExpr"/>
+    <g:zeroOrMore>
+      <g:string>with</g:string>
+      <g:ref name="InstanceofExpr"/>
+    </g:zeroOrMore>
+  </g:production>
+  
   <g:production name="InstanceofExpr">
     <g:ref name="TreatExpr"/>
     <g:optional>

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1649,20 +1649,20 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   </g:production>
   
   <g:production name="IntersectExceptExpr">
-    <g:ref name="WithExpr"/>
+    <g:ref name="RecordPutExpr"/>
     <g:zeroOrMore>
       <g:choice>
         <g:string>intersect</g:string>
         <g:string>except</g:string>
       </g:choice>
-      <g:ref name="WithExpr"/>
+      <g:ref name="RecordPutExpr"/>
     </g:zeroOrMore>
   </g:production>
   
-  <g:production name="WithExpr">
+  <g:production name="RecordPutExpr">
     <g:ref name="InstanceofExpr"/>
     <g:zeroOrMore>
-      <g:string>with</g:string>
+      <g:string>+:=</g:string>
       <g:ref name="InstanceofExpr"/>
     </g:zeroOrMore>
   </g:production>

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -2973,9 +2973,9 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   
   <g:production name="FieldDeclaration" if="xpath40 xquery40 xslt40-patterns">
     <g:ref name="FieldName"/>
-    <g:optional>
+    <!--<g:optional>
       <g:string>?</g:string>
-    </g:optional>
+    </g:optional>-->
     <g:optional>
       <g:string>as</g:string>
       <g:ref name="SequenceType"/>

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1649,13 +1649,13 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   </g:production>
   
   <g:production name="IntersectExceptExpr">
-    <g:ref name="InstanceofExpr"/>
+    <g:ref name="WithExpr"/>
     <g:zeroOrMore>
       <g:choice>
         <g:string>intersect</g:string>
         <g:string>except</g:string>
       </g:choice>
-      <g:ref name="InstanceofExpr"/>
+      <g:ref name="WithExpr"/>
     </g:zeroOrMore>
   </g:production>
   

--- a/specifications/image-sources/item-types.xml
+++ b/specifications/image-sources/item-types.xml
@@ -99,11 +99,16 @@
                     <phrase role="kind"> (user-defined)</phrase>
                  </p>
               </item>
-              <item role="function user-defined">
-                 <p>
-                    <phrase>user-defined record types</phrase>
-                    <phrase role="kind"> (user-defined)</phrase>
-                 </p>
+              <item role = "abstract function">
+                <p><phrase>record</phrase><phrase role="kind"> (function item)</phrase></p>
+                <ulist>
+                  <item role="function user-defined">
+                     <p>
+                        <phrase>user-defined record types</phrase>
+                        <phrase role="kind"> (user-defined)</phrase>
+                     </p>
+                  </item>
+                </ulist>
               </item>
             </ulist>
           </item>

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -6257,6 +6257,63 @@ values, only on keys. The semantics of equality when comparing keys are describe
   to which it belongs.</p>
   
   <p>All operations applicable to maps are also applicable to records.
+    Two additional operations are available, defined below:</p>
+  
+  <div3 id="dm-record-get">
+    <head><code>record-get</code> Accessor</head>
+    <example role="signature">
+      <proto class="dm" name="record-get" return-type="item()" returnSeq="yes">
+        <arg name="key" type="xs:string"/>
+      </proto>     
+    </example>
+    
+    <p>The <code>dm:record-get</code> accessor returns the value associated with a given key,
+    provided that the key is the name of one of the fields defined by the record type appearing
+    as the type annotation of the record. If the key is any other value, the accessor function
+    raises a type error.</p>
+    
+    <p>The <code>dm:record-get</code> accessor is invoked by the XPath/XQuery lookup operator
+    (<code>?</code>) when the left-hand operand is a record.</p>
+ 
+  </div3>
+  
+  <div3 id="dm-record-put">
+    <head><code>record-put</code> Constructor</head>
+    <example role="signature">
+      <proto class="dm" name="record-put" return-type="record(*)" returnSeq="no">
+        <arg name="record" type="record(*)"/>
+        <arg name="key" type="xs:string"/>
+        <arg name="value" type="item()*"/>
+      </proto>
+    </example>
+    
+    <p>The <code>dm:record-put</code> constructor returns a new record based on the contents of a supplied record.</p>
+    <p>If the type annotation of <code>$record</code> is <var>T</var>, then the returned record <var>R</var> has 
+      same type annotation <var>T</var>, and all entries in <var>R</var> are
+      the same as in <code>$record</code> except for the entry whose key is <code>$key</code>, which acquires
+      the new value <code>$value</code>, coerced to the declared type of the corresponding field in <var>T</var>.</p>
+    <p>The function raises a type error if either of the following conditions is true:</p>
+    <olist>
+      <item><p>The supplied <code>$key</code> does not match the name of any field in <var>T</var>.</p></item>
+      <item><p>The supplied <code>$value</code> cannot be coerced to the declared type of the corresponding
+          field in <var>T</var>.</p></item>
+    </olist>
+    
+    <p>The <code>dm:record-put</code> constructor is invoked by the XPath/XQuery <code>with</code> operator.</p>  
+      
+    </olist>
+    
+    <note>
+    <p>The <termref def="dt-entry-order"/> in the returned
+      map reflects the <termref def="dt-entry-order"/> in the supplied <code>$map</code>. If the key of
+      the new entry was present in <code>$map</code> then the new entry replaces that entry retaining
+      its current position; otherwise, the new entry is added after all existing entries.</p>
+    </note>
+    
+    <p>The function is exposed in XPath through the function <function>map:put</function>.</p>
+  </div3>
+  
+  
   However, some operations are constrained, in order to ensure greater type safety:</p>
   
   <ulist>

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -1128,6 +1128,12 @@ constraints of the selected version of XML.</p></item>
         map type <code>map(*)</code>, of more specific map types <code>map(K, V)</code> defining the
         types of the keys and values, and perhaps of one or more record types that associate a type with 
         specific key values.</p>
+      <p>A <termref def="dt-record"/> is a map item whose keys and values are constrained
+        by a <termref def="dt-record-type"/> definition. For example the record type
+      <code>record(height as xs:double, width as xs:double)</code> constrains record
+      instances to have two entries: an entry with key <code>"height"</code> whose value is
+      an <code>xs:double</code>, and an entry with key <code>"width"</code> whose value is
+      also an <code>xs:double</code>.</p>
       <p>An <termref def="dt-array-item"/>, as well as being a function, is also an instance of the generic
         array type <code>array(*)</code>, and also of more specific array types <code>array(M)</code>
         defining the type of the array's members.</p></item>
@@ -1248,13 +1254,15 @@ another atomic type.</termdef>
 <term>primitive simple types</term> are the types defined
 in <specref ref="xs-types"/>.</termdef></p>
     
-    <p diff="chg" at="2022-11-05"><termdef id="dt-type-annotation" term="type annotation">The term <term>type annotation</term> has
-      two slightly different meanings. For an <termref def="dt-atomic-item"/>, the type annotation of the value
+    <p diff="chg" at="2022-11-05"><termdef id="dt-type-annotation" term="type annotation">A
+        <term>type annotation</term> is a property of an item that defines its type.
+        For an <termref def="dt-atomic-item"/>, the type annotation of the value
       is the most specific <termref def="dt-atomic-type"/> that it is an instance of (it is also an instance of every type from which that
       type is derived). For an element or attribute node, the type annotation is the <termref def="dt-schema-type"/>
       (a simple or complex type) against which the node has been validated, defaulting to
       <code>xs:untypedAtomic</code> for unvalidated attribute nodes, and <code>xs:untyped</code>
-      for unvalidated element nodes.</termdef></p>  
+      for unvalidated element nodes. For a <termref def="dt-record"/>, the type annotation
+      is the <termref def="dt-record-type"/> to which it belongs.</termdef></p>  
 
     <p><phrase diff="chg" at="2022-11-05">Named types are identified</phrase> in the data model by an
     <termref def="dt-expanded-qname">expanded QName</termref>. <phrase diff="add" at="2022-11-05">A schema 
@@ -6223,6 +6231,55 @@ values, only on keys. The semantics of equality when comparing keys are describe
   </div3>
 
 </div2>
+    
+<div2 id="records">
+  <head>Record</head>
+  <changes>
+    <change date="2026-03-31">Records are now a subtype of maps.</change>
+  </changes>
+  
+  <p>A record is a set of key-value pairs where the keys are strings
+  that are statically known. Records are maps, but are constrained
+  to have a regular structure.</p>
+  
+  <p><termdef id="dt-record-type" term="record type">A <term>record type</term>
+  defines a sequence of fields, each field being characterized by a name (which
+  can be any <termref def="dt-string"/>), and a <termref def="dt-sequence-type"/> (which
+  constrains the associated values).</termdef></p>
+  
+  <p><termdef id="dt-record" term="record">A <term>record</term> is a map that
+  is constrained by a <termref def="dt-record-type"/>. The keys of a <term>record</term>
+  are always instances of <code>xs:string</code>; the keys are constrained by
+  the record type definition to a fixed set of strings, and the record type
+  also defined the permitted type of value for each key.</termdef></p>
+  
+  <p>A record has a <termref def="dt-type-annotation"/> that identifies the <termref def="dt-record-type"/>
+  to which it belongs.</p>
+  
+  <p>All operations applicable to maps are also applicable to records.
+  However, some operations are constrained, in order to ensure greater type safety:</p>
+  
+  <ulist>
+    <item><p>The <code>get</code> operation to get the entry with a specific key fails
+    with a type error (rather than returning an empty sequence) if the 
+    supplied key is not defined for the record type.</p></item>
+    <item><p>The <code>put</code> operation to replace the entry with a specific key
+    fails if the result would not meet the constraints defined by the
+    record type: that is, if the supplied key is not defined for the
+    record type, or if the replacement value is not valid for that record
+    type.</p></item>
+  </ulist>
+  
+  <p>These type errors may be reported statically if they can be detected
+  statically.</p>
+  
+  <p>The order of entries in a record always corresponds to the
+  order of the field definitions in the record type.</p>
+  
+</div2>
+  
+  
+    
 
 <div2 id="array-items">
   <head>Array Items</head>

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -6264,35 +6264,36 @@ values, only on keys. The semantics of equality when comparing keys are describe
   <p>All operations applicable to maps are also applicable to records.
     Two additional operations are available, defined below:</p>
   
-  <div3 id="dm-record-get">
-    <head><code>record-get</code> Accessor</head>
+  <div3 id="dm-record-get-value">
+    <head><code>record-get-value</code> Accessor</head>
     <example role="signature">
-      <proto class="dm" name="record-get" return-type="item()" returnSeq="yes">
+      <proto class="dm" name="record-get-value" return-type="item()" returnSeq="yes">
+        <arg name="record" type="record(*)"/>
         <arg name="key" type="xs:string"/>
       </proto>     
     </example>
     
-    <p>The <code>dm:record-get</code> accessor returns the value associated with a given key,
+    <p>The <code>dm:record-get-value</code> accessor returns the value associated with a given key,
     provided that the key is the name of one of the fields defined by the record type appearing
     as the type annotation of the record. If the key is any other value, the accessor function
     raises a type error.</p>
     
-    <p>The <code>dm:record-get</code> accessor is invoked by the XPath/XQuery lookup operator
+    <p>The <code>dm:record-get-value</code> accessor is invoked by the XPath/XQuery lookup operator
     (<code>?</code>) when the left-hand operand is a record.</p>
  
   </div3>
   
-  <div3 id="dm-record-put">
-    <head><code>record-put</code> Constructor</head>
+  <div3 id="dm-record-replace-value">
+    <head><code>record-replace-v</code> Constructor</head>
     <example role="signature">
-      <proto class="dm" name="record-put" return-type="record(*)" returnSeq="no">
+      <proto class="dm" name="record-replace-value" return-type="record(*)" returnSeq="no">
         <arg name="record" type="record(*)"/>
         <arg name="key" type="xs:string"/>
         <arg name="value" type="item()*"/>
       </proto>
     </example>
     
-    <p>The <code>dm:record-put</code> constructor returns a new record based on the contents of a supplied record.</p>
+    <p>The <code>dm:record-replace-value</code> constructor returns a new record based on the contents of a supplied record.</p>
     <p>If the type annotation of <code>$record</code> is <var>T</var>, then the returned record <var>R</var> has 
       same type annotation <var>T</var>, and all entries in <var>R</var> are
       the same as in <code>$record</code> except for the entry whose key is <code>$key</code>, which acquires
@@ -6304,7 +6305,7 @@ values, only on keys. The semantics of equality when comparing keys are describe
           field in <var>T</var>.</p></item>
     </olist>
     
-    <p>The <code>dm:record-put</code> constructor is invoked by the XPath/XQuery <code>with</code> operator.</p>  
+    <p>The <code>dm:record-replace-value</code> constructor is invoked by the XPath/XQuery <code>with</code> operator.</p>  
       
     
  

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -6264,6 +6264,34 @@ values, only on keys. The semantics of equality when comparing keys are describe
   <p>All operations applicable to maps are also applicable to records.
     Two additional operations are available, defined below:</p>
   
+  <div3 id="dm-make-record">
+    <head><code>make-record</code> Constructor</head>
+    
+    <p>This constructor can be represented by a pseudo-function:</p>
+    
+    <example role="signature">
+      <proto class="dm" name="make-record" return-type="item()" returnSeq="yes">
+        <arg name="data" type="map(xs:string, item()*)"/>
+        <arg name="record-type" type="item-type"/>
+      </proto>     
+    </example>
+    
+    <p>The constructor takes as input a map whose keys are strings, and returns a record
+    of the required type.</p>
+    
+    <olist>
+      <item><p>The entries in the supplied map must correspond one-for-one with the fields defined
+      in the required record type.</p></item>
+      <item><p>The key of the entry must match a defined field in the record type.</p></item>
+      <item><p>The corresponding value in the entry must be an instance of the required type of that field.</p></item>
+    </olist>
+    
+    <p>The result is a <termref def="dt-record"/> that is deep-equal to <code>$data</code> and whose
+    type annotation is the supplied <code>$record-type</code>. The order of entries in the returned
+    record corresponds to the order of field definitions in <code>$record-type</code>.</p>
+ 
+  </div3>
+  
   <div3 id="dm-record-get-value">
     <head><code>record-get-value</code> Accessor</head>
     <example role="signature">
@@ -6283,34 +6311,8 @@ values, only on keys. The semantics of equality when comparing keys are describe
  
   </div3>
   
-  <div3 id="dm-record-replace-value">
-    <head><code>record-replace-v</code> Constructor</head>
-    <example role="signature">
-      <proto class="dm" name="record-replace-value" return-type="record(*)" returnSeq="no">
-        <arg name="record" type="record(*)"/>
-        <arg name="key" type="xs:string"/>
-        <arg name="value" type="item()*"/>
-      </proto>
-    </example>
-    
-    <p>The <code>dm:record-replace-value</code> constructor returns a new record based on the contents of a supplied record.</p>
-    <p>If the type annotation of <code>$record</code> is <var>T</var>, then the returned record <var>R</var> has 
-      same type annotation <var>T</var>, and all entries in <var>R</var> are
-      the same as in <code>$record</code> except for the entry whose key is <code>$key</code>, which acquires
-      the new value <code>$value</code>, coerced to the declared type of the corresponding field in <var>T</var>.</p>
-    <p>The function raises a type error if either of the following conditions is true:</p>
-    <olist>
-      <item><p>The supplied <code>$key</code> does not match the name of any field in <var>T</var>.</p></item>
-      <item><p>The supplied <code>$value</code> cannot be coerced to the declared type of the corresponding
-          field in <var>T</var>.</p></item>
-    </olist>
-    
-    <p>The <code>dm:record-replace-value</code> constructor is invoked by the XPath/XQuery <code>with</code> operator.</p>  
-      
-    
- 
 
-  </div3>
+
   
   
   

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -6249,12 +6249,17 @@ values, only on keys. The semantics of equality when comparing keys are describe
   
   <p><termdef id="dt-record" term="record">A <term>record</term> is a <termref def="dt-map-item"/> that
   is constrained by a <termref def="dt-record-type"/>. The keys of a <term>record</term>
-  are always instances of <code>xs:string</code>; the keys are constrained by
-  the record type definition to a fixed set of strings, and the record type
-  also defines the permitted type of value for each key.</termdef></p>
+  are always instances of <code>xs:string</code>, and are constrained by
+  the record type definition to a fixed set of strings. The record type
+  also defines the permitted type of value corresponding to each key.</termdef></p>
   
   <p>A record has a <termref def="dt-type-annotation"/> that identifies the <termref def="dt-record-type"/>
   to which it belongs.</p>
+  
+ 
+  <p>The order of entries in a record always corresponds to the
+  order of the field definitions in the record type.</p>
+  
   
   <p>All operations applicable to maps are also applicable to records.
     Two additional operations are available, defined below:</p>
@@ -6301,37 +6306,12 @@ values, only on keys. The semantics of equality when comparing keys are describe
     
     <p>The <code>dm:record-put</code> constructor is invoked by the XPath/XQuery <code>with</code> operator.</p>  
       
-    </olist>
     
-    <note>
-    <p>The <termref def="dt-entry-order"/> in the returned
-      map reflects the <termref def="dt-entry-order"/> in the supplied <code>$map</code>. If the key of
-      the new entry was present in <code>$map</code> then the new entry replaces that entry retaining
-      its current position; otherwise, the new entry is added after all existing entries.</p>
-    </note>
-    
-    <p>The function is exposed in XPath through the function <function>map:put</function>.</p>
+ 
+
   </div3>
   
   
-  However, some operations are constrained, in order to ensure greater type safety:</p>
-  
-  <ulist>
-    <item><p>The <code>get</code> operation to get the entry with a specific key fails
-    with a type error (rather than returning an empty sequence) if the 
-    supplied key is not defined for the record type.</p></item>
-    <item><p>The <code>put</code> operation to replace the entry with a specific key
-    fails if the result would not meet the constraints defined by the
-    record type: that is, if the supplied key is not defined for the
-    record type, or if the replacement value is not valid for that record
-    type.</p></item>
-  </ulist>
-  
-  <p>These type errors may be reported statically if they can be detected
-  statically.</p>
-  
-  <p>The order of entries in a record always corresponds to the
-  order of the field definitions in the record type.</p>
   
 </div2>
   

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -1129,7 +1129,7 @@ constraints of the selected version of XML.</p></item>
         types of the keys and values, and perhaps of one or more record types that associate a type with 
         specific key values.</p>
       <p>A <termref def="dt-record"/> is a map item whose keys and values are constrained
-        by a <termref def="dt-record-type"/> definition. For example the record type
+        by a <termref def="dt-record-type"/> definition. For example, the record type
       <code>record(height as xs:double, width as xs:double)</code> constrains record
       instances to have two entries: an entry with key <code>"height"</code> whose value is
       an <code>xs:double</code>, and an entry with key <code>"width"</code> whose value is
@@ -6233,9 +6233,9 @@ values, only on keys. The semantics of equality when comparing keys are describe
 </div2>
     
 <div2 id="records">
-  <head>Record</head>
+  <head>Records</head>
   <changes>
-    <change date="2026-03-31">Records are now a subtype of maps.</change>
+    <change issue="1979" PR="2566" date="2026-03-31">Records are now a subtype of maps.</change>
   </changes>
   
   <p>A record is a set of key-value pairs where the keys are strings
@@ -6247,11 +6247,11 @@ values, only on keys. The semantics of equality when comparing keys are describe
   can be any <termref def="dt-string"/>), and a <termref def="dt-sequence-type"/> (which
   constrains the associated values).</termdef></p>
   
-  <p><termdef id="dt-record" term="record">A <term>record</term> is a map that
+  <p><termdef id="dt-record" term="record">A <term>record</term> is a <termref def="dt-map-item"/> that
   is constrained by a <termref def="dt-record-type"/>. The keys of a <term>record</term>
   are always instances of <code>xs:string</code>; the keys are constrained by
   the record type definition to a fixed set of strings, and the record type
-  also defined the permitted type of value for each key.</termdef></p>
+  also defines the permitted type of value for each key.</termdef></p>
   
   <p>A record has a <termref def="dt-type-annotation"/> that identifies the <termref def="dt-record-type"/>
   to which it belongs.</p>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -38,57 +38,57 @@
       <fos:summary>
          <p>This record type represents the components of a URI.</p>
       </fos:summary>
-      <fos:field name="uri" type="xs:string?" required="false">
+      <fos:field name="uri" type="xs:string?" required="true">
          <fos:meaning>
             <p>The original URI. This element is returned by <function>fn:parse-uri</function>,
             but ignored by <function>fn:build-uri</function>.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="scheme" type="xs:string?" required="false">
+      <fos:field name="scheme" type="xs:string?" required="true">
          <fos:meaning>
             <p>The URI scheme (e.g., “https” or “file”).</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="absolute" type="xs:boolean?" required="false">
+      <fos:field name="absolute" type="xs:boolean?" required="true">
          <fos:meaning>
             <p>The URI is an absolute URI.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="hierarchical" type="xs:boolean?" required="false">
+      <fos:field name="hierarchical" type="xs:boolean?" required="true">
          <fos:meaning>
             <p>Whether the URI is hierarchical or not.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="authority" type="xs:string?" required="false">
+      <fos:field name="authority" type="xs:string?" required="true">
          <fos:meaning>
             <p>The authority portion of the URI (e.g., “example.com:8080”).</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="userinfo" type="xs:string?" required="false">
+      <fos:field name="userinfo" type="xs:string?" required="true">
          <fos:meaning><p>Any userinfo that was passed as part of the authority.</p></fos:meaning>
       </fos:field>
-      <fos:field name="host" type="xs:string?" required="false">
+      <fos:field name="host" type="xs:string?" required="true">
          <fos:meaning><p>The host passed as part of the authority (e.g., “example.com”). </p></fos:meaning>
       </fos:field>
-      <fos:field name="port" type="xs:integer?" required="false">
+      <fos:field name="port" type="xs:integer?" required="true">
          <fos:meaning><p>The port passed as part of the authority (e.g., “8080”).</p></fos:meaning>
       </fos:field>
-      <fos:field name="path" type="xs:string?" required="false">
+      <fos:field name="path" type="xs:string?" required="true">
          <fos:meaning><p>The path portion of the URI.</p></fos:meaning>
       </fos:field>
-      <fos:field name="query" type="xs:string?" required="false">
+      <fos:field name="query" type="xs:string?" required="true">
          <fos:meaning><p>Any query string.</p></fos:meaning>
       </fos:field>
-      <fos:field name="fragment" type="xs:string?" required="false">
+      <fos:field name="fragment" type="xs:string?" required="true">
          <fos:meaning><p>Any fragment identifier.</p></fos:meaning>
       </fos:field>
-      <fos:field name="path-segments" type="xs:string*" required="false">
+      <fos:field name="path-segments" type="xs:string*" required="true">
          <fos:meaning><p>Parsed and unescaped path segments.</p></fos:meaning>
       </fos:field>
-      <fos:field name="query-parameters" type="map(xs:string, xs:string*)?" required="false">
+      <fos:field name="query-parameters" type="map(xs:string, xs:string*)?" required="true">
          <fos:meaning><p>Parsed and unescaped query key-value pairs.</p></fos:meaning>
       </fos:field>
-      <fos:field name="filepath" type="xs:string?" required="false">
+      <fos:field name="filepath" type="xs:string?" required="true">
          <fos:meaning><p>The path of the URI, treated as a filepath.</p></fos:meaning>
       </fos:field>
    </fos:record-type>
@@ -109,12 +109,12 @@
             <p>Defines the overall strategy for converting the element content.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="child" type="xs:string?" required="false">
+      <fos:field name="child" type="xs:string?" required="true">
          <fos:meaning>
             <p>For list layouts, defines the name of the child element type contained in the list.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="type" type="enum('numeric', 'boolean', 'string')" required="false">
+      <fos:field name="type" type="enum('numeric', 'boolean', 'string')?" required="true">
          <fos:meaning>
             <p>For elements with simple content, defines whether they should be represented
                as numbers or booleans instead of the default representation as strings.</p>
@@ -164,7 +164,7 @@
             
          </fos:meaning>
       </fos:field>
-      <fos:field name="primitive-type" type="fn() as schema-type-record" required="false">
+      <fos:field name="primitive-type" type="(fn() as schema-type-record)?" required="true">
          <fos:meaning>
             <p>For an atomic type, a function item returning the primitive type from which this 
                type is ultimately derived. Corresponds to the
@@ -175,8 +175,7 @@
          </fos:meaning>
       </fos:field>
       <fos:field name="variety" 
-                 required="false" 
-                 type='enum("atomic", "list", "union", "empty", "simple", "element-only", "mixed")'>
+                 type='enum("atomic", "list", "union", "empty", "simple", "element-only", "mixed")?' required="true">
          <fos:meaning>
             <p>For a simple type, one of <code>"atomic"</code>, <code>"list"</code>, or <code>"union"</code>, corresponding to the
                <xtermref spec="XS11-1" ref="std-variety">{variety}</xtermref> of the simple type in the XSD component model. For a complex type, one of
@@ -187,7 +186,7 @@
             for the type <code>xs:anySimpleType</code>.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="members" required="false" type="fn() as schema-type-record*">
+      <fos:field name="members" type="fn() as schema-type-record*" required="true">
          <fos:meaning>
             <p>For a simple type with variety <code>"union"</code>, a function that returns a sequence of
                records representing the member types of the union, in order, corresponding to the
@@ -198,7 +197,7 @@
             the <xtermref spec="XS11-1" ref="std-item_type_definition">{item type definition}</xtermref> property in the XSD component model. In all other cases, absent.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="simple-content-type" required="false" type="fn() as schema-type-record">
+      <fos:field name="simple-content-type" type="(fn() as schema-type-record)?" required="true">
          <fos:meaning>
             <p>For a complex type with variety <code>"simple"</code> (that is, a complex type with simple content), 
                a function that returns a record representing the relevant simple type, corresponding to 
@@ -207,14 +206,14 @@
                In all other cases, absent.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="matches" type="fn(xs:anyAtomicType) as xs:boolean" required="false">
+      <fos:field name="matches" type="(fn(xs:anyAtomicType) as xs:boolean)?"  required="true">
          <fos:meaning>
             <p>For a <xtermref spec="XP40" ref="dt-generalized-atomic-type"/>, 
                a function item that can be called to establish whether the supplied atomic item
                is an instance of this type. In all other cases, absent.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="constructor" type="fn(xs:anyAtomicType?) as xs:anyAtomicType*" required="false">
+      <fos:field name="constructor" type="(fn(xs:anyAtomicType?) as xs:anyAtomicType*)?"  required="true">
          <fos:meaning>
             <p>For a simple type, a function item that can be used to construct instances of this type. In the case of a named
              type that is present in the dynamic context, the result is the same function as returned by 
@@ -378,40 +377,40 @@
             <code>xs:date</code>, <code>xs:time</code>, <code>xs:gYear</code>, <code>xs:gYearMonth</code>,
             <code>xs:gMonth</code>, <code>xs:gMonthDay</code>, or <code>xs:gDay</code>.</p>
       </fos:summary>
-      <fos:field name="year" type="xs:integer" required="false">
+      <fos:field name="year" type="xs:integer?"  required="true">
          <fos:meaning>
             <p>The value of the <code>year</code> component. Range is implementation-defined.
             If years less than one are supported, then the integer zero represents the year
             before year one, and the integer -1 represents the year before year zero.</p>
          </fos:meaning>        
       </fos:field>
-      <fos:field name="month" type="xs:integer" required="false">
+      <fos:field name="month" type="xs:integer?" required="true">
          <fos:meaning>
             <p>The value of the <code>month</code> component. A valid value is in the range 1 to 12 inclusive.</p>
          </fos:meaning>        
       </fos:field>
-      <fos:field name="day" type="xs:integer" required="false">
+      <fos:field name="day" type="xs:integer?" required="true">
          <fos:meaning>
             <p>The value of the <code>day</code> component. A valid value is in the range 1 to 31 inclusive.</p>
          </fos:meaning>        
       </fos:field>
-      <fos:field name="hours" type="xs:integer" required="false">
+      <fos:field name="hours" type="xs:integer?"  required="true">
          <fos:meaning>
             <p>The value of the <code>hours</code> component. A valid value is in the range 0 to 23 inclusive.</p>
          </fos:meaning>        
       </fos:field>
-      <fos:field name="minutes" type="xs:integer" required="false">
+      <fos:field name="minutes" type="xs:integer?" required="true">
          <fos:meaning>
             <p>The value of the <code>minutes</code> component. A valid value is in the range 0 to 59 inclusive.</p>
          </fos:meaning>        
       </fos:field>
-      <fos:field name="seconds" type="xs:decimal" required="false">
+      <fos:field name="seconds" type="xs:decimal?" required="true">
          <fos:meaning>
             <p>The value of the <code>seconds</code> component. A valid value is in the range 0 (inclusive) to 60 (exclusive).
             (Thus 59.9999999 is valid, but 60 is not.)</p>
          </fos:meaning>        
       </fos:field>
-      <fos:field name="timezone" type="xs:dayTimeDuration" required="false">
+      <fos:field name="timezone" type="xs:dayTimeDuration?"  required="true">
          <fos:meaning>
             <p>The timezone offset, if the value has a timezone. A valid value corresponds to an integral number
             of minutes between -840 and +840 inclusive.</p>
@@ -11364,8 +11363,7 @@ return ($value - unix-dateTime()) div seconds(0.001)</eg>
       <fos:rules>
          <p>If <code>$value</code> is the empty sequence, the function returns the empty sequence.</p>
          <p>Otherwise, the function returns a record whose fields are as follows. If a particular component
-         is not present in the value, the corresponding entry will be absent from the map (the returned
-         map will never contain any entry whose value is the empty sequence).</p>
+         is not present in the value, the corresponding entry will be the empty sequence.</p>
          <table>
             <thead>
                <tr>
@@ -11464,10 +11462,7 @@ return ($value - unix-dateTime()) div seconds(0.001)</eg>
          <p>If <code>$value</code> is the empty sequence, the function returns the empty sequence.</p>
          <p>Otherwise, the function returns a <termref def="dt-gregorian"/> value based on the supplied component
             values. The result will be the <termref def="dt-gregorian"/> value <code>$R</code> such that
-            <code>deep-equal( $significant(parts-of-dateTime($R)), $significant($value) )</code>,
-            where <code>$significant</code> is the function <code>map:filter(?, fn($K, $V){$K eq "timezone" or exists($V)})</code>,
-         that is, a function that discards entries in a map whose value is the empty sequence, other than the entry
-         with key <code>"timezone"</code>.</p>
+            <code>deep-equal( parts-of-dateTime($R), $value )</code>.</p>
          <p>If all seven components are present (year, month, day, hours, minutes, seconds, and timezone)
          then the result will be of type <code>xs:dateTimeStamp</code>.</p>
          <p>The range of years supported is <termref def="implementation-defined"/>. If years earlier than
@@ -11492,8 +11487,7 @@ return ($value - unix-dateTime()) div seconds(0.001)</eg>
         <p>A dynamic error is raised <errorref class="RG" code="0001" /> if any other component of <code>$value</code> is outside the permitted range specified by the target date/time datatype, for example: if <code>minutes</code> is less than zero or greater than 59; or if <code>day</code> is 30 and <code>month</code> is 2.  See <xspecref spec="DM31" ref="dates-and-times" />.</p>
       </fos:errors>
       <fos:notes>
-         <p>Components that are present in <code>$value</code> but with an empty value are treated
-         as if they were absent.</p>
+         
          <p>The timezone, if present, must correspond to an integral number of minutes in the range
          -840 to +840.</p>
          <p>Midnight must be expressed with the <code>hours</code> value set to zero, not 24.</p>
@@ -11528,6 +11522,20 @@ build-dateTime({
                <fos:expression><eg>
 build-dateTime({ "year": 2007, "month": 5, "timezone": xs:dayTimeDuration("PT0S") })</eg></fos:expression>
                <fos:result><eg>xs:gYearMonth("2007-05Z")</eg></fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>build-dateTime({ "year": (), "hours": 13, "minutes": 30, "seconds": 4.2678 })</eg></fos:expression>
+               <fos:result><eg>xs:time("13:30:04.2678")</eg></fos:result>
+               <fos:postamble>An empty field is treated as absent.</fos:postamble>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>build-dateTime({ "year": 2000, "quarter": 1, "month": 3 })</eg></fos:expression>
+               <fos:result><eg>xs:gYearMonth("2000-03")</eg></fos:result>
+               <fos:postamble>The coercion from map to record discards superfluous entries.</fos:postamble>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -35366,14 +35374,14 @@ exists(filter($input, $predicate))
       </fos:properties>
 
       <fos:summary>
-         <p>Parses the URI provided and returns a map of its parts.</p>
+         <p>Parses the URI provided and returns a record representing its parts.</p>
       </fos:summary>
 
       <fos:rules>
          <p>If <code>$value</code> is the empty sequence, the result is the empty sequence.</p>
 
          <p>The function parses the <code>$value</code> provided,
-         returning a map containing its constituent parts: scheme,
+         returning a record containing its constituent parts: scheme,
          authority components, path, etc.
          In addition to parsing URIs as defined by <bibref ref="rfc3986"/>
          (and <bibref ref="rfc3987"/>), this function also attempts to
@@ -36211,11 +36219,11 @@ path with an explicit <code>file:</code> scheme.</p>
         </fos:options>
 
         <p>The components are derived from the contents of the
-        <code>$parts</code> map. To simplify the description below, a
-        value is considered to be present in the map if the relevant
-        field exists and is non-empty.</p>
+        <code>$parts</code> record. To simplify the description below, a
+        value is said to be present in the record if the relevant
+        field is non-empty.</p>
 
-        <p>If the <code>scheme</code> key is present in the map,
+        <p>If the <code>scheme</code> key is present,
         the URI begins with the value of that key. A URI is considered to be
         non-hierarchical if either the <code>hierarchical</code> key
         is present in the <code>$parts</code> map with the value
@@ -36259,7 +36267,7 @@ path with an explicit <code>file:</code> scheme.</p>
         </p>
 
         <p>If any of <code>$userinfo</code>, <code>$host</code>, or <code>$port</code>
-        exist, the following authority is added to the URI under construction:
+        is present, the following authority is added to the URI under construction:
         <eg>concat(
   if (exists($userinfo)) { $userinfo || "@" },
   $host,
@@ -36267,7 +36275,7 @@ path with an explicit <code>file:</code> scheme.</p>
 )</eg></p>
 
         <p>If none of <code>userinfo</code>, <code>host</code>, or <code>port</code>
-        is present, and <code>authority</code> is present, the value of the
+        is present, but <code>authority</code> is present, the value of the
         <code>authority</code> key is added to the URI. (In this case, no attempt
         is made to determine if a password or standard port are present,
         the <code>authority</code> value is simply added to the string.)</p>
@@ -36291,8 +36299,8 @@ path with an explicit <code>file:</code> scheme.</p>
         <code>query-parameters</code> keys out of the map.</p>
 
         <ulist>
-           <item><p>If the <code>path-segments</code> key exists in
-           the map, then the path is constructed from the segments. To
+           <item><p>If the <code>path-segments</code> key is present
+           then the path is constructed from the segments. To
            construct the path, the possibly encoded segments are
            concatentated together, separated by
            <char>U+002F</char> characters.</p>
@@ -36333,7 +36341,7 @@ path with an explicit <code>file:</code> scheme.</p>
 
         <p>The path is added to the URI.</p>
 
-        <p>If the <code>query-parameters</code> key exists in the map, its value
+        <p>If the <code>query-parameters</code> key is present, its value
         must be a map. A sequence of strings is constructed from the values in the map.</p>
 
         <p>To construct the string, each <emph>key</emph> and <emph>value</emph>
@@ -36365,7 +36373,7 @@ path with an explicit <code>file:</code> scheme.</p>
         <p>If there is a query, it is added to the URI with
         a preceding <char>U+003F</char>.</p>
 
-        <p>If the <code>fragment</code> key exists in the map, then
+        <p>If the <code>fragment</code> key is present, then
         the value of that key is encoded and added to the URI with a
         preceding <char>U+0023</char>.
 

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -26349,7 +26349,7 @@ map:size($map) eq 0
                >same key</termref> as <code>$key</code>. If there is such an entry, it returns the associated value.</p>
          
          <p>If there is no entry with the required key, the function returns the supplied <code>$default</code> value
-                  (which defaults to an empty sequence).</p></item>           
+                  (which defaults to an empty sequence).</p>          
          
 
       </fos:rules>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -38,57 +38,57 @@
       <fos:summary>
          <p>This record type represents the components of a URI.</p>
       </fos:summary>
-      <fos:field name="uri" type="xs:string?" required="true">
+      <fos:field name="uri" type="xs:string?" required="false">
          <fos:meaning>
             <p>The original URI. This element is returned by <function>fn:parse-uri</function>,
             but ignored by <function>fn:build-uri</function>.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="scheme" type="xs:string?" required="true">
+      <fos:field name="scheme" type="xs:string?" required="false">
          <fos:meaning>
             <p>The URI scheme (e.g., “https” or “file”).</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="absolute" type="xs:boolean?" required="true">
+      <fos:field name="absolute" type="xs:boolean?" required="false">
          <fos:meaning>
             <p>The URI is an absolute URI.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="hierarchical" type="xs:boolean?" required="true">
+      <fos:field name="hierarchical" type="xs:boolean?" required="false">
          <fos:meaning>
             <p>Whether the URI is hierarchical or not.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="authority" type="xs:string?" required="true">
+      <fos:field name="authority" type="xs:string?" required="false">
          <fos:meaning>
             <p>The authority portion of the URI (e.g., “example.com:8080”).</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="userinfo" type="xs:string?" required="true">
+      <fos:field name="userinfo" type="xs:string?" required="false">
          <fos:meaning><p>Any userinfo that was passed as part of the authority.</p></fos:meaning>
       </fos:field>
-      <fos:field name="host" type="xs:string?" required="true">
+      <fos:field name="host" type="xs:string?" required="false">
          <fos:meaning><p>The host passed as part of the authority (e.g., “example.com”). </p></fos:meaning>
       </fos:field>
-      <fos:field name="port" type="xs:integer?" required="true">
+      <fos:field name="port" type="xs:integer?" required="false">
          <fos:meaning><p>The port passed as part of the authority (e.g., “8080”).</p></fos:meaning>
       </fos:field>
-      <fos:field name="path" type="xs:string?" required="true">
+      <fos:field name="path" type="xs:string?" required="false">
          <fos:meaning><p>The path portion of the URI.</p></fos:meaning>
       </fos:field>
-      <fos:field name="query" type="xs:string?" required="true">
+      <fos:field name="query" type="xs:string?" required="false">
          <fos:meaning><p>Any query string.</p></fos:meaning>
       </fos:field>
-      <fos:field name="fragment" type="xs:string?" required="true">
+      <fos:field name="fragment" type="xs:string?" required="false">
          <fos:meaning><p>Any fragment identifier.</p></fos:meaning>
       </fos:field>
-      <fos:field name="path-segments" type="xs:string*" required="true">
+      <fos:field name="path-segments" type="xs:string*" required="false">
          <fos:meaning><p>Parsed and unescaped path segments.</p></fos:meaning>
       </fos:field>
-      <fos:field name="query-parameters" type="map(xs:string, xs:string*)?" required="true">
+      <fos:field name="query-parameters" type="map(xs:string, xs:string*)?" required="false">
          <fos:meaning><p>Parsed and unescaped query key-value pairs.</p></fos:meaning>
       </fos:field>
-      <fos:field name="filepath" type="xs:string?" required="true">
+      <fos:field name="filepath" type="xs:string?" required="false">
          <fos:meaning><p>The path of the URI, treated as a filepath.</p></fos:meaning>
       </fos:field>
    </fos:record-type>
@@ -109,12 +109,12 @@
             <p>Defines the overall strategy for converting the element content.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="child" type="xs:string?" required="true">
+      <fos:field name="child" type="xs:string?" required="false">
          <fos:meaning>
             <p>For list layouts, defines the name of the child element type contained in the list.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="type" type="enum('numeric', 'boolean', 'string')?" required="true">
+      <fos:field name="type" type="enum('numeric', 'boolean', 'string')" required="false">
          <fos:meaning>
             <p>For elements with simple content, defines whether they should be represented
                as numbers or booleans instead of the default representation as strings.</p>
@@ -164,7 +164,7 @@
             
          </fos:meaning>
       </fos:field>
-      <fos:field name="primitive-type" type="(fn() as schema-type-record)?" required="true">
+      <fos:field name="primitive-type" type="fn() as schema-type-record" required="false">
          <fos:meaning>
             <p>For an atomic type, a function item returning the primitive type from which this 
                type is ultimately derived. Corresponds to the
@@ -175,7 +175,8 @@
          </fos:meaning>
       </fos:field>
       <fos:field name="variety" 
-                 type='enum("atomic", "list", "union", "empty", "simple", "element-only", "mixed")?' required="true">
+                 required="false" 
+                 type='enum("atomic", "list", "union", "empty", "simple", "element-only", "mixed")'>
          <fos:meaning>
             <p>For a simple type, one of <code>"atomic"</code>, <code>"list"</code>, or <code>"union"</code>, corresponding to the
                <xtermref spec="XS11-1" ref="std-variety">{variety}</xtermref> of the simple type in the XSD component model. For a complex type, one of
@@ -186,7 +187,7 @@
             for the type <code>xs:anySimpleType</code>.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="members" type="fn() as schema-type-record*" required="true">
+      <fos:field name="members" required="false" type="fn() as schema-type-record*">
          <fos:meaning>
             <p>For a simple type with variety <code>"union"</code>, a function that returns a sequence of
                records representing the member types of the union, in order, corresponding to the
@@ -197,7 +198,7 @@
             the <xtermref spec="XS11-1" ref="std-item_type_definition">{item type definition}</xtermref> property in the XSD component model. In all other cases, absent.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="simple-content-type" type="(fn() as schema-type-record)?" required="true">
+      <fos:field name="simple-content-type" required="false" type="fn() as schema-type-record">
          <fos:meaning>
             <p>For a complex type with variety <code>"simple"</code> (that is, a complex type with simple content), 
                a function that returns a record representing the relevant simple type, corresponding to 
@@ -206,14 +207,14 @@
                In all other cases, absent.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="matches" type="(fn(xs:anyAtomicType) as xs:boolean)?"  required="true">
+      <fos:field name="matches" type="fn(xs:anyAtomicType) as xs:boolean" required="false">
          <fos:meaning>
             <p>For a <xtermref spec="XP40" ref="dt-generalized-atomic-type"/>, 
                a function item that can be called to establish whether the supplied atomic item
                is an instance of this type. In all other cases, absent.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="constructor" type="(fn(xs:anyAtomicType?) as xs:anyAtomicType*)?"  required="true">
+      <fos:field name="constructor" type="fn(xs:anyAtomicType?) as xs:anyAtomicType*" required="false">
          <fos:meaning>
             <p>For a simple type, a function item that can be used to construct instances of this type. In the case of a named
              type that is present in the dynamic context, the result is the same function as returned by 
@@ -377,40 +378,40 @@
             <code>xs:date</code>, <code>xs:time</code>, <code>xs:gYear</code>, <code>xs:gYearMonth</code>,
             <code>xs:gMonth</code>, <code>xs:gMonthDay</code>, or <code>xs:gDay</code>.</p>
       </fos:summary>
-      <fos:field name="year" type="xs:integer?"  required="true">
+      <fos:field name="year" type="xs:integer" required="false">
          <fos:meaning>
             <p>The value of the <code>year</code> component. Range is implementation-defined.
             If years less than one are supported, then the integer zero represents the year
             before year one, and the integer -1 represents the year before year zero.</p>
          </fos:meaning>        
       </fos:field>
-      <fos:field name="month" type="xs:integer?" required="true">
+      <fos:field name="month" type="xs:integer" required="false">
          <fos:meaning>
             <p>The value of the <code>month</code> component. A valid value is in the range 1 to 12 inclusive.</p>
          </fos:meaning>        
       </fos:field>
-      <fos:field name="day" type="xs:integer?" required="true">
+      <fos:field name="day" type="xs:integer" required="false">
          <fos:meaning>
             <p>The value of the <code>day</code> component. A valid value is in the range 1 to 31 inclusive.</p>
          </fos:meaning>        
       </fos:field>
-      <fos:field name="hours" type="xs:integer?"  required="true">
+      <fos:field name="hours" type="xs:integer" required="false">
          <fos:meaning>
             <p>The value of the <code>hours</code> component. A valid value is in the range 0 to 23 inclusive.</p>
          </fos:meaning>        
       </fos:field>
-      <fos:field name="minutes" type="xs:integer?" required="true">
+      <fos:field name="minutes" type="xs:integer" required="false">
          <fos:meaning>
             <p>The value of the <code>minutes</code> component. A valid value is in the range 0 to 59 inclusive.</p>
          </fos:meaning>        
       </fos:field>
-      <fos:field name="seconds" type="xs:decimal?" required="true">
+      <fos:field name="seconds" type="xs:decimal" required="false">
          <fos:meaning>
             <p>The value of the <code>seconds</code> component. A valid value is in the range 0 (inclusive) to 60 (exclusive).
             (Thus 59.9999999 is valid, but 60 is not.)</p>
          </fos:meaning>        
       </fos:field>
-      <fos:field name="timezone" type="xs:dayTimeDuration?"  required="true">
+      <fos:field name="timezone" type="xs:dayTimeDuration" required="false">
          <fos:meaning>
             <p>The timezone offset, if the value has a timezone. A valid value corresponds to an integral number
             of minutes between -840 and +840 inclusive.</p>
@@ -8855,45 +8856,6 @@ satisfies compare($t, replace($token, '^\s*|\s*$', ''), $collation) eq 0
          </fos:example>
       </fos:examples>
    </fos:function>
-   <!--<fos:function name="boolean-equal" prefix="op">
-      <fos:signatures>
-         <fos:proto name="boolean-equal" return-type="xs:boolean">
-            <fos:arg name="value1" type="xs:boolean"/>
-            <fos:arg name="value2" type="xs:boolean"/>
-         </fos:proto>
-      </fos:signatures>
-      <fos:opermap operator="eq" types="xs:boolean numeric"
-            >Defines the semantics of the <code>eq</code>
-         operator when applied to two <code>xs:boolean</code> values.</fos:opermap>
-      <fos:summary>
-         <p>Returns <code>true</code> if the two arguments are the same boolean value.</p>
-      </fos:summary>
-      <fos:rules>
-         <p>The function returns <code>true</code> if both arguments are <code>true</code> or if
-            both arguments are <code>false</code>. It returns <code>false</code> if one of the
-            arguments is <code>true</code> and the other argument is <code>false</code>. </p>
-      </fos:rules>
-   </fos:function>-->
-   <!--<fos:function name="boolean-less-than" prefix="op">
-      <fos:signatures>
-         <fos:proto name="boolean-less-than" return-type="xs:boolean">
-            <fos:arg name="arg1" type="xs:boolean"/>
-            <fos:arg name="arg2" type="xs:boolean"/>
-         </fos:proto>
-      </fos:signatures>
-      <fos:opermap operator="lt" types="xs:boolean numeric" other-operators="ge"
-            >Defines the
-         semantics of the <code>lt</code> operator when applied to two <code>xs:boolean</code> values. Also
-         used in the definition of the <code>ge</code> operator.</fos:opermap>
-      <fos:summary>
-         <p>Returns <code>true</code> if the first argument is <code>false</code> and the second is <code>true</code>.</p>
-      </fos:summary>
-      <fos:rules>
-         <p>The function returns <code>true</code> if <code>$arg1</code> is <code>false</code> and
-               <code>$arg2</code> is <code>true</code>. Otherwise, it returns
-            <code>false</code>.</p>
-      </fos:rules>
-   </fos:function>-->
 
    <fos:function name="boolean" prefix="fn">
       <fos:signatures>
@@ -9030,177 +8992,8 @@ satisfies compare($t, replace($token, '^\s*|\s*$', ''), $collation) eq 0
       </fos:examples>
    </fos:function>
    
-   <!--<fos:function name="yearMonthDuration-less-than" prefix="op">
-      <fos:signatures>
-         <fos:proto name="yearMonthDuration-less-than" return-type="xs:boolean">
-            <fos:arg name="arg1" type="xs:yearMonthDuration"/>
-            <fos:arg name="arg2" type="xs:yearMonthDuration"/>
-         </fos:proto>
-      </fos:signatures>
-      <fos:opermap operator="lt" types="xs:yearMonthDuration numeric" other-operators="ge"
-            >Defines
-         the semantics of the <code>lt</code> operator when applied to two <code>xs:yearMonthDuration</code>
-         values. Also used in the definition of the <code>ge</code> operator.</fos:opermap>
-      <fos:summary>
-         <p>Returns <code>true</code> if <code>$arg1</code> is a shorter duration than <code>$arg2</code>.</p>
-      </fos:summary>
-      <fos:rules>
-         <p>If the number of months in <code>$arg1</code> is numerically less than the
-            number of months in <code>$arg2</code>, the function returns <code>true</code>.</p>
-         <p>Otherwise, the function returns <code>false</code>.</p>
-      </fos:rules>
-      <fos:notes>
-         <p>Either or both durations may be negative.</p>
-      </fos:notes>
-   </fos:function>-->
-
-   <!--<fos:function name="dayTimeDuration-less-than" prefix="op">
-      <fos:signatures>
-         <fos:proto name="dayTimeDuration-less-than" return-type="xs:boolean">
-            <fos:arg name="arg1" type="xs:dayTimeDuration"/>
-            <fos:arg name="arg2" type="xs:dayTimeDuration"/>
-         </fos:proto>
-      </fos:signatures>
-      <fos:opermap operator="lt" types="xs:dayTimeDuration numeric" other-operators="ge"
-            >Defines the
-         semantics of the <code>lt</code> operator when applied to two <code>xs:dayTimeDuration</code> values.
-         Also used in the definition of the <code>ge</code> operator.</fos:opermap>
-      <fos:summary>
-         <p>Returns <code>true</code> if <code>$arg1</code> is a shorter duration than <code>$arg2</code>.</p>
-      </fos:summary>
-      <fos:rules>
-         <p>If the number of seconds in <code>$arg1</code> is numerically less than the
-            number of seconds in <code>$arg2</code>, the function returns <code>true</code>.</p>
-         <p>Otherwise, the function returns <code>false</code>.</p>
-      </fos:rules>
-      <fos:notes>
-         <p>Either or both durations may be negative</p>
-      </fos:notes>
-   </fos:function>
--->
-   <!--<fos:function name="duration-equal" prefix="op">
-      <fos:signatures>
-         <fos:proto name="duration-equal" return-type="xs:boolean">
-            <fos:arg name="arg1" type="xs:duration"/>
-            <fos:arg name="arg2" type="xs:duration"/>
-         </fos:proto>
-      </fos:signatures>
-      <fos:opermap operator="eq" types="xs:duration numeric" other-operators="ne"
-            >Defines the
-         semantics of the <code>eq</code> operators when applied to two <code>xs:duration</code> values. Also
-         used in the definition of the <code>ne</code> operator.</fos:opermap>
-      <fos:summary>
-         <p>Returns <code>true</code> if <code>$arg1</code> and <code>$arg2</code> are durations of the same
-            length.</p>
-      </fos:summary>
-      <fos:rules>
-         <p>If the <code>xs:yearMonthDuration</code> components of <code>$arg1</code> and
-               <code>$arg2</code> are equal and the <code>xs:dayTimeDuration</code> components of
-               <code>$arg1</code> and <code>$arg2</code> are equal, the function returns
-               <code>true</code>.</p>
-         <p>Otherwise, the function returns <code>false</code>.</p>
-         <p>The semantics of this function are:</p>
-         <eg xml:space="preserve">
-xs:yearMonthDuration($arg1) div xs:yearMonthDuration('P1M')  eq
-xs:yearMonthDuration($arg2) div xs:yearMonthDuration('P1M')
-    and
-xs:dayTimeDuration($arg1) div xs:dayTimeDuration('PT1S')  eq
-xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
-</eg>
-         <p>that is, the function returns <code>true</code> if the months and seconds values of the
-            two durations are equal.</p>
-      </fos:rules>
-      <fos:notes>
-         <p>Note that this function, like any other, may be applied to arguments that are derived
-            from the types given in the function signature, including the two subtypes
-               <code>xs:dayTimeDuration</code> and <code>xs:yearMonthDuration</code>. With the
-            exception of the zero-length duration, no instance of <code>xs:dayTimeDuration</code>
-            can ever be equal to an instance of <code>xs:yearMonthDuration</code>.</p>
-      </fos:notes>
-      <fos:examples>
-         <fos:example>
-            <fos:test>
-               <fos:expression><eg>op:duration-equal(
-  xs:duration("P1Y"),
-  xs:duration("P12M")
-)</eg></fos:expression>
-               <fos:result>true()</fos:result>
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <fos:test>
-               <fos:expression><eg>op:duration-equal(
-  xs:duration("PT24H"),
-  xs:duration("P1D")
-)</eg></fos:expression>
-               <fos:result>true()</fos:result>
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <fos:test>
-               <fos:expression><eg>op:duration-equal(
-  xs:duration("P1Y"),
-  xs:duration("P365D")
-)</eg></fos:expression>
-               <fos:result>false()</fos:result>
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <fos:test>
-               <fos:expression><eg>op:duration-equal(
-  xs:yearMonthDuration("P0Y"),
-  xs:dayTimeDuration("P0D")
-)</eg></fos:expression>
-               <fos:result>true()</fos:result>
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <fos:test>
-               <fos:expression><eg>op:duration-equal(
-  xs:yearMonthDuration("P1Y"),
-  xs:dayTimeDuration("P365D")
-)</eg></fos:expression>
-               <fos:result>false()</fos:result>
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <fos:test>
-               <fos:expression><eg>op:duration-equal(
-  xs:yearMonthDuration("P2Y"),
-  xs:yearMonthDuration("P24M")
-)</eg></fos:expression>
-               <fos:result>true()</fos:result>
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <fos:test>
-               <fos:expression><eg>op:duration-equal(
-  xs:dayTimeDuration("P10D"),
-  xs:dayTimeDuration("PT240H")
-)</eg></fos:expression>
-               <fos:result>true()</fos:result>
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <fos:test>
-               <fos:expression><eg>op:duration-equal(
-  xs:duration("P2Y0M0DT0H0M0S"),
-  xs:yearMonthDuration("P24M")
-)</eg></fos:expression>
-               <fos:result>true()</fos:result>
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <fos:test>
-               <fos:expression><eg>op:duration-equal(
-  xs:duration("P0Y0M10D"),
-  xs:dayTimeDuration("PT240H")
-)</eg></fos:expression>
-               <fos:result>true()</fos:result>
-            </fos:test>
-         </fos:example>
-      </fos:examples>
-   </fos:function>-->
+   
+   
    
    <fos:function name="seconds" prefix="fn">
       <fos:signatures>
@@ -9225,11 +9018,8 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
 
       </fos:rules>
       <fos:notes>
-         <p>The result of <code>seconds($n)</code> is approximately equal to the result of
-         the expression <code>xs:dayTimeDuration('PT1S') * $n</code>. The equivalence is only
-         approximate, because <code>seconds($n)</code> uses the exact <code>xs:decimal</code>
-         value supplied, whereas multiplying a duration by a number first converts the number
-         to an <code>xs:double</code> value, which may lose precision.</p>
+         <p>The result of <code>seconds($n)</code> is equal to the result of
+         the expression <code>xs:dayTimeDuration('PT1S') × $n</code>.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -9264,7 +9054,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression><eg>xs:dateTime('1970-01-01T00:00:00Z') + 1706702400 * seconds(1)</eg></fos:expression>
+               <fos:expression><eg>xs:dateTime('1970-01-01T00:00:00Z') + 1_706_702_400 × seconds(1)</eg></fos:expression>
                <fos:result>xs:dateTime('2024-01-31T12:00:00Z')</fos:result>
                <fos:postamble>The expression converts a Unix timestamp to an <code>xs:dateTime</code> value</fos:postamble>
             </fos:test>
@@ -9722,95 +9512,189 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          </fos:example>
       </fos:examples>
    </fos:function>
-   <fos:function name="multiply-yearMonthDuration" prefix="op">
+   <fos:function name="multiply-duration-by-number" prefix="op">
       <fos:signatures>
-         <fos:proto name="multiply-yearMonthDuration" return-type="xs:yearMonthDuration">
-            <fos:arg name="arg1" type="xs:yearMonthDuration"/>
-            <fos:arg name="arg2" type="xs:double"/>
+         <fos:proto name="multiply-duration-by-number" return-type="xs:duration">
+            <fos:arg name="arg1" type="xs:duration"/>
+            <fos:arg name="arg2" type="xs:numeric"/>
          </fos:proto>
       </fos:signatures>
-      <fos:opermap operator="*" types="xs:yearMonthDuration numeric"
+      <fos:opermap operator="*" types="xs:duration decimal"
             >Defines the semantics of the
-         <code>*</code> operator when applied to an <code>xs:yearMonthDuration</code> and a numeric
-         value.</fos:opermap>
+         <code>*</code> or <code>×</code> operator when applied to an <code>xs:duration</code> and a number.</fos:opermap>
       <fos:summary>
-         <p>Returns the result of multiplying  <code>$arg1</code> by <code>$arg2</code>.
-            The result is rounded to the nearest month.</p>
+         <p>Returns the result of multiplying a duration by a number.</p>
       </fos:summary>
       <fos:rules>
-         <p>The result is the <code>xs:yearMonthDuration</code> whose length in months is equal to
-            the result of applying the <function>fn:round</function> function to the value obtained by
-            multiplying the length in months of <code>$arg1</code> by the value of
-               <code>$arg2</code>.</p>
-         <p>If <code>$arg2</code> is positive or negative zero, the result is a zero-length
-            duration. For handling of overflow, underflow, and rounding, 
-            including the case where <code>$arg2</code> is positive or negative infinity, 
-            see <specref ref="duration-conformance"/>.</p>
+         <p>The result is an <code>xs:duration</code> value as follows:</p>
+         <ulist>
+            <item><p>The value of <code>$arg2</code> is cast to <code>xs:decimal</code>. This raises
+            an error if the value is NaN or infinite.</p></item>
+            <item><p>The value of the months component is formed by multiplying the months component
+            of <code>$arg1</code> by the decimal value of <code>$arg2</code> and rounding the result
+            to an integer by applying the <function>fn:round#1</function> function.</p></item>
+            <item><p>The value of the seconds component is formed by multiplying the seconds component
+            of <code>$arg1</code> by the decimal value of <code>$arg2</code> and rounding the result
+            to the maxumum precision supported by the implementation.</p></item>
+            <item><p>If <code>$arg1</code> is an instance of <code>xs:yearMonthDuration</code> then
+            the result is cast to <code>xs:yearMonthDuration</code>.</p></item>
+            <item><p>If <code>$arg1</code> is an instance of <code>xs:dayTimeDuration</code> then
+            the result is cast to <code>xs:dayTimeDuration</code>.</p></item>
+         </ulist>        
+         <p>For handling of overflow, underflow, and rounding, see <specref ref="duration-conformance"/>.</p>
       </fos:rules>
-      <fos:errors>
-         <p>A dynamic error is raised <errorref class="CA" code="0005"
-               /> if <code>$arg2</code> is
-               <code>NaN</code>.</p>
-      </fos:errors>
       <fos:notes>
-         <p>Either duration (and therefore the result) may be negative.</p>
+         <p>Either argument (and therefore the result) may be negative.</p>
+         <p>Because the months and seconds components are rounded independently of each
+         other, the result may be counter-intuitive. For example, the result
+         of <code>xs:duration('P1M1D') × 0.5</code> is <code>xs:duration('P1MT12H')</code>.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression><eg>op:multiply-yearMonthDuration(
+               <fos:expression><eg>op:multiply-duration-by-number(
   xs:yearMonthDuration("P2Y11M"),
   2.3
 )</eg></fos:expression>
                <fos:result>xs:yearMonthDuration("P6Y9M")</fos:result>
             </fos:test>
          </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>op:multiply-duration-by-number(
+  xs:duration("P11M"),
+  0.5
+)</eg></fos:expression>
+               <fos:result>xs:yearMonthDuration("P6M")</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>op:multiply-duration-by-number(
+  xs:dayTimeDuration("PT2H10M"),
+  2.1
+)</eg></fos:expression>
+               <fos:result>xs:dayTimeDuration('PT4H33M')</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>op:multiply-duration-by-number(
+  xs:duration("P1Y1D"),
+  2
+)</eg></fos:expression>
+               <fos:result>xs:duration('P2Y2D')</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>op:multiply-duration-by-number(
+  xs:duration("P1Y1D"),
+  -1
+)</eg></fos:expression>
+               <fos:result>xs:duration('-P1Y1D')</fos:result>
+            </fos:test>
+         </fos:example>
       </fos:examples>
+      <fos:changes>
+         <fos:change issue="2617" PR="2628" date="2026-05-12"><p>The operation now applies to any <code>xs:duration</code>,
+         not exclusively to instances of <code>xs:yearMonthDuration</code> and <code>xs:dayTimeDuration</code>.
+         The second argument is now converted to <code>xs:decimal</code> rather than <code>xs:double</code>.
+         This may affect the result of any rounding, as well as error codes when the argument
+         is NaN or infinity.</p></fos:change>
+      </fos:changes>
    </fos:function>
-   <fos:function name="divide-yearMonthDuration" prefix="op">
+   
+   <fos:function name="divide-duration-by-number" prefix="op">
       <fos:signatures>
-         <fos:proto name="divide-yearMonthDuration" return-type="xs:yearMonthDuration">
-            <fos:arg name="arg1" type="xs:yearMonthDuration"/>
-            <fos:arg name="arg2" type="xs:double"/>
+         <fos:proto name="divide-duration-by-number" return-type="xs:duration">
+            <fos:arg name="arg1" type="xs:duration"/>
+            <fos:arg name="arg2" type="xs:numeric"/>
          </fos:proto>
       </fos:signatures>
-      <fos:opermap operator="div" types="xs:yearMonthDuration numeric"
+      <fos:opermap operator="div" types="xs:duration decimal"
             >Defines the semantics of the
-         <code>div</code> operator when applied to an <code>xs:yearMonthDuration</code> and a numeric
-         value.</fos:opermap>
+         <code>div</code> or <code>÷</code> operator when applied to an <code>xs:duration</code> and a number.</fos:opermap>
       <fos:summary>
-         <p>Returns the result of dividing <code>$arg1</code> by <code>$arg2</code>.
-            The result is rounded to the nearest month.</p>
+         <p>Returns the result of dividing a duration by a number.</p>
       </fos:summary>
       <fos:rules>
-         <p>The result is the <code>xs:yearMonthDuration</code> whose length in months is equal to
-            the result of applying the <function>fn:round</function> function to the value obtained by
-            dividing the length in months of <code>$arg1</code> by the value of
-            <code>$arg2</code>.</p>
-         <p>If <code>$arg2</code> is positive or negative infinity, the result is a zero-length
-            duration. For handling of overflow, underflow, and rounding, see <specref ref="duration-conformance"/>.</p>
+         <p>The result is an <code>xs:duration</code> value as follows:</p>
+         <ulist>
+            <item><p>The value of <code>$arg2</code> is cast to <code>xs:decimal</code>. This raises
+            an error if the value is NaN or infinite.</p></item>
+            <item><p>The value of the months component is formed by dividing the months component
+            of <code>$arg1</code> by the decimal value of <code>$arg2</code> and rounding the result
+            to an integer by applying the <function>fn:round#1</function> function.</p></item>
+            <item><p>The value of the seconds component is formed by dividing the seconds component
+            of <code>$arg1</code> by the decimal value of <code>$arg2</code> and rounding the result
+            to the maxumum precision supported by the implementation.</p></item>
+            <item><p>If <code>$arg1</code> is an instance of <code>xs:yearMonthDuration</code> then
+            the result is cast to <code>xs:yearMonthDuration</code>.</p></item>
+            <item><p>If <code>$arg1</code> is an instance of <code>xs:dayTimeDuration</code> then
+            the result is cast to <code>xs:dayTimeDuration</code>.</p></item>
+         </ulist>        
+         <p>For handling of overflow, underflow, and rounding, see <specref ref="duration-conformance"/>.</p>
       </fos:rules>
       <fos:errors>
-         <p>A dynamic error is raised <errorref class="CA" code="0005"
-               /> if <code>$arg2</code> is
-               <code>NaN</code>.</p>
          <p>Division by zero raises <errorref class="DT" code="0002"/>.</p>
       </fos:errors>
       <fos:notes>
-         <p>Either operand (and therefore the result) may be negative.</p>
+         <p>Either argument (and therefore the result) may be negative.</p>
+         <p>Because the months and seconds components are rounded independently of each
+         other, the result may be counter-intuitive. For example, the result
+         of <code>xs:duration('P1M1D') ÷ 2</code> is <code>xs:duration('P1MT12H')</code>.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression><eg>op:divide-yearMonthDuration(
+               <fos:expression><eg>op:divide-duration-by-number(
   xs:yearMonthDuration("P2Y11M"),
+  2
+)</eg></fos:expression>
+               <fos:result>xs:yearMonthDuration("P1Y6M")</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>op:divide-duration-by-number(
+  xs:duration("P15M"),
+  2
+)</eg></fos:expression>
+               <fos:result>xs:duration("P8M")</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>op:divide-duration-by-number(
+  xs:dayTimeDuration("P1DT2H30M10.5S"),
   1.5
 )</eg></fos:expression>
-               <fos:result>xs:yearMonthDuration("P1Y11M")</fos:result>
+               <fos:result>xs:dayTimeDuration("PT17H40M7S")</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>op:divide-duration-by-number(
+  xs:duration("P2Y10D"),
+  2
+)</eg></fos:expression>
+               <fos:result>xs:dayTimeDuration("P1Y5D")</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:changes>
+         <fos:change issue="2617" PR="2628" date="2026-05-12"><p>The function now applies to any <code>xs:duration</code>,
+         not exclusively to instances of <code>xs:yearMonthDuration</code> and <code>xs:dayTimeDuration</code>.
+         The second argument is now defined as <code>xs:decimal</code> rather than <code>xs:double</code>.
+         This may affect the result of any rounding, as well as error codes when the argument
+         is NaN or infinity.</p></fos:change>
+      </fos:changes>
    </fos:function>
+   
+   
+   
+   
    <fos:function name="divide-yearMonthDuration-by-yearMonthDuration" prefix="op">
       <fos:signatures>
          <fos:proto name="divide-yearMonthDuration-by-yearMonthDuration" return-type="xs:decimal">
@@ -9914,6 +9798,9 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
             length in seconds of <code>$arg2</code>.</p>
          <p>For handling of overflow, see <specref ref="duration-conformance"/>.</p>
       </fos:rules>
+      <fos:errors>
+         <p>Division by a zero-length duration raises <errorref class="DT" code="0002"/>.</p>
+      </fos:errors>
       <fos:notes>
          <p>Either duration (and therefore the result) may be negative.</p>
       </fos:notes>
@@ -9927,100 +9814,19 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
                <fos:result>xs:dayTimeDuration('P1DT1H30M')</fos:result>
             </fos:test>
          </fos:example>
-      </fos:examples>
-   </fos:function>
-   <fos:function name="multiply-dayTimeDuration" prefix="op">
-      <fos:signatures>
-         <fos:proto name="multiply-dayTimeDuration" return-type="xs:dayTimeDuration">
-            <fos:arg name="arg1" type="xs:dayTimeDuration"/>
-            <fos:arg name="arg2" type="xs:double"/>
-         </fos:proto>
-      </fos:signatures>
-      <fos:opermap operator="*" types="xs:dayTimeDuration numeric"
-            >Defines the semantics of the <code>*</code>
-         operator when applied to an <code>xs:dayTimeDuration</code> and a numeric
-         value.</fos:opermap>
-      <fos:summary>
-         <p>Returns the result of multiplying a <code>xs:dayTimeDuration</code> by a number.</p>
-      </fos:summary>
-      <fos:rules>
-         <p>The function returns the result of multiplying <code>$arg1</code> by
-               <code>$arg2</code>. The result is the <code>xs:dayTimeDuration</code> whose length in
-            seconds is equal to the length in seconds of <code>$arg1</code> multiplied by the
-            numeric value <code>$arg2</code>.</p>
-
-         <p>If <code>$arg2</code> is positive or negative zero, the result is a zero-length
-            duration. If <code>$arg2</code> is positive or negative infinity, the result overflows
-            and is handled as described in <specref
-               ref="duration-conformance"/>. </p>
-         <p>For handling of overflow, underflow, and rounding, see <specref ref="duration-conformance"/>.</p>
-      </fos:rules>
-      <fos:errors>
-         <p>A dynamic error is raised <errorref class="CA" code="0005"
-               /> if <code>$arg2</code> is
-               <code>NaN</code>.</p>
-      </fos:errors>
-      <fos:notes>
-         <p>Either operand (and therefore the result) may be negative.</p>
-      </fos:notes>
-      <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression><eg>op:multiply-dayTimeDuration(
-  xs:dayTimeDuration("PT2H10M"),
-  2.1
+               <fos:expression><eg>op:subtract-dayTimeDurations(
+  xs:dayTimeDuration("P30D"),
+  xs:dayTimeDuration("P40DT6H")
 )</eg></fos:expression>
-               <fos:result>xs:dayTimeDuration('PT4H33M')</fos:result>
+               <fos:result>xs:dayTimeDuration('-P10DT6H')</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
    </fos:function>
-   <fos:function name="divide-dayTimeDuration" prefix="op">
-      <fos:signatures>
-         <fos:proto name="divide-dayTimeDuration" return-type="xs:dayTimeDuration">
-            <fos:arg name="arg1" type="xs:dayTimeDuration"/>
-            <fos:arg name="arg2" type="xs:double"/>
-         </fos:proto>
-      </fos:signatures>
-      <fos:opermap operator="div" types="xs:dayTimeDuration numeric"
-            >Defines the semantics of the
-         <code>div</code> operator when applied to two <code>xs:dayTimeDuration</code> values.</fos:opermap>
-      <fos:summary>
-         <p>Returns the result of multiplying a <code>xs:dayTimeDuration</code> by a number.</p>
-      </fos:summary>
-      <fos:rules>
-         <p>The function returns the result of dividing <code>$arg1</code> by
-               <code>$arg2</code>. The result is the <code>xs:dayTimeDuration</code> whose length in
-            seconds is equal to the length in seconds of <code>$arg1</code> divided by the numeric
-            value <code>$arg2</code>.</p>
-         <p>If <code>$arg2</code> is positive or negative infinity, the result is a zero-length
-            duration. If <code>$arg2</code> is positive or negative zero, the result overflows and
-            is handled as described in <specref
-               ref="duration-conformance"/>. </p>
- 
-         <p>For handling of overflow, underflow, and rounding, see <specref ref="duration-conformance"/>.</p>
-      </fos:rules>
-      <fos:errors>
-         <p>A dynamic error is raised <errorref class="CA" code="0005"
-               /> if <code>$arg2</code> is
-               <code>NaN</code>.</p>
-         <p>Division by zero raises <errorref class="DT" code="0002"/>.</p>
-      </fos:errors>
-      <fos:notes>
-         <p>Either operand (and therefore the result) may be negative.</p>
-      </fos:notes>
-      <fos:examples>
-         <fos:example>
-            <fos:test>
-               <fos:expression><eg>op:divide-dayTimeDuration(
-  xs:dayTimeDuration("P1DT2H30M10.5S"),
-  1.5
-)</eg></fos:expression>
-               <fos:result>xs:duration("PT17H40M7S")</fos:result>
-            </fos:test>
-         </fos:example>
-      </fos:examples>
-   </fos:function>
+   
+   
    <fos:function name="divide-dayTimeDuration-by-dayTimeDuration" prefix="op">
       <fos:signatures>
          <fos:proto name="divide-dayTimeDuration-by-dayTimeDuration" return-type="xs:decimal">
@@ -11363,7 +11169,8 @@ return ($value - unix-dateTime()) div seconds(0.001)</eg>
       <fos:rules>
          <p>If <code>$value</code> is the empty sequence, the function returns the empty sequence.</p>
          <p>Otherwise, the function returns a record whose fields are as follows. If a particular component
-         is not present in the value, the corresponding entry will be the empty sequence.</p>
+         is not present in the value, the corresponding entry will be absent from the map (the returned
+         map will never contain any entry whose value is the empty sequence).</p>
          <table>
             <thead>
                <tr>
@@ -11462,7 +11269,10 @@ return ($value - unix-dateTime()) div seconds(0.001)</eg>
          <p>If <code>$value</code> is the empty sequence, the function returns the empty sequence.</p>
          <p>Otherwise, the function returns a <termref def="dt-gregorian"/> value based on the supplied component
             values. The result will be the <termref def="dt-gregorian"/> value <code>$R</code> such that
-            <code>deep-equal( parts-of-dateTime($R), $value )</code>.</p>
+            <code>deep-equal( $significant(parts-of-dateTime($R)), $significant($value) )</code>,
+            where <code>$significant</code> is the function <code>map:filter(?, fn($K, $V){$K eq "timezone" or exists($V)})</code>,
+         that is, a function that discards entries in a map whose value is the empty sequence, other than the entry
+         with key <code>"timezone"</code>.</p>
          <p>If all seven components are present (year, month, day, hours, minutes, seconds, and timezone)
          then the result will be of type <code>xs:dateTimeStamp</code>.</p>
          <p>The range of years supported is <termref def="implementation-defined"/>. If years earlier than
@@ -11487,7 +11297,8 @@ return ($value - unix-dateTime()) div seconds(0.001)</eg>
         <p>A dynamic error is raised <errorref class="RG" code="0001" /> if any other component of <code>$value</code> is outside the permitted range specified by the target date/time datatype, for example: if <code>minutes</code> is less than zero or greater than 59; or if <code>day</code> is 30 and <code>month</code> is 2.  See <xspecref spec="DM31" ref="dates-and-times" />.</p>
       </fos:errors>
       <fos:notes>
-         
+         <p>Components that are present in <code>$value</code> but with an empty value are treated
+         as if they were absent.</p>
          <p>The timezone, if present, must correspond to an integral number of minutes in the range
          -840 to +840.</p>
          <p>Midnight must be expressed with the <code>hours</code> value set to zero, not 24.</p>
@@ -11522,20 +11333,6 @@ build-dateTime({
                <fos:expression><eg>
 build-dateTime({ "year": 2007, "month": 5, "timezone": xs:dayTimeDuration("PT0S") })</eg></fos:expression>
                <fos:result><eg>xs:gYearMonth("2007-05Z")</eg></fos:result>
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <fos:test>
-               <fos:expression><eg>build-dateTime({ "year": (), "hours": 13, "minutes": 30, "seconds": 4.2678 })</eg></fos:expression>
-               <fos:result><eg>xs:time("13:30:04.2678")</eg></fos:result>
-               <fos:postamble>An empty field is treated as absent.</fos:postamble>
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <fos:test>
-               <fos:expression><eg>build-dateTime({ "year": 2000, "quarter": 1, "month": 3 })</eg></fos:expression>
-               <fos:result><eg>xs:gYearMonth("2000-03")</eg></fos:result>
-               <fos:postamble>The coercion from map to record discards superfluous entries.</fos:postamble>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -26346,11 +26143,8 @@ map:size($map) eq 0
                >map</termref> supplied as <code>$map</code> that has 
             the <termref
                def="dt-same-key"
-               >same key</termref> as <code>$key</code>. If there is such an entry, it returns the associated value.</p>
-         
-         <p>If there is no entry with the required key, the function returns the supplied <code>$default</code> value
-                  (which defaults to an empty sequence).</p>          
-         
+               >same key</termref> as <code>$key</code>. If there is such an entry, it returns the associated value;
+            if not, it returns the supplied <code>$default</code> value.</p>
 
       </fos:rules>
       <fos:equivalent style="dm-primitive">
@@ -26365,7 +26159,6 @@ return (
   else $default
 )
       </fos:equivalent>
- 
       <fos:notes>
          <p>A return value of <code>()</code> from <function>map:get#2</function> could indicate that
             the key is present in the map with an associated value of <code>()</code>, or it could
@@ -26373,15 +26166,16 @@ return (
             either by calling <function>map:contains</function> to test whether an entry is present, or by using
             a <code>$default</code> value to return a value known never to appear in the map.</p>
          
+         <p>When <code>map:get</code> is applied to a record, the rules are the same as for any other map:
+         there is no error if the supplied <code>$key</code> is not present in the record, instead the
+         value of <code>$default</code> (defaulting to the empty sequence) is returned. When <code>$R</code>
+         is a record, the effect of <code>map:get($R, $K)</code> differs from <code>$R($K)</code>.</p>
 
-
-         <p>Invoking the <termref def="dt-map"
-               >map</termref> as a function item has the same effect
-            as calling <code>get</code> with no <code>$default</code>
-            argument: that is, when <code>$map</code> is a map, the expression
-               <code>$map($K)</code> is equivalent to <code>map:get($map, $K)</code>. Similarly, the
+         <p>In other cases (that is, where <code>$map</code> is not a record),
+            invoking <code>map:get($map, $K)</code> returns the same result as <code>$map($K)</code>.
+            This means that the
             expression <code>map:get(map:get(map:get($map, 'employee'), 'name'), 'first')</code> can
-            be written as <code>$map('employee')('name')('first')</code>.</p>
+            also be written as <code>$map('employee')('name')('first')</code>.</p>
 
       </fos:notes>
       <fos:examples>
@@ -26404,11 +26198,10 @@ return (
                <fos:postamble>An empty sequence as the result can also signify that the key is
                   present and the associated value is the empty sequence.</fos:postamble>
             </fos:test>
-            <fos:test>
-               <fos:expression><eg>let $map as record(x, y) := {'x':1, 'y':2}
-return map:get($map, 'z')</eg></fos:expression>
-               <fos:error-result error-code="FOTY0016"/>
-               <fos:postamble>A type error occurs because the key is not defined in the record type.</fos:postamble>
+            <fos:test use="v-map-get-week">
+               <fos:expression>map:get($week, 7, "n/a")</fos:expression>
+               <fos:result>"n/a"</fos:result>
+               <fos:postamble>The third argument supplies a default value.</fos:postamble>
             </fos:test>
             <!--<fos:test>
                <fos:expression><eg>{ 1: "single", 2: "double", 3: "triple" }
@@ -26573,7 +26366,6 @@ declare function map:find(
          returns a map containing all entries from the supplied <code>$map</code>
          (retaining their relative position) followed by a new entry whose key
          is <code>$key</code> and whose associated value is <code>$value</code>.</p>
-        
 
       </fos:rules>
       
@@ -26597,10 +26389,6 @@ declare function map:find(
          value in a different timezone. In this situation it is 
          <termref def="implementation-dependent"/> whether the key that appears in the result map
          is the supplied <code>$key</code> or the existing key.</p>
-         
-         <p>When <function>map:put</function> is applied to a record, the result is a map:
-         it is not a record, and the new key and value are not constrainted in any way
-         by the type annotations of the supplied record.</p>
 
       </fos:notes>
 
@@ -26789,8 +26577,7 @@ map:of-pairs((
             that key value is simply ignored</phrase>.</p>
          <p>The relative position of retained entries in the result map 
             is the same as their relative position in <code>$map</code>.</p>
-         <p>The function <function>map:remove</function> is not applicable to records, because records
-         have a fixed set of entries corresponding to the field names in the definition of the record type.</p>
+        
       </fos:rules>
       <fos:equivalent style="xpath-expression">
 map:filter(
@@ -26798,10 +26585,6 @@ map:filter(
   fn($k, $v) { not(some($keys, atomic-equal($k, ?))) }
 )
       </fos:equivalent>
-      <fos:errors>
-         <p>A type error <errorref class="TY" code="0017"/> is raised 
-            if <code>$map</code> is a <xtermref spec="DM40" ref="record"/> .</p>
-      </fos:errors>
 
       <fos:examples>
          <fos:variable name="week" id="v-map-remove-week"
@@ -35353,14 +35136,14 @@ exists(filter($input, $predicate))
       </fos:properties>
 
       <fos:summary>
-         <p>Parses the URI provided and returns a record representing its parts.</p>
+         <p>Parses the URI provided and returns a map of its parts.</p>
       </fos:summary>
 
       <fos:rules>
          <p>If <code>$value</code> is the empty sequence, the result is the empty sequence.</p>
 
          <p>The function parses the <code>$value</code> provided,
-         returning a record containing its constituent parts: scheme,
+         returning a map containing its constituent parts: scheme,
          authority components, path, etc.
          In addition to parsing URIs as defined by <bibref ref="rfc3986"/>
          (and <bibref ref="rfc3987"/>), this function also attempts to
@@ -36198,11 +35981,11 @@ path with an explicit <code>file:</code> scheme.</p>
         </fos:options>
 
         <p>The components are derived from the contents of the
-        <code>$parts</code> record. To simplify the description below, a
-        value is said to be present in the record if the relevant
-        field is non-empty.</p>
+        <code>$parts</code> map. To simplify the description below, a
+        value is considered to be present in the map if the relevant
+        field exists and is non-empty.</p>
 
-        <p>If the <code>scheme</code> key is present,
+        <p>If the <code>scheme</code> key is present in the map,
         the URI begins with the value of that key. A URI is considered to be
         non-hierarchical if either the <code>hierarchical</code> key
         is present in the <code>$parts</code> map with the value
@@ -36246,7 +36029,7 @@ path with an explicit <code>file:</code> scheme.</p>
         </p>
 
         <p>If any of <code>$userinfo</code>, <code>$host</code>, or <code>$port</code>
-        is present, the following authority is added to the URI under construction:
+        exist, the following authority is added to the URI under construction:
         <eg>concat(
   if (exists($userinfo)) { $userinfo || "@" },
   $host,
@@ -36254,7 +36037,7 @@ path with an explicit <code>file:</code> scheme.</p>
 )</eg></p>
 
         <p>If none of <code>userinfo</code>, <code>host</code>, or <code>port</code>
-        is present, but <code>authority</code> is present, the value of the
+        is present, and <code>authority</code> is present, the value of the
         <code>authority</code> key is added to the URI. (In this case, no attempt
         is made to determine if a password or standard port are present,
         the <code>authority</code> value is simply added to the string.)</p>
@@ -36278,8 +36061,8 @@ path with an explicit <code>file:</code> scheme.</p>
         <code>query-parameters</code> keys out of the map.</p>
 
         <ulist>
-           <item><p>If the <code>path-segments</code> key is present
-           then the path is constructed from the segments. To
+           <item><p>If the <code>path-segments</code> key exists in
+           the map, then the path is constructed from the segments. To
            construct the path, the possibly encoded segments are
            concatentated together, separated by
            <char>U+002F</char> characters.</p>
@@ -36320,7 +36103,7 @@ path with an explicit <code>file:</code> scheme.</p>
 
         <p>The path is added to the URI.</p>
 
-        <p>If the <code>query-parameters</code> key is present, its value
+        <p>If the <code>query-parameters</code> key exists in the map, its value
         must be a map. A sequence of strings is constructed from the values in the map.</p>
 
         <p>To construct the string, each <emph>key</emph> and <emph>value</emph>
@@ -36352,7 +36135,7 @@ path with an explicit <code>file:</code> scheme.</p>
         <p>If there is a query, it is added to the URI with
         a preceding <char>U+003F</char>.</p>
 
-        <p>If the <code>fragment</code> key is present, then
+        <p>If the <code>fragment</code> key exists in the map, then
         the value of that key is encoded and added to the URI with a
         preceding <char>U+0023</char>.
 

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -26348,15 +26348,9 @@ map:size($map) eq 0
                def="dt-same-key"
                >same key</termref> as <code>$key</code>. If there is such an entry, it returns the associated value.</p>
          
-         <p>If there is no entry with the required key, then:</p>
-         <ulist>
-            <item><p>If <code>$map</code> is a <xtermref spec="DM40" ref="dt-record"/> whose
-               <xtermref spec="DM40" ref="dt-type-annotation"/> is a <xtermref spec="DM40" ref="dt-record-type"/>
-               that contains no field definition matching the required key, a type error
-               <errorref class="TY" code="0016"/> is raised.</p></item>
-            <item><p>Otherwise, the function returns the supplied <code>$default</code> value
+         <p>If there is no entry with the required key, the function returns the supplied <code>$default</code> value
                   (which defaults to an empty sequence).</p></item>           
-         </ulist>
+         
 
       </fos:rules>
       <fos:equivalent style="dm-primitive">
@@ -26371,11 +26365,7 @@ return (
   else $default
 )
       </fos:equivalent>
-      <fos:errors>
-         <p>Raises type error <errorref class="TY" code="0016"/> if <code>$map</code> is a record
-         whose type annotation does not define a field whose name is equal to the supplied
-         key value, when compared using <function>fn:atomic-equal</function>.</p>
-      </fos:errors>
+ 
       <fos:notes>
          <p>A return value of <code>()</code> from <function>map:get#2</function> could indicate that
             the key is present in the map with an associated value of <code>()</code>, or it could
@@ -26583,17 +26573,7 @@ declare function map:find(
          returns a map containing all entries from the supplied <code>$map</code>
          (retaining their relative position) followed by a new entry whose key
          is <code>$key</code> and whose associated value is <code>$value</code>.</p>
-         
-         <p>If <code>$map</code> is a <xtermref spec="DM40" ref="dt-record"/>
-         with a <xtermref spec="DM40" ref="dt-type-annotation"/> <var>R</var>,
-         then:</p>
-         
-         <ulist>
-            <item><p>The result map is coerced to type <var>R</var> by applying
-            the <xtermref spec="XP40" ref="dt-coercion-rules"/>.</p></item>
-            <item><p>If the coercion fails, a type error is raised: 
-            <errorref class="TY" code="0016"/>.</p></item>
-         </ulist>
+        
 
       </fos:rules>
       
@@ -26618,15 +26598,9 @@ declare function map:find(
          <termref def="implementation-dependent"/> whether the key that appears in the result map
          is the supplied <code>$key</code> or the existing key.</p>
          
-         <p>When <function>map:put</function> is applied to a record, the result will always
-         be an instance of the same record type as the supplied map; a type error is raised
-         if this is not the case (this occurs when <code>$key</code> is not a defined
-            field name in the record type, or when <code>$value</code> is not an appropriate
-            value for this field). In many cases a processor may be able to detect the
-            error statically. When this checking is not wanted, it is possible
-         to bypass it by first converting the record to an ordinary map, which
-         can be conveniently achieved by writing the argument in curly braces:
-         <code>map:put({$record}, 'extra-key', 'extra-value')</code>.</p>
+         <p>When <function>map:put</function> is applied to a record, the result is a map:
+         it is not a record, and the new key and value are not constrainted in any way
+         by the type annotations of the supplied record.</p>
 
       </fos:notes>
 

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -26815,7 +26815,8 @@ map:of-pairs((
             that key value is simply ignored</phrase>.</p>
          <p>The relative position of retained entries in the result map 
             is the same as their relative position in <code>$map</code>.</p>
-        
+         <p>The function <function>map:remove</function> is not applicable to records, because records
+         have a fixed set of entries corresponding to the field names in the definition of the record type.</p>
       </fos:rules>
       <fos:equivalent style="xpath-expression">
 map:filter(
@@ -26823,6 +26824,10 @@ map:filter(
   fn($k, $v) { not(some($keys, atomic-equal($k, ?))) }
 )
       </fos:equivalent>
+      <fos:errors>
+         <p>A type error <errorref class="TY" code="0017"/> is raised 
+            if <code>$map</code> is a <xtermref spec="DM40" ref="record"/> .</p>
+      </fos:errors>
 
       <fos:examples>
          <fos:variable name="week" id="v-map-remove-week"

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -26338,8 +26338,17 @@ map:size($map) eq 0
                >map</termref> supplied as <code>$map</code> that has 
             the <termref
                def="dt-same-key"
-               >same key</termref> as <code>$key</code>. If there is such an entry, it returns the associated value;
-            if not, it returns the supplied <code>$default</code> value.</p>
+               >same key</termref> as <code>$key</code>. If there is such an entry, it returns the associated value.</p>
+         
+         <p>If there is no entry with the required key, then:</p>
+         <ulist>
+            <item><p>If <code>$map</code> is a <xtermref spec="DM40" ref="dt-record"/> whose
+               <xtermref spec="DM40" ref="dt-type-annotation"/> is a <xtermref spec="DM40" ref="dt-record-type"/>
+               that contains no field definition matching the required key, a type error
+               <errorref class="TY" code="0016"/> is raised.</p></item>
+            <item><p>Otherwise, the function returns the supplied <code>$default</code> value
+                  (which defaults to an empty sequence).</p></item>           
+         </ulist>
 
       </fos:rules>
       <fos:equivalent style="dm-primitive">
@@ -26354,6 +26363,11 @@ return (
   else $default
 )
       </fos:equivalent>
+      <fos:errors>
+         <p>Raises type error <errorref class="TY" code="0016"/> if <code>$map</code> is a record
+         whose type annotation does not define a field whose name is equal to the supplied
+         key value, when compared using <function>fn:atomic-equal</function>.</p>
+      </fos:errors>
       <fos:notes>
          <p>A return value of <code>()</code> from <function>map:get#2</function> could indicate that
             the key is present in the map with an associated value of <code>()</code>, or it could
@@ -26392,10 +26406,11 @@ return (
                <fos:postamble>An empty sequence as the result can also signify that the key is
                   present and the associated value is the empty sequence.</fos:postamble>
             </fos:test>
-            <fos:test use="v-map-get-week">
-               <fos:expression>map:get($week, 7, "n/a")</fos:expression>
-               <fos:result>"n/a"</fos:result>
-               <fos:postamble>The third argument supplies a default value.</fos:postamble>
+            <fos:test>
+               <fos:expression><eg>let $map as record(x, y) := {'x':1, 'y':2}
+return map:get($map, 'z')</eg></fos:expression>
+               <fos:error-result error-code="FOTY0016"/>
+               <fos:postamble>A type error occurs because the key is not defined in the record type.</fos:postamble>
             </fos:test>
             <!--<fos:test>
                <fos:expression><eg>{ 1: "single", 2: "double", 3: "triple" }
@@ -26560,6 +26575,17 @@ declare function map:find(
          returns a map containing all entries from the supplied <code>$map</code>
          (retaining their relative position) followed by a new entry whose key
          is <code>$key</code> and whose associated value is <code>$value</code>.</p>
+         
+         <p>If <code>$map</code> is a <xtermref spec="DM40" ref="dt-record"/>
+         with a <xtermref spec="DM40" ref="dt-type-annotation"/> <var>R</var>,
+         then:</p>
+         
+         <ulist>
+            <item><p>The result map is coerced to type <var>R</var> by applying
+            the <xtermref spec="XP40" ref="dt-coercion-rules"/>.</p></item>
+            <item><p>If the coercion fails, a type error is raised: 
+            <errorref class="TY" code="0016"/>.</p></item>
+         </ulist>
 
       </fos:rules>
       
@@ -26583,6 +26609,16 @@ declare function map:find(
          value in a different timezone. In this situation it is 
          <termref def="implementation-dependent"/> whether the key that appears in the result map
          is the supplied <code>$key</code> or the existing key.</p>
+         
+         <p>When <function>map:put</function> is applied to a record, the result will always
+         be an instance of the same record type as the supplied map; a type error is raised
+         if this is not the case (this occurs when <code>$key</code> is not a defined
+            field name in the record type, or when <code>$value</code> is not an appropriate
+            value for this field). In many cases a processor may be able to detect the
+            error statically. When this checking is not wanted, it is possible
+         to bypass it by first converting the record to an ordinary map, which
+         can be conveniently achieved by writing the argument in curly braces:
+         <code>map:put({$record}, 'extra-key', 'extra-value')</code>.</p>
 
       </fos:notes>
 

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -14573,6 +14573,11 @@ ISBN 0 521 77752 6.</bibl>
                <p>Raised by <function>fn:deep-equal</function> if either input sequence contains a
                   function item.</p> 
             </error>-->
+            <error class="TY" code="0016" label="Key value not defined in record type"
+               type="type">
+               <p>Raised by <function>map:get</function>, or similar operations, when requesting
+                  access by key to a record of a type that does not include the key.</p>
+            </error>
             <error class="UT" code="1170" label="Invalid URI reference."
                type="dynamic">
                <p>Raised by <function>fn:unparsed-text</function> or <function>fn:unparsed-text-lines</function>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -6597,8 +6597,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             
             <p>The functions defined in this section use a conventional namespace prefix <code>map</code>, which
                is assumed to be bound to the namespace URI <code>http://www.w3.org/2005/xpath-functions/map</code>.</p>
-            
-            
+           
             
             
             <p>The function call <code>map:get($map, $key)</code> can be used to retrieve the value associated with a given key.</p>
@@ -6613,12 +6612,14 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             if the <term>·jvalue·</term> property of the JNode is a map, then the map is automatically
             extracted as if by the <function>jvalue</function> function.</p>
             
+            <p>Because records are maps, these functions can all be used to process records. The result, however,
+            is not a record and is not constrained by the type annotation of the input record.</p>
             
             
             <?local-function-index?>
             
             
-            <div3 id="func-map-build" diff="add" at="A">
+            <div3 id="func-map-build">
                <head><?function map:build?></head>
             </div3>
             <div3 id="func-map-contains">
@@ -6627,13 +6628,13 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <div3 id="func-map-empty">
                <head><?function map:empty?></head>
             </div3>
-            <div3 id="func-map-entries" diff="add" at="2023-04-19">
+            <div3 id="func-map-entries">
                <head><?function map:entries?></head>
             </div3>
             <div3 id="func-map-entry">
                <head><?function map:entry?></head>
             </div3>
-            <div3 id="func-map-filter" diff="add" at="A">
+            <div3 id="func-map-filter">
                <head><?function map:filter?></head>
             </div3>
             <div3 id="func-map-find">
@@ -6645,7 +6646,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <div3 id="func-map-get">
                <head><?function map:get?></head>
             </div3>
-            <div3 id="func-map-items" diff="add" at="2023-04-19">
+            <div3 id="func-map-items">
                <head><?function map:items?></head>
             </div3>
             <div3 id="func-map-keys">
@@ -6657,15 +6658,6 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <div3 id="func-map-merge">
                <head><?function map:merge?></head>
             </div3>
-            <!--<div3 id="func-map-of-pairs" diff="add" at="2023-04-03">
-               <head><?function map:of-pairs?></head>
-            </div3>-->
-            <!--<div3 id="func-map-pair">
-               <head><?function map:pair?></head>
-            </div3>-->
-            <!--<div3 id="func-map-pairs" diff="add" at="2023-04-03">
-               <head><?function map:pairs?></head>
-            </div3>-->
             <div3 id="func-map-put">
                <head><?function map:put?></head>
             </div3>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -6705,7 +6705,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                <item><p><function>map:size</function> returns the number of fields
                      in the record type definition.</p>
                   <p>To count the number of fields that
-               have a non-empty value, use <code>map:size(map:filter(fn($k, $v){exists($v)})</code>.</p></item>
+               have a non-empty value, use <code>map:filter(fn($k, $v){ exists($v) }) => map:size()</code>.</p></item>
             </ulist>
             
             <p>A record <var>$R</var> can be converted to a non-record map having the same keys and values 

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -6679,6 +6679,61 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             
          </div2>
          
+         <div2 id="applying-functions-to-records">
+            <head>Applying functions to records</head>
+            
+            <p>A <xtermref spec="DM40" ref="record"/> is a <termref def="dt-map"/>, and any function
+            that takes a map as an argument can therefore also be used to process a record.</p>
+            
+            <p>Two of the map functions (the functions listed in <specref ref="map-functions"/>) 
+               treat records specially:</p>
+            
+            <ulist>
+               <item><p><function>map:get</function> raises a type error when applied to a record
+               if the requested key does not match any field name defined for the corresponding
+               record type.</p></item>
+               <item><p><function>map:put</function>, when applied to a record, returns an instance 
+                     of the same record type, and therefore raises a type error if either the supplied
+               key or the supplied value is not valid for that record type.</p></item>
+            </ulist>
+            
+            <p>When the return type of a function is declared as a map type, the result will not be
+            a record unless otherwise specified.</p>
+            
+            <p>Some observations about specific map functions when applied to records:</p>
+            
+            <ulist>
+               <item><p><function>map:contains</function> returns <code>true</code> if the
+               supplied key is the name of a field in the record type definition, or
+               <code>false</code> otherwise.</p></item>
+               <item><p><function>map:keys</function> returns the names of the fields
+                     in the record type definition, in order.</p></item>
+               <item><p>The argument to <function>map:remove</function> must not be a
+               record.</p></item>
+               <item><p><function>map:size</function> returns the number of fields
+                     in the record type definition.</p>
+                  <p>To count the number of fields that
+               have a non-empty value, use <code>map:size(map:filter(fn($k, $v){exists($v)})</code>.</p></item>
+            </ulist>
+            
+            <p>A record <var>$R</var> can be converted to a non-record map having the same keys and values 
+            in a number of ways, including:</p>
+            
+            <ulist>
+               <item><p>map:merge($R)</p></item>
+               <item><p>map:filter($R, true#0)</p></item>
+               <item><p>{$R}</p></item>
+            </ulist>
+            
+            <p>A map is converted to a record of type <var>T</var> by applying the coercion rules with
+            <var>T</var> as the required type. It may be convenient to define a function such as:</p>
+            
+            <eg>let $build-<var>T</var> as (fn($map as map(*)) as <var>T</var>) := fn{$map}</eg>
+            
+            <p>to invoke this conversion. (The functions <function>build-uri</function> and 
+               <function>build-dateTime</function> follow this pattern.)</p>
+         </div2>
+         
          <div2 id="xml-to-json-mappings">
             <head>Converting elements to maps</head>
             <changes>
@@ -14575,8 +14630,14 @@ ISBN 0 521 77752 6.</bibl>
             </error>-->
             <error class="TY" code="0016" label="Key value not defined in record type"
                type="type">
-               <p>Raised by <function>map:get</function>, or similar operations, when requesting
-                  access by key to a record of a type that does not include the key.</p>
+               <p>Raised by <function>map:get</function> when requesting
+                  access by key to a record of a type that does not include the key, and by <function>map:put</function>
+                  if either the supplied key or value is not allowed by the record type definition.
+               </p>
+            </error>
+            <error class="TY" code="0017" label="Argument to map:remove is a record"
+               type="type">
+               <p>Raised by <function>map:remove</function> if applied to a record.</p>
             </error>
             <error class="UT" code="1170" label="Invalid URI reference."
                type="dynamic">

--- a/specifications/xquery-40/src/ebnf.xml
+++ b/specifications/xquery-40/src/ebnf.xml
@@ -1052,37 +1052,37 @@
         <tr>
           <td>13</td>
           <td>
-            <nt def="InstanceofExpr">instance of</nt>
+            <nt def="RecordPutExpr">+:=</nt>
           </td>
-          <td>NA</td>
+          <td>left-to-right</td>
         </tr>
         <tr>
           <td>14</td>
           <td>
-            <nt def="TreatExpr">treat as</nt>
+            <nt def="InstanceofExpr">instance of</nt>
           </td>
           <td>NA</td>
         </tr>
         <tr>
           <td>15</td>
           <td>
-            <nt def="CastableExpr">castable as</nt>
+            <nt def="TreatExpr">treat as</nt>
           </td>
           <td>NA</td>
         </tr>
         <tr>
           <td>16</td>
           <td>
-            <nt def="CastExpr">cast as</nt>
+            <nt def="CastableExpr">castable as</nt>
           </td>
           <td>NA</td>
         </tr>
         <tr>
           <td>17</td>
           <td>
-            <nt def="PipelineExpr">-></nt>
+            <nt def="CastExpr">cast as</nt>
           </td>
-          <td>left-to-right</td>
+          <td>NA</td>
         </tr>
         <tr>
           <td>18</td>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -6134,60 +6134,113 @@ name.</p>
                      Extensible map types are dropped; instead, the coercion rules cause undefined
                      map entries to be discarded.
                   </change>
+                  <change date="2026-03-31">
+                     Records now carry a type annotation identifying a record type, and their behavior
+                     as well as their content is constrained by that record type. Optional fields in records
+                     are dropped (there is no longer a distinction between absent values and empty values).
+                  </change>
                </changes>
                
-               <p>A <nt def="RecordType">RecordType</nt> matches maps that meet specific criteria.</p>
+               <p><termdef id="dt-record" term="record">A <term>record</term> is a <termref def="dt-map"/>
+               whose structure and behavior is constrained by a <termref def="dt-record-type"/>.</termdef></p>
+               
+               <p><termdef id="dt-record-type" term="record type">A <term>record type</term>
+               is a sequence of field declarations, where each field declaration defines a name (an arbitrary
+               <xtermref spec="DM40" ref="dt-string"/>) and a type (an arbitrary <termref def="dt-sequence-type"/>).</termdef></p>
+               
+               <p>The syntax for defining a <termref def="dt-record-type"/> is the production
+               <nt def="RecordType">RecordType</nt>.</p>
+               
+               
+               <scrap>
+                  <prodrecap ref="RecordType"/>
+               </scrap>
 
+
+               
+               
                <p>For example, the <code>RecordType</code>
                   <code>record(r as xs:double, i as xs:double)</code>
-		             matches a map if the map has exactly two entries: an entry with key <code>"r"</code>
-		                whose value is a <termref def="dt-singleton"/> <code>xs:double</code> value, and an entry with key <code>"i"</code>
+		             defines a record type with two fields: an field with key <code>"r"</code>
+		                whose value is a <termref def="dt-singleton"/> <code>xs:double</code> value, and a field with key <code>"i"</code>
 		                whose value is also a <termref def="dt-singleton"/> <code>xs:double</code> value.</p>
+               
+               <p>If the type declaration for a field is omitted, then <code>item()*</code> is assumed: that is,
+		             the map entry may have any type.</p>
+               
+               <p>For generality, the syntax <code>record()</code> defines a record type that has no explicit fields. 
+                  The only thing it matches is an <xtermref spec="DM40" ref="dt-empty-map"/>.</p>
                
                <p>Record types describe a subset of the value space of maps. They do not define any new kinds of
 		             values, or any additional operations. They are useful in many cases to describe more accurately the
 		             type of a variable, function parameter, or function result, giving benefits both in the readability
 		             of the code, and in the ability of the processor to detect and diagnose type errors and to optimize
 		             execution.</p>
-
-
-               <scrap>
-                  <prodrecap ref="RecordType"/>
-               </scrap>
-
-              
+               
+               <p>A map <var>M</var> matches a record type <var>R</var> if and only if both the
+                  following conditions are true:</p>
+               
+               <olist>
+                  <item><p>For every field definition
+                     <var>F</var> in <var>R</var>, one of the following conditions is true:</p>
+               
+                     <olist>
+                        <item><p><var>M</var> contains an entry whose key is the <termref def="dt-same-key"/>
+                        value as the name of <var>F</var>, and whose associated value matches the declared type of
+                        <var>F</var>.</p></item>
+                        <item><p><var>M</var> contains no entry whose key is the <termref def="dt-same-key"/>
+                        value as the name of <var>F</var>, and the empty sequence matches the declared type of
+                        <var>F</var>.</p></item>
+                     </olist>
+                     
+                  </item>
+                  <item>
+                     <p>For every entry <var>E</var> in <var>M</var>, <var>R</var> contains a field
+                     definition <var>F</var> whose name is the <termref def="dt-same-key"/> value
+                     as the key of <var>E</var>.</p>
+                  </item>
+               </olist> 
+               
+               <note>
+                  <p>It is not necessary that <var>M</var> should be a <termref def="dt-record"/>,
+                  nor that (in the case where it is a record) its type annotation should be a subtype of <var>R</var>.
+                  However, if <var>M</var> is a record and its type annotation is a subtype of <var>R</var>,
+                  then it will necessarily match <var>R</var>, which can make type checking more efficient.</p>
+                  <p>For type matching against a record type, absent values and empty values are considered
+                  equivalent: if the required type of a field permits an empty sequence, then it also
+                  matches a map in which the corresponding entry is absent.</p>
+                  <p>The <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> of a map 
+                     is of no consequence when deciding whether or not
+                  the map matches a given record type.</p>
+               </note>
+               
+               <p>Record types provide stronger type checking than general maps. Accessing an entry
+               within a record gives a type error (rather than an empty result) if the key is not one of
+               the field names defined for the record, and replacing a value for a field gives a type error
+               if the new value does not conform to the required type. These type errors can be reported
+               statically if they are detected statically, which will often be possible if variables and
+               function parameters declare their required type as a record type.</p>
+               
+               <p>Records are created by coercing a map to the required
+                  record type, as described in <specref ref="id-item-coercion-rules"/>.
+               </p> 
                
 
-               <!--<p>If the list of fields ends with <code>",*"</code> then the record type is said to be
-		                <term>extensible</term>. For example, the <code>RecordType</code>
-                  <code>record(e as element(Employee), *)</code>
-		             matches a map if it has an entry with key <code>"e"</code> whose value matches <code>element(Employee)</code>,
-		             regardless what other entries the map might contain.</p>-->
-               
-               <p>For generality, the syntax <code>record()</code> defines a record type that has no explicit fields. 
-                  The only thing it matches is an <xtermref spec="DM40" ref="dt-empty-map"/>.</p>
-               
+
                <p>A record type can describe only maps whose keys are strings.
 		             A field whose key is a string can be expressed using an (unquoted) NCName if the key conforms to
 		             NCName syntax, or using a (quoted) string literal otherwise.</p>
                
-               <p>Although constructors for named record types produce a map in which the
-                  <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> reflects
-                  the order of field definitions in the record type definition,
-                  the <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref>
-                  of a map has no effect on whether the map matches a particular
-                  record type: the entries in a map do not have to be in any particular order.</p>
-
+               
                <note>
                   <p>Lookup expressions have been extended in 4.0 so that non-NCName keys can be used without
 		             parentheses: <code>employee?"middle name"</code></p>
                </note>
 
 
-               <p>If the type declaration for a field is omitted, then <code>item()*</code> is assumed: that is,
-		             the map entry may have any type.</p>
+               
 
-               <p>If the field name is followed by a question mark,
+               <!--<p>If the field name is followed by a question mark,
 		             then the value must have the specified type if it is present, but it may also be absent. For example,
 		             the <code>RecordType</code>
                   <code>record(first as xs:string, middle? as xs:string, last as xs:string)</code>
@@ -6196,19 +6249,14 @@ name.</p>
 		                entry must be a single <code>xs:string</code>. Declaring the type as 
 		                <code>record(first as xs:string, middle? as xs:string?, last as xs:string)</code> also allows
 		             the entry with key <code>"middle"</code> to be present but empty.</p>
-               
+               -->
                <p>A map that contains an entry whose key corresponds to no field in the record type does not
                match the record type. However, it can be coerced to such a record type when the <termref def="dt-coercion-rules"/>
                are applied. In practice this means that when the required type of an argument is declared using a record
                type, the map that is supplied as a value for this argument may contain additional fields, which are discarded
                so they are invisible to the called function.</p>
                
-               <!--<note>
-                  <p>Within an extensible record type, a <code>FieldDeclaration</code> that is marked optional 
-                     and has no declared type does not constrain the
-                     map in any way, so it serves no practical purpose, but it is permitted because it may have
-                     documentary value.</p>
-               </note>-->
+               
                
                <p>The names of the fields in a record type must be distinct <errorref class="ST" code="0021"/>.</p>
                
@@ -6218,14 +6266,14 @@ name.</p>
                
 
                
-
+<!--
                <p>If a variable <code>$rec</code> is known to conform to a particular
 		             record type, then when a lookup expression <code>$rec?field</code> is used, (a) the processor
 		             can report a type error if <code>$rec</code> cannot contain an entry with name <code>field</code>
                    (see <specref ref="id-implausible-lookup-expressions"/>),
 		             and (b) the processor can make static type inferences about the type of value returned by 
 		             <code>$rec?field</code>.</p>
-
+-->
                <note>
                   <p>(TODO: change function signatures as suggested here!) A number of functions in the standard 
                      function library use maps as function arguments;
@@ -6234,8 +6282,8 @@ name.</p>
 		                as <code>map(*)</code>, which gives very little information (and places very few constraints)
 		                on the values that are actually passed across. Using record types offers the possibility of
 		                improving this: for example, the options argument of <function>fn:parse-json</function>, previously
-		                given as <code>map(*)</code>, can now be expressed as <code>record(liberal? as xs:boolean, 
-		                   duplicates? as xs:string, escape? as xs:boolean, fallback as fn(xs:string) as xs:string)</code>.
+		                given as <code>map(*)</code>, can now be expressed as <code>record(liberal as xs:boolean?, 
+		                   duplicates as xs:string?, escape as xs:boolean?, fallback as (fn(xs:string) as xs:string)?)</code>.
 		                In principle the <code>xs:string</code> type used to describe the <code>duplicates</code>
 		                   option could also be replaced by a schema-defined subtype
 		                of <code>xs:string</code> that enumerates the permitted values (<code>"reject"</code>,
@@ -6331,9 +6379,9 @@ name.</p>
                   <head>A Binary Tree</head>
                   <p>A record used to represent a node in a binary tree might be represented (using XQuery syntax) as:</p>
                   <eg>declare record t:binary-tree 
-   ( left? as t:binary-tree, 
+   ( left as t:binary-tree?, 
      value as item()*, 
-     right? as t:binary-tree
+     right as t:binary-tree?
    )</eg>
                   <p>A recursive function to walk this tree and enumerate all the values in depth-first order might be written 
                      (again using XQuery syntax) as:</p>
@@ -7782,17 +7830,19 @@ declare record Particle (
                            <item><p><var>A</var> is a record type.</p></item>
                            <item><p><var>B</var> is a record type.</p></item>
                            <item><p>Every field in <var>A</var> is also declared in <var>B</var>.</p></item>
-                           <item><p>Every mandatory field in <var>B</var> is also declared  as mandatory in <var>A</var>.</p></item>
                            <item><p>For every field that is declared in both <var>A</var> and <var>B</var>,
                               where the declared type in <var>A</var> is <var>T</var> 
                               and the declared type in <var>B</var> is <var>U</var>, <code><var>T</var> ⊑ <var>U</var></code>.</p>                               
+                           </item>
+                           <item><p>For every field that is declared in <var>B</var> but is not declared in <var>A</var>
+                           the empty sequence matches the declared type in <var>B</var>.</p> 
                            </item>
                         </olist>
                         <example>
                            <head>Examples:</head>
                            <ulist>
                               <item><p><code>record(x, y as xs:integer) ⊆ record(x, y as xs:decimal)</code></p></item>
-                              <item><p><code>record(x, y) ⊆ record(x, y, z?)</code></p></item>
+                              <item><p><code>record(x, y) ⊆ record(x, y, z)</code></p></item>
                            </ulist>
                         </example>
                      </item>
@@ -8369,26 +8419,35 @@ declare record Particle (
                   <item diff="add" at="A">
                      <p>If <var>R</var> is a <nt def="RecordType"
                            >RecordType</nt> and <var>J</var> is a map, then <var>J</var> is converted
-                        to a new map as follows:</p>
+                        to a new <termref def="dt-record"/> <var>N</var> as follows:</p>
                      <olist>
-                        <item><p>The keys in the supplied map are unchanged.</p></item>
-                        <item><p>In any map entry whose key is equal to the
-                        name of one of the field declarations in <var>R</var> (under the rules
-                           of the <function>atomic-equal</function> function), the corresponding
-                           value is converted to the required type defined by that field declaration, 
-                           by applying the coercion rules recursively 
-                           (but with XPath 1.0 compatibility mode treated as false).</p></item>
-                        <item><p>Any map entry in the supplied map whose key is not equal to the name
-                        of any of the field declarations in <var>R</var> (under the same rules) is
-                        removed from the map.</p></item>
-                        <item><p>The order of entries in the map is changed to match the order of the 
-                              field declarations in <var>R</var>.</p></item>
+                        <item><p>The type annotation of <var>N</var> is <var>R</var>.</p></item>
+                        <item><p>For every field declaration <var>F</var> in <var>R</var>,
+                        <var>N</var> contains an entry (key/value pair) as follows:</p>
+                           <olist>
+                              <item><p>If <var>J</var> contains an entry <var>E</var> with the <termref def="dt-same-key"/>
+                              value as the name of <var>F</var>, then an entry whose key is the
+                              name of <var>F</var> and whose associated value is the value part
+                              of <var>E</var>, coerced to the declared type of <var>F</var>
+                              by applying these coercion rules recursively.</p></item>
+                              <item><p>Otherwise (if <var>J</var> contains no such entry),
+                              and entry whose key is the name of <var>F</var> and whose
+                              associated value is the empty sequence; a type error occurs
+                              if the empty sequence does not match the declared type of <var>F</var>.</p></item>
+                           </olist>
+                        </item>
+                        <item><p>Entries in <var>J</var> whose key does not match the name of
+                        any field in <var>R</var> are discarded.</p></item>
+                        <item><p>The order of entries in <var>N</var> corresponds to the order
+                        of field declarations in <var>R</var>.</p> 
+                        </item>
+                        
                      </olist>
 
                      <note><p>For example, if the required type is
                      <code>record(longitude as xs:double, latitude as xs:double)</code> and the supplied value is 
                         <code>{ "latitude": 53.2, "longitude": 0, "altitude": 3_500 }</code>,
-                        then the map is converted to <code>{ "longitude": 0.0e0, "latitude": 53.2e0 }</code>.</p></note>
+                        then the map is converted to the record <code>{ "longitude": 0.0e0, "latitude": 53.2e0 }</code>.</p></note>
 
                   </item>
 
@@ -22078,6 +22137,10 @@ return { $persons/*/* }
                   for cases where keys are items other than integers or NCNames.
                   It can also be followed by a variable reference or a context value reference.
                </change>
+               <change issue="1979" date="2026-03-31">
+                  When applied to a record, the lookup operator <code>?</code> now raises a type
+                  error if the requested key is not present in the record.
+               </change>
 
             </changes>
 
@@ -22197,8 +22260,12 @@ return { $persons/*/* }
                               <p>The order of items in the result reflects the order of keys in
                               <code>$K</code>: <code>{'a':10, 'b':20, 'c':30}?('c', 'a')</code> 
                                  returns <code>(30, 10)</code>.</p>
-                              <p>There is no error when <code>$K</code> includes a key that is not
-                              present in the map.</p>
+                              <p>If <var>$V</var> is a <termref def="dt-record"/>,
+                                 this rule results in a type error <xerrorref spec="FO40" class="TY" code="0016"/>
+                                 when <code>$K</code> includes a key that does not
+                                 match the name of any field in the type annotation of the record.
+                                 This type error may be reported statically if it can be detected statically.
+                                 There is no such error when <code>$V</code> is a map other than a record.</p>
                            </note>
                         </item>
                      
@@ -22347,6 +22414,13 @@ return { $persons/*/* }
                         <code>([ 1, 2, 3 ], [ 1, 2, 5 ], [ 1, 2 ])[?3 = 5]</code> raises an error,
                         because <code>?3</code> applied to one of the
                         items in the sequence fails.</p>
+                  </item>
+                  <item>
+                     <eg>let $r as record(x, y) := {'x': 12, 'y': 13}
+return $r?z</eg>
+                     <p>raises a type error <xerrorref spec="FO40" class="TY" code="0016"/> 
+                        (typically reported statically) because the key <code>"z"</code> 
+                     does not match any of the fields in the record type <code>record(x, y)</code>.</p>
                   </item>
       
                   

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -21974,6 +21974,14 @@ return { $persons/*/* }
                         /> with map lookups.)</p>
                   </item>
                </ulist>
+               
+               <note>
+                  <p>Because the function call <code>$map($key)</code> is equivalent to
+                  <code>map:get($map, $key)</code>, it follows that if <code>$map</code>
+                  is a <termref def="dt-record"/> and <code>$key</code> does not match
+                  the name of any field defined for the corresponding <termref def="dt-record-type"/>,
+                  the call will fail with a type error <xerrorref spec="FO40" class="TY" code="0016"/>.</p>
+               </note>
             </div4>
 
 

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -6175,11 +6175,11 @@ name.</p>
                   <item><p>The syntax <code>record()</code> defines a record type that has no fields. 
                   The only thing it matches is an <xtermref spec="DM40" ref="dt-empty-map"/> with the
                   type annotation <code>record()</code>.</p></item>
-                  <item><p>The syntax <code>record(*)</code> matches any record: that is, any map
+                  <item><p>The syntax <code>record(*)</code> matches any <termref def="dt-record"/>: that is, any map
                   with a type annotation identifying it as a record, regardless of the record type.
                    (Note that the syntax <code>record(*)</code> does not correspond to any specific 
                         record type.)</p></item>
-               </ulist></p>
+               </ulist>
                
                <p>Record types inherit all operations available for maps, but offer the possibility
                   of stronger type checking, because the names of the fields (keys) are generally
@@ -8454,8 +8454,8 @@ declare record Particle (
                   </item>
 
                   <item diff="add" at="A">
-                     <p>If <var>R</var> is a <nt def="RecordType"
-                           >RecordType</nt> and <var>J</var> is a map, then <var>J</var> is converted
+                     <p>If <var>R</var> is a <nt def="TypedRecordType"
+                           >TypedRecordType</nt> and <var>J</var> is a map, then <var>J</var> is converted
                         to a new <termref def="dt-record"/> <var>N</var> as follows:</p>
                      <olist>
                         <item><p>The type annotation of <var>N</var> is <var>R</var>.</p></item>
@@ -22590,6 +22590,69 @@ return $r?z</eg>
             </div4>
          </div3>
          
+         <div3 id="id-with-expression">
+               <head>The <code>with</code> Operator</head>
+            
+               <changes>
+                  <change issue="1979" PR="2566" date="2026-04-18">The <code>with</code> operator
+                  provides a convenient way of updating maps and records, with appropriate type
+                  checking.</change>
+               </changes>
+            
+            <scrap>
+               <prodrecap ref="WithExpr"/>
+            </scrap>
+            
+            <p>A <nt def="WithExpr">WithExpr</nt> can be used to update a map or record:
+            that is, to construct a new map or record whose content differs from a supplied map
+            or record.</p>
+            
+            <p>For example, with maps, the result of the expression:</p>
+            
+            <eg>{"a":1, "b":2} with {"c":3}</eg>
+            
+            <p>is the map</p>
+            
+            <eg>{"a":1, "b":2, "c":3}</eg>
+            
+            <p>With records, the effect is similar, but the result will always be a record of the same type
+            as the input, and a type error results if this would make the update invalid. For example:</p>
+            
+            <eg>build-dateTime({"hours":12, "minutes":30, "seconds":0}) 
+                  with {"timezone": xs:duration("PT1H")} => build-dateTime()</eg>
+            
+            <p>produces the value <code>xs:time("12:30:00+01:00")</code>.</p>
+            
+            <p>However, the outcome of the expression:</p>
+         
+            <eg>build-dateTime({"hours":12, "minutes":30, "seconds":0}) 
+                  with {"time-zone": xs:duration("PT1H")} => build-dateTime()</eg>
+            
+            <p>is a type error (which might be reported statically), because the name of the <code>timezone</code>
+            field has been misspelled.</p>
+            
+            <p>A <nt def="WithExpr">WithExpr</nt> is a binary expression evaluated from left to right:
+            that is, <code>A with B with C</code> is evaluated as <code>(A with B) with C</code>. The operands
+            are arbitrary expressions, with a required type of <code>map(*)</code>. This means that if a JNode
+            is supplied, it will be coerced to a map.</p>
+            
+            <p>If the left-hand operand is a map and is not a record, then the effect of the expression
+            <code>$A with $B</code> is equivalent to the effect of the function call 
+               <code>map:merge(($A, $B), {'duplicates':'use-last'})</code>.</p>
+            
+            <p>If the left-hand operand is a record with type annotation <var>R</var>, then the effect
+            of the expression <code>$A with $B</code> is equivalent to:</p>
+            
+            <eg>let $temp as <var>R</var> := map:merge(($A, $B), {'duplicates':'use-last'})
+return $temp</eg>
+            
+            <p>In effect this means that the keys and values supplied in <var>$B</var> must be
+            appropriate for a record of type <var>R</var>; if not, a type error is raised. The coercion
+            rules apply: in the example given above where <code>"timezone"</code> is supplied as
+            an instance of <code>xs:duration</code>, the coercion rules ensure that it will be cast
+            to the required type <code>xs:dayTimeDuration</code>.</p>
+         </div3> 
+         
          <div3 id="id-methods">
                <head>Methods and Method Calls</head>
                
@@ -22626,9 +22689,8 @@ let $rectangle := {
                  2 × ($rect?height + $rect?width) 
                },
   'resize':    fn ($rect, $factor) { 
-                  $rect 
-                     => map:put('height', $rect?height × $factor)
-                     => map:put('width', $rect?width × $factor)
+                  $rect with {'height': $rect?height × $factor}
+                        with {'width', $rect?width × $factor}
                }
 }
                </eg>
@@ -22746,7 +22808,8 @@ return $lib =?> product((1.2, 1.3, 1.4))
                is twice the size of the original, so <code>$rectangle =?> resize(2) =?> area()</code> returns the area of the
                enlarged rectangle.</p>
                
-               <note><p>Note how the <code>resize</code> function is implemented using <code>map:put</code>, which
+               <note><p>Note how the <code>resize</code> function is implemented using a
+                     <nt def="WithExpr">WithExpr</nt> (see <specref ref="id-with-expression"/>), which
                ensures that the map entries holding function items (<code>area</code>, <code>perimeter</code>, and
                <code>resize</code>) are automatically present and unchanged in the modified map.</p></note>
                
@@ -22772,9 +22835,9 @@ declare record my:rectangle (
      := fn{?height × ?width},
    resize as fn(my:rectangle, xs:double) as my:rectangle 
      := fn($rect, $factor) {
-           $rect => map:put('height', $rect?height × $factor)
-             => map:put('width', $rect?width × $factor)
-             => map:put('children', $rect?children =?> resize($factor))
+           $rect with {'height': $rect?height × $factor,
+                       'width': $rect?width × $factor,
+                       'children': $rect?children =?> resize($factor)}
         },
    contents as fn(my:rectangle) as my:rectangle*
      := fn{?children}

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -8503,8 +8503,8 @@ declare record Particle (
                               if the empty sequence does not match the declared type of <var>F</var>.</p></item>
                            </olist>
                         </item>
-                        <item><p>Entries in <var>J</var> whose key does not match the name of
-                        any field in <var>R</var> are discarded.</p></item>
+                        <!--<item><p>Entries in <var>J</var> whose key does not match the name of
+                        any field in <var>R</var> are discarded.</p></item>-->
                         <item><p>The order of entries in <var>N</var> corresponds to the order
                         of field declarations in <var>R</var>.</p> 
                         </item>
@@ -8513,8 +8513,11 @@ declare record Particle (
 
                      <note><p>For example, if the required type is
                      <code>record(longitude as xs:double, latitude as xs:double)</code> and the supplied value is 
-                        <code>{ "latitude": 53.2, "longitude": 0, "altitude": 3_500 }</code>,
-                        then the map is converted to the record <code>{ "longitude": 0.0e0, "latitude": 53.2e0 }</code>.</p></note>
+                        <code>{ "latitude": 53.2, "longitude": 0}</code>,
+                        then the map is converted to the record <code>{ "longitude": 0.0e0, "latitude": 53.2e0 }</code>.
+                     But if the supplied value is <code>{ "latitude": 53.2, "longitude": 0, "altitude": 3_500 }</code>,
+                     then a type error occurs because the field <code>"altitude"</code> is not defined
+                     in the record type.</p></note>
 
                   </item>
 

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -6173,13 +6173,23 @@ name.</p>
                
                <ulist>
                   <item><p>The syntax <code>record()</code> defines a record type that has no fields. 
-                  The only thing it matches is an <xtermref spec="DM40" ref="dt-empty-map"/> with the
-                  type annotation <code>record()</code>.</p></item>
+                  The only thing it matches is an <xtermref spec="DM40" ref="dt-empty-map"/> whose 
+                  type annotation is <code>record()</code> (the empty record type).</p></item>
                   <item><p>The syntax <code>record(*)</code> matches any <termref def="dt-record"/>: that is, any map
                   with a type annotation identifying it as a record, regardless of the record type.
-                   (Note that the syntax <code>record(*)</code> does not correspond to any specific 
-                        record type.)</p></item>
+                  The record type <code>record(*)</code> is an abstract type: every instance
+                        belongs to some more specific record type.</p></item>
                </ulist>
+               
+               <p>Records are generally constructed by coercing a map (which may itself be a record)
+               to a required record type. For example:</p>
+               
+               <eg>let $complex as record(r as xs:double, i as xs:double) := {"r":0, "i":0}</eg>
+               
+               <p>binds the variable <code>$complex</code> to a newly constructed record. Coercion of maps
+               to records is described in <specref ref="id-item-coercion-rules"/>. The rules for the coercion operation
+               ensure that the resulting record has one entry for every field in the corresponding record definition,
+               and that the values of those entries are instances of the required type for the relevant field.</p>
                
                <p>Record types inherit all operations available for maps, but offer the possibility
                   of stronger type checking, because the names of the fields (keys) are generally
@@ -6188,42 +6198,13 @@ name.</p>
 		             of the code, and in the ability of the processor to detect and diagnose type errors and to optimize
 		             execution.</p>
                
-               <p>A map <var>M</var> matches a record type <var>R</var> if and only if both the
-                  following conditions are true:</p>
+               <p>A record <var>R</var> matches a record type <var>T</var> if and only if the type annotation
+                  of <var>R</var> is a subtype of <var>T</var>, as described in <specref ref="id-item-subtype-records"/>.</p>
                
-               <olist>
-                  <item><p>For every field definition
-                     <var>F</var> in <var>R</var>, one of the following conditions is true:</p>
+               <ednote><edtext>We expect in due course to define facilities that allow one record type to be
+               defined as a subtype of another, by extension or restriction.</edtext></ednote>
                
-                     <olist>
-                        <item><p><var>M</var> contains an entry whose key is the <termref def="dt-same-key"/>
-                        value as the name of <var>F</var>, and whose associated value matches the declared type of
-                        <var>F</var>.</p></item>
-                        <item><p><var>M</var> contains no entry whose key is the <termref def="dt-same-key"/>
-                        value as the name of <var>F</var>, and the empty sequence matches the declared type of
-                        <var>F</var>.</p></item>
-                     </olist>
-                     
-                  </item>
-                  <item>
-                     <p>For every entry <var>E</var> in <var>M</var>, <var>R</var> contains a field
-                     definition <var>F</var> whose name is the <termref def="dt-same-key"/> value
-                     as the key of <var>E</var>.</p>
-                  </item>
-               </olist> 
                
-               <note>
-                  <p>It is not necessary that <var>M</var> should be a <termref def="dt-record"/>,
-                  nor that (in the case where it is a record) its type annotation should be a subtype of <var>R</var>.
-                  However, if <var>M</var> is a record and its type annotation is a subtype of <var>R</var>,
-                  then it will necessarily match <var>R</var>, which can make type checking more efficient.</p>
-                  <p>For type matching against a record type, absent values and empty values are considered
-                  equivalent: if the required type of a field permits an empty sequence, then it also
-                  matches a map in which the corresponding entry is absent.</p>
-                  <p>The <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> of a map 
-                     is of no consequence when deciding whether or not
-                  the map matches a given record type.</p>
-               </note>
                
                <p>Record types provide stronger type checking than general maps. Accessing an entry
                within a record gives a type error (rather than an empty result) if the key is not one of
@@ -6232,10 +6213,7 @@ name.</p>
                statically if they are detected statically, which will often be possible if variables and
                function parameters declare their required type as a record type.</p>
                
-               <p>Records are created by coercing a map to the required
-                  record type, as described in <specref ref="id-item-coercion-rules"/>.
-               </p> 
-               
+              
 
 
                <p>A record type can describe only maps whose keys are strings.
@@ -6261,12 +6239,12 @@ name.</p>
 		                <code>record(first as xs:string, middle? as xs:string?, last as xs:string)</code> also allows
 		             the entry with key <code>"middle"</code> to be present but empty.</p>
                -->
-               <p>A map that contains an entry whose key does not correspond to any field in the record type fails to
+               <!--<p>A map that contains an entry whose key does not correspond to any field in the record type fails to
                match the record type. However, it can be coerced to such a record type when the <termref def="dt-coercion-rules"/>
                are applied. In practice this means that when the required type of a function argument is declared as being a record
                type, the map that is supplied as a value for this argument may contain additional fields, which are discarded
                so they are invisible to the called function.</p>
-               
+               -->
                
                
                <p>The names of the fields in a record type must be distinct <errorref class="ST" code="0021"/>.</p>
@@ -6348,37 +6326,7 @@ name.</p>
                <p>Rules defining whether one record type is a <termref def="dt-subtype"/> of another
                   are given in <specref ref="id-item-subtype-records"/>.</p>
 
-            <div5 id="id-records-as-functions">
-               <head>Records as Functions</head>
-               
-               <p>Records are maps, and like all maps, they are therefore 
-                  <termref def="dt-function-item">function items</termref>.</p>
-               
-               <p>For example, if <code>$loc</code> is an instance of
-               <code>record(longitude, latitude)</code>, then the dynamic function call
-               <code>$loc("longitude")</code> returns the value of the <code>"longitude"</code> field.</p>
-               
-               <p>When considered as a function item, if <var>R</var> is a record
-               of type <var>T</var>, and the names of the fields defined for <var>T</var>
-               are <var>F1</var>, <var>F2</var>, <var>F3</var>, ... <var>F/n</var>, then the
-               signature of the corresponding function item is:</p>
-               
-               <eg>fn(enum(<var>F1</var>, <var>F2</var>, <var>F3</var>, ... <var>F/n</var>)) as item()*</eg>
-               
-               <p>For example, consider the function <function>fn:load-xquery-module</function>, which
-               returns a record of type <code>fn:load-xquery-module-record</code>. This record type
-               defines two fields, <code>variables</code> and <code>functions</code>. The corresponding
-               function signature is therefore <code>fn(enum("variables", "functions")) as item()*</code>,
-               which means that any call on this function supplying a key value other than <code>"variables"</code>
-               or <code>"functions"</code> will fail with a type error.</p>
-               
-               <note>
-                  <p>If <code>$R</code> is a record of type <var>T</var>, then <code>$R($S)</code> fails if
-                  <var>$S</var> is not one of the defined fields of <var>T</var>. The lookup expression
-                  <code>$R?$S</code> fails in a similar way. The function call <code>map:get($S)</code> succeeds,
-                  however, returning an empty sequence.</p>
-               </note>
-            </div5>
+            
             
             <div5 id="id-recursive-record-tests" diff="add" at="issue295">
                <head>Recursive Record Types</head>
@@ -7845,42 +7793,61 @@ declare record Particle (
                      </olist>
                </div4>
                <div4 id="id-item-subtype-records">
-                  <head>Subtyping Records</head>
-                  <changes>
+                  <head>Subtyping Non-recursive Record Types</head>
+                  <!--<changes>
                      <change issue="2365" PR="2413" date="2026-01-28">
                         Extensible map types are dropped; instead, the coercion rules cause undefined
                         map entries to be discarded.
                      </change>
-                  </changes>
+                  </changes>-->
+                  <note><p>For recursive record types, see <specref ref="id-itemtype-subtype-aliases"/>.</p></note>
+                  
                   <p>Given item types <var>A</var> and <var>B</var>, <var>A</var> <code>⊆</code> <var>B</var> is true if any of the following apply:</p>
                   <olist>
-                     <!--<item diff="add" at="issue52">
-                        <p><var>A</var> is <code>map(*)</code> and <var>B</var> is <code>record(*)</code>.</p>
-                     </item>-->
-                     <item diff="add" at="A">
+                     
+                     <item>
                         <p>All of the following are true:</p>
                         <olist>
-                           <item><p><var>A</var> is a record type.</p></item>
-                           <item><p><var>B</var> is <code>map(*)</code>.</p></item>
+                           <item><p><var>A</var> is <code>record(*)</code>.</p></item>
+                           <item><p><var>B</var> is <code>map(xs:string, item()*)</code>.</p></item>
+                        </olist>
+                        <example>
+                           <head>Examples:</head>
+                           <ulist>
+                              <item><p><code>record(*)</code> ⊆ <code>map(xs:string, item()*)</code></p></item>
+                              <item><p><code>record(*)</code> ⊆ <code>map(xs:anyAtomicType, item()*)</code></p></item>
+                              <item><p><code>record(*)</code> ⊆ <code>map(*)</code></p></item>
+                              <item><p><code>record(longitude, latitude)</code> ⊆ <code>map(xs:string, item()*)</code></p></item>
+                           </ulist>
+                           <p>The last three examples follow from the transitivity rules.</p>
+                        </example>
+                     </item>
+                     
+                     <!--<item>
+                        <p>All of the following are true:</p>
+                        <olist>
+                           <item><p><var>A</var> is <code>record(*)</code>.</p></item>
+                           <item><p><var>B</var> is <code>map(xs:string, item()*)</code>.</p></item>
                         </olist>
                         <example>
                            <head>Example:</head>
-                           <p><code>record(longitude, latitude)</code> ⊆ <code>map(*)</code></p>
-                           <p><code>record(longitude as xs:double, latitude as xs:double)</code> ⊆ <code>map(*)</code></p>
+                           <p><code>record(longitude, latitude)</code> ⊆ <code>map(xs:string, item()*)</code></p>
+                           <p><code>record(longitude as xs:double, latitude as xs:double)</code> ⊆ <code>map(xs:string, item()*)</code></p>
                            <p><code>record(longitude, latitude, altitude?)</code> ⊆ <code>map(*)</code></p>
                            
                         </example>
-                     </item>
+                     </item>-->
                      
                      <item diff="add" at="A">
                         <p>All of the following are true:</p>
                         <olist>
-                           <item><p><var>A</var> is a record type</p></item>
+                           <item><p><var>A</var> is a record type <code>record(<var>F1</var> as <var>T1</var>, 
+                           <var>F2</var> as <var>T2</var>, ...,  <var>F/n</var> as <var>T/n</var>)</code>
+                           (where the default for <var>T/i</var> is <code>item()*</code>)</p></item>
                            <item><p><var>B</var> is <code>map(<var>K</var>, <var>V</var>)</code></p></item>
                            <item><p><var>K</var> is either <code>xs:string</code> or <code>xs:anyAtomicType</code></p></item>
-                           <item><p>For every field <var>F</var> in <var>A</var>,
-                              where <var>T</var> is the declared type of <var>F</var> (or its default, <code>item()*</code>),
-                              <code><var>T</var> ⊑ <var>V</var></code>.</p></item>
+                           <item><p>For every <var>i</var> in 1 to <var>n</var>,
+                              <code><var>T/i</var> ⊑ <var>V</var></code>.</p></item>
                         </olist>
                         <example>
                            <head>Examples:</head>
@@ -7896,7 +7863,7 @@ declare record Particle (
                         <olist>
                            <item><p><var>A</var> is a record type.</p></item>
                            <item><p><var>B</var> is a record type.</p></item>
-                           <item><p>Every field in <var>A</var> is also declared in <var>B</var>.</p></item>
+                           <item><p>Every field name in <var>A</var> is also declared in <var>B</var>.</p></item>
                            <item><p>For every field that is declared in both <var>A</var> and <var>B</var>,
                               where the declared type in <var>A</var> is <var>T</var> 
                               and the declared type in <var>B</var> is <var>U</var>, <code><var>T</var> ⊑ <var>U</var></code>.</p>                               
@@ -21593,24 +21560,19 @@ return upper-case($x)
          <p>Most modern programming languages have support for collections of
 key/value pairs, which may be called maps, dictionaries, associative
 arrays, hash tables, keyed lists, or objects (these are not the same
-thing as objects in object-oriented systems). In &language;, we call
-these maps. Most modern programming languages also support ordered
+thing as objects in object-oriented systems). In &language; these are called
+maps. Most modern programming languages also support ordered
 lists of values, which may be called arrays, vectors, or sequences.
-In &language;, we have both
+In &language;, there are two kinds of ordered lists, called
 sequences and arrays. Unlike sequences, an array is an
 item, and can appear as an item in a sequence.</p>
 
-         <p diff="del" at="B">In previous versions of the language, element structures and
-sequences were the only complex data structures.  We are adding maps
-and arrays to &language; in order to provide lightweight data
-structures that are easier to optimize and less complex to use for
-intermediate processing and to allow programs to easily combine XML
-processing with JSON processing.</p>
+         
 
 
          <note>
-            <p>The &language; specification focuses on syntax provided for maps
-  and arrays, especially constructors and lookup.</p>
+            <p>This specification focuses on &language; syntax provided for maps
+  and arrays, especially constructors and lookup expressions.</p>
 
             <p>Some of the functionality typically needed for maps and
   arrays is provided by functions defined in <xspecref spec="FO40" ref="maps"/>
@@ -22026,34 +21988,77 @@ return { $persons/*/* }
                   the call will fail with a type error <xerrorref spec="FO40" class="TY" code="0016"/>.</p>
                </note>-->
             </div4>
+            
+            <div4 id="id-records-as-functions">
+               <head>Records as Functions</head>
+               
+               <p>Records are maps, and like all maps, they are therefore 
+                  <termref def="dt-function-item">function items</termref>.</p>
+               
+               <p>For example, if <code>$loc</code> is an instance of
+               <code>record(longitude, latitude)</code>, then the dynamic function call
+               <code>$loc("longitude")</code> returns the value of the <code>"longitude"</code> field.</p>
+               
+               <p>When considered as a function item, if <var>R</var> is a record
+               of type <var>T</var>, and the names of the fields defined for <var>T</var>
+               are <var>F1</var>, <var>F2</var>, <var>F3</var>, ... <var>F/n</var>, then the
+               signature of the corresponding function item is:</p>
+               
+               <eg>fn(enum(<var>F1</var>, <var>F2</var>, <var>F3</var>, ... <var>F/n</var>)) as item()*</eg>
+               
+               <p>For example, consider the function <function>fn:load-xquery-module</function>, which
+               returns a record of type <code>fn:load-xquery-module-record</code>. This record type
+               defines two fields, <code>variables</code> and <code>functions</code>. The corresponding
+               function signature is therefore <code>fn(enum("variables", "functions")) as item()*</code>,
+               which means that any call on this function supplying a key value other than <code>"variables"</code>
+               or <code>"functions"</code> will fail with a type error.</p>
+               
+               <note>
+                  <p>If <code>$R</code> is a record of type <var>T</var>, then <code>$R($S)</code> fails if
+                  <var>$S</var> is not one of the defined fields of <var>T</var>. The lookup expression
+                  <code>$R?$S</code> fails in a similar way. The function call <code>map:get($S)</code> succeeds,
+                  however, returning an empty sequence.</p>
+               </note>
+            </div4>
 
 
 
          </div3>
          <div3 id="id-arrays">
             <head>Arrays</head>
-            <p/>
+            <p>
+                  <termdef id="dt-array" term="array"
+                     >An <term>array</term> is
+                   a <termref def="dt-function-item"/> that associates a set of positions, represented as
+                   positive integer keys, with values.</termdef> The first position
+                   in an array is associated with the integer 1.
+                   <termdef
+                                  id="dt-member" term="member"
+                                     >The values of an array are called
+                   its <term>members</term>.</termdef></p>
+
+      <p>In the type hierarchy, array has a distinct type, which is
+      derived from <code>function(*)</code>.</p>
+            
+      <p>Atomization converts arrays to sequences (see <termref
+                     def="dt-atomization">Atomization</termref>).  
+      </p>
             <div4 id="id-array-constructors">
                <head>Array Constructors</head>
 
-               <p>
-                  <termdef id="dt-array" term="array"
-                     >An <term>array</term> is
-      a <termref def="dt-function-item"/> that associates a set of positions, represented as
-      positive integer keys, with values.</termdef> The first position
-      in an array is associated with the integer 1.
-      <termdef
-                     id="dt-member" term="member"
-                        >The values of an array are called
-      its <term>members</term>.</termdef>
+               
 
-      In the type hierarchy, array has a distinct type, which is
-      derived from function.
-      Atomization converts arrays to sequences (see <termref
-                     def="dt-atomization">Atomization</termref>).  
-      </p>
-
-               <p>An array is created using an <nt def="ArrayConstructor">ArrayConstructor</nt>.</p>
+               <p>An array is created using an <nt def="ArrayConstructor">ArrayConstructor</nt>. There are two
+               kinds of array constructor:</p>
+               
+               <ulist>
+                  <item><p>A <code>SquareArrayConstructor</code> such as <code>[$a, $b, $c]</code>
+                  returns an array with <var>N</var> members, where <var>N</var> is the number of
+                  commas in the constructor plus one.</p></item>
+                  <item><p>A <code>CurlyArrayConstructor</code> such as <code>{$a, $b, $c}</code>
+                  returns an array whose members are single items; in this example the members
+                  are the items in the sequence <code>($a, $b, $c)</code>.</p></item>
+               </ulist>
                <scrap>
                   <prodrecap ref="ArrayConstructor"/>
                </scrap>
@@ -22331,7 +22336,7 @@ return { $persons/*/* }
                         or a <code>ParenthesizedExpr</code>,
                         then it is evaluated as an expression to produce a value <code>$K</code>
                         and the result is:</p> 
-                           <eg><![CDATA[data($K) ! map:get($V, .)]]></eg>
+                           <eg><![CDATA[data($K) ! $V(.)]]></eg>
                            <note>
                               <p>The focus for evaluating the key specifier expression is the 
                                  same as the focus for the <code>Lookup</code> expression itself.</p>
@@ -22339,11 +22344,12 @@ return { $persons/*/* }
                               <code>$K</code>: <code>{'a':10, 'b':20, 'c':30}?('c', 'a')</code> 
                                  returns <code>(30, 10)</code>.</p>
                               <p>If <var>$V</var> is a <termref def="dt-record"/>,
-                                 this rule results in a type error <xerrorref spec="FO40" class="TY" code="0016"/>
+                                 this rule results in a type error <xerrorref spec="FO40" class="TY" code="0004"/>
                                  when <code>$K</code> includes a key that does not
                                  match the name of any field in the type annotation of the record.
                                  This type error may be reported statically if it can be detected statically.
-                                 There is no such error when <code>$V</code> is a map other than a record.</p>
+                                 There is no such error when <code>$V</code> is a map other than a record: in this case,
+                                 the call on <code>$V(.)</code> returns the empty sequence.</p>
                            </note>
                         </item>
                      
@@ -22497,7 +22503,7 @@ return { $persons/*/* }
                      <p>The following expression:</p>
                      <eg>let $r as record(x, y) := {'x': 12, 'y': 13}
 return $r?z</eg>
-                     <p>raises a type error <xerrorref spec="FO40" class="TY" code="0016"/> 
+                     <p>raises a type error <xerrorref spec="FO40" class="TY" code="0004"/> 
                         (typically reported statically) because the key specifier <code>"z"</code> 
                      does not match any of the fields in the record type <code>record(x, y)</code>.</p>
                   </item>
@@ -22563,7 +22569,7 @@ return $r?z</eg>
                   is not a defined field in the corresponding record type, whereas the equivalent path
                   expression succeeds, returning the empty sequence. For example,
                   <code>fn:dateTime-record(2026, 4, 1)?quarter</code> raises 
-                  <xerrorref spec="FO40" class="TY" code="0016"/>, whereas
+                  <xerrorref spec="FO40" class="TY" code="0004"/>, whereas
                   <code>fn:dateTime-record(2026, 4, 1)/get("quarter")</code>
                      returns an empty sequence.
                   </p>
@@ -22675,6 +22681,12 @@ return $r?z</eg>
             
             <eg>let $temp as <var>R</var> := map:merge(($A, $B), {'duplicates':'use-last'})
 return $temp</eg>
+            
+            <p>That is: the values of the two operands are merged as maps, with the value from the second
+            operand taking precedence in the case of duplicates; the result is then coerced to the record
+            typed defined by the type annotation of the first operand, raising a type error if the result
+            cannot be coerced to this record type.
+            </p>
             
             <p>In effect this means that the keys and values supplied in <var>$B</var> must be
             appropriate for a record of type <var>R</var>; if not, a type error 

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -22624,46 +22624,46 @@ return $r?z</eg>
          </div3>
          
          <div3 id="id-with-expression">
-               <head>The <code>with</code> Operator</head>
+               <head>The <code>+:=</code> (Record Put) Operator</head>
             
                <changes>
-                  <change issue="1979" PR="2566" date="2026-04-18">The <code>with</code> operator
-                  provides a convenient way of updating maps and records, with appropriate type
+                  <change issue="1979" PR="2566" date="2026-04-18">The <code>+:=</code> operator
+                  provides a convenient way of updating records, with appropriate type
                   checking.</change>
                </changes>
             
             <scrap>
-               <prodrecap ref="WithExpr"/>
+               <prodrecap ref="RecordPutExpr"/>
             </scrap>
             
-            <p>A <nt def="WithExpr">WithExpr</nt> can be used to update a record:
+            <p>A <nt def="RecordPutExpr">RecordPutExpr</nt> can be used to update a record:
             more precisely, to construct a new <termref def="dt-record"/> whose content differs from a supplied
             record. The new record has the same type annotation as the original, and must
             match the <termref def="dt-record-type"/> of the original.</p>
             
             <p>For example, consider the expression:</p>
             
-            <eg>parts-of-dateTime(current-date()) with {"timezone" : ()} => build-dateTime()</eg>
+            <eg>(parts-of-dateTime(current-date()) +:= {"timezone" : ()}) => build-dateTime()</eg>
             
             <p>The first part of this expression, <code>parts-of-dateTime(current-date())</code>, returns
             a record of type <code>fn:dateTime-record</code> containing seven fields (<code>year</code>,
             <code>month</code>, <code>day</code>, <code>hours</code>, <code>minutes</code>, <code>seconds</code>, and
             <code>timezone</code>) of which the first three are empty (the value of the field is an empty
-            sequence). The <code>with</code> expression takes this record as input, and produces another
+            sequence). The <nt def="RecordPutExpr">RecordPutExpr</nt> expression takes this record as input, 
+               and produces another
             record, also of type <code>fn:dateTime-record</code>, in which the <code>timezone</code>
             field is set to an empty sequence. The final part of the expression (<code>=> build-dateTime())</code>
             converts this record to an <code>xs:date</code> value having no timezone.</p>
             
            
-            <p>The <code>with</code> expression is type-safe, in that a type error is raised if the
+            <p>The <code>+:=</code> expression is type-safe, in that a type error is raised if the
                name of a field in the right-hand operand does not correspond to one of the named
                fields defined by the relevant record type, or if the supplied value does not
                conform to the required type for that field.</p>
             
-            <p>A <nt def="WithExpr">WithExpr</nt> is a binary expression evaluated from left to right:
-            that is, <code>A with B with C</code> is evaluated as <code>(A with B) with C</code>. The operands
-            are arbitrary expressions, with a required type of <code>map(*)</code>. This means that if a JNode
-            is supplied, it will be coerced to a map.</p>
+            <p>A <nt def="RecordPutExpr">RecordPutExpr</nt> is a binary expression evaluated from left to right:
+            that is, <code>A +:= B +:= C</code> is evaluated as <code>(A +:= B) +:= C</code>. The operands
+            are arbitrary expressions.</p>
             
             <p>The required type for the left hand operand is <code>record(*)</code>, and for the right
             hand operand, <code>map(*)</code>. In both cases the supplied value will be coerced to the
@@ -22671,7 +22671,7 @@ return $r?z</eg>
             it has an appropriate <term>·jvalue·</term>.</p>
             
             <p>If the left-hand operand is a record with type annotation <var>R</var>, then the effect
-            of the expression <code>$A with $B</code> is equivalent to:</p>
+            of the expression <code>$A +:= $B</code> is equivalent to:</p>
             
             <eg>let $temp as <var>R</var> := map:merge(($A, $B), {'duplicates':'use-last'})
 return $temp</eg>
@@ -22723,8 +22723,8 @@ let $rectangle := {
                  2 × ($rect?height + $rect?width) 
                },
   'resize':    fn ($rect, $factor) { 
-                  $rect with {'height': $rect?height × $factor}
-                        with {'width': $rect?width × $factor}
+                  $rect +:= {'height': $rect?height × $factor}
+                        +:= {'width': $rect?width × $factor}
                }
 }
                </eg>
@@ -22843,7 +22843,7 @@ return $lib =?> product((1.2, 1.3, 1.4))
                enlarged rectangle.</p>
                
                <note><p>Note how the <code>resize</code> function is implemented using a
-                     <nt def="WithExpr">WithExpr</nt> (see <specref ref="id-with-expression"/>), which
+                     <nt def="RecordPutExpr">RecordPutExpr</nt> (see <specref ref="id-with-expression"/>), which
                ensures that the map entries holding function items (<code>area</code>, <code>perimeter</code>, and
                <code>resize</code>) are automatically present and unchanged in the modified map.</p></note>
                
@@ -22869,9 +22869,9 @@ declare record my:rectangle (
      := fn{?height × ?width},
    resize as fn(my:rectangle, xs:double) as my:rectangle 
      := fn($rect, $factor) {
-           $rect with {'height': $rect?height × $factor,
-                       'width': $rect?width × $factor,
-                       'children': $rect?children =?> resize($factor)}
+           $rect +:= {'height': $rect?height × $factor,
+                      'width': $rect?width × $factor,
+                      'children': $rect?children =?> resize($factor)}
         },
    contents as fn(my:rectangle) as my:rectangle*
      := fn{?children}

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -6348,7 +6348,37 @@ name.</p>
                <p>Rules defining whether one record type is a <termref def="dt-subtype"/> of another
                   are given in <specref ref="id-item-subtype-records"/>.</p>
 
-            
+            <div5 id="id-records-as-functions">
+               <head>Records as Functions</head>
+               
+               <p>Records are maps, and like all maps, they are therefore 
+                  <termref def="dt-function-item">function items</termref>.</p>
+               
+               <p>For example, if <code>$loc</code> is an instance of
+               <code>record(longitude, latitude)</code>, then the dynamic function call
+               <code>$loc("longitude")</code> returns the value of the <code>"longitude"</code> field.</p>
+               
+               <p>When considered as a function item, if <var>R</var> is a record
+               of type <var>T</var>, and the names of the fields defined for <var>T</var>
+               are <var>F1</var>, <var>F2</var>, <var>F3</var>, ... <var>F/n</var>, then the
+               signature of the corresponding function item is:</p>
+               
+               <eg>fn(enum(<var>F1</var>, <var>F2</var>, <var>F3</var>, ... <var>F/n</var>)) as item()*</eg>
+               
+               <p>For example, consider the function <function>fn:load-xquery-module</function>, which
+               returns a record of type <code>fn:load-xquery-module-record</code>. This record type
+               defines two fields, <code>variables</code> and <code>functions</code>. The corresponding
+               function signature is therefore <code>fn(enum("variables", "functions")) as item()*</code>,
+               which means that any call on this function supplying a key value other than <code>"variables"</code>
+               or <code>"functions"</code> will fail with a type error.</p>
+               
+               <note>
+                  <p>If <code>$R</code> is a record of type <var>T</var>, then <code>$R($S)</code> fails if
+                  <var>$S</var> is not one of the defined fields of <var>T</var>. The lookup expression
+                  <code>$R?$S</code> fails in a similar way. The function call <code>map:get($S)</code> succeeds,
+                  however, returning an empty sequence.</p>
+               </note>
+            </div5>
             
             <div5 id="id-recursive-record-tests" diff="add" at="issue295">
                <head>Recursive Record Types</head>
@@ -22603,42 +22633,39 @@ return $r?z</eg>
                <prodrecap ref="WithExpr"/>
             </scrap>
             
-            <p>A <nt def="WithExpr">WithExpr</nt> can be used to update a map or record:
-            that is, to construct a new map or record whose content differs from a supplied map
-            or record.</p>
+            <p>A <nt def="WithExpr">WithExpr</nt> can be used to update a record:
+            more precisely, to construct a new <termref def="dt-record"/> whose content differs from a supplied
+            record. The new record has the same type annotation as the original, and must
+            match the <termref def="dt-record-type"/> of the original.</p>
             
-            <p>For example, with maps, the result of the expression:</p>
+            <p>For example, consider the expression:</p>
             
-            <eg>{"a":1, "b":2} with {"c":3}</eg>
+            <eg>parts-of-dateTime(current-date()) with {"timezone" : ()} => build-dateTime()</eg>
             
-            <p>is the map</p>
+            <p>The first part of this expression, <code>parts-of-dateTime(current-date())</code>, returns
+            a record of type <code>fn:dateTime-record</code> containing seven fields (<code>year</code>,
+            <code>month</code>, <code>day</code>, <code>hours</code>, <code>minutes</code>, <code>seconds</code>, and
+            <code>timezone</code>) of which the first three are empty (the value of the field is an empty
+            sequence). The <code>with</code> expression takes this record as input, and produces another
+            record, also of type <code>fn:dateTime-record</code>, in which the <code>timezone</code>
+            field is set to an empty sequence. The final part of the expression (<code>=> build-dateTime())</code>
+            converts this record to an <code>xs:date</code> value having no timezone.</p>
             
-            <eg>{"a":1, "b":2, "c":3}</eg>
-            
-            <p>With records, the effect is similar, but the result will always be a record of the same type
-            as the input, and a type error results if this would make the update invalid. For example:</p>
-            
-            <eg>build-dateTime({"hours":12, "minutes":30, "seconds":0}) 
-                  with {"timezone": xs:duration("PT1H")} => build-dateTime()</eg>
-            
-            <p>produces the value <code>xs:time("12:30:00+01:00")</code>.</p>
-            
-            <p>However, the outcome of the expression:</p>
-         
-            <eg>build-dateTime({"hours":12, "minutes":30, "seconds":0}) 
-                  with {"time-zone": xs:duration("PT1H")} => build-dateTime()</eg>
-            
-            <p>is a type error (which might be reported statically), because the name of the <code>timezone</code>
-            field has been misspelled.</p>
+           
+            <p>The <code>with</code> expression is type-safe, in that a type error is raised if the
+               name of a field in the right-hand operand does not correspond to one of the named
+               fields defined by the relevant record type, or if the supplied value does not
+               conform to the required type for that field.</p>
             
             <p>A <nt def="WithExpr">WithExpr</nt> is a binary expression evaluated from left to right:
             that is, <code>A with B with C</code> is evaluated as <code>(A with B) with C</code>. The operands
             are arbitrary expressions, with a required type of <code>map(*)</code>. This means that if a JNode
             is supplied, it will be coerced to a map.</p>
             
-            <p>If the left-hand operand is a map and is not a record, then the effect of the expression
-            <code>$A with $B</code> is equivalent to the effect of the function call 
-               <code>map:merge(($A, $B), {'duplicates':'use-last'})</code>.</p>
+            <p>The required type for the left hand operand is <code>record(*)</code>, and for the right
+            hand operand, <code>map(*)</code>. In both cases the supplied value will be coerced to the
+            required type by applying the coercion rules. This means that a JNode can be supplied, provided
+            it has an appropriate <term>·jvalue·</term>.</p>
             
             <p>If the left-hand operand is a record with type annotation <var>R</var>, then the effect
             of the expression <code>$A with $B</code> is equivalent to:</p>
@@ -22647,10 +22674,14 @@ return $r?z</eg>
 return $temp</eg>
             
             <p>In effect this means that the keys and values supplied in <var>$B</var> must be
-            appropriate for a record of type <var>R</var>; if not, a type error is raised. The coercion
-            rules apply: in the example given above where <code>"timezone"</code> is supplied as
-            an instance of <code>xs:duration</code>, the coercion rules ensure that it will be cast
-            to the required type <code>xs:dayTimeDuration</code>.</p>
+            appropriate for a record of type <var>R</var>; if not, a type error 
+               <errorref class="TY" code="0004"/> is raised. The coercion
+            rules apply: for example, the record type <code>fn:dateTime-record</code>
+               requires the <code>timezone</code> to be an instance of <code>xs:dayTimeDuration</code>,
+               but supplying <code>xs:duration("PT0S")</code> will succeed because this can be
+               coerced to an <code>xs:dayTimeDuration</code>.</p>
+            
+
          </div3> 
          
          <div3 id="id-methods">

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -6134,10 +6134,11 @@ name.</p>
                      Extensible map types are dropped; instead, the coercion rules cause undefined
                      map entries to be discarded.
                   </change>
-                  <change date="2026-03-31">
+                  <change issue="1979" PR="2566" date="2026-03-31">
                      Records now carry a type annotation identifying a record type, and their behavior
                      as well as their content is constrained by that record type. Optional fields in records
-                     are dropped (there is no longer a distinction between absent values and empty values).
+                     are dropped (in records, there is no longer a distinction between absent values 
+                     and empty values).
                   </change>
                </changes>
                
@@ -6159,7 +6160,7 @@ name.</p>
 
                
                
-               <p>For example, the <code>RecordType</code>
+               <p>For example, the <nt def="RecordType">RecordType</nt>
                   <code>record(r as xs:double, i as xs:double)</code>
 		             defines a record type with two fields: an field with key <code>"r"</code>
 		                whose value is a <termref def="dt-singleton"/> <code>xs:double</code> value, and a field with key <code>"i"</code>
@@ -6250,15 +6251,41 @@ name.</p>
 		                <code>record(first as xs:string, middle? as xs:string?, last as xs:string)</code> also allows
 		             the entry with key <code>"middle"</code> to be present but empty.</p>
                -->
-               <p>A map that contains an entry whose key corresponds to no field in the record type does not
+               <p>A map that contains an entry whose key does not correspond to any field in the record type fails to
                match the record type. However, it can be coerced to such a record type when the <termref def="dt-coercion-rules"/>
-               are applied. In practice this means that when the required type of an argument is declared using a record
+               are applied. In practice this means that when the required type of a function argument is declared as being a record
                type, the map that is supplied as a value for this argument may contain additional fields, which are discarded
                so they are invisible to the called function.</p>
                
                
                
                <p>The names of the fields in a record type must be distinct <errorref class="ST" code="0021"/>.</p>
+               
+               <p>Record types may be named, or they may be anonymous. Naming a record type has
+               a number of benefits:</p>
+               
+               <ulist>
+                  <item><p>It avoids repeated use of a type definition that may be lengthy.</p></item>
+                  <item><p>It means that when the details of the type definition change, the change
+                  need only be made in one place, and there is less risk of multiple definitions diverging.</p></item>
+                  <item><p>A named record type definition automatically has an associated constructor
+                  function that can be used to construct instances of the record type.</p></item>
+                  <item><p>Named record type definitions can be recursive, allowing more complex data structures
+                  such as lists and trees to be defined: see <specref ref="id-recursive-record-tests"/>.</p></item>
+                  <item><p>Use of named record type definitions may make it easier for a processor to check
+                  that a record conforms to a particular record type.</p></item>
+               </ulist>
+               
+               <p>Some record types used to define the parameters or results of built-in functions use
+               names in the <code>fn</code> namespace: for example the result of <function>fn:parts-of-dateTime</function>,
+               and the argument to <function>fn:build-dateTime</function>, is defined using the named record type
+               <code>fn:dateTime-record</code>.</p>
+               
+               <p>User-defined named record types may be declared in XQuery using the <code>declare record</code>
+               construct<phrase role="xquery"> (see <specref ref="id-named-record-types"/>)</phrase>, and 
+               in XSLT using an <code>xsl:record-type</code> declaration.</p>
+               
+               <p>Some built-in functions also use unnamed record types in their signatures.</p>
                
               
                
@@ -6275,7 +6302,7 @@ name.</p>
 		             <code>$rec?field</code>.</p>
 -->
                <note>
-                  <p>(TODO: change function signatures as suggested here!) A number of functions in the standard 
+                  <!--<p>(TODO: change function signatures as suggested here!) A number of functions in the standard 
                      function library use maps as function arguments;
 		                this is a useful technique where the information to be supplied across the interface is highly
 		                variable. However, the type signature for such functions typically declares the argument type
@@ -6288,14 +6315,14 @@ name.</p>
 		                   option could also be replaced by a schema-defined subtype
 		                of <code>xs:string</code> that enumerates the permitted values (<code>"reject"</code>,
 		                   <code>"use-first"</code>, <code>"use-last"</code>). 
-		                </p>
-                  <p>The use of a record type in the signature of such a function causes the 
+		                </p>-->
+                  <p>The use of a record type in the signature of a function (whether named or unnamed) causes the 
 		                   <termref def="dt-coercion-rules">coercion rules</termref>
-		                to be invoked. So, for example, if the function expects an entry in the map to be an <code>xs:double</code>
+		                to be invoked. So, for example, if the function expects an entry in the supplied record to be an <code>xs:double</code>
 		                value, it becomes possible to supply a map in which the corresponding entry has type <code>xs:integer</code>.</p>
-                  <p>Greater precision in defining the types of such arguments also enables better type checking,
+                  <!--<p>Greater precision in defining the types of such arguments also enables better type checking,
 		                better diagnostics, better optimization, better documentation, and better syntax-directed
-		                editing tools.</p>
+		                editing tools.</p>-->
                </note>
 
                <note>
@@ -6383,10 +6410,10 @@ name.</p>
      value as item()*, 
      right as t:binary-tree?
    )</eg>
-                  <p>A recursive function to walk this tree and enumerate all the values in depth-first order might be written 
+                  <p>A recursive function to walk this tree and return all the leaf values in depth-first order might be written 
                      (again using XQuery syntax) as:</p>
-                  <eg><![CDATA[declare function t:values($tree as t:binary-tree?) as item()* {
-  $tree ! (t:values(?left), ?value, t:values(?right))   
+                  <eg><![CDATA[declare function t:walk-tree($tree as t:binary-tree?) as item()* {
+  $tree ! (t:walk-tree(?left), ?value, t:walk-tree(?right))   
 }]]></eg>
                </example>
                
@@ -7834,7 +7861,7 @@ declare record Particle (
                               where the declared type in <var>A</var> is <var>T</var> 
                               and the declared type in <var>B</var> is <var>U</var>, <code><var>T</var> ⊑ <var>U</var></code>.</p>                               
                            </item>
-                           <item><p>For every field that is declared in <var>B</var> but is not declared in <var>A</var>
+                           <item><p>For every field that is declared in <var>B</var> but is not declared in <var>A</var>,
                            the empty sequence matches the declared type in <var>B</var>.</p> 
                            </item>
                         </olist>
@@ -8431,7 +8458,7 @@ declare record Particle (
                               of <var>E</var>, coerced to the declared type of <var>F</var>
                               by applying these coercion rules recursively.</p></item>
                               <item><p>Otherwise (if <var>J</var> contains no such entry),
-                              and entry whose key is the name of <var>F</var> and whose
+                              an entry whose key is the name of <var>F</var> and whose
                               associated value is the empty sequence; a type error occurs
                               if the empty sequence does not match the declared type of <var>F</var>.</p></item>
                            </olist>
@@ -22137,7 +22164,7 @@ return { $persons/*/* }
                   for cases where keys are items other than integers or NCNames.
                   It can also be followed by a variable reference or a context value reference.
                </change>
-               <change issue="1979" date="2026-03-31">
+               <change  issue="1979" PR="2566" date="2026-03-31">
                   When applied to a record, the lookup operator <code>?</code> now raises a type
                   error if the requested key is not present in the record.
                </change>
@@ -22416,10 +22443,11 @@ return { $persons/*/* }
                         items in the sequence fails.</p>
                   </item>
                   <item>
+                     <p>The following expression:</p>
                      <eg>let $r as record(x, y) := {'x': 12, 'y': 13}
 return $r?z</eg>
                      <p>raises a type error <xerrorref spec="FO40" class="TY" code="0016"/> 
-                        (typically reported statically) because the key <code>"z"</code> 
+                        (typically reported statically) because the key specifier <code>"z"</code> 
                      does not match any of the fields in the record type <code>record(x, y)</code>.</p>
                   </item>
       
@@ -22475,10 +22503,19 @@ return $r?z</eg>
 
                   <p>Lookup expressions on arrays result in a dynamic error if the subscript is out
                   of bounds, whereas the equivalent path expression succeeds, returning the empty
-                  sequence. For example <code>array{1 to 5}?10</code> raises 
+                  sequence. For example, <code>array{1 to 5}?10</code> raises 
                      <xerrorref spec="FO40" class="AY" code="0001"/>, whereas <code>array{1 to 5}/get(10)</code>
                      returns a empty sequence.
                  </p>
+                  
+                  <p>Lookup expressions on records result in a type error if the requested key value
+                  is not a defined field in the corresponding record type, whereas the equivalent path
+                  expression succeeds, returning the empty sequence. For example,
+                  <code>fn:dateTime-record(2026, 4, 1)?quarter</code> raises 
+                  <xerrorref spec="FO40" class="TY" code="0016"/>, whereas
+                  <code>fn:dateTime-record(2026, 4, 1)/get("quarter")</code>
+                     returns an empty sequence.
+                  </p>
 
                </div4>
                

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -6150,7 +6150,7 @@ name.</p>
                <xtermref spec="DM40" ref="dt-string"/>) and a type (an arbitrary <termref def="dt-sequence-type"/>).</termdef></p>
                
                <p>The syntax for defining a <termref def="dt-record-type"/> is the production
-               <nt def="RecordType">RecordType</nt>.</p>
+               <nt def="TypedRecordType">TypedRecordType</nt>.</p>
                
                
                <scrap>
@@ -6160,20 +6160,30 @@ name.</p>
 
                
                
-               <p>For example, the <nt def="RecordType">RecordType</nt>
+               <p>For example, the <nt def="TypedRecordType">TypedRecordType</nt>
                   <code>record(r as xs:double, i as xs:double)</code>
 		             defines a record type with two fields: an field with key <code>"r"</code>
 		                whose value is a <termref def="dt-singleton"/> <code>xs:double</code> value, and a field with key <code>"i"</code>
 		                whose value is also a <termref def="dt-singleton"/> <code>xs:double</code> value.</p>
                
-               <p>If the type declaration for a field is omitted, then <code>item()*</code> is assumed: that is,
+               <p>If the type declaration for a particular field is omitted, then <code>item()*</code> is assumed: that is,
 		             the map entry may have any type.</p>
                
-               <p>For generality, the syntax <code>record()</code> defines a record type that has no explicit fields. 
-                  The only thing it matches is an <xtermref spec="DM40" ref="dt-empty-map"/>.</p>
+               <p>For generality:</p>
                
-               <p>Record types describe a subset of the value space of maps. They do not define any new kinds of
-		             values, or any additional operations. They are useful in many cases to describe more accurately the
+               <ulist>
+                  <item><p>The syntax <code>record()</code> defines a record type that has no fields. 
+                  The only thing it matches is an <xtermref spec="DM40" ref="dt-empty-map"/> with the
+                  type annotation <code>record()</code>.</p></item>
+                  <item><p>The syntax <code>record(*)</code> matches any record: that is, any map
+                  with a type annotation identifying it as a record, regardless of the record type.
+                   (Note that the syntax <code>record(*)</code> does not correspond to any specific 
+                        record type.)</p></item>
+               </ulist></p>
+               
+               <p>Record types inherit all operations available for maps, but offer the possibility
+                  of stronger type checking, because the names of the fields (keys) are generally
+                  known statically. Record types are useful in many cases to describe more accurately the
 		             type of a variable, function parameter, or function result, giving benefits both in the readability
 		             of the code, and in the ability of the processor to detect and diagnose type errors and to optimize
 		             execution.</p>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -6342,7 +6342,7 @@ name.</p>
 		             such as <code>{longitude: 130.2, latitude: 53.4}</code> relies instead on recognizing the property
 		             names appearing in the object. XSLT 4.0, by integrating record types into pattern matching syntax,
 		             allows such an object to be matched with a pattern of the form 
-		                <code>match="record(longitude, latitude)"</code></p>
+		                <code>match="~record(longitude, latitude)"</code></p>
                </note>
 
                <p>Rules defining whether one record type is a <termref def="dt-subtype"/> of another
@@ -21985,13 +21985,13 @@ return { $persons/*/* }
                   </item>
                </ulist>
                
-               <note>
+               <!--<note>
                   <p>Because the function call <code>$map($key)</code> is equivalent to
                   <code>map:get($map, $key)</code>, it follows that if <code>$map</code>
                   is a <termref def="dt-record"/> and <code>$key</code> does not match
                   the name of any field defined for the corresponding <termref def="dt-record-type"/>,
                   the call will fail with a type error <xerrorref spec="FO40" class="TY" code="0016"/>.</p>
-               </note>
+               </note>-->
             </div4>
 
 
@@ -22690,7 +22690,7 @@ let $rectangle := {
                },
   'resize':    fn ($rect, $factor) { 
                   $rect with {'height': $rect?height × $factor}
-                        with {'width', $rect?width × $factor}
+                        with {'width': $rect?width × $factor}
                }
 }
                </eg>

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -2172,7 +2172,8 @@ local:depth(doc("partlist.xml"))
        <item><p>As a function, it must not have an arity range that overlaps the arity range of any
        other function declaration having the same name in the same static context.</p></item>
        <item><p>The order of field declarations is significant, because it determines the order of
-       arguments in a call to the constructor function.</p></item>
+       arguments in a call to the constructor function, as well as the order of entries
+       in the underlying map.</p></item>
        <item><p>The fields must have distinct names. <errorref class="ST" code="0021"/></p></item>
        <item><p>In order to work as both a record type and a function declaration, the names of the
        fields must be simple NCNames in no namespace; the names must not be written as string literals
@@ -2305,7 +2306,7 @@ local:depth(doc("partlist.xml"))
        indicator.</p></item>
        <item><p>The body of the function is a <nt def="MapConstructor">MapConstructor</nt>
            containing one <nt def="MapConstructorEntry">MapConstructorEntry</nt> for each field of the record type,
-           in the form <code>N : $N</code>, where <var>N</var> is the field name.</p>
+           in the form <code>"<var>N</var>" : $<var>N</var></code>, where <var>N</var> is the field name.</p>
          
        </item>  
  

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -2296,7 +2296,7 @@ local:depth(doc("partlist.xml"))
          <item><p>The declared type of the parameter is the declared type of the field, defaulting to 
              <code>item()*</code>.</p></item>
          <item><p>The default value for the parameter is given by the initializing expression in
-         the <nt def="ExtendedFieldDeclaration"/>, if present.</p></item>
+         the <nt def="ExtendedFieldDeclaration">ExtendedFieldDeclaration</nt>, if present.</p></item>
        </ulist></item>
        
        

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -2215,7 +2215,7 @@ local:depth(doc("partlist.xml"))
         in the case of a recursive definition, simple textual replacement would not terminate.</p></note>
       
         <p>A recursive record type will only be instantiable if every field whose value may contain instances of the record type
-        (directly or indirectly) is optional or emptiable. Specifically, it must either be an optional field, or its type
+        (directly or indirectly) is emptiable. Specifically, its type
         declaration must be such that it can hold an empty sequence or a value of a different type. 
         A recursive record type that is not instantiable is considered to be <termref def="dt-implausible"/>, 
         which means that a processor may treat it as an error but is not obliged to do so <errorref class="ST" code="0023"/>.</p>
@@ -2238,29 +2238,30 @@ local:depth(doc("partlist.xml"))
       <p>implicitly defines the function:</p>
        
        <eg>declare function cx:complex($r as xs:double, $i as xs:double := 0) as cx:complex {
-  map:merge(({ "r": $r }, { "i": $i }))
+   { "r": $r, "i": $i }
 };
        </eg>
       
       <p>So the call <code>cx:complex(3, 2)</code> produces the value <code>{ "r": 3e0, "i": 2e0 }</code>,
       while the call <code>cx:complex(3)</code> produces the value <code>{ "r": 3e0, "i": 0e0 }</code></p>
       
-      <p>The order of entries in the map corresponds
+      <p>The result of the function is a <termref def="dt-record"/> whose type annotation is the
+      declared <termref def="dt-record-type"/>.</p>
+      
+      <!--<p>The order of entries in the map corresponds
       to the order of field declarations in the record type. This means, for example, that when
       the map is serialized using the JSON output method, the order of entries in the output will
-      correspond to the order of field declarations.</p>
+      correspond to the order of field declarations.</p>-->
       
-      <p>If a field is declared as optional, by including a question mark after the name, and if it has no initializer,
+      <!--<p>If a field is declared as optional, by including a question mark after the name, and if it has no initializer,
       then the initializer <code>:= ()</code> is added implicitly. If the declared type of an optional field does
         not permit an empty sequence, then the declared type of the function parameter is adjusted by changing the
         occurrence indicator (from absent to <code>?</code> or from <code>+</code> to <code>*</code>) in order
-      to make the empty sequence an acceptable value.</p>
+      to make the empty sequence an acceptable value.</p>-->
       
-      <p>Furthermore, if a field is optional and has no explicit initializer, the relevant entry in the constructed 
-        map will be absent when the value supplied (implicitly or explicitly) to the function argument is an empty sequence. 
-        This is achieved by modifying the function body. Given the declaration:</p>
+      <!--<p>Given the declaration:</p>
       
-      <eg>declare record cx:complex(r as xs:double, i? as xs:double);</eg>
+      <eg>declare record cx:complex(r as xs:double, i as xs:double? := ());</eg>
       
       <p>the equivalent function declaration is:</p>
        
@@ -2271,10 +2272,10 @@ local:depth(doc("partlist.xml"))
   ), { "retain-order" : true() })
 };
        </eg>
+      -->
       
-      
-      <p>If any field is either declared optional, or has an explicit initializer, 
-        then all subsequent fields must also either be declared optional, or have an explicit initializer
+      <p>If any field has an explicit initializer, 
+        then all subsequent fields must also have an explicit initializer
         <errorref class="ST" code="0148"/>.</p>
       
       
@@ -2292,32 +2293,20 @@ local:depth(doc("partlist.xml"))
        declaration, in order.</p>
        <ulist>
          <item><p>The name of the parameter is the name of the field (always an NCName).</p></item>
-         <item><p>The declared type of the parameter is the declared type of the field, if present; but
-         if the field is optional, indicated by a question mark (<code>?</code>) after its name, and has no initializer,
-           then the occurrence indicator is adjusted to permit an empty sequence, as described earlier.</p></item>
+         <item><p>The declared type of the parameter is the declared type of the field, defaulting to 
+             <code>item()*</code>.</p></item>
          <item><p>The default value for the parameter is given by the initializing expression in
-         the <nt def="ExtendedFieldDeclaration"/>, if present. If the field is optional and has no initializer, then
-         it is given a default value of <code>()</code>, the empty sequence.</p></item>
+         the <nt def="ExtendedFieldDeclaration"/>, if present.</p></item>
        </ulist></item>
        
        
        
-       <item><p>The return type of the function is the name of the record declaration, with no occurrence
+       <item><p>The return type of the function is the <termref def="dt-record-type"/> being declared, with no occurrence
        indicator.</p></item>
-       <item><p>The body of the function is a call of the function <code>map:merge</code> with two arguments:</p>
-         <ulist>
-           <item><p>The first argument is a parenthesized expression containing a 
-             comma-separated sequence of subexpressions, containing one
-           subexpression for each field, in order.</p></item>
-           <item><p>By default, the relevant subexpression is the map constructor <code>{ "N": $N }</code>
-           where <var>N</var> is the field name.</p></item>
-           <item><p>If the field is optional and is declared without an explicit initializer, then the
-           relevant subexpression takes the form <code>if (exists($N)) { { "N": $N } }</code>
-           where <var>N</var> is the field name.</p></item>
-           
-           <item><p>The second argument in the call of the function <code>map:merge</code>
-           is the map <code>{ "duplicates": "use-first" }</code>.</p></item>
-         </ulist>
+       <item><p>The body of the function is a <nt def="MapConstructor">MapConstructor</nt>
+           containing one <nt def="MapConstructorEntry">MapConstructorEntry</nt> for each field of the record type,
+           in the form <code>N : $N</code>, where <var>N</var> is the field name.</p>
+         
        </item>  
  
  
@@ -2325,7 +2314,7 @@ local:depth(doc("partlist.xml"))
       
        
       
-       <p>Note that a question mark <code>?</code> after the field name indicates that the field is optional from the point of
+       <!--<p>Note that a question mark <code>?</code> after the field name indicates that the field is optional from the point of
        view of conformance of an item to the record type. The presence of an initializer indicates that it is optional
        from the point of view of a call on the constructor function. The two things are independent of each other. For example:</p>
      
@@ -2344,7 +2333,7 @@ local:depth(doc("partlist.xml"))
              record and in the function call: but because a default value has been supplied explicitly,
              the constructed map will always have an entry for <code>altitude</code>.</p>
          </item>
-       </ulist>
+       </ulist>-->
       
       <note>
         <p>Although the constructor function for a named record type produces a map in which the

--- a/specifications/xslt-40/src/element-catalog.xml
+++ b/specifications/xslt-40/src/element-catalog.xml
@@ -1813,16 +1813,16 @@
     
     <e:element-syntax name="record">
         <e:in-category name="instruction"/>
-        <e:attribute name="xsl:as" default="'map(*)'">
+        <e:attribute name="xsl:as" required="yes">
             <e:data-type name="item-type"/>
         </e:attribute>
-        <e:attribute name="xsl:duplicates" required="no" default="fn($a, $b) { error(xs:QName(err:XTDE3365)) }">
+        <!--<e:attribute name="xsl:duplicates" required="no" default="fn($a, $b) { error(xs:QName(err:XTDE3365)) }">
             <e:data-type name="expression"/>
-        </e:attribute>
+        </e:attribute>-->
         <e:attribute name="*" required="yes">
            <e:data-type name="expression"/>
         </e:attribute>
-        <e:model name="sequence-constructor"/>
+        <e:empty/>
         <e:allowed-parents>
             <e:parent-category name="sequence-constructor"/>
         </e:allowed-parents>

--- a/specifications/xslt-40/src/element-catalog.xml
+++ b/specifications/xslt-40/src/element-catalog.xml
@@ -1811,7 +1811,7 @@
       </e:allowed-parents>
    </e:element-syntax>
     
-    <e:element-syntax name="record">
+    <!--<e:element-syntax name="record">
         <e:in-category name="instruction"/>
         <e:attribute name="as" required="no">
             <e:data-type name="item-type"/>
@@ -1825,9 +1825,9 @@
         <e:allowed-parents>
             <e:parent-category name="sequence-constructor"/>
         </e:allowed-parents>
-    </e:element-syntax>
+    </e:element-syntax>-->
    
-    <e:element-syntax name="with-fields">
+    <!--<e:element-syntax name="with-fields">
         <e:attribute name="*" required="yes">
            <e:data-type name="expression"/>
         </e:attribute>
@@ -1835,7 +1835,7 @@
         <e:allowed-parents>
             <e:parent-category name="record"/>
         </e:allowed-parents>
-    </e:element-syntax>
+    </e:element-syntax>-->
    
    <e:element-syntax name="array">
       <e:in-category name="instruction"/>

--- a/specifications/xslt-40/src/element-catalog.xml
+++ b/specifications/xslt-40/src/element-catalog.xml
@@ -1813,18 +1813,27 @@
     
     <e:element-syntax name="record">
         <e:in-category name="instruction"/>
-        <e:attribute name="xsl:as" required="yes">
+        <e:attribute name="as" required="no">
             <e:data-type name="item-type"/>
         </e:attribute>
-        <!--<e:attribute name="xsl:duplicates" required="no" default="fn($a, $b) { error(xs:QName(err:XTDE3365)) }">
+        <e:attribute name="select" required="no">
             <e:data-type name="expression"/>
-        </e:attribute>-->
+        </e:attribute>
+        <e:sequence>
+           <e:element name="with-fields"/>
+        </e:sequence>
+        <e:allowed-parents>
+            <e:parent-category name="sequence-constructor"/>
+        </e:allowed-parents>
+    </e:element-syntax>
+   
+    <e:element-syntax name="with-fields">
         <e:attribute name="*" required="yes">
            <e:data-type name="expression"/>
         </e:attribute>
         <e:empty/>
         <e:allowed-parents>
-            <e:parent-category name="sequence-constructor"/>
+            <e:parent-category name="record"/>
         </e:allowed-parents>
     </e:element-syntax>
    

--- a/specifications/xslt-40/src/element-catalog.xml
+++ b/specifications/xslt-40/src/element-catalog.xml
@@ -927,9 +927,9 @@
       <e:attribute name="as" default="'item()*'">
          <e:data-type name="sequence-type"/>
       </e:attribute>
-      <e:attribute name="required" default="'yes'">
+      <!--<e:attribute name="required" default="'yes'">
          <e:data-type name="boolean"/>
-      </e:attribute>
+      </e:attribute>-->
       <e:attribute name="default">
          <e:data-type name="expression"/>
       </e:attribute>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -1597,8 +1597,9 @@ Michael Sperberg-McQueen (1954–2024).</p>
                </item>
                <item>
                   <p>instructions that construct maps and arrays: <elcode>xsl:array</elcode>,
-                      <elcode>xsl:array-member</elcode>, <elcode>xsl:map</elcode>, 
-                     <elcode>xsl:map-entry</elcode>, <elcode>xsl:record</elcode>;</p>
+                      <elcode>xsl:array-member</elcode>, <elcode>xsl:map</elcode>,
+                      <elcode>xsl:map-entry</elcode><!--, <elcode>xsl:record</elcode>-->;</p>
+
                </item>
                <item>
                   <p>instructions that copy nodes: <elcode>xsl:copy</elcode>,
@@ -17742,7 +17743,7 @@ return $tree =?> depth()]]></eg>
                   A variable-binding with no <code>as</code> or <code>select</code> attribute no longer
                   attempts to create an implicit document node if the sequence constructor contains
                   certain instructions (such as <elcode>xsl:map</elcode>, <elcode>xsl:array</elcode>, 
-                  <elcode>xsl:record</elcode>, and <elcode>xsl:select</elcode>).
+                  <!--<elcode>xsl:record</elcode>,--> and <elcode>xsl:select</elcode>).
                </change>
             </changes>
             <p>A <termref def="dt-variable-binding-element">variable-binding element</termref> may
@@ -17952,7 +17953,7 @@ return $tree =?> depth()]]></eg>
             
             <p><termdef id="dt-disqualifying-element" term="disqualifying element">The <term>disqualifying elements</term>
             are <elcode>xsl:map</elcode>, <elcode>xsl:map-entry</elcode>, <elcode>xsl:array</elcode>, 
-            <elcode>xsl:array-member</elcode>, <elcode>xsl:record</elcode>, and <elcode>xsl:select</elcode>. If a sequence
+            <elcode>xsl:array-member</elcode>, <!--<elcode>xsl:record</elcode>,--> and <elcode>xsl:select</elcode>. If a sequence
             constructor includes one of these elements, then construction of the implicit document node does
             not take place.</termdef></p>
             
@@ -28146,8 +28147,8 @@ the same group, and the-->
 
              </changes>
 
-            <p>Three instructions are added to XSLT to facilitate the construction of maps:
-            <elcode>xsl:map</elcode>, <elcode>xsl:map-entry</elcode>, and <elcode>xsl:record</elcode>.</p>
+            <p>New instructions are added to XSLT to facilitate the construction of maps:
+            <elcode>xsl:map</elcode>, and <elcode>xsl:map-entry</elcode><!--, and <elcode>xsl:record</elcode>-->.</p>
             
             <div3 id="id-xsl-map-and-entry">
                <head>The <code>xsl:map</code> and <code>xsl:map-entry</code> instructions</head>
@@ -28281,7 +28282,7 @@ the same group, and the-->
   &lt;/xsl:map&gt;
 &lt;/xsl:variable&gt;  
 </eg>
-                <p>In simple cases like this the same effect can be achieved using the
+                <!--<p>In simple cases like this the same effect can be achieved using the
                 <elcode>xsl:record</elcode> instruction:</p>
                 <eg role="xslt-declaration" xml:space="preserve">
 &lt;xsl:variable name="week" as="map(xs:string, xs:string)"&gt;
@@ -28294,8 +28295,8 @@ the same group, and the-->
     Sa="'Saturday'"
     Su="'Sunday'"/&gt;
 &lt;/xsl:variable&gt;  
-</eg>
-                <p>A third option is to construct the map in XPath:</p>
+</eg>-->
+                <p>Another option is to construct the map in XPath:</p>
 <eg role="xslt-declaration" xml:space="preserve">
 &lt;xsl:variable name="week" as="map(xs:string, xs:string)"&gt;
   &lt;xsl:select>
@@ -28399,9 +28400,9 @@ the same group, and the-->
                   values of the <code>duplicates</code> option of the 
                   <xfunction>map:merge</xfunction> function.</p>
                
-                <p>The result of the <elcode>xsl:map</elcode> or <elcode>xsl:record</elcode> instruction is defined by reference to 
+                <p>The result of the <elcode>xsl:map</elcode> <!--or <elcode>xsl:record</elcode>--> instruction is defined by reference to 
                the function <xfunction>map:merge</xfunction>. Specifically, if <code>$maps</code>
-               is the input sequence to <elcode>xsl:map</elcode> or <elcode>xsl:record</elcode>, and <code>$duplicates</code>
+               is the input sequence to <elcode>xsl:map</elcode> <!--or <elcode>xsl:record</elcode>-->, and <code>$duplicates</code>
                is the <termref def="dt-effective-value"/> of the <code>[xsl:]duplicates</code>
                attribute, then the result of the instruction is the result of the function
                call <code>map:merge($maps, { "duplicates": $duplicates })</code>.</p>
@@ -28528,7 +28529,7 @@ the same group, and the-->
                
             </div3>
             
-            <div3 id="record-instructions" diff="add" at="2025-03-14">
+            <!--<div3 id="record-instructions" diff="add" at="2025-03-14">
                  <head>Record Instruction</head>
                  <changes>
                  <change issue="322 1979" PR="1858 2566" date="2025-03-25"> The <elcode>xsl:record</elcode> instruction is introduced
@@ -28688,7 +28689,7 @@ the same group, and the-->
                 instances can be generated.</p>
              </example>
             </div3>
-           
+           -->
          </div2>
 
          

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -12291,21 +12291,16 @@ return $tree =?> depth()]]></eg>
                                  <code>"red"</code>, <code>"green"</code>, or <code>"blue"</code>.</p>
                            </item>
                            <item>
-                              <p><code>~record(first, last)[?location = 'UK']</code> matches any map whose keys include the strings <code>"first"</code>
-                                 and <code>"last"</code>, and that also has an entry with key <code>"location"</code> whose
-                              value is <code>"UK"</code>.</p>
-                              <p>This can also be written <code>~record(first, last, location as enum('UK'))</code>.</p>
-                           </item>
-                           <item>
-                              <p><code>~record(longitude, latitude)</code> matches any map with exactly two entries,
+                              <p><code>~record(longitude, latitude)</code> matches any record with exactly two entries,
                                  whose keys are the strings <code>"longitude"</code>
                                  and <code>"latitude"</code>.</p>
                            </item>
                            <item>
-                              <p><code>~record(title, author as enum("Dickens"))</code> matches having an entry whose keys is the string <code>"title"</code>,
-                                 plus an entry whose key is the string <code>"author"</code> and whose associated value
-                                 is the string <code>"Dickens"</code>.</p>
+                              <p><code>~record(longitude, latitude)[?latitude gt 0]</code> matches any record with exactly two entries,
+                                 whose keys are the strings <code>"longitude"</code>
+                                 and <code>"latitude"</code>, where the value of <code>latitude</code> is greater than zero.</p>
                            </item>
+        
                            <item>
                               <p><code>~array(xs:integer)[array:size(.) eq 4]</code> matches any array of four integers.</p>
                            </item>
@@ -12473,15 +12468,15 @@ return $tree =?> depth()]]></eg>
                               <p><code>jnode(books, array(record(Author, Title)))</code> 
                                  matches any JNode representing a map
                                  entry whose key is <code>"books"</code> and whose content is an array of records,
-                                 each record having entries named <code>"Author"</code> and <code>"Title"</code> (with other
-                                 entries also allowed).</p>
+                                 each record having entries named <code>"Author"</code> and <code>"Title"</code> (with no other
+                                 entries allowed).</p>
                            </item>
                            <item>
                               <p><code>jnode(*, record(Author as enum("Dickens"), Title))</code> 
                                  matches any JNode whose content is a map
                                  having an entry with key <code>"Author"</code> and value <code>"Dickens"</code>,
-                                 plus an entry with key <code>"Title"</code> (with other
-                                 entries also allowed).</p>
+                                 plus an entry with key <code>"Title"</code> (with no other
+                                 entries allowed).</p>
                            </item>
                            <item>
                               <p><code>jnode(())</code> matches any root JNode (that is, a JNode whose <term>·jkey·</term> property
@@ -12625,9 +12620,9 @@ return $tree =?> depth()]]></eg>
                   <p>A type pattern matches an item if both the following conditions are true:</p>
                   
                   <ulist>
-                     <item><p>The item can be successfully coerced to the given item type, by applying the
-                     <termref def="dt-coercion-rules"/>.</p></item>
-                     <item><p>The item (after such coercion) satisfies each of the predicates.</p></item>
+                     <item><p>The item matches the item type according to the 
+                           rules of <xspecref spec="XP40" ref="id-matching-item"/>.</p></item>
+                     <item><p>The item satisfies each of the predicates.</p></item>
                   </ulist>
                   
                   
@@ -12644,10 +12639,19 @@ return $tree =?> depth()]]></eg>
                         <code>node()</code>, which for historical reasons only matches  element, text, comment, 
                         and processing instruction nodes).</p></item>
                      <item><p><code>~record(first as enum("Sharon"), last)</code>
-                        matches any map having entries with the string-valued keys <code>"first"</code> and <code>"last"</code>,
-                        where the entry for the key <code>"first"</code> is equal to the string <code>"Sharon"</code></p></item>
+                        matches any record having entries with the string-valued keys <code>"first"</code> and <code>"last"</code>,
+                        where the entry for the key <code>"first"</code> is equal to the string <code>"Sharon"</code>.
+                        The record must not have any additional entries.</p>
+                        <note><p>A more flexible way to match records, if required, is to use a map pattern:
+                        see <specref ref="id-map-patterns"/>. Map patterns unlike record type patterns,
+                        do not require all the fields to be enumerated.</p></note>
+                     </item>
                      <item><p><code>~jnode(address, record(address-line-1, address-line-2))</code> matches a JNode whose
                      ·jkey· property is the string <code>"address"</code>, and whose content matches the given record type.</p></item>
+                     <item><p><code>~fn:dateTime-record</code> matches an instance of the system-defined record type
+                     <code>fn:dateTime-record</code> (produced typically as the result of the function <function>parse-dateTime</function>).</p></item>
+                     <item><p><code>~my:custom-record</code> matches an instance of the user-defined record type
+                     <code>my:custom-record</code>, defined in an <elcode>xsl:record-type</elcode> declaration.</p></item>
                   </ulist>
                   
                   
@@ -12971,6 +12975,11 @@ return $tree =?> depth()]]></eg>
                   handling in patterns ensure that any JNode whose ·jkey· value is of a type other
                   than <code>xs:date</code> does not match, because evaluation of the predicate raises an error.</p></item>
                </ulist>
+                  
+                  <ednote>
+                     <edtext>It would be useful to be able to use a map pattern within a JNode pattern,
+                     for example <code>match="jnode(*, {'first', 'middle', "last'})"</code>.</edtext>
+                  </ednote>
                   
                </example>
                

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -28531,11 +28531,12 @@ the same group, and the-->
             <div3 id="record-instructions" diff="add" at="2025-03-14">
                  <head>Record Instruction</head>
                  <changes>
-                 <change issue="322" PR="1858" date="2025-03-25"> The <elcode>xsl:record</elcode> instruction is introduced
+                 <change issue="322 1979" PR="1858 2566" date="2025-03-25"> The <elcode>xsl:record</elcode> instruction is introduced
                      to make construction of records simpler. </change>
                  </changes>
 
              <?element xsl:record?>
+             <?element xsl:with-fields?>
 
              <p>(The notation <code>* = expression</code> indicates that this instruction accepts
              any number of additional attributes in no namespace.)</p>
@@ -28544,101 +28545,105 @@ the same group, and the-->
                              to declare 'any permitted attribute of a given name type/pattern', in this case <code>xs:NCName</code>
              
                              </edtext></ednote></p>
-             <p>The instruction <elcode>xsl:record</elcode> constructs and returns a new
-                 record, permitting entries to be declared as attributes on the
-                 instruction. The <code>xsl:as</code> attribute is required, and its
-                value must be a record type.</p>
+             <p>The instruction <elcode>xsl:record</elcode> can be used to construct and return a new
+                 record, or to construct a record by modifying an existing record.
+                 The values of fields to be included in the resulting record can be supplied as attributes on the
+                 contained <elcode>xsl:with-fields</elcode> instruction.</p>
+               
+               <p>All attributes on the <elcode>xsl:with-fields</elcode> instruction must be unprefixed (in no namespace),
+                  and the XSLT standard attributes such as <code>xpath-default-namespace</code>,
+                  <code>use-when</code>, and <code>version</code>
+                  are not recognized as having their usual XSLT-defined meaning. Attributes whose names start with
+                  an underscore are not treated as shadow attributes.</p>
+               
+               <ulist>
+                  <item>
+                     <p>To construct a new record, the <code>as</code> attribute is required, and its value must
+                     be an item type that designates a <xtermref spec="XP40" def="dt-record-type"/>. The <code>select</code>
+                     attribute is omitted. The entries
+                     in the new record are taken from the attributes of the contained <elcode>xsl:with-fields</elcode>
+                     element: each attribute represents one key-value pair. The attribute names must correspond
+                     to fields declared within the record type, and the values must be expressions that evaluate
+                     to values of the appropriate type for the relevant field declaration. The <termref def="dt-coercion-rules"/>
+                     are applied to convert the value of each field to the required type if necessary; however,
+                     attribute names that do not correspond to any field name are disallowed. A type error is raised
+                     if the result is not a valid instance of the chosen record type.</p>
+                     <p>If the record type declaration includes a field for which there is no corresponding
+                     attribute in the <elcode>xs:with-fields</elcode> element, the corresponding field is
+                     initialized to an empty sequence; a type error is raised if the empty sequence is not
+                     a valid value for the field.</p>
+                     <p>It is not possible to populate fields unless their names follow the rules for an
+                     <code>xs:NCName</code>.</p>
+                  </item>
+               
+               
+               
+               
+                  <item>                  
+                     <p>To modify an existing record or map, the existing record or map is first obtained as the
+                     value of the expression in the <code>select</code> attribute. The required type
+                     for this expression is <code>map(*)</code>, and the coercion rules are applied
+                     if necessary (so a JNode may be supplied if its value is a map or record).</p>
+                  
+                     <ulist>
+                        <item><p>If the existing value is a record, then the <code>as</code> attribute may
+                        be omitted; it defaults to the type annotation of the existing record.</p></item>
+                        <item><p>In other cases, the <code>as</code> attribute must be supplied, and must
+                              be a record type. The existing value is coerced to this record type by applying
+                              the coercion rules.
+                      </p></item>
+                     </ulist>
+                   
+                     <p>The entries in the result record will be as follows:</p>
+                     
+                     <ulist>
+                        <item>
+                           <p>For an attribute that is present in the <elcode>xsl:with-fields</elcode> element,
+                           an entry whose key is the attribute name (as an <code>xs:string</code>) and
+                           whose corresponding value is the result of evaluating the expression in the
+                           attribute value, coerced if necessary to the required type for the field.</p>
+                        </item>
+                        <item>
+                           <p>For an entry that is present in the existing record or map supplied in the
+                           <code>select</code> expression, a copy of that key/value pair, but with the value
+                           coerced if necessary to the required type for the field.</p>
+                        </item>
+                        <item>
+                           <p>For any field declared in the record type declaration that is not present
+                           either as an entry in the existing record or map, nor as an attribute on the
+                           <elcode>xsl:with-fields</elcode> element, an empty sequence.</p>
+                        </item>
+                     </ulist>
+                     
+                     <p>If an attribute is present on the <elcode>xsl:with-fields</elcode> element that
+                     does not correspond to the name of any field in the required record type, a type error is
+                     raised.</p>
+                     
+                     <p>However, an entry in the existing record or map that does not correspond to any
+                     field in the required record type is silently discarded.</p>
+                     
+                     <p>Any value that cannot be coerced to the required type of the relevant field
+                     in the required record type results in a type error.</p>
+                  </item>
+                  
+               </ulist>
                 
-                <p>The instruction is intended to make writing maps where the entry keys are
-                 NCNames simpler and more concise, avoiding larger XSLT constructs using
-                 <elcode>xsl:map</elcode> and <elcode>xsl:map-entry</elcode> or
-                 <elcode>xsl:sequence</elcode> containing map-constructing XPath
-                 expressions.</p>
-                 
-                 <note>
-                     <p>Unlike all other <termref def="dt-xslt-element">XSLT elements</termref>, the names of the attributes <code>xsl:as</code> and
-                         <code>xsl:duplicates</code> as well as the <termref def="dt-standard-attributes">standard
-                             attributes</termref> (such as <code>use-when</code> or <code>xpath-default-namespace</code>) attached to the <elcode>xsl:record</elcode> instruction <rfc2119>must</rfc2119> be in the <termref def="dt-xslt-namespace">XSLT namespace</termref>, 
-                         as opposed to being in no namespace. This has been chosen to
-                         avoid reserving the names of such attributes (e.g. <code>as</code>, <code>duplicates</code>, <code>use-when</code> etc.) as potential
-                         entry keys, leaving any valid NCName as a candidate.</p>
-                 </note>
+                
+                
                 
                 <ednote><edtext>Need to update the schemas (XSD and RNG) for xsl:record</edtext></ednote>
                  
                  
              
-             <p>The <elcode>xsl:record</elcode> instruction generates a new record: call this
-                 <code>$record</code>. For each of the attributes of the instruction whose name
-                 is an <code>xs:NCName</code> an entry is added to <code>$record</code> whose
-                 key is the name of the attribute (as an <code>xs:string</code>) and whose value is
-                 the result of evaluating the value of that attribute as an expression in the
-                 current context.</p>
-                
-                <p>The resulting record is coerced to the record type specified in the <code>xsl:as</code>
-                attribute, and acquires a type annotation to mark it as an instance of this record type.</p>
-                 <note>
-                     <p>As the values of the attributes whose names are <code>xs:NCName</code> are considered to be XPath expressions,
-                     two consequences follow for such attributes:
-                     <olist>
-                         <item>They <rfc2119>must not</rfc2119> be considered as shadow attributes (see <specref ref="shadow-attributes"/>) 
-                             as a leading underscore is a valid character within an <code>xs:NCName</code>.</item>
-                         <item>They are not designated as <termref def="dt-attribute-value-template">attribute
-                                 value templates</termref>.</item>
-                     </olist> These restrictions do not apply to attributes of <elcode>xsl:record</elcode> whose names are in namespaces.</p>
-                 </note>
-                 
-             <!--<p>After processing the applicable attributes of the instruction, any contained
-                 sequence constructor is evaluated and the result <rfc2119>must</rfc2119> be a
-                 (possibly empty) sequence of maps. The entries in these maps are merged into
-                 <code>$record</code>. By this means entries can be added whose keys are not
-                 NCNames, or conditionally generated entries can be included.</p>-->
-             <!--<p> Each of the map entries in
-                 <code>$record</code> is modified by applying the <termref def="dt-coercion-rules"/>
-                 to convert the singleton map to the type declared in the <code>xsl:as</code>
-                 attribute of the <elcode>xsl:record</elcode> instruction, if present. 
-                 This may contain a record type declaration or 
-                 a reference to one of the <xtermref
-                     spec="XP40" ref="dt-in-scope-named-item-types"/>, which may include record types.</p>
-             -->    
-             <!--<p>The treatment of duplicate keys between entries defined in the attributes of
-                 <elcode>xsl:record</elcode> and any generated by a contained sequence
-                 constructor is described in <specref ref="duplicate-keys"/> below. Note that in
-                 the absence of a sequence constructor, no duplicate keys can appear, as all
-                 attributes of <elcode>xsl:record</elcode> must have a unique name within the
-                 element tag.</p>-->
+             
            
-                 <!--<p>The effect of this instruction, in the absence of errors, is equivalent to execution of the XSLT <elcode>xsl:map</elcode> instruction generated by the 
-                     the following source transformation of the <elcode>xsl:record</elcode> subtree</p>
-                 <eg role="xslt-declaration" xml:space="preserve">
-                   <![CDATA[<xsl:namespace-alias stylesheet-prefix="t" result-prefix="xsl"/>
-...
-
-<xsl:mode name="record" on-no-match="shallow-copy">
-   <xsl:template match="xsl:record">
-      <xsl:variable name="xsl-attributes" select="@xsl:*"/>
-      <xsl:variable name="ncname-attributes" select="@*[empty(prefix-from-QName(node-name()))]"/>
-      <xsl:variable name="other-attributes"
-          select="@* except ($xsl-attributes, $ncname-attributes)"/>
-      <t:map>
-         <xsl:sequence select="$other-attributes"/>
-         <xsl:apply-templates select="$xsl-attributes, $ncname-attributes, node()"/>
-      </t:map>
-   </xsl:template>
-   <xsl:template match="xsl:record/@*">
-      <t:map-entry key="'{name()}'" select="{.}"/>
-   </xsl:template>
-   <xsl:template match="xsl:record/@xsl:*" priority="1">
-      <xsl:attribute name="{local-name()}" select="."/>
-   </xsl:template>
-</xsl:mode>]]>
-                 </eg>-->
                  <p>For example, the instruction:</p>
-                 <eg><![CDATA[ <xsl:record xsl:as="eg:book" 
+                 <eg><![CDATA[ <xsl:record as="eg:book">
+     <xsl:with-fields               
                author="string(AUTHOR)"
                title="string(TITLE)" 
                price="xs:decimal(PRICE)" 
-               publisher="string(../@name)">
+               publisher="string(../@name)"/>          
    </xsl:record>]]></eg>
                  <p>is equivalent to the call on the constructor function:</p>
                 <eg><![CDATA[<xsl:select>
@@ -28655,13 +28660,13 @@ the same group, and the-->
                  <head>Generating a record with <elcode>xsl:record</elcode></head>
                  <p>The following example constructs a record using <elcode>xsl:record</elcode></p>
                  <eg role="xslt-declaration" xml:space="preserve"><![CDATA[<xsl:template match="book" as="map(*)">
-   <xsl:record author="string(AUTHOR)"
+   <xsl:record as="eg:book"
+        select="if (@private) then {'private entry': true()} else {}"
+      <xsl:with-fields>
+               author="string(AUTHOR)"
                title="string(TITLE)" 
                price="xs:decimal(PRICE)" 
-               publisher="string(../@name)">
-      <xsl:if test="@private">
-         <xsl:map-entry name="'private entry'" select="true()"/>
-      </xsl:if>
+               publisher="string(../@name)"/>
    </xsl:record>
 </xsl:template>]]></eg>
                  <p>with the following input</p>
@@ -28675,6 +28680,10 @@ the same group, and the-->
                  <p>will produce a resulting map:</p>
                  <eg>map{'author':'MHK', 'title': 'XSLT 4.0', 'price':123.45, 
                      'publisher':'QT4 Community', 'private entry': true()} </eg>
+                
+                <p>This example illustrates how entries in the result record can be generated
+                conditionally, and how entries whose names are not <code>xs:NCName</code>
+                instances can be generated.</p>
              </example>
             </div3>
            

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -28632,19 +28632,21 @@ the same group, and the-->
                 
                 
                 <ednote><edtext>Need to update the schemas (XSD and RNG) for xsl:record</edtext></ednote>
+               
+                <ednote><edtext>Need to define error codes for xsl:record</edtext></ednote>
                  
                  
              
              
            
                  <p>For example, the instruction:</p>
-                 <eg><![CDATA[ <xsl:record as="eg:book">
+                 <eg><![CDATA[<xsl:record as="eg:book">
      <xsl:with-fields               
                author="string(AUTHOR)"
                title="string(TITLE)" 
                price="xs:decimal(PRICE)" 
                publisher="string(../@name)"/>          
-   </xsl:record>]]></eg>
+</xsl:record>]]></eg>
                  <p>is equivalent to the call on the constructor function:</p>
                 <eg><![CDATA[<xsl:select>
   eg:book(author := string(AUTHOR), 

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -10413,10 +10413,16 @@ and <code>version="1.0"</code> otherwise.</p>
                      Extensible map types are dropped; instead, the coercion rules cause undefined
                      map entries to be discarded.
                   </change>
+                  <change issue="1979" PR="2566" date="2026-03-31">
+                     Fields in a record type can no longer be optional; absent values are represented
+                     by an empty sequence.
+                  </change>
                </changes>
                
                <?element xsl:record-type?>
                <?element xsl:field?>
+               
+               <ednote><edtext>Schema change required to drop "xsl:field/@required" attribute</edtext></ednote>
                
                <p>An <elcode>xsl:record-type</elcode> declaration associates a name 
                   with a record type, and allows the record type
@@ -10449,11 +10455,11 @@ and <code>version="1.0"</code> otherwise.</p>
                      declaration are not distinct.</p>
                </error></p>
                
-               <p><error spec="XT" class="SE" code="4051" type="static">
+               <!--<p><error spec="XT" class="SE" code="4051" type="static">
                   <p>It is a <termref def="dt-static-error"/> 
                      if an <elcode>xsl:field</elcode> element has a <code>default</code>
                      attribute unless it specifies <code>required="no"</code>.</p>
-               </error></p>
+               </error></p>-->
                
               <p>An <elcode>xsl:record-type</elcode> declaration has two effects:</p>
                
@@ -10488,10 +10494,7 @@ and <code>version="1.0"</code> otherwise.</p>
      <xsl:attribute name="as">
         <xsl:text>record(</xsl:text>
         <xsl:for-each select="xsl:field" separator=", ">
-           <xsl:variable name="optional"
-                         as="xs:boolean"
-                         select="normalize-space(@required) = ('no','false','0')"/>
-           {@name}{'?'[$optional]} as {@as otherwise 'item()*'}
+           {@name} as {@as otherwise 'item()*'}
         </xsl:for-each>
         <xsl:text>)</xsl:text>
       </xsl:attribute>  
@@ -10532,48 +10535,20 @@ and <code>version="1.0"</code> otherwise.</p>
       <!-- declare the parameters -->
       <xsl:for-each select="xsl:field">
          <t:param name="{@name}"
-                  required="{@required otherwise 'yes'}">
-            <xsl:attribute name="as">
-               <xsl:variable name="as" 
-                             select="normalize-space(@as otherwise 'item()*')"/>
-               <xsl:variable name="optional" 
-                             select="normalize-space(@required) = ('no', 'false', '0')"/>
-               <xsl:choose>
-                  <xsl:when test="not($optional)" select="$as"/>
-                  <!-- for optional fields, amend the required type to allow () -->
-                  <xsl:when test="matches($as, '[?*]$')" select="$as"/>
-                  <xsl:when test="matches($as, '\+$')" select="replace($as, '\+$', '*')"/>
-                  <xsl:otherwise select="$as || '?'"/>
-               </xsl:choose>
-            </xsl:attribute>
+                  required="{@required otherwise 'yes'}"
+                  as="{@as}">
             <xsl:if test="@default">
                <xsl:attribute name="select" select="@default"/>
             </xsl:if>   
          </t:param>
       </xsl:for-each>
       
-        
-      
+            
       <!-- function body: construct a map -->
       <t:map duplicates="fn($first, $second){{$first}}">
          <xsl:for-each select="xsl:field">
-            <xsl:variable name="optional" 
-                          select="normalize-space(@required) = ('no', 'false', '0')"/>
-            <xsl:choose>
-              <xsl:when test="$optional and not(@default)">
-                 <!-- omit map entries for optional fields if no value is supplied -->
-                 <t:if test="exists(${@name})">
-                    <t:map-entry key="'{@name}'" select="${@name}"/>
-                 </t:if>
-              </xsl:when>
-              <xsl:otherwise>
-                <t:map-entry key="'{@name}'" select="${@name}"/>
-              </xsl:otherwise>  
-            </xsl:choose>  
+             <t:map-entry key="'{@name}'" select="${@name}"/> 
          </xsl:for-each>
-        
-
-
       </t:map>
     </t:function>          
 </xsl:template>]]></eg>
@@ -10582,7 +10557,7 @@ and <code>version="1.0"</code> otherwise.</p>
                
                <eg><![CDATA[<xsl:record-type name="cx:complex">
     <xsl:field name="r" as="xs:double"/>
-    <xsl:field name="i" as="xs:double" required="no" default="0"/>
+    <xsl:field name="i" as="xs:double" default="0"/>
 </xsl:record-type>]]></eg>
                
                <p>produces the equivalent function declaration:</p>
@@ -10596,28 +10571,7 @@ and <code>version="1.0"</code> otherwise.</p>
     </xsl:map>
 </xsl:function>]]></eg>
                
-               <p>No entry is generated in the constructed map for a field that
-               is declared as optional with no default. So the declaration:</p>
-               
-               <eg><![CDATA[<xsl:record-type name="cx:complex" visibility="public">
-    <xsl:field name="r" as="xs:double"/>
-    <xsl:field name="i" as="xs:double" required="no"/>
-</xsl:record-type>]]></eg>
-               
-               <p>produces the equivalent function declaration:</p>
-               
-               <eg><![CDATA[<xsl:function name="cx:complex" as="cx:complex" visibility="public">
-    <xsl:param name="r" as="xs:double"/>
-    <xsl:param name="i" as="xs:double?" required="no"/>
-    <xsl:map>
-       <xsl:map-entry key="'r'" select="$r"/>
-       <xsl:if test="exists($i)">
-          <xsl:map-entry key="'i'" select="$i"/>
-       </xsl:if>   
-    </xsl:map>
-</xsl:function>]]></eg>
-               
-               
+ 
                
                <p>This generated <elcode>xsl:function</elcode> declaration must
                meet all the constraints placed on user-written 
@@ -28409,155 +28363,7 @@ the same group, and the-->
 
             </div3>
 
-             <div3 id="record-instructions" diff="add" at="2025-03-14">
-                 <head>Record Instruction</head>
-                 <changes>
-                 <change issue="322" PR="1858" date="2025-03-25"> The <elcode>xsl:record</elcode> instruction is introduced
-                     to make construction of records simpler. </change>
-                 </changes>
-
-             <?element xsl:record?>
-
-             <p>(The notation <code>* = expression</code> indicates that this instruction accepts
-             any number of additional attributes in no namespace.)</p>
-             
-                 <p><ednote><edtext>There needs to be a construct available within <code>element-catalog.xml</code>
-                             to declare 'any permitted attribute of a given name type/pattern', in this case <code>xs:NCName</code>
-             
-                             </edtext></ednote></p>
-             <p>The instruction <elcode>xsl:record</elcode> constructs and returns a new
-                 record, permitting entries to be declared as attributes on the
-                 instruction. The <code>xsl:as</code> attribute is required, and its
-                value must be a record type.</p>
-                
-                <p>The instruction is intended to make writing maps where the entry keys are
-                 NCNames simpler and more concise, avoiding larger XSLT constructs using
-                 <elcode>xsl:map</elcode> and <elcode>xsl:map-entry</elcode> or
-                 <elcode>xsl:sequence</elcode> containing map-constructing XPath
-                 expressions.</p>
-                 
-                 <note>
-                     <p>Unlike all other <termref def="dt-xslt-element">XSLT elements</termref>, the names of the attributes <code>xsl:as</code> and
-                         <code>xsl:duplicates</code> as well as the <termref def="dt-standard-attributes">standard
-                             attributes</termref> (such as <code>use-when</code> or <code>xpath-default-namespace</code>) attached to the <elcode>xsl:record</elcode> instruction <rfc2119>must</rfc2119> be in the <termref def="dt-xslt-namespace">XSLT namespace</termref>, 
-                         as opposed to being in no namespace. This has been chosen to
-                         avoid reserving the names of such attributes (e.g. <code>as</code>, <code>duplicates</code>, <code>use-when</code> etc.) as potential
-                         entry keys, leaving any valid NCName as a candidate.</p>
-                 </note>
-                
-                <ednote><edtext>Need to update the schemas (XSD and RNG) for xsl:record</edtext></ednote>
-                 
-                 
-             
-             <p>The <elcode>xsl:record</elcode> instruction generates a new record: call this
-                 <code>$record</code>. For each of the attributes of the instruction whose name
-                 is an <code>xs:NCName</code> an entry is added to <code>$record</code> whose
-                 key is the name of the attribute (as an <code>xs:string</code>) and whose value is
-                 the result of evaluating the value of that attribute as an expression in the
-                 current context.</p>
-                
-                <p>The resulting record is coerced to the record type specified in the <code>xsl:as</code>
-                attribute, and acquires a type annotation to mark it as an instance of this record type.</p>
-                 <note>
-                     <p>As the values of the attributes whose names are <code>xs:NCName</code> are considered to be XPath expressions,
-                     two consequences follow for such attributes:
-                     <olist>
-                         <item>They <rfc2119>must not</rfc2119> be considered as shadow attributes (see <specref ref="shadow-attributes"/>) 
-                             as a leading underscore is a valid character within an <code>xs:NCName</code>.</item>
-                         <item>They are not designated as <termref def="dt-attribute-value-template">attribute
-                                 value templates</termref>.</item>
-                     </olist> These restrictions do not apply to attributes of <elcode>xsl:record</elcode> whose names are in namespaces.</p>
-                 </note>
-                 
-             <!--<p>After processing the applicable attributes of the instruction, any contained
-                 sequence constructor is evaluated and the result <rfc2119>must</rfc2119> be a
-                 (possibly empty) sequence of maps. The entries in these maps are merged into
-                 <code>$record</code>. By this means entries can be added whose keys are not
-                 NCNames, or conditionally generated entries can be included.</p>-->
-             <p> Each of the map entries in
-                 <code>$record</code> is modified by applying the <termref def="dt-coercion-rules"/>
-                 to convert the singleton map to the type declared in the <code>xsl:as</code>
-                 attribute of the <elcode>xsl:record</elcode> instruction, if present. 
-                 This may contain a record type declaration or 
-                 a reference to one of the <xtermref
-                     spec="XP40" ref="dt-in-scope-named-item-types"/>, which may include record types.</p>
-                 
-             <!--<p>The treatment of duplicate keys between entries defined in the attributes of
-                 <elcode>xsl:record</elcode> and any generated by a contained sequence
-                 constructor is described in <specref ref="duplicate-keys"/> below. Note that in
-                 the absence of a sequence constructor, no duplicate keys can appear, as all
-                 attributes of <elcode>xsl:record</elcode> must have a unique name within the
-                 element tag.</p>-->
-             <!--<note>-->
-                 <p>The effect of this instruction, in the absence of errors, is equivalent to execution of the XSLT <elcode>xsl:map</elcode> instruction generated by the 
-                     the following source transformation of the <elcode>xsl:record</elcode> subtree</p>
-                 <eg role="xslt-declaration" xml:space="preserve">
-                   <![CDATA[<xsl:namespace-alias stylesheet-prefix="t" result-prefix="xsl"/>
-...
-
-<xsl:mode name="record" on-no-match="shallow-copy">
-   <xsl:template match="xsl:record">
-      <xsl:variable name="xsl-attributes" select="@xsl:*"/>
-      <xsl:variable name="ncname-attributes" select="@*[empty(prefix-from-QName(node-name()))]"/>
-      <xsl:variable name="other-attributes"
-          select="@* except ($xsl-attributes, $ncname-attributes)"/>
-      <t:map>
-         <xsl:sequence select="$other-attributes"/>
-         <xsl:apply-templates select="$xsl-attributes, $ncname-attributes, node()"/>
-      </t:map>
-   </xsl:template>
-   <xsl:template match="xsl:record/@*">
-      <t:map-entry key="'{name()}'" select="{.}"/>
-   </xsl:template>
-   <xsl:template match="xsl:record/@xsl:*" priority="1">
-      <xsl:attribute name="{local-name()}" select="."/>
-   </xsl:template>
-</xsl:mode>]]>
-                 </eg>
-                 <p>which for the instruction:</p>
-                 <eg><![CDATA[ <xsl:record xsl:as="eg:book" author="string(AUTHOR)"
-               title="string(TITLE)" 
-               price="xs:decimal(PRICE)" 
-               publisher="string(../@name)">
-   </xsl:record>]]></eg>
-                 <p>would produce</p>
-                 <eg><![CDATA[ <xsl:map as="eg:book">
-      <xsl:map-entry key="'author'" select="string(AUTHOR)"/>
-      <xsl:map-entry key="'title'" select="string(TITLE)"/>
-      <xsl:map-entry key="'price'" select="xs:decimal(PRICE)"/>
-      <xsl:map-entry key="'publisher'" select="string(../@name)"/>
-   </xsl:map>]]></eg>
-             <!--</note>-->
-             
-
-
-             <example diff="add" at="2025-02-25">
-                 <head>Generating a record with <elcode>xsl:record</elcode></head>
-                 <p>The following example constructs a record using <elcode>xsl:record</elcode></p>
-                 <eg role="xslt-declaration" xml:space="preserve"><![CDATA[<xsl:template match="book" as="map(*)">
-   <xsl:record author="string(AUTHOR)"
-               title="string(TITLE)" 
-               price="xs:decimal(PRICE)" 
-               publisher="string(../@name)">
-      <xsl:if test="@private">
-         <xsl:map-entry name="'private entry'" select="true()"/>
-      </xsl:if>
-   </xsl:record>
-</xsl:template>]]></eg>
-                 <p>with the following input</p>
-                 <eg><![CDATA[<catalog name="QT4 Community">
-  <book private="true">
-    <AUTHOR>MHK</AUTHOR>
-    <TITLE>XSLT 4.0</TITLE>
-    <PRICE>123.45</PRICE>
-  </book>
-</catalog>]]></eg>
-                 <p>will produce a resulting map:</p>
-                 <eg>map{'author':'MHK', 'title': 'XSLT 4.0', 'price':123.45, 
-                     'publisher':'QT4 Community', 'private entry': true()} </eg>
-             </example>
-            </div3>
-             
+               
             <div3 id="duplicate-keys" diff="add" at="2022-01-01">
                <head>Handling of duplicate keys</head>
                
@@ -28567,10 +28373,10 @@ the same group, and the-->
                   allowing control over how duplicate keys are handled by the <elcode>xsl:map</elcode>
                   instruction.
                   </change>
-                   <change issue="322" PR="1858" date="2025-03-14">
+                   <!--<change issue="322" PR="1858" date="2025-03-14">
                        Attribute <code>xsl:record/@xsl:duplicates</code> is added to control duplicate keys handling in the <elcode>xsl:record</elcode>
                        instruction.
-                   </change>
+                   </change>-->
                </changes>
                
                <p>This section describes what happens when two or more maps in the input sequence of
@@ -28582,7 +28388,7 @@ the same group, and the-->
                   <p>In the absence of the <code>[xsl:]duplicates</code> attribute, 
                      a <termref def="dt-dynamic-error">dynamic error</termref> occurs if the set of
                      keys in the maps making up the input sequence
-                      <error.extra>of an <elcode>xsl:map</elcode> or <elcode>xsl:record</elcode> instruction</error.extra>
+                      <error.extra>of an <elcode>xsl:map</elcode> instruction</error.extra>
                      contains duplicates.</p>
                </error></p>
                
@@ -28721,6 +28527,157 @@ the same group, and the-->
                
                
             </div3>
+            
+            <div3 id="record-instructions" diff="add" at="2025-03-14">
+                 <head>Record Instruction</head>
+                 <changes>
+                 <change issue="322" PR="1858" date="2025-03-25"> The <elcode>xsl:record</elcode> instruction is introduced
+                     to make construction of records simpler. </change>
+                 </changes>
+
+             <?element xsl:record?>
+
+             <p>(The notation <code>* = expression</code> indicates that this instruction accepts
+             any number of additional attributes in no namespace.)</p>
+             
+                 <p><ednote><edtext>There needs to be a construct available within <code>element-catalog.xml</code>
+                             to declare 'any permitted attribute of a given name type/pattern', in this case <code>xs:NCName</code>
+             
+                             </edtext></ednote></p>
+             <p>The instruction <elcode>xsl:record</elcode> constructs and returns a new
+                 record, permitting entries to be declared as attributes on the
+                 instruction. The <code>xsl:as</code> attribute is required, and its
+                value must be a record type.</p>
+                
+                <p>The instruction is intended to make writing maps where the entry keys are
+                 NCNames simpler and more concise, avoiding larger XSLT constructs using
+                 <elcode>xsl:map</elcode> and <elcode>xsl:map-entry</elcode> or
+                 <elcode>xsl:sequence</elcode> containing map-constructing XPath
+                 expressions.</p>
+                 
+                 <note>
+                     <p>Unlike all other <termref def="dt-xslt-element">XSLT elements</termref>, the names of the attributes <code>xsl:as</code> and
+                         <code>xsl:duplicates</code> as well as the <termref def="dt-standard-attributes">standard
+                             attributes</termref> (such as <code>use-when</code> or <code>xpath-default-namespace</code>) attached to the <elcode>xsl:record</elcode> instruction <rfc2119>must</rfc2119> be in the <termref def="dt-xslt-namespace">XSLT namespace</termref>, 
+                         as opposed to being in no namespace. This has been chosen to
+                         avoid reserving the names of such attributes (e.g. <code>as</code>, <code>duplicates</code>, <code>use-when</code> etc.) as potential
+                         entry keys, leaving any valid NCName as a candidate.</p>
+                 </note>
+                
+                <ednote><edtext>Need to update the schemas (XSD and RNG) for xsl:record</edtext></ednote>
+                 
+                 
+             
+             <p>The <elcode>xsl:record</elcode> instruction generates a new record: call this
+                 <code>$record</code>. For each of the attributes of the instruction whose name
+                 is an <code>xs:NCName</code> an entry is added to <code>$record</code> whose
+                 key is the name of the attribute (as an <code>xs:string</code>) and whose value is
+                 the result of evaluating the value of that attribute as an expression in the
+                 current context.</p>
+                
+                <p>The resulting record is coerced to the record type specified in the <code>xsl:as</code>
+                attribute, and acquires a type annotation to mark it as an instance of this record type.</p>
+                 <note>
+                     <p>As the values of the attributes whose names are <code>xs:NCName</code> are considered to be XPath expressions,
+                     two consequences follow for such attributes:
+                     <olist>
+                         <item>They <rfc2119>must not</rfc2119> be considered as shadow attributes (see <specref ref="shadow-attributes"/>) 
+                             as a leading underscore is a valid character within an <code>xs:NCName</code>.</item>
+                         <item>They are not designated as <termref def="dt-attribute-value-template">attribute
+                                 value templates</termref>.</item>
+                     </olist> These restrictions do not apply to attributes of <elcode>xsl:record</elcode> whose names are in namespaces.</p>
+                 </note>
+                 
+             <!--<p>After processing the applicable attributes of the instruction, any contained
+                 sequence constructor is evaluated and the result <rfc2119>must</rfc2119> be a
+                 (possibly empty) sequence of maps. The entries in these maps are merged into
+                 <code>$record</code>. By this means entries can be added whose keys are not
+                 NCNames, or conditionally generated entries can be included.</p>-->
+             <!--<p> Each of the map entries in
+                 <code>$record</code> is modified by applying the <termref def="dt-coercion-rules"/>
+                 to convert the singleton map to the type declared in the <code>xsl:as</code>
+                 attribute of the <elcode>xsl:record</elcode> instruction, if present. 
+                 This may contain a record type declaration or 
+                 a reference to one of the <xtermref
+                     spec="XP40" ref="dt-in-scope-named-item-types"/>, which may include record types.</p>
+             -->    
+             <!--<p>The treatment of duplicate keys between entries defined in the attributes of
+                 <elcode>xsl:record</elcode> and any generated by a contained sequence
+                 constructor is described in <specref ref="duplicate-keys"/> below. Note that in
+                 the absence of a sequence constructor, no duplicate keys can appear, as all
+                 attributes of <elcode>xsl:record</elcode> must have a unique name within the
+                 element tag.</p>-->
+           
+                 <!--<p>The effect of this instruction, in the absence of errors, is equivalent to execution of the XSLT <elcode>xsl:map</elcode> instruction generated by the 
+                     the following source transformation of the <elcode>xsl:record</elcode> subtree</p>
+                 <eg role="xslt-declaration" xml:space="preserve">
+                   <![CDATA[<xsl:namespace-alias stylesheet-prefix="t" result-prefix="xsl"/>
+...
+
+<xsl:mode name="record" on-no-match="shallow-copy">
+   <xsl:template match="xsl:record">
+      <xsl:variable name="xsl-attributes" select="@xsl:*"/>
+      <xsl:variable name="ncname-attributes" select="@*[empty(prefix-from-QName(node-name()))]"/>
+      <xsl:variable name="other-attributes"
+          select="@* except ($xsl-attributes, $ncname-attributes)"/>
+      <t:map>
+         <xsl:sequence select="$other-attributes"/>
+         <xsl:apply-templates select="$xsl-attributes, $ncname-attributes, node()"/>
+      </t:map>
+   </xsl:template>
+   <xsl:template match="xsl:record/@*">
+      <t:map-entry key="'{name()}'" select="{.}"/>
+   </xsl:template>
+   <xsl:template match="xsl:record/@xsl:*" priority="1">
+      <xsl:attribute name="{local-name()}" select="."/>
+   </xsl:template>
+</xsl:mode>]]>
+                 </eg>-->
+                 <p>For example, the instruction:</p>
+                 <eg><![CDATA[ <xsl:record xsl:as="eg:book" 
+               author="string(AUTHOR)"
+               title="string(TITLE)" 
+               price="xs:decimal(PRICE)" 
+               publisher="string(../@name)">
+   </xsl:record>]]></eg>
+                 <p>is equivalent to the call on the constructor function:</p>
+                <eg><![CDATA[<xsl:select>
+  eg:book(author := string(AUTHOR), 
+          title := string(TITLE),
+          price := xs:decimal(PRICE),
+          publisher := string(../@name))
+</xsl:select>]]></eg>
+ 
+             
+
+
+             <example diff="add" at="2025-02-25">
+                 <head>Generating a record with <elcode>xsl:record</elcode></head>
+                 <p>The following example constructs a record using <elcode>xsl:record</elcode></p>
+                 <eg role="xslt-declaration" xml:space="preserve"><![CDATA[<xsl:template match="book" as="map(*)">
+   <xsl:record author="string(AUTHOR)"
+               title="string(TITLE)" 
+               price="xs:decimal(PRICE)" 
+               publisher="string(../@name)">
+      <xsl:if test="@private">
+         <xsl:map-entry name="'private entry'" select="true()"/>
+      </xsl:if>
+   </xsl:record>
+</xsl:template>]]></eg>
+                 <p>with the following input</p>
+                 <eg><![CDATA[<catalog name="QT4 Community">
+  <book private="true">
+    <AUTHOR>MHK</AUTHOR>
+    <TITLE>XSLT 4.0</TITLE>
+    <PRICE>123.45</PRICE>
+  </book>
+</catalog>]]></eg>
+                 <p>will produce a resulting map:</p>
+                 <eg>map{'author':'MHK', 'title': 'XSLT 4.0', 'price':123.45, 
+                     'publisher':'QT4 Community', 'private entry': true()} </eg>
+             </example>
+            </div3>
+           
          </div2>
 
          

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -28192,7 +28192,12 @@ the same group, and the-->
 
              </changes>
 
-            <p>Three instructions are added to XSLT to facilitate the construction of maps.</p>
+            <p>Three instructions are added to XSLT to facilitate the construction of maps:
+            <elcode>xsl:map</elcode>, <elcode>xsl:map-entry</elcode>, and <elcode>xsl:record</elcode>.</p>
+            
+            <div3 id="id-xsl-map-and-entry">
+               <head>The <code>xsl:map</code> and <code>xsl:map-entry</code> instructions</head>
+            
 
             <?element xsl:map?>
 
@@ -28402,13 +28407,13 @@ the same group, and the-->
 ]]></eg>
              </example>          
 
-             
+            </div3>
 
              <div3 id="record-instructions" diff="add" at="2025-03-14">
                  <head>Record Instruction</head>
                  <changes>
                  <change issue="322" PR="1858" date="2025-03-25"> The <elcode>xsl:record</elcode> instruction is introduced
-                     to make construction of record maps simpler. </change>
+                     to make construction of records simpler. </change>
                  </changes>
 
              <?element xsl:record?>
@@ -28421,8 +28426,11 @@ the same group, and the-->
              
                              </edtext></ednote></p>
              <p>The instruction <elcode>xsl:record</elcode> constructs and returns a new
-                 populated map, permitting entries to be declared as attributes on the
-                 instruction. It is intended to make writing maps where the entry keys are
+                 record, permitting entries to be declared as attributes on the
+                 instruction. The <code>xsl:as</code> attribute is required, and its
+                value must be a record type.</p>
+                
+                <p>The instruction is intended to make writing maps where the entry keys are
                  NCNames simpler and more concise, avoiding larger XSLT constructs using
                  <elcode>xsl:map</elcode> and <elcode>xsl:map-entry</elcode> or
                  <elcode>xsl:sequence</elcode> containing map-constructing XPath
@@ -28436,15 +28444,20 @@ the same group, and the-->
                          avoid reserving the names of such attributes (e.g. <code>as</code>, <code>duplicates</code>, <code>use-when</code> etc.) as potential
                          entry keys, leaving any valid NCName as a candidate.</p>
                  </note>
+                
+                <ednote><edtext>Need to update the schemas (XSD and RNG) for xsl:record</edtext></ednote>
                  
                  
              
-             <p>The <elcode>xsl:record</elcode> generates a new map: call this
+             <p>The <elcode>xsl:record</elcode> instruction generates a new record: call this
                  <code>$record</code>. For each of the attributes of the instruction whose name
                  is an <code>xs:NCName</code> an entry is added to <code>$record</code> whose
-                 key is the name of the attribute (as <code>xs:string</code>) and whose value is
+                 key is the name of the attribute (as an <code>xs:string</code>) and whose value is
                  the result of evaluating the value of that attribute as an expression in the
                  current context.</p>
+                
+                <p>The resulting record is coerced to the record type specified in the <code>xsl:as</code>
+                attribute, and acquires a type annotation to mark it as an instance of this record type.</p>
                  <note>
                      <p>As the values of the attributes whose names are <code>xs:NCName</code> are considered to be XPath expressions,
                      two consequences follow for such attributes:
@@ -28455,31 +28468,26 @@ the same group, and the-->
                                  value templates</termref>.</item>
                      </olist> These restrictions do not apply to attributes of <elcode>xsl:record</elcode> whose names are in namespaces.</p>
                  </note>
-                 <note>
-                     <p>The order of attribute-generated entries in <code>$record</code> will reflect
-                         the order of attributes returned along the <code>attribute::</code> axis, which is <termref def="dt-implementation-dependent"/> but stable.</p>
-                 </note>
-             <p>After processing the applicable attributes of the instruction, any contained
+                 
+             <!--<p>After processing the applicable attributes of the instruction, any contained
                  sequence constructor is evaluated and the result <rfc2119>must</rfc2119> be a
                  (possibly empty) sequence of maps. The entries in these maps are merged into
                  <code>$record</code>. By this means entries can be added whose keys are not
-                 NCNames, or conditionally generated entries can be included.</p>
+                 NCNames, or conditionally generated entries can be included.</p>-->
              <p> Each of the map entries in
                  <code>$record</code> is modified by applying the <termref def="dt-coercion-rules"/>
                  to convert the singleton map to the type declared in the <code>xsl:as</code>
                  attribute of the <elcode>xsl:record</elcode> instruction, if present. 
-                 This may contain a map type declaration or 
+                 This may contain a record type declaration or 
                  a reference to one of the <xtermref
-                     spec="XP40" ref="dt-in-scope-named-item-types"/>, which may include record types. 
-                 Unless any type restriction is violated <code>$record</code> is returned as the instruction result.</p>
-                 <p><ednote><edtext>This implies that <elcode>xsl:map</elcode> and possibly <elcode>xsl:map-entry</elcode>
-                             should support an <code>as</code> attribute, restricting type.</edtext></ednote></p>
-             <p>The treatment of duplicate keys between entries defined in the attributes of
+                     spec="XP40" ref="dt-in-scope-named-item-types"/>, which may include record types.</p>
+                 
+             <!--<p>The treatment of duplicate keys between entries defined in the attributes of
                  <elcode>xsl:record</elcode> and any generated by a contained sequence
                  constructor is described in <specref ref="duplicate-keys"/> below. Note that in
                  the absence of a sequence constructor, no duplicate keys can appear, as all
                  attributes of <elcode>xsl:record</elcode> must have a unique name within the
-                 element tag.</p>
+                 element tag.</p>-->
              <!--<note>-->
                  <p>The effect of this instruction, in the absence of errors, is equivalent to execution of the XSLT <elcode>xsl:map</elcode> instruction generated by the 
                      the following source transformation of the <elcode>xsl:record</elcode> subtree</p>
@@ -28511,9 +28519,6 @@ the same group, and the-->
                title="string(TITLE)" 
                price="xs:decimal(PRICE)" 
                publisher="string(../@name)">
-      <xsl:if test="@private">
-         <xsl:map-entry name="'private entry'" select="true()"/>
-      </xsl:if>
    </xsl:record>]]></eg>
                  <p>would produce</p>
                  <eg><![CDATA[ <xsl:map as="eg:book">
@@ -28521,17 +28526,14 @@ the same group, and the-->
       <xsl:map-entry key="'title'" select="string(TITLE)"/>
       <xsl:map-entry key="'price'" select="xs:decimal(PRICE)"/>
       <xsl:map-entry key="'publisher'" select="string(../@name)"/>
-      <xsl:if test="@private">
-         <xsl:map-entry name="'private entry'" select="true()"/>
-      </xsl:if>
    </xsl:map>]]></eg>
              <!--</note>-->
              
 
 
              <example diff="add" at="2025-02-25">
-                 <head>Generating a map with <elcode>xsl:record</elcode></head>
-                 <p>The following example constructs a map using <elcode>xsl:record</elcode></p>
+                 <head>Generating a record with <elcode>xsl:record</elcode></head>
+                 <p>The following example constructs a record using <elcode>xsl:record</elcode></p>
                  <eg role="xslt-declaration" xml:space="preserve"><![CDATA[<xsl:template match="book" as="map(*)">
    <xsl:record author="string(AUTHOR)"
                title="string(TITLE)" 
@@ -28572,7 +28574,7 @@ the same group, and the-->
                </changes>
                
                <p>This section describes what happens when two or more maps in the input sequence of
-               an <elcode>xsl:map</elcode> or <elcode>xsl:record</elcode> instruction contain duplicate keys: that is, when one of these
+               an <elcode>xsl:map</elcode>  instruction contain duplicate keys: that is, when one of these
                maps contains an entry with key <var>K</var>, and another contains an entry with key <var>L</var>,
                   and <code>fn:atomic-equal(<var>K</var>, <var>L</var>)</code> returns <code>true</code>.</p>
                

--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -3593,8 +3593,11 @@ is described in <specref ref="serdm"/>.</p>
     <termref def="to-a-json-string">to a JSON string</termref>, followed by
     the serialized JSON value of the entry,
     separated by delimiters according to the JSON object 
-    syntax, i.e. <code>{key:value, key:value, ...}</code>.
-    The key/value pairs in the serialized output retain the 
+    syntax, i.e. <code>{key:value, key:value, ...}</code>.</p>
+      <p>If the map item is a <xtermref spec="DM40" ref="dt-record"/> then
+        an entry whose value is an empty sequence is omitted from the serialized
+        result rather than being present with the value <code>null</code>.</p>
+    <p>The key/value pairs in the serialized output retain the 
       <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> of entries in the map,
     unless <code>canonical</code> is <code>true</code>, in
       which case map entries <rfc2119>MUST</rfc2119> be sorted according to the rules of <bibref ref="RFC8785"/>. 


### PR DESCRIPTION
First cut for review: the PR probably needs further passes before it is ready for acceptance.

We introduce the idea of records, being maps that have a type annotation which is a specific record type. A map acquires the type annotation when it is coerced to the record type. A map that has a record type annotation (a "record") throws a type error if map:get() (or a lookup expression) requests a key that is not one of the declared field names for that type. The type error can be raised statically.

map:put() applied to a record is constrained to produce a record with the same type annotation. (I've no objection to the "with" operator for this, but that can be done separately.)

Optional fields in record types are dropped; in a record, there is no distinction between an absent field and a field whose value is the empty sequence. There is no longer any need for this distinction, and eliminating it simplifies things a lot. (But we will need to decide whether to treat the fields as present or absent when serialising to JSON).

Fix #1979
Fix #2537