### PR TITLE
2568 Error code changes for dateTime functions

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -11485,10 +11485,12 @@ return ($value - unix-dateTime()) div seconds(0.001)</eg>
             <item><p>day, and optional timezone (delivering an <code>xs:gDay</code>)</p></item>
             <item><p>hours, minutes, seconds, and optional timezone (delivering an <code>xs:time</code>)</p></item>
          </ulist>
-         <p><A dynamic error is raised <errorref class="RG" code="0001" /> (or <errorref class="DT" code="0003" /> in relation to a timezone value) if any of the components in <code>$value</code> is outside the permitted range
-            specified by the target date/time datatype.  For example if the value of the <code>minutes</code> component is less than zero or
-            greater than 59, or if the timezone is outside the range <code>-PT14H</code> to <code>PT14H</code>).  See <xspecref 
-               spec="DM31" ref="dates-and-times"/>.</p>
+      	<p>A dynamic error is raised <errorref class="DT" code="0003" /> if the timezone component of <code>$value</code> is outside the range <code>-PT14H</code> to <code>PT14H</code></p>
+      	<p>A dynamic error is raised <errorref class="DT" code="0006" /> if the hours component of <code>$value</code> is <code>24</code></p>
+         <p><A dynamic error is raised <errorref class="RG" code="0001" /> if any other component of <code>$value</code> is outside the permitted range
+            specified by the target date/time datatype, for example: if <code>minutes</code> is less than zero or
+            greater than 59; or if <code>day</code> is 30 and <code>month</code> is 2.  See <xspecref 
+               spec="DM31" ref="dates-and-times".</p>
       </fos:errors>
       <fos:notes>
          <p>Components that are present in <code>$value</code> but with an empty value are treated

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -11485,12 +11485,10 @@ return ($value - unix-dateTime()) div seconds(0.001)</eg>
             <item><p>day, and optional timezone (delivering an <code>xs:gDay</code>)</p></item>
             <item><p>hours, minutes, seconds, and optional timezone (delivering an <code>xs:time</code>)</p></item>
          </ulist>
-         <p>A dynamic error is raised <errorref class="DT" code="0006"/> if any of the
-            components in <code>$value</code> is outside the permitted range
-            (for example if the value of the <code>minutes</code> component is less than zero or
-            greater than 59, or if the timezone is outside the range <code>-PT14H</code> to <code>PT14H</code>), 
-            or if the combination of fields is not a valid date/time (for example,
-            if <code>month</code> is 4 and <code>day</code> is 31).</p>
+         <p><A dynamic error is raised <errorref class="RG" code="0001" /> (or <errorref class="DT" code="0003" /> in relation to a timezone value) if any of the components in <code>$value</code> is outside the permitted range
+            specified by the target date/time datatype.  For example if the value of the <code>minutes</code> component is less than zero or
+            greater than 59, or if the timezone is outside the range <code>-PT14H</code> to <code>PT14H</code>).  See <xspecref 
+               spec="DM31" ref="dates-and-times"/>.</p>
       </fos:errors>
       <fos:notes>
          <p>Components that are present in <code>$value</code> but with an empty value are treated

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -11486,7 +11486,7 @@ return ($value - unix-dateTime()) div seconds(0.001)</eg>
             <item><p>hours, minutes, seconds, and optional timezone (delivering an <code>xs:time</code>)</p></item>
          </ulist>
       	<p>A dynamic error is raised <errorref class="DT" code="0003" /> if the timezone component of <code>$value</code> is outside the range <code>-PT14H</code> to <code>PT14H</code></p>
-        <p>A dynamic error is raised <errorref class="RG" code="0001" /> if a component of <code>$value</code> is outside the permitted range specified by the target date/time datatype, for example: if <code>minutes</code> is less than zero or greater than 59; or if <code>day</code> is 30 and <code>month</code> is 2.  See <xspecref spec="DM31" ref="dates-and-times" />.</p>
+        <p>A dynamic error is raised <errorref class="RG" code="0001" /> if any other component of <code>$value</code> is outside the permitted range specified by the target date/time datatype, for example: if <code>minutes</code> is less than zero or greater than 59; or if <code>day</code> is 30 and <code>month</code> is 2.  See <xspecref spec="DM31" ref="dates-and-times" />.</p>
       </fos:errors>
       <fos:notes>
          <p>Components that are present in <code>$value</code> but with an empty value are treated

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -11486,11 +11486,7 @@ return ($value - unix-dateTime()) div seconds(0.001)</eg>
             <item><p>hours, minutes, seconds, and optional timezone (delivering an <code>xs:time</code>)</p></item>
          </ulist>
       	<p>A dynamic error is raised <errorref class="DT" code="0003" /> if the timezone component of <code>$value</code> is outside the range <code>-PT14H</code> to <code>PT14H</code></p>
