### PR TITLE
2550 Shadow attributes in RELAX NG grammar (alt)

### DIFF
--- a/specifications/xslt-40/src/schema-for-xslt40.rnc
+++ b/specifications/xslt-40/src/schema-for-xslt40.rnc
@@ -36,7 +36,7 @@ start =
   | package.element
   | literal-result-element-as-stylesheet
 
-sequence-constructor.model = (instruction.category | record.element | literal-result-element | text)*
+sequence-constructor.model = (instruction.category | record.element | literal-result-element | note.element | text)*
 
 literal-result-element-as-stylesheet =
   element * - xsl:* {
@@ -54,6 +54,8 @@ literal-result-element =
 literal-result-element.atts =
   literal-result-element-no-version.atts,
   attribute xsl:version { text }?
+
+empty.model = note.element*
 
 # These attributes may also appear on a literal result element, but in this case, to distinguish them from user-defined attributes,
 # the names of the attributes are in the XSLT namespace. They are thus typically written as
@@ -100,7 +102,7 @@ anyElement =
 
 extension.atts = attribute * - (xsl:* | local:*) { text }*
 
-declarations.model = (declaration.category | top-level-extension)*
+declarations.model = (declaration.category | top-level-extension | note.element)*
 
 # [Definition: There are a number of standard attributes that may appear on any XSLT element: specifically
 # default-collation,
@@ -131,8 +133,9 @@ global.atts =
    attribute version { decimal.datatype }?,
    attribute _version { avt.datatype }?,
    attribute xpath-default-namespace { uri.datatype }?,
-   attribute _xpath-default-namespace { avt.datatype }?
-
+   attribute _xpath-default-namespace { avt.datatype }?,
+   attribute schema-role { ncname.datatype }?,
+   attribute _schema-role { avt.datatype }?
 
 global.atts.except.version =
    attribute default-collation { uris.datatype }?,
@@ -160,7 +163,7 @@ qname.datatype = xsd:NCName | qname.strict
 #[99]   URIQualifiedName ::= BracedURILiteral NCName
 #[100]  BracedURILiteral ::= "Q" "{" [^{}]* "}"
 
-uri.qualified.name = xsd:token { pattern = "Q\{[^\{\}]*\}[\i-[:]][\c-[:]]*" }
+uri.qualified.name = xsd:token { pattern = "Q\{[^\{\}]*\}[\i-[:]][\c]*" }
 eqname.datatype = qname.datatype | uri.qualified.name
 qnames.datatype = list { qname.datatype* }
 eqnames.datatype = list { eqname.datatype* }
@@ -195,6 +198,13 @@ on-no-match.datatype = "deep-copy" | "shallow-copy" | "shallow-copy-all" | "deep
 streamability.datatype = eqname.datatype | "unclassified" | "absorbing" | "inspection" | "filter" | "shallow-descent" | "deep-descent" | "ascent"
 validation.datatype = "strict" | "lax" | "preserve" | "strip"
 method.datatype = eqname.datatype | "xml" | "xhtml" | "html" | "text" | "json" | "adaptive"
+
+avt.datatype =
+  xsd:string
+# {
+#    pattern =
+#      """([^\{\}]|\{\{|\}\}|\{([^"'\{\}]|"[^"]*"|'[^']*')+\})*""" # this regexp will not work in all the case.
+#      }
 
 # #standard or NCName or prefix=URI or URI
 fixed-namespaces.datatype = xsd:string
@@ -325,7 +335,7 @@ expose.element =
       attribute _names { avt.datatype }?,
       attribute visibility { visibility-not-hidden.datatype }?,
       attribute _visibility { avt.datatype }?,
-      empty
+      empty.model
    }
 package-location.element =
    element package-location {
@@ -341,7 +351,7 @@ package-location.element =
       attribute _is-priority { avt.datatype }?,
       attribute format { string.datatype }?,
       attribute _format { avt.datatype }?,
-      empty
+      empty.model
    }
 accept.element =
    element accept {
@@ -353,7 +363,7 @@ accept.element =
        attribute _names { avt.datatype })+,
       (attribute visibility { "public" | "private" | "final" | "abstract" | "hidden" } |
        attribute _visibility { avt.datatype })+,
