### PR TITLE
2587 Streamability of context value expressions

### DIFF
--- a/specifications/xslt-streaming-40/src/xslt-streaming.xml
+++ b/specifications/xslt-streaming-40/src/xslt-streaming.xml
@@ -7568,7 +7568,7 @@ return ($m?price - $m?discount)</eg>
                <div3 id="streamability-of-pipeline-expressions">
                   <head>Streamability of Pipeline Expressions</head>
                   <changes>
-                     <change PR="2587" date="2026-04-21">New streamability rule for a new construct.</change>
+                     <change PR="2587" PR="2589" date="2026-04-21">New streamability rule for a new construct.</change>
                   </changes>
                   <p>The pipeline operator <code>-></code> is assessed as follows:</p>
                   
@@ -8113,33 +8113,7 @@ return ($m?price - $m?discount)</eg>
                         expressions. See <specref ref="streamability-of-axis-steps"/>.</p>
                   </note>
                </div3>
-               <div3 id="streamability-of-filterAM-expressions">
-                  <head>Streamability of Filter Expressions for Maps and Arrays</head>
-                  <changes>
-                     <change PR="2587" date="2026-04-21">New streamability rule for a new construct.</change>
-                  </changes>
-                  <p>The <xnt spec="XP40" ref="FilterExprAM">FilterExprAM</xnt> construct
-                     <code><var>E1</var>[<var>E2</var>]</code> is assessed as follows:</p>
-                  
-                  <ulist>
-                     <item><p>If <var>E1</var> and <var>E2</var> are both grounded and motionless,
-                     then the filter expression as a whole is grounded and motionless.</p>
-                     <note><p>This is the normal case, because a <xnt spec="XP40" ref="FilterExprAM">FilterExprAM</xnt>
-                     is designed to process maps and arrays.</p></note></item>
-                     <item><p>In other cases, a pipeline expression is <termref def="dt-roaming"/>
-                           and <termref def="dt-free-ranging"/>.</p>
-                     <note><p>This might happen, for example, if the predicate contains a reference to
-                     a parameter of a streamable stylesheet function.</p></note></item>
-                     
-                  </ulist>
-                  
-                  <note><p>A pipeline expression is streamable only in special cases. If the
-                  left-hand operand potentially selects more than one streamed node, then the
-                  context value for the right-hand operand will potentially contain multiple
-                  streamed nodes, whereas the streamability analysis for focus-dependent expressions
-                  generally works only if there is a single context item.</p></note>
-                  
-               </div3>
+               
                <div3 id="streamability-of-dynamic-function-calls">
                   <head>Streamability of Dynamic Function Calls</head>
                   
@@ -8221,7 +8195,7 @@ return ($m?price - $m?discount)</eg>
                   <head>Streamability of the Context Value Expression</head>
                   
                   <changes>
-                     <change issue="2587" date="2026-04-22">The explanation is extended because of changes to
+                     <change issue="2587" PR="2589" date="2026-04-22">The explanation is extended because of changes to
                      the semantics of the context value expression.</change>
                   </changes>
 
@@ -8237,12 +8211,10 @@ return ($m?price - $m?discount)</eg>
                         containing expression will be <termref def="dt-free-ranging"/>.</p>
                      <p>In XPath 4.0, the semantics have changed so the expression <code>.</code> can sometimes
                      deliver a sequence of items rather than a singleton; the name has therefore changed from
-                     "context item expression" to "context value expression". In XSLT, the only places where
-                     the result of <code>.</code> is not a singleton are within the predicate of 
-                        a filter expression for maps and arrays (<code><var>E1</var>?[<var>E2</var>]</code>), 
-                        and on the right-hand side of the pipeline operator (<code><var>E1</var> -> <var>E2</var></code>).
-                        These situations are covered by rules in <specref ref="streamability-of-filterAM-expressions"/>
-                        and <specref ref="streamability-of-pipeline-expressions"/> respectively.</p>
+                     "context item expression" to "context value expression". In XSLT, the only place where
+                     the result of <code>.</code> is not a singleton is 
+                        on the right-hand side of the pipeline operator (<code><var>E1</var> -> <var>E2</var></code>).
+                        This situation is covered by rules in <specref ref="streamability-of-pipeline-expressions"/>.</p>
                   </note>
                </div3>
                <div3 id="streamability-of-function-calls">

--- a/specifications/xslt-streaming-40/src/xslt-streaming.xml
+++ b/specifications/xslt-streaming-40/src/xslt-streaming.xml
@@ -2341,7 +2341,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
                            steps;</p>
                      </item>
                      <item>
-                        <p>Constructs with implicit inputs, such as the context item expression
+                        <p>Constructs with implicit inputs, such as the context value expression
                               <code>.</code> (dot);</p>
                      </item>
                      <item>
@@ -2504,7 +2504,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
                stream.</p>
 
             <note>
-               <p>The context item expression <code>.</code> is classified as motionless; however a
+               <p>The context value expression <code>.</code> is classified as motionless; however a
                   construct that uses <code>.</code> as an <termref def="dt-operand"/> (for example,
                      <code>string(.)</code>) might be <termref def="dt-consuming"/>. The
                   streamability rules effectively consider expressions such as <code>.</code> within
