### PR TITLE
2553 File Module: delete empty directories

### DIFF
--- a/specifications/EXPath/file/src/function-catalog.xml
+++ b/specifications/EXPath/file/src/function-catalog.xml
@@ -704,14 +704,13 @@ return try {
       <p>Deletes a file or a directory from the file system if it exists:</p>
       <ulist>
         <item>
-          <p>If <code>$path</code> points to a file, the file is deleted.</p>
+          <p>If <code>$path</code> points to a file or empty directory, it is deleted.</p>
         </item>
         <item>
-          <p>Otherwise, if <code>$path</code> points to a directory, then:</p>
+          <p>Otherwise, if <code>$path</code> points to a non-empty directory:</p>
           <ulist>
             <item>
-              <p>if it is non-empty and <code>$recursive</code> is <code>false</code>,
-                 an error is raised.</p>
+              <p>if <code>$recursive</code> is <code>false</code>, an error is raised.</p>
             </item>
             <item>
               <p>Otherwise, the directory and all its contents are deleted recursively.</p>


### PR DESCRIPTION
Clarification for empty directories (which should always be deleted, as defined earlier).

Closes #2553