-      empty
+      empty.model
    }
 override.element =
    element override {
@@ -425,7 +435,7 @@ include.element =
       global.atts,
       (attribute href { uri.datatype }
        | attribute _href { avt.datatype })+,
-      empty
+      empty.model
    }
 import.element =
    element import {
@@ -433,7 +443,7 @@ import.element =
       global.atts,
       (attribute href { uri.datatype }
       | attribute _href { avt.datatype })+,
-      empty
+      empty.model
    }
 import-schema.element =
    element import-schema {
@@ -441,9 +451,11 @@ import-schema.element =
       global.atts,
       attribute namespace { uri.datatype }?,
       attribute _namespace { avt.datatype }?,
-      ((attribute schema-location { uri.datatype }
-        | attribute _schema-location { avt.datatype })+
-      | xs_schema.element)
+      attribute schema-location { uri.datatype }?,
+      attribute _schema-location { avt.datatype }?,
+      attribute role { ncname.datatype }?,
+      attribute _role { avt.datatype }?,
+      (xs_schema.element? & note.element*)
    }
 strip-space.element =
    element strip-space {
@@ -451,7 +463,7 @@ strip-space.element =
       global.atts,
       (attribute elements { tokens.datatype }
       | attribute _elements { avt.datatype })+,
-      empty
+      empty.model
    }
 preserve-space.element =
    element preserve-space {
@@ -459,7 +471,7 @@ preserve-space.element =
       global.atts,
       (attribute elements { tokens.datatype }
       | attribute _elements { avt.datatype })+,
-      empty
+      empty.model
    }
 decimal-format.element =
    element decimal-format {
@@ -489,7 +501,7 @@ decimal-format.element =
       attribute _digit { avt.datatype }?,
       attribute pattern-separator { char.datatype }?,
       attribute _pattern-separator { avt.datatype }?,
-      empty
+      empty.model
    }
 template.element =
    element template {
@@ -519,7 +531,7 @@ apply-templates.element =
       attribute _mode { avt.datatype }?,
       attribute separator { avt.datatype }?,
       attribute _separator { avt.datatype }?,
-      (sort.element | with-param.element)*
+      (sort.element | with-param.element | note.element)*
    }
 mode.element =
    element mode {
@@ -547,7 +559,7 @@ mode.element =
       attribute _visibility { avt.datatype }?,
       attribute use-accumulators { tokens.datatype }?,
       attribute _use-accumulators { avt.datatype }?,
-      empty
+      (template.element | fallback.element | note.element)*
    }
 context-item.element =
    element context-item {
@@ -557,7 +569,7 @@ context-item.element =
       attribute _as { avt.datatype }?,
       attribute use { "required" | "optional" | "absent" }?,
       attribute _use { avt.datatype }?,
-      empty
+      empty.model
    }
 global-context-item.element =
    element global-context-item {
@@ -567,7 +579,7 @@ global-context-item.element =
       attribute _as { avt.datatype }?,
       attribute use { "required" | "optional" | "absent" }?,
       attribute _use { avt.datatype }?,
-      empty
+      empty.model
    }
 apply-imports.element =
    element apply-imports {
@@ -789,7 +801,7 @@ namespace-alias.element =
       | attribute _stylesheet-prefix { avt.datatype })+,
       (attribute result-prefix { prefix.datatype | "#default" }
       | attribute _result-prefix { avt.datatype })+,
-      empty
+      empty.model
    }
 element.element =
    element element {
@@ -873,6 +885,7 @@ record.element =
       attribute _as { avt.datatype }?,
       attribute duplicates { expression.datatype }?,
       attribute _duplicates { avt.datatype }?,
+      attribute * - (as | _as | duplicates | _duplicates) { text }*,
       sequence-constructor.model
   }
 record-type.element =
@@ -893,7 +906,7 @@ field.element =
       attribute _required { avt.datatype }?,
       attribute \default { expression.datatype }?,
       attribute _default { expression.datatype }?,
-      empty
+      empty.model
   }
 
 select.element =
@@ -946,7 +959,7 @@ copy-of.element =
       attribute _type { avt.datatype }?,
       attribute validation { validation.datatype }?,
       attribute _validation { avt.datatype }?,
-      empty
+      empty.model
    }
 sequence.element =
    element sequence {
@@ -1002,7 +1015,7 @@ number.element =
       attribute _grouping-separator { avt.datatype }?,
       attribute grouping-size { integer.datatype | avt.datatype }?,
       attribute _grouping-size { avt.datatype }?,
-      empty
+      empty.model
    }
 sort.element =
    element sort {
@@ -1370,7 +1383,11 @@ output.element =
       attribute _use-character-maps { avt.datatype }?,
       attribute version { nmtoken.datatype }?,
       attribute _version { avt.datatype }?,
-      empty
+      attribute escape-solidus { boolean.datatype }?,
+      attribute _escape-solidus { avt.datatype }?,
+      attribute json-lines { boolean.datatype }?,
+      attribute _json-lines { avt.datatype }?,
+      empty.model
    }
 character-map.element =
    element character-map {
@@ -1390,11 +1407,10 @@ output-character.element =
       | attribute _character { avt.datatype })+,
       (attribute string { string.datatype }
       | attribute _string { avt.datatype })+,
-      empty
+      empty.model
    }