@@ -2593,7 +2593,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
                <p>For an example of a case where an expression is <termref def="dt-roaming"/> but
                   not <termref def="dt-free-ranging"/>, consider the right-hand operand of the
                   relative path expression <code>(preceding::x/.)</code>. The rules for the
-                  streamability of a context item expression (see <specref ref="streamability-of-context-item-expression"/>) give <code>.</code> in this
+                  streamability of a context value expression (see <specref ref="streamability-of-context-item-expression"/>) give <code>.</code> in this
                   context a <termref def="dt-roaming"/> posture, combined with <termref def="dt-motionless"/> sweep. But the relative path expression as a whole is
                      <termref def="dt-roaming"/> and <termref def="dt-free-ranging"/> (see <specref ref="streamability-of-path-expressions"/>), so the apparent inconsistency is
                   transient.</p>
@@ -5490,7 +5490,7 @@ return ($m?price - $m?discount)</eg>
 
                   <olist>
                      <item>
-                        <p>An implicit operand: a context item expression (<code>.</code>), with
+                        <p>An implicit operand: a context value expression (<code>.</code>), with
                            usage <termref def="dt-absorption"/>;</p>
                      </item>
                      <item>
@@ -5756,7 +5756,7 @@ return ($m?price - $m?discount)</eg>
                   <olist>
                      <item>
                         <p>The expression in the <code>select</code> attribute, defaulting to a
-                           context item expression (<code>.</code>) (usage <termref def="dt-inspection"/>)</p>
+                           context value expression (<code>.</code>) (usage <termref def="dt-inspection"/>)</p>
                      </item>
                      <item>
                         <p>The contained sequence constructor (usage <termref def="dt-absorption"/>), assessed with <termref def="dt-context-posture"/> and context item
@@ -8059,7 +8059,7 @@ return ($m?price - $m?discount)</eg>
                            <item>
                               <p>Neither <var>P</var>, nor any operand of <var>P</var>, at any depth
                                  provided it has <var>F</var> as its focus-setting container, is a
-                                 context item expression, an axis expression, or a call on a
+                                 context value expression, an axis expression, or a call on a
                                  focus-dependent function</p>
                            </item>
                         </olist>
@@ -8211,7 +8211,7 @@ return ($m?price - $m?discount)</eg>
                         containing expression will be <termref def="dt-free-ranging"/>.</p>
                      <p>In XPath 4.0, the semantics have changed so the expression <code>.</code> can sometimes
                      deliver a sequence of items rather than a singleton; the name has therefore changed from
-                     "context item expression" to "context value expression". In XSLT, the only place where
+                     “context item expression” to “context value expression”. In XSLT, the only place where
                      the result of <code>.</code> is not a singleton is 
                         on the right-hand side of the pipeline operator (<code><var>E1</var> -> <var>E2</var></code>).
                         This situation is covered by rules in <specref ref="streamability-of-pipeline-expressions"/>.</p>

--- a/specifications/xslt-streaming-40/src/xslt-streaming.xml
+++ b/specifications/xslt-streaming-40/src/xslt-streaming.xml
@@ -7568,7 +7568,7 @@ return ($m?price - $m?discount)</eg>
                <div3 id="streamability-of-pipeline-expressions">
                   <head>Streamability of Pipeline Expressions</head>
                   <changes>
-                     <change PR="2587" PR="2589" date="2026-04-21">New streamability rule for a new construct.</change>
+                     <change issue="2587" PR="2589" date="2026-04-21">New streamability rule for a new construct.</change>
                   </changes>
                   <p>The pipeline operator <code>-></code> is assessed as follows:</p>
                   

--- a/specifications/xslt-streaming-40/src/xslt-streaming.xml
+++ b/specifications/xslt-streaming-40/src/xslt-streaming.xml
@@ -7565,6 +7565,33 @@ return ($m?price - $m?discount)</eg>
                   a discussion of the streamability difficulties associated with <code>document-node()</code> tests.</p></note>
                   
                </div3>
+               <div3 id="streamability-of-pipeline-expressions">
+                  <head>Streamability of Pipeline Expressions</head>
+                  <changes>
+                     <change PR="2587" date="2026-04-21">New streamability rule for a new construct.</change>
+                  </changes>
+                  <p>The pipeline operator <code>-></code> is assessed as follows:</p>
+                  
+                  <ulist>
+                     <item><p>If the cardinality of the left-hand operand is zero or one then 
+                     the a pipeline expression is semantically equivalent to a simple
+                     mapping expression, and the rules of <specref ref="streamability-of-simple-mapping-expressions"/>
+                     apply.</p></item>
+                     <item><p>If the left-hand operand is <termref def="dt-grounded"/>
+                     then the expression as a whole is <termref def="dt-grounded"/> and 
+                           <termref def="dt-motionless"/>.</p>
+                     </item>
+                     <item><p>In all other cases, a pipeline expression is <termref def="dt-roaming"/>
+                           and <termref def="dt-free-ranging"/>.</p></item>
+                  </ulist>
+                  
+                  <note><p>A pipeline expression is streamable only in special cases. If the
+                  left-hand operand potentially selects more than one streamed node, then the
+                  context value for the right-hand operand will potentially contain multiple
+                  streamed nodes, whereas the streamability analysis for focus-dependent expressions
+                  generally works only if there is a single context item.</p></note>
+                  
+               </div3>
                <div3 id="streamability-of-simple-mapping-expressions">
                   <head>Streamability of Simple Mapping Expressions</head>
                   <p>The mapping operator <code>!</code> is treated as a left-associative binary
