### PR TITLE
DM edits on XML Schema data types

### DIFF
--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -702,39 +702,37 @@ a reference to a type definition in the Schema Component Model.
 <ulist>
 <item>
 <p>The 19 <phrase diff="add" at="2022-11-05">primitive atomic</phrase> types defined in
-<xspecref spec="XS2" ref="built-in-primitive-datatypes"/>
-of <bibref ref="xmlschema11-2"/>.</p>
+<xspecref spec="XS2" ref="built-in-primitive-datatypes"/> of <bibref ref="xmlschema-2"/>
+and subsequently adopted in <xspecref spec="XS11-2" ref="built-in-primitive-datatypes"/> of <bibref ref="xmlschema11-2"/>.</p>
 </item>
 <item>
 <p>Three built-in list types:
-<code>xs:NMTOKENS</code>, <code>xs:IDREFS</code>, and <code>xs:ENTITIES</code>.
-</p>
+<code>xs:NMTOKENS</code>, <code>xs:IDREFS</code>, and <code>xs:ENTITIES</code>, defined in
+<xspecref spec="XS2" ref="built-in-derived"/> of <bibref ref="xmlschema-2"/>
+and subsequently adopted in <xspecref spec="XS11-2" ref="ordinary-built-ins"/> of <bibref ref="xmlschema11-2"/>.</p>
 </item>
 <item>
 <p>The following types, which were originally defined in
 <bibref ref="xpath-datamodel-30"/> and were subsequently adopted by
-<bibref ref="xmlschema11-2"/>:
+<bibref ref="xmlschema11-2"/> (<xspecref spec="XS11-2" ref="special-datatypes"/> and <xspecref spec="XS11-2" ref="ordinary-built-ins"/>):
 <code>xs:anyAtomicType</code>, <code>xs:dayTimeDuration</code>,
-<code>xs:yearMonthDuration</code>.
+<code>xs:yearMonthDuration</code>. See <specref ref="types-predefined"/>.
 </p>
 </item>
 <item>
-<p>In the case of a processor that supports
-<bibref ref="xmlschema11-2"/>, 
-the new union type <code>xs:error</code> (a type with no instances)
-and the new derived type <code>xs:dateTimeStamp</code>.</p>
+<p>The derived type <code>xs:dateTimeStamp</code>, defined in
+<xspecref spec="XS11-2" ref="built-in-derived"/> of <bibref ref="xmlschema11-2"/>.</p>
 </item>
 <item>
-<p>The following types, which use the <code>xs:</code> namespace
-and are defined here in the data model but not in XML Schema:
-<code>xs:untypedAtomic</code>, and
-<code>xs:numeric</code>,
-a union type whose members are <code>xs:double</code>, <code>xs:float</code>
-and <code>xs:decimal</code>.
-</p>
+<p>The simple type <code>xs:error</code>, defined in
+<xspecref spec="XS11-1" ref="builtin-stds"/> of <bibref ref="xmlschema11-1"/>. See <xspecref spec="XP40" ref="id-xs-error"></xspecref></p>
 </item>
+
 </ulist>
-  
+
+  <p diff="add" at="2026-04-27">In addition to the above schema types, there are predefined types, discussed at 
+    <specref ref="types-predefined"/>.</p>
+
   <p diff="add" at="2022-11-05">Schema types fulfill a role different from <termref def="dt-item-type">item types</termref>.
   Schema types other than atomic types arise in the data model only as <termref def="dt-type-annotation">type annotations</termref>
   on element and attribute nodes. Nodes are not instances of schema types in the sense of the XPath <code>instance of</code>
@@ -751,6 +749,79 @@ and <code>xs:decimal</code>.
   </ulist>
 </div3>
 