-avt.datatype =
-  xsd:string
-# {
-#    pattern =
-#      """([^\{\}]|\{\{|\}\}|\{([^"'\{\}]|"[^"]*"|'[^']*')+\})*""" # this regexp will not work in all the case.
-#      }
+
+note.element =
+    element note {
+        (anyElement | text)*
+    }

--- a/specifications/xslt-40/src/schema-for-xslt40.rnc
+++ b/specifications/xslt-40/src/schema-for-xslt40.rnc
@@ -1,10 +1,10 @@
 # XSLT 4.0 Relax NG Schema
-# 
+#
 # Copyright (c) 2010-2016, Mohamed ZERGAOUI (Innovimax)
 # Portions © 2024-2026, XQuery and XSLT Extensions Community Group
-# 
+#
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:us
 # Redistributions of source code must retain the above copyright notice, this
@@ -14,7 +14,7 @@
 # with the distribution. Neither the name of Mohamed ZERGAOUI or Innovimax
 # nor the names of other contributors may be used to endorse or promote products
 # derived from this software without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -25,7 +25,7 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-# 
+#
 namespace local = ""
 default namespace xsl = "http://www.w3.org/1999/XSL/Transform"
 namespace xs = "http://www.w3.org/2001/XMLSchema"
@@ -33,9 +33,9 @@ namespace xs = "http://www.w3.org/2001/XMLSchema"
 start =
   stylesheet.element
   | transform.element
-  | package.element  
+  | package.element
   | literal-result-element-as-stylesheet
-  
+
 sequence-constructor.model = (instruction.category | record.element | literal-result-element | text)*
 
 literal-result-element-as-stylesheet =
@@ -55,8 +55,8 @@ literal-result-element.atts =
   literal-result-element-no-version.atts,
   attribute xsl:version { text }?
 
-# These attributes may also appear on a literal result element, but in this case, to distinguish them from user-defined attributes, 
-# the names of the attributes are in the XSLT namespace. They are thus typically written as 
+# These attributes may also appear on a literal result element, but in this case, to distinguish them from user-defined attributes,
+# the names of the attributes are in the XSLT namespace. They are thus typically written as
 # xsl:default-collation,
 # xsl:default-mode,
 # xsl:default-validation,
@@ -97,29 +97,29 @@ anyElement =
          | text
          | element * { any })*
     }
-    
+
 extension.atts = attribute * - (xsl:* | local:*) { text }*
 
 declarations.model = (declaration.category | top-level-extension)*
 
-# [Definition: There are a number of standard attributes that may appear on any XSLT element: specifically 
-# default-collation, 
-# default-mode, 
-# default-validation, 
-# exclude-result-prefixes, 
-# expand-text, 
-# extension-element-prefixes, 
-# use-when, 
-# version, 
+# [Definition: There are a number of standard attributes that may appear on any XSLT element: specifically
+# default-collation,
+# default-mode,
+# default-validation,
+# exclude-result-prefixes,
+# expand-text,
+# extension-element-prefixes,
+# use-when,
+# version,
 # and xpath-default-namespace.]
 
-global.atts = 
+global.atts =
    attribute default-collation { uris.datatype }?,
    attribute _default-collation { avt.datatype }?,
    attribute default-mode { eqname.datatype | '#unnamed' }?,
    attribute _default-mode { avt.datatype }?,
    attribute default-validation  { "preserve" | "strip" }?,
-   attribute _default-validation { avt.datatype }?,   
+   attribute _default-validation { avt.datatype }?,
    attribute exclude-result-prefixes { exclude.prefixes.datatype }?,
    attribute _exclude-result-prefixes { avt.datatype }?, # or prefixes.datatype ?
    attribute expand-text { boolean.datatype }?,
@@ -132,9 +132,9 @@ global.atts =
    attribute _version { avt.datatype }?,
    attribute xpath-default-namespace { uri.datatype }?,
    attribute _xpath-default-namespace { avt.datatype }?
-   
 
-global.atts.except.version = 
+
+global.atts.except.version =
    attribute default-collation { uris.datatype }?,
    attribute _default-collation { avt.datatype }?,
    attribute exclude-result-prefixes { exclude.prefixes.datatype }?,
@@ -147,7 +147,7 @@ global.atts.except.version =
    attribute _use-when { avt.datatype }?,
    attribute xpath-default-namespace { uri.datatype }?,
    attribute _xpath-default-namespace { avt.datatype }?
-   
+
 # In XSLT 4.0, prefixes can be defined with the fixed-namespaces attribute
 # on the xsl:stylesheet, so we can't rely on XML declarations for QNames.
 qname.strict = xsd:token { pattern = "[\i-[:]][\c-[:]]*:[\i-[:]][\c-[:]]*" }
