### PR TITLE
2568 Error code changes for dateTime functions

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -11486,12 +11486,10 @@ return ($value - unix-dateTime()) div seconds(0.001)</eg>
             <item><p>day, and optional timezone (delivering an <code>xs:gDay</code>)</p></item>
             <item><p>hours, minutes, seconds, and optional timezone (delivering an <code>xs:time</code>)</p></item>
          </ulist>
-         <p>A dynamic error is raised <errorref class="DT" code="0006"/> if any of the
-            components in <code>$value</code> is outside the permitted range
-            (for example if the value of the <code>minutes</code> component is less than zero or
-            greater than 59, or if the timezone is outside the range <code>-PT14H</code> to <code>PT14H</code>), 
-            or if the combination of fields is not a valid date/time (for example,
-            if <code>month</code> is 4 and <code>day</code> is 31).</p>
+         <p><A dynamic error is raised <errorref class="RG" code="0001" /> (or <errorref class="DT" code="0003" /> in relation to a timezone value) if any of the components in <code>$value</code> is outside the permitted range
+            specified by the target date/time datatype.  For example if the value of the <code>minutes</code> component is less than zero or
+            greater than 59, or if the timezone is outside the range <code>-PT14H</code> to <code>PT14H</code>).  See <xspecref 
+               spec="DM31" ref="dates-and-times"/>.</p>
       </fos:errors>
       <fos:notes>
          <p>Components that are present in <code>$value</code> but with an empty value are treated

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -14330,11 +14330,7 @@ ISBN 0 521 77752 6.</bibl>
             <error class="DT" code="0005" label="Invalid combination of date/time fields" type="dynamic">
                <p>Raised by <code>build-dateTime</code> if the set of fields supplied does not correspond to those present in one of the
                   <termref def="dt-gregorian"/> types.</p> 
-            </error>
-            <error class="DT" code="0006" label="Invalid component of date/time vallue" type="dynamic">
-               <p>Raised by <code>build-dateTime</code> if one of the fields supplied has a value that is outside the
-                  supported range.</p> 
-            </error>
+            </error>           
 			<error class="FD" code="1340" label="Invalid date/time formatting parameters."
                    type="dynamic">
                <p>This error is raised if the picture string or calendar supplied to <function>fn:format-date</function>, <function>fn:format-time</function>, 


### PR DESCRIPTION
* Deleting `err:FODT0006` 
* Updating the information about errors thrown by `fn:build-dateTime`
* No change to the text for `fn:parts-of-dateTime`, as it doesn't currently include a section on errors.  This is consistent with  the current expectation that neither `fn:parts-of-dateTime` nor the implicit constructor for `fn:dateTime-record` will check that the values supplied represent a valid date/time datatype.

As outlined in issue #2568, this represents a proposal to drop `err:FODT0006`, which is currently only expected to be thrown by `fn:build-dateTime`.  

Like the [functions for extracting components of dates and times](https://qt4cg.org/specifications/xpath-functions-40/Overview.html#component-extraction-dateTime), `fn:build-dateTime` essentially orchestrates casting from one date/time-related datatype to another date/time-related datatype; determining which standard date/time constructor needs to be used and supplying the relevant arguments.  The errors thrown by date/time constructors are already defined: most commonly `err:FORG0001` but also `err:FODT0003` for an out-of-range timezone value.  My suggestion is that, as with the functions for extracting components of dates and times, there is no need for an error code specific to `fn:build-dateTime`.

`err:FODT0005` would remain unchanged and still be thrown by `fn:build-dateTime` if the combination of arguments supplied can't be mapped to a date/time datatype.