+<div3 id="types-predefined" diff="chg" at="2023-09-28">
+<head>Predefined Types</head>
+  
+  <changes>
+    <change issue="2216">An ordering is now defined for all instances of <code>xs:duration</code>.</change>
+  </changes>
+ 
+  
+  <p>The three atomic types <code>xs:anyAtomicType</code>,
+    <code>xs:dayTimeDuration</code>, and
+    <code>xs:yearMonthDuration</code> were first introduced in the 2.0 version of this specification,
+  and were subsequently adopted by XSD 1.1. These types are always present in the XDM data model,
+  with the definitions as given in XSD 1.1, whether or not the processor actually supports XSD 1.1.</p>
+  
+  <note>
+    <p>The types <code>xs:dayTimeDuration</code>, and
+      <code>xs:yearMonthDuration</code> have a special status in these specifications because many
+    arithmetic operations are available in XPath only on these
+    subtypes of <code>xs:duration</code>, not on the primitive type <code>xs:duration</code> itself.</p>
+    
+    <p>In 4.0, however, ordering is defined over all instances of <code>xs:duration</code>, not
+    only over these subtypes.</p>
+    
+    <p>The datatype <code>xs:anyAtomicType</code> is an atomic type that
+      includes all atomic items (and no values that are not atomic). Its
+      base type is <code>xs:anySimpleType</code>, from which all simple
+      types, including atomic, list, and union types are derived. All
+      primitive atomic types, such as <code>xs:decimal</code> and
+      <code>xs:string</code>, have <code>xs:anyAtomicType</code>
+      as their base type.</p>
+    <p>No type may be derived from <code>xs:anyAtomicType</code>
+      by restriction, union, or list.</p>
+  </note>
+  
+  
+  <p>In 4.0, several types are predefined, using the <code>xs:</code> namespace.
+    They are defined here in this XDM specification but not in XML Schema:
+  </p>
+  
+  <ulist>
+    <item>
+      <p>The type <term>xs:untypedAtomic</term> denotes untyped atomic
+        data, such as text that has not been assigned a more specific type. It is
+        classified as an atomic type. An attribute that has not been validated 
+        (or that has been validated in skip mode) is represented in the data
+        model by an attribute node with the type annotation <code>xs:untypedAtomic</code>. No
+        predefined types are derived from <code>xs:untypedAtomic</code>
+        <phrase>and no such derivations are allowed</phrase>.
+      </p>
+    </item>
+    <item>
+      <p>The type <term>xs:numeric</term> is defined as a union type whose members are 
+        <code>xs:double</code>, <code>xs:float</code> and <code>xs:decimal</code>.
+      </p>
+    </item>
+    <item>
+      <p>The datatype <term>xs:untyped</term> is used as the type annotation of
+        an element node that has not been validated, or that has been validated in
+        skip mode. It is a classified as a complex type. The properties of <code>xs:untyped</code>
+        are the same as the properties of <code>xs:anyType</code> except for
+        the base type and name. The base type of <code>xs:untyped</code> is
+        <code>xs:anyType</code>.
+        No predefined types are derived from <code>xs:untyped</code>
+        <phrase>and no such derivations are allowed</phrase>.</p>
+    </item>
+  </ulist>
+
+  
+
+
+
+</div3>
+      
 <div3 id="schema-consistency" diff="add" at="Issue451">
   <head>Schema Consistency</head>
   
@@ -909,65 +980,6 @@ size and scope of the processing context.</p>
 
 </div3>
 
-<div3 id="types-predefined" diff="chg" at="2023-09-28">
-<head>Predefined Types</head>
-  
-  <changes>
-    <change issue="2216">An ordering is now defined for all instances of <code>xs:duration</code>.</change>
-  </changes>
- 
-  
-  <p>The three atomic types <code>xs:anyAtomicType</code>,
-    <code>xs:dayTimeDuration</code>, and
-    <code>xs:yearMonthDuration</code> were first introduced in the 2.0 version of this specification,
-  and were subsequently adopted by XSD 1.1. These types are always present in the XDM data model,
-  with the definitions as given in XSD 1.1, whether or not the processor actually supports XSD 1.1.</p>
-  
-  <note>
-    <p>The types <code>xs:dayTimeDuration</code>, and
-      <code>xs:yearMonthDuration</code> have a special status in these specifications because many
-    arithmetic operations are available in XPath only on these
-    subtypes of <code>xs:duration</code>, not on the primitive type <code>xs:duration</code> itself.</p>
-    
-    <p>In 4.0, however, ordering is defined over all instances of <code>xs:duration</code>, not
-    only over these subtypes.</p>
-    
-    <p>The datatype <code>xs:anyAtomicType</code> is an atomic type that
-      includes all atomic items (and no values that are not atomic). Its
-      base type is <code>xs:anySimpleType</code>, from which all simple
-      types, including atomic, list, and union types are derived. All
-      primitive atomic types, such as <code>xs:decimal</code> and
-      <code>xs:string</code>, have <code>xs:anyAtomicType</code>
-      as their base type.</p>
-    <p>No type may be derived from <code>xs:anyAtomicType</code>
-      by restriction, union, or list.</p>
-  </note>
-  
-  <p>The types <code>xs:untyped</code> and <code>xs:untypedAtomic</code>, although
-  they have names in the XSD namespace, are defined in this XDM specification, and not
-  in XSD.</p>
-
-  <p>The type <term>xs:untypedAtomic</term> denotes untyped atomic
-    data, such as text that has not been assigned a more specific type. It is
-    classified as an atomic type. An attribute that has not been validated 
-    (or that has been validated in skip mode) is represented in the data
-    model by an attribute node with the type annotation <code>xs:untypedAtomic</code>. No
-    predefined types are derived from <code>xs:untypedAtomic</code>
-    <phrase>and no such derivations are allowed</phrase>.
-  </p>
-  
-  <p>The datatype <term>xs:untyped</term> is used as the type annotation of
-    an element node that has not been validated, or that has been validated in
-    skip mode. It is a classified as a complex type. The properties of <code>xs:untyped</code>
-    are the same as the properties of <code>xs:anyType</code> except for
-    the base type and name. The base type of <code>xs:untyped</code> is
-    <code>xs:anyType</code>.
-    No predefined types are derived from <code>xs:untyped</code>
-    <phrase>and no such derivations are allowed</phrase>.</p>
-
-
-
-</div3>
 
 <div3 id="xml-and-xsd-versions">
 <head>XML and XSD Versions</head>

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -751,7 +751,7 @@ and subsequently adopted in <xspecref spec="XS11-2" ref="ordinary-built-ins"/> o
 </div3>
 
 <div3 id="types-predefined" diff="chg" at="2023-09-28">