@@ -160,13 +160,13 @@ qname.datatype = xsd:NCName | qname.strict
 #[99]   URIQualifiedName ::= BracedURILiteral NCName
 #[100]  BracedURILiteral ::= "Q" "{" [^{}]* "}"
 
-uri.qualified.name = xsd:token { pattern = "Q\{[^\{\}]*\}[\i-[:]][\c-[:]]*" } 
+uri.qualified.name = xsd:token { pattern = "Q\{[^\{\}]*\}[\i-[:]][\c-[:]]*" }
 eqname.datatype = qname.datatype | uri.qualified.name
 qnames.datatype = list { qname.datatype* }
 eqnames.datatype = list { eqname.datatype* }
 ncname.datatype = xsd:NCName
 prefix.datatype = xsd:NCName
-boolean.datatype = "yes" | "no" | "true" | "false" | "0" | "1" 
+boolean.datatype = "yes" | "no" | "true" | "false" | "0" | "1"
 expression.datatype = text
 char.datatype = xsd:string { length = "1" }
 string.datatype = text
@@ -187,14 +187,22 @@ qname-but-not-ncname.datatype = xsd:QName { pattern = ".*:.*" }
 xs_schema.element = element xs:schema { anyElement* }
 item-type.datatype = text
 sequence-type.datatype = text
+component.datatype = "template" | "function" | "variable" | "attribute-set" | "mode" | "*"
+visibility.datatype = "public" | "private" | "final" | "abstract" | "hidden"
+visibility-not-hidden.datatype = "public" | "private" | "final" | "abstract"
+mode.datatype = eqname.datatype | "#unnamed" | "#default" | "#current"
+on-no-match.datatype = "deep-copy" | "shallow-copy" | "shallow-copy-all" | "deep-skip" | "shallow-skip" | "text-only-copy" | "fail"
+streamability.datatype = eqname.datatype | "unclassified" | "absorbing" | "inspection" | "filter" | "shallow-descent" | "deep-descent" | "ascent"
+validation.datatype = "strict" | "lax" | "preserve" | "strip"
+method.datatype = eqname.datatype | "xml" | "xhtml" | "html" | "text" | "json" | "adaptive"
 
 # #standard or NCName or prefix=URI or URI
 fixed-namespaces.datatype = xsd:string
 
 select-or-sequence-constructor.model =
-  ((attribute select { expression.datatype }
-    | attribute _select { avt.datatype })+
-   | sequence-constructor.model)
+   ((attribute select { expression.datatype }
+     | attribute _select { avt.datatype })+
+    | sequence-constructor.model)
 
 declaration.category =
    use-package.element
@@ -311,38 +319,40 @@ expose.element =
    element expose {
       extension.atts,
       global.atts,
-      attribute component { "template" | "function" | "attribute-set" | "variable" | "mode" | "*" }?,
+      attribute component { component.datatype }?,
       attribute _component { avt.datatype }?,
       attribute names { tokens.datatype }?,
       attribute _names { avt.datatype }?,
-      attribute visibility { "public" | "private" | "final" | "abstract" }?,
+      attribute visibility { visibility-not-hidden.datatype }?,
       attribute _visibility { avt.datatype }?,
       empty
    }
 package-location.element =
    element package-location {
       extension.atts,
-      global.atts,    
-      (attribute path-in-archive { string.datatype } |
-      attribute _path-in-archive { avt.datatype })+,
-      (attribute archive-type { string.datatype } |
-      attribute _archive-type { avt.datatype })+,
-      (attribute is-priority { boolean.datatype } |
-      attribute _is-priority { avt.datatype })+,
-      (attribute format { string.datatype } |
-      attribute _format { avt.datatype })+,
+      global.atts,
+      attribute href { uri.datatype }?,
+      attribute _href { avt.datatype }?,
+      attribute path-in-archive { string.datatype }?,
+      attribute _path-in-archive { avt.datatype }?,
+      attribute archive-type { string.datatype }?,
+      attribute _archive-type { avt.datatype }?,
+      attribute is-priority { boolean.datatype }?,
+      attribute _is-priority { avt.datatype }?,
+      attribute format { string.datatype }?,
+      attribute _format { avt.datatype }?,
       empty
-   }   
+   }
 accept.element =
    element accept {
       extension.atts,
       global.atts,
-      (attribute component { "template" | "function" | "attribute-set" | "variable" | "mode" | "*" } |
-      attribute _component { avt.datatype })+,
+      (attribute component { component.datatype } |
+       attribute _component { avt.datatype })+,
       (attribute names { tokens.datatype } |
-      attribute _names { avt.datatype })+,
+       attribute _names { avt.datatype })+,
       (attribute visibility { "public" | "private" | "final" | "abstract" | "hidden" } |
-      attribute _visibility { avt.datatype })+,
+       attribute _visibility { avt.datatype })+,
       empty
    }
 override.element =