-      	<p>A dynamic error is raised <errorref class="DT" code="0006" /> if the hours component of <code>$value</code> is <code>24</code></p>
-        <p>A dynamic error is raised <errorref class="RG" code="0001" /> if any other component of <code>$value</code> is outside the permitted range
-            specified by the target date/time datatype, for example: if <code>minutes</code> is less than zero or
-            greater than 59; or if <code>day</code> is 30 and <code>month</code> is 2.  See <xspecref 
-               spec="DM31" ref="dates-and-times" />.</p>
+        <p>A dynamic error is raised <errorref class="RG" code="0001" /> if a component of <code>$value</code> is outside the permitted range specified by the target date/time datatype, for example: if <code>minutes</code> is less than zero or greater than 59; or if <code>day</code> is 30 and <code>month</code> is 2.  See <xspecref spec="DM31" ref="dates-and-times" />.</p>
       </fos:errors>
       <fos:notes>
          <p>Components that are present in <code>$value</code> but with an empty value are treated

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -11487,10 +11487,10 @@ return ($value - unix-dateTime()) div seconds(0.001)</eg>
          </ulist>
       	<p>A dynamic error is raised <errorref class="DT" code="0003" /> if the timezone component of <code>$value</code> is outside the range <code>-PT14H</code> to <code>PT14H</code></p>
       	<p>A dynamic error is raised <errorref class="DT" code="0006" /> if the hours component of <code>$value</code> is <code>24</code></p>
-         <p><A dynamic error is raised <errorref class="RG" code="0001" /> if any other component of <code>$value</code> is outside the permitted range
+        <p>A dynamic error is raised <errorref class="RG" code="0001" /> if any other component of <code>$value</code> is outside the permitted range
             specified by the target date/time datatype, for example: if <code>minutes</code> is less than zero or
             greater than 59; or if <code>day</code> is 30 and <code>month</code> is 2.  See <xspecref 
-               spec="DM31" ref="dates-and-times".</p>
+               spec="DM31" ref="dates-and-times" />.</p>
       </fos:errors>
       <fos:notes>
          <p>Components that are present in <code>$value</code> but with an empty value are treated

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -14325,6 +14325,9 @@ ISBN 0 521 77752 6.</bibl>
                <p>Raised by <code>build-dateTime</code> if the set of fields supplied does not correspond to those present in one of the
                   <termref def="dt-gregorian"/> types.</p> 
             </error>           
+			<error class="DT" code="0006" label="Invalid hour value" type="dynamic">
+               <p>Raised by <function>fn:build-dateTime</function> if the hours field has the value <code>24</code>.</p> 
+            </error>
 			<error class="FD" code="1340" label="Invalid date/time formatting parameters."
                    type="dynamic">
                <p>This error is raised if the picture string or calendar supplied to <function>fn:format-date</function>, <function>fn:format-time</function>, 

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -14325,9 +14325,6 @@ ISBN 0 521 77752 6.</bibl>
                <p>Raised by <code>build-dateTime</code> if the set of fields supplied does not correspond to those present in one of the
                   <termref def="dt-gregorian"/> types.</p> 
             </error>           
-			<error class="DT" code="0006" label="Invalid hour value" type="dynamic">
-               <p>Raised by <function>fn:build-dateTime</function> if the hours field has the value <code>24</code>.</p> 
-            </error>
 			<error class="FD" code="1340" label="Invalid date/time formatting parameters."
                    type="dynamic">
                <p>This error is raised if the picture string or calendar supplied to <function>fn:format-date</function>, <function>fn:format-time</function>, 

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -14324,11 +14324,7 @@ ISBN 0 521 77752 6.</bibl>
             <error class="DT" code="0005" label="Invalid combination of date/time fields" type="dynamic">
                <p>Raised by <code>build-dateTime</code> if the set of fields supplied does not correspond to those present in one of the
                   <termref def="dt-gregorian"/> types.</p> 
-            </error>
-            <error class="DT" code="0006" label="Invalid component of date/time vallue" type="dynamic">
-               <p>Raised by <code>build-dateTime</code> if one of the fields supplied has a value that is outside the
-                  supported range.</p> 
-            </error>
+            </error>           
 			<error class="FD" code="1340" label="Invalid date/time formatting parameters."
                    type="dynamic">
                <p>This error is raised if the picture string or calendar supplied to <function>fn:format-date</function>, <function>fn:format-time</function>, 


### PR DESCRIPTION
Replaces https://github.com/qt4cg/qtspecs/pull/2599 to fix #2568

Error code `FODT0006` is retained but reserved only for reporting when the value of `hours` is 24.  This is the only rule that applies to a valid combination of components, that diverges from the existing rules for the date/time constructors.