-<head>Predefined types outside of XML Schema</head>
+<head>Types predefined outside of XML Schema</head>
   
   <changes>
     <change issue="2216">An ordering is now defined for all instances of <code>xs:duration</code>.</change>

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -807,9 +807,9 @@ and subsequently adopted in <xspecref spec="XS11-2" ref="ordinary-built-ins"/> o
       </p>
     </item>
     <item>
-      <p>The datatype <term>xs:untyped</term> is used as the type annotation of
+      <p>The type <term>xs:untyped</term> is used as the type annotation of
         an element node that has not been validated, or that has been validated in
-        skip mode. It is a classified as a complex type. The properties of <code>xs:untyped</code>
+        skip mode. It is classified as a complex type. The properties of <code>xs:untyped</code>
         are the same as the properties of <code>xs:anyType</code> except for
         the base type and name. The base type of <code>xs:untyped</code> is
         <code>xs:anyType</code>.

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -714,14 +714,15 @@ and subsequently adopted in <xspecref spec="XS11-2" ref="ordinary-built-ins"/> o
 <item>
 <p>The following types, which were originally defined in
 <bibref ref="xpath-datamodel-30"/> and were subsequently adopted by
-<bibref ref="xmlschema11-2"/> (<xspecref spec="XS11-2" ref="special-datatypes"/> and <xspecref spec="XS11-2" ref="ordinary-built-ins"/>):
+<bibref ref="xmlschema11-2"/> (see <xspecref spec="XS11-2" ref="special-datatypes"/> and 
+<xspecref spec="XS11-2" ref="ordinary-built-ins"/>):
 <code>xs:anyAtomicType</code>, <code>xs:dayTimeDuration</code>,
 <code>xs:yearMonthDuration</code>. See <specref ref="types-predefined"/>.
 </p>
 </item>
 <item>
 <p>The derived type <code>xs:dateTimeStamp</code>, defined in
-<xspecref spec="XS11-2" ref="built-in-derived"/> of <bibref ref="xmlschema11-2"/>.</p>
+<xspecref spec="XS11-2" ref="ordinary-built-ins"/> of <bibref ref="xmlschema11-2"/>.</p>
 </item>
 <item>
 <p>The simple type <code>xs:error</code>, defined in
@@ -750,7 +751,7 @@ and subsequently adopted in <xspecref spec="XS11-2" ref="ordinary-built-ins"/> o
 </div3>
 
 <div3 id="types-predefined" diff="chg" at="2023-09-28">
-<head>Predefined Types</head>
+<head>Predefined types outside of XML Schema</head>
   
   <changes>
     <change issue="2216">An ordering is now defined for all instances of <code>xs:duration</code>.</change>
@@ -759,9 +760,10 @@ and subsequently adopted in <xspecref spec="XS11-2" ref="ordinary-built-ins"/> o
   
   <p>The three atomic types <code>xs:anyAtomicType</code>,
     <code>xs:dayTimeDuration</code>, and
-    <code>xs:yearMonthDuration</code> were first introduced in the 2.0 version of this specification,
-  and were subsequently adopted by XSD 1.1. These types are always present in the XDM data model,
-  with the definitions as given in XSD 1.1, whether or not the processor actually supports XSD 1.1.</p>
+    <code>xs:yearMonthDuration</code>, not defined by XSD 1.0, were first introduced in the 
+    2.0 version of this specification, and were subsequently adopted by XSD 1.1. These types are 
+    always present in the XDM data model, with the definitions as given in XSD 1.1, whether or not 
+    the processor actually supports XSD 1.1.</p>
   
   <note>
     <p>The types <code>xs:dayTimeDuration</code>, and
@@ -784,8 +786,8 @@ and subsequently adopted in <xspecref spec="XS11-2" ref="ordinary-built-ins"/> o
   </note>
   
   
-  <p>In 4.0, several types are predefined, using the <code>xs:</code> namespace.
-    They are defined here in this XDM specification but not in XML Schema:
+  <p>In 4.0, several types are predefined here in this XDM specification but not in XML Schema, 
+    using the <code>xs:</code> namespace:
   </p>
   
   <ulist>


### PR DESCRIPTION
Edits here were motivated by several points that caused me confusion tonight:

- 4.1.2 and 4.1.5 had duplicate text, an indication that they belong next to each other.
- In 4.1.2 there were no pointers to the definitions of the datatypes discussed.
- The fifth bullet point in 4.1.2 is not a schema type (which is the topic of the unordered list). The material belongs outside the list.
- The fifth bullet point claims that XDM defines two data types, but it doesn't. And it doesn't mention another data type discussed in predefined data types.
- There is a long discussion of `xs:error` in the XPath specs, but the reader of this section has no clue on where `xs:error` is defined or explained.

Etc. I suspect my draft here still has problems, but I hope it's an improvement.