@@ -413,8 +423,8 @@ include.element =
    element include {
       extension.atts,
       global.atts,
-      attribute href { uri.datatype }?,
-      attribute _href { avt.datatype }?,
+      (attribute href { uri.datatype }
+       | attribute _href { avt.datatype })+,
       empty
    }
 import.element =
@@ -431,9 +441,9 @@ import-schema.element =
       global.atts,
       attribute namespace { uri.datatype }?,
       attribute _namespace { avt.datatype }?,
-      attribute schema-location { uri.datatype }?,
-      attribute _schema-location { avt.datatype }?,
-      xs_schema.element?
+      ((attribute schema-location { uri.datatype }
+        | attribute _schema-location { avt.datatype })+
+      | xs_schema.element)
    }
 strip-space.element =
    element strip-space {
@@ -485,17 +495,17 @@ template.element =
    element template {
       extension.atts,
       global.atts,
-      (attribute match { pattern.datatype }
-      | attribute _match { avt.datatype }
-      | attribute name { eqname.datatype }
-      | attribute _name { avt.datatype })+,
+      attribute match { pattern.datatype }?,
+      attribute _match { avt.datatype }?,
       attribute priority { decimal.datatype }?,
       attribute _priority { avt.datatype }?,
       attribute mode { list { '#all' | ('#default' | '#unnamed' | eqname.datatype)* } }?,
       attribute _mode { avt.datatype }?,
+      attribute name { eqname.datatype }?,
+      attribute _name { avt.datatype }?,
       attribute as { sequence-type.datatype }?,
       attribute _as { avt.datatype }?,
-      attribute visibility { "public" | "private" | "final" | "abstract" }?,
+      attribute visibility { visibility-not-hidden.datatype }?,
       attribute _visibility { avt.datatype }?,
       (context-item.element?, param.element*, sequence-constructor.model)
    }
@@ -505,7 +515,7 @@ apply-templates.element =
       global.atts,
       attribute select { expression.datatype }?,
       attribute _select { avt.datatype }?,
-      attribute mode { (eqname.datatype | '#unnamed' | '#default' | '#current') }?,
+      attribute mode { mode.datatype }?,
       attribute _mode { avt.datatype }?,
       attribute separator { avt.datatype }?,
       attribute _separator { avt.datatype }?,
@@ -515,28 +525,28 @@ mode.element =
    element mode {
       extension.atts,
       global.atts,
-      (attribute as { sequence-type.datatype }?
-      | attribute _as { avt.datatype }?),
-      (attribute copy-namespaces { boolean.datatype }?
-      | attribute _copy-namespaces { boolean.datatype }?),
-      (attribute name { eqname.datatype }?
-      | attribute _name { avt.datatype }?),
-      (attribute streamable { boolean.datatype }?
-      | attribute _streamable { avt.datatype }?),
-      (attribute on-no-match { "deep-copy" | "shallow-copy" | "shallow-copy-all" | "deep-skip" | "shallow-skip" | "text-only-copy" | "fail" }?
-      | attribute _on-no-match { avt.datatype }?),
-      (attribute on-multiple-match { "use-last" | "fail" }?
-      | attribute _on-multiple-match { avt.datatype }?),
-      (attribute warning-on-no-match { boolean.datatype }?
-      | attribute _warning-on-no-match { avt.datatype }?),
-      (attribute warning-on-multiple-match { boolean.datatype }?
-      | attribute _warning-on-multiple-match { avt.datatype }?),
-      (attribute typed { boolean.datatype | "strict" | "lax" | "unspecified" }?
-      | attribute _typed { avt.datatype }?),
-      (attribute visibility { "public" | "private" | "final" }?
-      | attribute _visibility { avt.datatype }?),
-      (attribute use-accumulators { tokens.datatype }?
-      | attribute _use-accumulators { avt.datatype }?),
+      attribute as { sequence-type.datatype }?,
+      attribute _as { avt.datatype }?,
+      attribute copy-namespaces { boolean.datatype }?,
+      attribute _copy-namespaces { boolean.datatype }?,
+      attribute name { eqname.datatype }?,
+      attribute _name { avt.datatype }?,
+      attribute streamable { boolean.datatype }?,
+      attribute _streamable { avt.datatype }?,
+      attribute on-no-match { on-no-match.datatype }?,
+      attribute _on-no-match { avt.datatype }?,
+      attribute on-multiple-match { "use-last" | "fail" }?,
+      attribute _on-multiple-match { avt.datatype }?,
+      attribute warning-on-no-match { boolean.datatype }?,
+      attribute _warning-on-no-match { avt.datatype }?,
+      attribute warning-on-multiple-match { boolean.datatype }?,
+      attribute _warning-on-multiple-match { avt.datatype }?,
+      attribute typed { boolean.datatype | "strict" | "lax" | "unspecified" }?,
+      attribute _typed { avt.datatype }?,
+      attribute visibility { "public" | "private" | "final" }?,
+      attribute _visibility { avt.datatype }?,
+      attribute use-accumulators { tokens.datatype }?,
+      attribute _use-accumulators { avt.datatype }?,
       empty
    }
 context-item.element =
@@ -675,7 +685,7 @@ variable.element =
       attribute _as { avt.datatype }?,
       attribute static { boolean.datatype }?,
       attribute _static { avt.datatype }?,
-      attribute visibility { "public" | "private" | "final" | "abstract" }?,
+      attribute visibility { visibility-not-hidden.datatype }?,
       attribute _visibility { avt.datatype }?,
       select-or-sequence-constructor.model
    }
