### PR TITLE
2312 Drop map:keys-where

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -25440,7 +25440,7 @@ map:for-each($map, fn($key, $value) { $key })
       </fos:examples>
    </fos:function>
    
-   <fos:function name="keys-where" prefix="map">
+   <!--<fos:function name="keys-where" prefix="map">
       <fos:signatures>
          <fos:proto name="keys-where" return-type="xs:anyAtomicType*">
             <fos:arg name="map" type="map(*)" usage="inspection"/>
@@ -25466,11 +25466,11 @@ map:for-each($map, fn($key, $value) { $key })
          <p>A return value of <code>()</code> from the predicate function is 
             treated as <code>false</code>.</p>
          
-         <!--<p>The function is <term>nondeterministic with respect to ordering</term>
+         <!-\-<p>The function is <term>nondeterministic with respect to ordering</term>
             (see <specref
                ref="properties-of-functions"
             />). This means that two calls with the same argument
-            are not guaranteed to produce the results in the same order.</p>-->
+            are not guaranteed to produce the results in the same order.</p>-\->
       </fos:rules>
       <fos:equivalent style="xpath-expression">
 map:for-each($map, fn($key, $value) {
@@ -25532,7 +25532,7 @@ return map:keys-where($birthdays, fn($name, $date) {
             <p>The <code>$predicate</code> callback function may return the empty sequence (meaning <code>false</code>).</p>
          </fos:change>
       </fos:changes>
-   </fos:function>
+   </fos:function>-->
    
    <fos:function name="items" prefix="map">
       <fos:signatures>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -6638,9 +6638,9 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <div3 id="func-map-keys">
                <head><?function map:keys?></head>
             </div3>
-            <div3 id="func-map-keys-where">
+            <!--<div3 id="func-map-keys-where">
                <head><?function map:keys-where?></head>
-            </div3>
+            </div3>-->
             <div3 id="func-map-merge">
                <head><?function map:merge?></head>
             </div3>


### PR DESCRIPTION
I propose dropping the `map:keys-where` function.

One of the suggestions in issue #2312.

The function isn't needed very often, and it's easily achieved in other ways. For example, to find all the keys of entries that are non-empty, you could use `map:keys-where($map, fn($k, $v){exists($v)})`, but it's just as easy to use 

`map:filter($map, fn($k, $v){exists($v)}) => map:keys()`

or 

`map:for-each($map, fn($k, $v){$k[exists($v)]})`

or

`for key $k value $v in $map where exists($v) return $k`

or

`map:keys($map)[exists($map(.))]`