@@ -7818,7 +7845,9 @@ return ($m?price - $m?discount)</eg>
                               <termref def="dt-motionless"/> and the posture is <termref def="dt-grounded"/>;</p>
                      </item>
                      <item>
-                        <p>If the <termref def="dt-context-posture"/> is <termref def="dt-roaming"/>, then the sweep is <termref def="dt-free-ranging"/> and the posture is <termref def="dt-roaming"/>;</p>
+                        <p>If the <termref def="dt-context-posture"/> is 
+                           <termref def="dt-roaming"/>, then the sweep is <termref def="dt-free-ranging"/> 
+                           and the posture is <termref def="dt-roaming"/>;</p>
                      </item>
                      <item>
                         <p>If the statically inferred <termref def="dt-context-item-type"/> is such
@@ -8084,6 +8113,33 @@ return ($m?price - $m?discount)</eg>
                         expressions. See <specref ref="streamability-of-axis-steps"/>.</p>
                   </note>
                </div3>
+               <div3 id="streamability-of-filterAM-expressions">
+                  <head>Streamability of Filter Expressions for Maps and Arrays</head>
+                  <changes>
+                     <change PR="2587" date="2026-04-21">New streamability rule for a new construct.</change>
+                  </changes>
+                  <p>The <xnt spec="XP40" ref="FilterExprAM">FilterExprAM</xnt> construct
+                     <code><var>E1</var>[<var>E2</var>]</code> is assessed as follows:</p>
+                  
+                  <ulist>
+                     <item><p>If <var>E1</var> and <var>E2</var> are both grounded and motionless,
+                     then the filter expression as a whole is grounded and motionless.</p>
+                     <note><p>This is the normal case, because a <xnt spec="XP40" ref="FilterExprAM">FilterExprAM</xnt>
+                     is designed to process maps and arrays.</p></note></item>
+                     <item><p>In other cases, a pipeline expression is <termref def="dt-roaming"/>
+                           and <termref def="dt-free-ranging"/>.</p>
+                     <note><p>This might happen, for example, if the predicate contains a reference to
+                     a parameter of a streamable stylesheet function.</p></note></item>
+                     
+                  </ulist>
+                  
+                  <note><p>A pipeline expression is streamable only in special cases. If the
+                  left-hand operand potentially selects more than one streamed node, then the
+                  context value for the right-hand operand will potentially contain multiple
+                  streamed nodes, whereas the streamability analysis for focus-dependent expressions
+                  generally works only if there is a single context item.</p></note>
+                  
+               </div3>
                <div3 id="streamability-of-dynamic-function-calls">
                   <head>Streamability of Dynamic Function Calls</head>
                   
@@ -8162,7 +8218,12 @@ return ($m?price - $m?discount)</eg>
 
                </div3>
                <div3 id="streamability-of-context-item-expression">
-                  <head>Streamability of the Context Item Expression</head>
+                  <head>Streamability of the Context Value Expression</head>
+                  
+                  <changes>
+                     <change issue="2587" date="2026-04-22">The explanation is extended because of changes to
+                     the semantics of the context value expression.</change>
+                  </changes>
 
                   <p>The <termref def="dt-posture"/> of the expression is the <termref def="dt-context-posture"/>, and the <termref def="dt-sweep"/> is <termref def="dt-motionless"/>.</p>
 
@@ -8174,6 +8235,14 @@ return ($m?price - $m?discount)</eg>
                         leads to the containing expression being <termref def="dt-consuming"/>.</p>
                      <p>Similarly, if <code>.</code> is used where the <termref def="dt-operand-usage"/> is <termref def="dt-navigation"/>, the
                         containing expression will be <termref def="dt-free-ranging"/>.</p>
+                     <p>In XPath 4.0, the semantics have changed so the expression <code>.</code> can sometimes
+                     deliver a sequence of items rather than a singleton; the name has therefore changed from
+                     "context item expression" to "context value expression". In XSLT, the only places where
+                     the result of <code>.</code> is not a singleton are within the predicate of 
+                        a filter expression for maps and arrays (<code><var>E1</var>?[<var>E2</var>]</code>), 
+                        and on the right-hand side of the pipeline operator (<code><var>E1</var> -> <var>E2</var></code>).
+                        These situations are covered by rules in <specref ref="streamability-of-filterAM-expressions"/>
+                        and <specref ref="streamability-of-pipeline-expressions"/> respectively.</p>
                   </note>
                </div3>
                <div3 id="streamability-of-function-calls">


### PR DESCRIPTION
Defines streamability rules for new 4.0 constructs impacted by the generalisation of context item to context value.

Fix #2587