@@ -735,20 +745,20 @@ function.element =
       global.atts,
       (attribute name { eqname.datatype }
       | attribute _name { avt.datatype })+,
-      (attribute as { sequence-type.datatype }?
-      | attribute _as { avt.datatype }?),
-      (attribute visibility { "public" | "private" | "final" | "abstract" }?
-      | attribute _visibility { avt.datatype }?),
-      (attribute streamability { "unclassified" | "absorbing" | "inspection" | "filter" | "shallow-descent" | "deep-descent" | "ascent" | eqname.datatype }?
-      | attribute _streamability { avt.datatype }?),
-      (attribute override-extension-function { boolean.datatype }?
-      | attribute _override-extension-function { avt.datatype }?),
-      (attribute override { boolean.datatype }?
-      | attribute _override { avt.datatype }?),
-      (attribute new-each-time { "yes" | "true" | "1" | "no" | "false" | "0" | "maybe" }?
-      | attribute _new-each-time { avt.datatype }?),
-      (attribute cache { boolean.datatype }?
-      | attribute _cache { avt.datatype }?),
+      attribute as { sequence-type.datatype }?,
+      attribute _as { avt.datatype }?,
+      attribute visibility { visibility-not-hidden.datatype }?,
+      attribute _visibility { avt.datatype }?,
+      attribute streamability { streamability.datatype }?,
+      attribute _streamability { avt.datatype }?,
+      attribute override-extension-function { boolean.datatype }?,
+      attribute _override-extension-function { avt.datatype }?,
+      attribute override { boolean.datatype }?,
+      attribute _override { avt.datatype }?,
+      attribute new-each-time { boolean.datatype | "maybe" }?,
+      attribute _new-each-time { avt.datatype }?,
+      attribute cache { boolean.datatype }?,
+      attribute _cache { avt.datatype }?,
       (param.element*, sequence-constructor.model)
    }
 evaluate.element =
@@ -793,10 +803,10 @@ element.element =
       attribute _inherit-namespaces { avt.datatype }?,
       attribute use-attribute-sets { eqnames.datatype }?,
       attribute _use-attribute-sets { avt.datatype }?,
-      ((attribute type { eqname.datatype }?,
-      attribute _type { avt.datatype }?) |
-      (attribute validation { "strict" | "lax" | "preserve" | "strip" }?,
-      attribute _validation { avt.datatype }? )), # type and validation are mutually exclusive
+      attribute type { eqname.datatype }?,
+      attribute _type { avt.datatype }?,
+      attribute validation { validation.datatype }?,
+      attribute _validation { avt.datatype }?,
       sequence-constructor.model
    }
 attribute.element =
@@ -809,10 +819,10 @@ attribute.element =
       attribute _namespace { avt.datatype }?,
       attribute separator { string.datatype | avt.datatype }?,
       attribute _separator { avt.datatype }?,
-      ((attribute type { eqname.datatype }?,
-      attribute _type { avt.datatype }?) |
-      (attribute validation { "strict" | "lax" | "preserve" | "strip" }?,
-      attribute _validation { avt.datatype }? )), # type and validation are mutually exclusive
+      attribute type { eqname.datatype }?,
+      attribute _type { avt.datatype }?,
+      attribute validation { validation.datatype }?,
+      attribute _validation { avt.datatype }?,
       select-or-sequence-constructor.model
    }
 text.element =
@@ -843,10 +853,10 @@ document.element =
    element document {
       extension.atts,
       global.atts,
-      ((attribute type { eqname.datatype }?,
-      attribute _type { avt.datatype }?) |
-      (attribute validation { "strict" | "lax" | "preserve" | "strip" }?,
-      attribute _validation { avt.datatype }? )), # type and validation are mutually exclusive
+      attribute type { eqname.datatype }?,
+      attribute _type { avt.datatype }?,
+      attribute validation { validation.datatype }?,
+      attribute _validation { avt.datatype }?,
       sequence-constructor.model
    }
 processing-instruction.element =
@@ -857,39 +867,39 @@ processing-instruction.element =
       | attribute _name { avt.datatype }),
       select-or-sequence-constructor.model
    }
-record.element = 
+record.element =
    element record {
-      (attribute as { sequence-type.datatype }?
-      | attribute _as { avt.datatype }?),
-      (attribute duplicates { expression.datatype }?
-      | attribute _duplicates { avt.datatype }?),
+      attribute as { sequence-type.datatype }?,
+      attribute _as { avt.datatype }?,
+      attribute duplicates { expression.datatype }?,
+      attribute _duplicates { avt.datatype }?,
       sequence-constructor.model
   }
-record-type.element = 
+record-type.element =
    element record-type {
       (attribute name { ncname.datatype | avt.datatype }
       | attribute _name { avt.datatype }),
-      (attribute visibility { "public" | "private" | "final" | "abstract" | "hidden" }?
-      | attribute _visibility { avt.datatype }?),
+      attribute visibility { visibility.datatype }?,
+      attribute _visibility { avt.datatype }?,
       field.element*
   }
-field.element = 
+field.element =
    element field {
       (attribute name { ncname.datatype | avt.datatype }
       | attribute _name { avt.datatype }),
-      (attribute as { sequence-type.datatype }?
-      | attribute _as { avt.datatype }?),
-      (attribute required { boolean.datatype }?
-      | attribute _required { avt.datatype }?),
-      (attribute \default { expression.datatype }?
-      |attribute _default { expression.datatype }?),
+      attribute as { sequence-type.datatype }?,
+      attribute _as { avt.datatype }?,
+      attribute required { boolean.datatype }?,
+      attribute _required { avt.datatype }?,
+      attribute \default { expression.datatype }?,
+      attribute _default { expression.datatype }?,
       empty
   }
 
-select.element = 
+select.element =
    element select {
-      (attribute as { sequence-type.datatype }?
-      | attribute _as { avt.datatype }?),
+      attribute as { sequence-type.datatype }?,
+      attribute _as { avt.datatype }?,
       (fallback.element | text)*
   }
 namespace.element =
@@ -916,10 +926,10 @@ copy.element =
       attribute _inherit-namespaces { avt.datatype }?,
       attribute use-attribute-sets { eqnames.datatype }?,
       attribute _use-attribute-sets { avt.datatype }?,
-      ((attribute type { eqname.datatype }?,
-      attribute _type { avt.datatype }?) |
-      (attribute validation { "strict" | "lax" | "preserve" | "strip" }?,
-      attribute _validation { avt.datatype }? )), # type and validation are mutually exclusive
+      attribute type { eqname.datatype }?,
+      attribute _type { avt.datatype }?,
+      attribute validation { validation.datatype }?,
+      attribute _validation { avt.datatype }?,
       sequence-constructor.model
    }
 copy-of.element =
@@ -932,10 +942,10 @@ copy-of.element =
       attribute _copy-accumulators { avt.datatype }?,
       attribute copy-namespaces { boolean.datatype }?,
       attribute _copy-namespaces { avt.datatype }?,
-      ((attribute type { eqname.datatype }?,
-      attribute _type { avt.datatype }?) |
-      (attribute validation { "strict" | "lax" | "preserve" | "strip" }?,
-      attribute _validation { avt.datatype }? )), # type and validation are mutually exclusive
+      attribute type { eqname.datatype }?,
+      attribute _type { avt.datatype }?,
+      attribute validation { validation.datatype }?,
+      attribute _validation { avt.datatype }?,
       empty
    }
 sequence.element =
@@ -1026,14 +1036,14 @@ for-each-group.element =
       global.atts,
       (attribute select { expression.datatype }
       | attribute _select { avt.datatype })+,
-      ((attribute group-by { expression.datatype }?,
-      attribute _group-by { avt.datatype }?) |
-      (attribute group-adjacent { expression.datatype }?,
-      attribute _group-adjacent { avt.datatype }?) |
-      (attribute group-starting-with { pattern.datatype }?,
-      attribute _group-starting-with { avt.datatype }?) |
-      (attribute group-ending-with { pattern.datatype }?,
-      attribute _group-ending-with { avt.datatype }?)),
+      attribute group-by { expression.datatype }?,
+      attribute _group-by { avt.datatype }?,
+      attribute group-adjacent { expression.datatype }?,
+      attribute _group-adjacent { avt.datatype }?,
+      attribute group-starting-with { pattern.datatype }?,
+      attribute _group-starting-with { avt.datatype }?,
+      attribute group-ending-with { pattern.datatype }?,
+      attribute _group-ending-with { avt.datatype }?,
       attribute composite { boolean.datatype }?,
       attribute _composite { avt.datatype }?,
       attribute collation { uri.datatype | avt.datatype }?,
@@ -1064,7 +1074,7 @@ merge-source.element =
       attribute _use-accumulators { avt.datatype }?,
       attribute sort-before-merge { boolean.datatype }?,
       attribute _sort-before-merge { avt.datatype }?,
-      attribute validation { "strict" | "lax" | "preserve" | "strip" }?,
+      attribute validation { validation.datatype }?,
       attribute _validation { avt.datatype }?,
       attribute type { eqname.datatype }?,
       attribute _type { avt.datatype }?,
@@ -1134,10 +1144,10 @@ source-document.element =
       | attribute _href { avt.datatype })+,
       attribute use-accumulators { tokens.datatype }?,
       attribute _use-accumulators { avt.datatype }?,
-      ((attribute type { eqname.datatype }?,
-      attribute _type { avt.datatype }?) |
-      (attribute validation { "strict" | "lax" | "preserve" | "strip" }?,
-      attribute _validation { avt.datatype }? )), # type and validation are mutually exclusive
+      attribute type { eqname.datatype }?,
+      attribute _type { avt.datatype }?,
+      attribute validation { validation.datatype }?,
+      attribute _validation { avt.datatype }?,
       attribute streamable { boolean.datatype }?,
       attribute _streamable { avt.datatype }?,
       sequence-constructor.model
@@ -1146,10 +1156,10 @@ accumulator.element =
    element accumulator {
       extension.atts,
       global.atts,
-      (attribute name { eqname.datatype }
-      | attribute _name { avt.datatype }),
-      (attribute initial-value { expression.datatype }
-      | attribute _initial-value { avt.datatype }),
+      attribute name { eqname.datatype }?,
+      attribute _name { avt.datatype }?,
+      attribute initial-value { expression.datatype }?,
+      attribute _initial-value { avt.datatype }?,
       attribute as { sequence-type.datatype }?,
       attribute _as { avt.datatype }?,
       attribute streamable { boolean.datatype }?,
@@ -1184,8 +1194,8 @@ key.element =
    }
 map.element =
    element map {
-      (attribute duplicates { expression.datatype }?
-      | attribute _duplicates { avt.datatype }?),
+      attribute duplicates { expression.datatype }?,
+      attribute _duplicates { avt.datatype }?,
       extension.atts,
       global.atts,
       select-or-sequence-constructor.model
@@ -1196,14 +1206,14 @@ map-entry.element =
       extension.atts,
       global.atts,
       (attribute key { expression.datatype }
-      | attribute _key { avt.datatype }),
+      | attribute _key { avt.datatype })+,
       select-or-sequence-constructor.model
    }
 
 array.element =
   element array {
-    (attribute for-each { expression.datatype }
-     | attribute _for-each { expression.datatype }),
+    attribute for-each { expression.datatype }?,
+    attribute _for-each { expression.datatype }?,
     extension.atts,
     global.atts,
     select-or-sequence-constructor.model
@@ -1252,11 +1262,11 @@ result-document.element =
       attribute _format { avt.datatype }?,
       attribute href { uri.datatype | avt.datatype }?,
       attribute _href { avt.datatype }?,
-      ((attribute type { eqname.datatype }?,
-      attribute _type { avt.datatype }?) |
-      (attribute validation { "strict" | "lax" | "preserve" | "strip" }?,
-      attribute _validation { avt.datatype }? )), # type and validation are mutually exclusive      
-      attribute method { "xml" | "html" | "xhtml" | "text" | "json" | "adaptive" | eqname.datatype | avt.datatype }?,
+      attribute type { eqname.datatype }?,
+      attribute _type { avt.datatype }?,
+      attribute validation { validation.datatype }?,
+      attribute _validation { avt.datatype }?,
+      attribute method { method.datatype | avt.datatype }?,
       attribute _method { avt.datatype }?,
       attribute allow-duplicate-names { boolean.datatype | avt.datatype }?,
       attribute _allow-duplicate-names { avt.datatype }?,
@@ -1312,7 +1322,7 @@ output.element =
       global.atts.except.version,
       attribute name { eqname.datatype }?,
       attribute _name { avt.datatype }?,
-      attribute method { "xml" | "html" | "xhtml" | "text" | "json" | "adaptive" | eqname.datatype }?,
+      attribute method { method.datatype }?,
       attribute _method { avt.datatype }?,
       attribute allow-duplicate-names { boolean.datatype }?,
       attribute _allow-duplicate-names { avt.datatype }?,


### PR DESCRIPTION
Attempt to tidy up the RELAX NG grammar

1. Removed constraints on attributes vs. shadow attributes
2. Generally removed co-constraints except for simple, required attributes
3. Added a few more data types

I’m thinking about trying to translate the XSD asserts into Schematron rules, but I guess that can be a separate PR if I make it work