### PR TITLE
2602 EXPath file and binary modules as optional features

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -20663,7 +20663,7 @@ return { "width": $int16-at($loc + 5),
                   <td><p><code>xs:boolean</code></p></td>
                   <td><p>Returns <code>true</code> if the processor offers the ability
                      to add schema components to the static context, using the schema import
-                     mechanism of XSLT or XQuery, or otherwise. The property indicates whether
+                     mechanism of XSLT or XQuery, or <code>false</code> otherwise. The property indicates whether
                      the processor has this capability, not whether a schema has actually been imported.</p></td>
                </tr>               
                <tr>
@@ -20671,20 +20671,21 @@ return { "width": $int16-at($loc + 5),
                   <td><p><code>xs:boolean</code></p></td>
                   <td><p>Returns <code>true</code> if the processor is capable of handling
                   nodes with a type annotation other than <code>xs:untyped</code> and <code>xs:untypedAtomic</code>,
-                  or <code>"no"</code> otherwise.</p></td>
+                  or <code>false</code> otherwise.</p></td>
                </tr>
                <tr>
                   <td><code>#supports-xinclude</code></td>
                   <td><p><code>xs:boolean</code></p></td>
                   <td><p>Returns <code>true</code> if the processor supports the option <code>"xinclude":true()</code>
-                        in calls to <function>fn:doc</function> and <function>fn:parse-xml</function>.</p></td>
+                        in calls to <function>fn:doc</function> and <function>fn:parse-xml</function>; otherwise <code>false</code>.
+                        </p></td>
                </tr>
                <tr>
                   <td><code>#supports-dtd</code></td>
                   <td><p><code>xs:boolean</code></p></td>
-                  <td><p>Returns <code>true</code> if the processor supports validation, entity expansion,
+                  <td><p>Returns <code>true</code> if the processor fully supports validation, entity expansion,
                         and attribute typing (recognition of ID and IDREF attributes) based on DTD processing 
-                        during XML parsing. Returns false if there are restrictions, even if some of these 
+                        during XML parsing. Returns <code>false</code> if there are restrictions, even if some of these 
                         capabilities are available.</p></td>
                </tr>
                <tr>
@@ -20732,6 +20733,10 @@ return { "width": $int16-at($loc + 5),
          <p>As indicated in the examples below, a call on this function will often be be followed
          by the lookup operator <code>?</code> and a key specifier in the form of a no-namespace
          QName literal such as <code>#xpath-version</code>.</p>
+         <p>In cases where a processor supports capability such as XInclude or DTD processing, but
+         the resources available to that capability are restricted for security or other operational
+         reasons, the returned property value should be <code>true</code>, unless the capability
+         has been disabled completely.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -20705,6 +20705,18 @@ return { "width": $int16-at($loc + 5),
                   <td><p>Returns <code>true</code> if the processor supports the use of the
                         <function>fn:transform</function> function.</p></td>
                </tr>
+               <tr>
+                  <td><code>#supports-binary-library</code></td>
+                  <td><p><code>xs:boolean</code></p></td>
+                  <td><p>Returns <code>true</code> if the static context includes implementations
+                        of the functions defined in <bibref ref="expath-binary-40"/>.</p></td>
+               </tr>
+               <tr>
+                  <td><code>#supports-file-library</code></td>
+                  <td><p><code>xs:boolean</code></p></td>
+                  <td><p>Returns <code>true</code> if the static context includes implementations
+                        of the functions defined in <bibref ref="expath-file-40"/>.</p></td>
+               </tr>
             </tbody>
          </table>
          

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -6125,7 +6125,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
          <p>The function <function>fn:unparsed-binary</function> reads an external resource and returns
          is content as an <code>xs:base64Binary</code> value.</p>
          
-         <p>A library of functions specific to processing of binary data can be found in <bibref ref="binary-40"/>.</p>
+         <p>A library of functions specific to processing of binary data can be found in <bibref ref="expath-binary-40"/>.</p>
          <!--<div2 id="binary-value-comparisons">
             <head>Comparing base64Binary and hexBinary values</head>
             <p diff="chg" at="2023-11-03">The following comparison operators on 
@@ -13963,8 +13963,13 @@ Consortium. <emph>XML Information Set (Second Edition).</emph> W3C Recommendatio
                  <emph>CITATION: T.B.D.</emph>
                </bibl>
                
-               <bibl  id="binary-40"
+               <bibl  id="expath-binary-40"
                       key="EXPath Binary Module 4.0">
+                 <emph>CITATION: T.B.D.</emph>
+               </bibl>
+               
+               <bibl  id="expath-file-40"
+                      key="EXPath File Module 4.0">
                  <emph>CITATION: T.B.D.</emph>
                </bibl>
  

--- a/specifications/xquery-40/src/back-matter.xml
+++ b/specifications/xquery-40/src/back-matter.xml
@@ -553,6 +553,10 @@ of the declared type).</p></item><item role="xquery"><p>Limits on ranges of valu
 <head>Normative References</head>
 
 <blist>
+  
+  <bibl id="expath-binary-40" key="EXPath Binary Module 4.0"><emph>TODO</emph></bibl>
+  
+  <bibl id="expath-file-40" key="EXPath File Module 4.0"><emph>TODO</emph></bibl>
 
 <bibl id="RFC2119" key="RFC2119">S. Bradner.
       <emph>Key Words for use in RFCs to Indicate Requirement Levels.</emph> IETF RFC 2119.

--- a/specifications/xquery-40/src/conformance.xml
+++ b/specifications/xquery-40/src/conformance.xml
@@ -13,6 +13,9 @@
           The module feature is no longer an optional feature; processing of library modules
           is now required.
         </change>
+        <change issue="2602" role="xquery">
+          The EXPath binary and file modules are now categorized as optional features.
+        </change>
     </changes>
 
     
@@ -157,26 +160,6 @@
         </div3>
 
         
-        <!--<div3 id="id-module-feature">
-            <head>Module Feature</head>
-            <p>
-                <termdef id="dt-module-feature" term="module feature">The <term>Module
-                        Feature</term> allows a query Prolog to contain a <term>Module Import</term>
-                    and allows <term>library modules</term> to be created.</termdef>
-            </p>
-            <p>An implementation that does not provide the Module Feature <termref def="must"
-                    >MUST</termref> raise a <termref def="dt-static-error">static error</termref>
-                <errorref class="ST" code="0016"/> if it encounters a <termref
-                    def="dt-module-declaration">module declaration</termref> or a <termref
-                    def="dt-module-import">module import</termref>. Since a <termref
-                    def="dt-module-declaration">module declaration</termref> is required in a
-                    <termref def="dt-library-module">library module</termref>, the Module Feature is
-                required in order to create a <termref def="dt-library-module">library module</termref>. </p>
-            <note>
-                <p>In the absence of the Module Feature, each query consists of a single <termref
-                        def="dt-main-module">main module</termref>.</p>
-            </note>
-        </div3>-->
         <div3 id="id-serialization-feature">
             <head>Serialization Feature</head>
             <p>
@@ -210,36 +193,85 @@
                     such as a persistent DOM.</p>
             </note>
         </div3>
-
-        <div3 id="id-higher-order-function-feature" diff="del" at="2023-01-29">
-            <head>Higher-Order Function Feature</head>
+        
+        <div3 id="id-expath-binary-feature">
+            <head>Binary Library Feature</head>
             <p>
-                The <term>Higher Order Function Feature</term> allows an expression to evaluate
-                    to a function item other than a map or array.
-            </p>
+                <termdef id="dt-binary-library-feature" term="binary library feature">The
+                        <term>Binary Library Feature</term> provides a set of functions
+                    for manipulating binary data, specifically, atomic values of type
+                    <code>xs:base64Binary</code> and <code>xs:hexBinary</code>.</termdef></p>
+            
+            <p>These functions are defined in <bibref ref="expath-binary-40"/>.</p>
+            
+            <p>An implementation claiming conformance to this feature <rfc2119>must</rfc2119>:</p>
+            
+            <olist>
+                <item><p>Include these functions in the static context of every query module;</p></item>
+                
+                <item><p>Include in the static context of each query module a namespace binding of the
+                prefix <code>"bin"</code> to the namespace URI <code>http://expath.org/ns/binary</code>
+                (subject to the same rules as other predeclared namespace bindings: see 
+                <specref ref="id-namespaces-and-qnames"/>);</p></item>
 
-            <p>An implementation that does not provide the Higher-Order Function Feature <termref
-                    def="must">MUST</termref> raise a static error [...] if it encounters a  
-                    <nt def="TypedFunctionType">TypedFunctionType</nt>, <termref
-                    def="dt-named-function-ref">named function reference</termref>, <termref
-                    def="dt-inline-func">inline function expression</termref>, or <termref
-                    def="dt-partial-function-application">partial function application</termref>.  
-                    The effect of this rule is that it is impossible to construct function items other than maps and arrays.
-                    Dynamic function calls are permitted, but the function that is called will necessarily be a map or array.
-                    The <nt def="AnyFunctionType">AnyFunctionType</nt> <termref def="dt-sequence-type">sequence type</termref> is permitted and will match either a map 
-                    or array.
-                Such an implementation <termref def="may">MAY</termref> raise a type error <errorref
-                    class="TY" code="0004"/> if an expression evaluates to a sequence that contains
-                a function.</p>
-
-            <p>If an implementation provides the Higher-Order Function Feature, then it <termref def="must">MUST</termref> provide
-                    all <xtermref spec="FO40" ref="dt-higher-order"/> functions defined in <bibref ref="xpath-functions-40"/>.
-                If an implementation does not provide the Higher
-                Order Function Feature, a <termref def="dt-static-error">static error</termref> is
-                raised <errorref class="ST" code="0017"/> if any of these functions is present in a
-                query. </p>
+                <item><p>Return <code>true</code> as the result of the expression
+                <code>fn:system-properties()?#supports-binary-library</code>.</p></item>
+            </olist>
+            
+            <p>An implementation that does not claim conformance to this feature:</p>
+            
+            <olist>
+                <item><p><rfc2119>May</rfc2119> provide a subset of the functions;</p></item>
+                <item><p><rfc2119>May</rfc2119> predeclare the <code>"bin"</code> namespace;</p></item>
+                <item><p><rfc2119>Must not</rfc2119> provide any functions in the <code>"bin"</code> namespace
+                        that do not conform to the cited specification;</p></item>
+                <item><p><rfc2119>Must</rfc2119> return <code>false</code> as the result of the expression
+                <code>fn:system-properties()?#supports-binary-library</code>.</p></item>
+            </olist>
 
         </div3>
+        
+        <div3 id="id-expath-file-feature">
+            <head>File Library Feature</head>
+            <p>
+                <termdef id="dt-file-library-feature" term="file library feature">The
+                        <term>File Library Feature</term> provides a set of functions
+                    for manipulating files in an external filestore.</termdef></p>
+            
+            <p>These functions are defined in <bibref ref="expath-file-40"/>.</p>
+            
+            <p>An implementation claiming conformance to this feature <rfc2119>must</rfc2119>:</p>
+            
+            <olist>
+                <item><p>Include these functions in the static context of every query module;</p></item>
+                
+                <item><p>Include in the static context of each query module a namespace binding of the
+                prefix <code>"file"</code> to the namespace URI <code>http://expath.org/ns/file</code>
+                (subject to the same rules as other predeclared namespace bindings: see 
+                <specref ref="id-namespaces-and-qnames"/>);</p></item>
+
+                <item><p>Return <code>true</code> as the result of the expression
+                <code>fn:system-properties()?#supports-file-library</code>.</p></item>
+                
+                <item><p>Provide <termref def="dt-implementation-defined"/> mechanisms
+                enabling predictable results from the invocation of functions with
+                side-effects: see <specref ref="functional-purity"/>.</p></item>
+            </olist>
+            
+            <p>An implementation that does not claim conformance to this feature:</p>
+            
+            <olist>
+                <item><p><rfc2119>May</rfc2119> provide a subset of the functions;</p></item>
+                <item><p><rfc2119>May</rfc2119> predeclare the <code>"file"</code> namespace;</p></item>
+                <item><p><rfc2119>Must not</rfc2119> provide any functions in the <code>"file"</code> namespace
+                        that do not conform to the cited specification;</p></item>
+                <item><p><rfc2119>Must</rfc2119> return <code>false</code> as the result of the expression
+                <code>fn:system-properties()?#supports-file-library</code>.</p></item>
+            </olist>
+
+        </div3>
+
+        
 
         
 

--- a/specifications/xquery-40/src/conformance.xml
+++ b/specifications/xquery-40/src/conformance.xml
@@ -13,7 +13,7 @@
           The module feature is no longer an optional feature; processing of library modules
           is now required.
         </change>
-        <change issue="2602" role="xquery">
+        <change issue="2602" PR="2603" date="2026-05-05" role="xquery">
           The EXPath binary and file modules are now categorized as optional features.
         </change>
     </changes>
@@ -204,29 +204,32 @@
             
             <p>These functions are defined in <bibref ref="expath-binary-40"/>.</p>
             
-            <p>An implementation claiming conformance to this feature <rfc2119>must</rfc2119>:</p>
+            <p>An implementation claiming conformance to this feature:</p>
             
             <olist>
-                <item><p>Include these functions in the static context of every query module;</p></item>
+                <item><p><rfc2119>Must</rfc2119> include these functions in the static context of every query module;</p></item>
                 
-                <item><p>Include in the static context of each query module a namespace binding of the
+                <item><p><rfc2119>Must</rfc2119> include in the static context of each query module a namespace binding of the
                 prefix <code>"bin"</code> to the namespace URI <code>http://expath.org/ns/binary</code>
                 (subject to the same rules as other predeclared namespace bindings: see 
                 <specref ref="id-namespaces-and-qnames"/>);</p></item>
 
-                <item><p>Return <code>true</code> as the result of the expression
+                <item><p><rfc2119>Must</rfc2119> return <code>true</code> as the result of the expression
                 <code>fn:system-properties()?#supports-binary-library</code>.</p></item>
+                
+                <item><p><rfc2119>Must not</rfc2119> include in the static context any function in the namespace 
+                        <code>http://expath.org/ns/binary</code> other than a function defined in the cited specification.</p></item>
             </olist>
             
             <p>An implementation that does not claim conformance to this feature:</p>
             
             <olist>
-                <item><p><rfc2119>May</rfc2119> provide a subset of the functions;</p></item>
+                <item><p><rfc2119>May</rfc2119> provide a subset of the functions, provided these conform to the cited specification;</p></item>
                 <item><p><rfc2119>May</rfc2119> predeclare the <code>"bin"</code> namespace;</p></item>
-                <item><p><rfc2119>Must not</rfc2119> provide any functions in the <code>"bin"</code> namespace
-                        that do not conform to the cited specification;</p></item>
                 <item><p><rfc2119>Must</rfc2119> return <code>false</code> as the result of the expression
                 <code>fn:system-properties()?#supports-binary-library</code>.</p></item>
+                <item><p><rfc2119>Must not</rfc2119> include in the static context any function in the namespace 
+                        <code>http://expath.org/ns/binary</code> other than a function defined in the cited specification.</p></item>
             </olist>
 
         </div3>
@@ -240,33 +243,37 @@
             
             <p>These functions are defined in <bibref ref="expath-file-40"/>.</p>
             
-            <p>An implementation claiming conformance to this feature <rfc2119>must</rfc2119>:</p>
+            <p>An implementation claiming conformance to this feature:</p>
             
             <olist>
-                <item><p>Include these functions in the static context of every query module;</p></item>
+                <item><p><rfc2119>Must</rfc2119> include these functions in the static context of every query module;</p></item>
                 
-                <item><p>Include in the static context of each query module a namespace binding of the
+                <item><p><rfc2119>Must</rfc2119> include in the static context of each query module a namespace binding of the
                 prefix <code>"file"</code> to the namespace URI <code>http://expath.org/ns/file</code>
                 (subject to the same rules as other predeclared namespace bindings: see 
                 <specref ref="id-namespaces-and-qnames"/>);</p></item>
 
-                <item><p>Return <code>true</code> as the result of the expression
+                <item><p><rfc2119>Must</rfc2119> return <code>true</code> as the result of the expression
                 <code>fn:system-properties()?#supports-file-library</code>.</p></item>
                 
-                <item><p>Provide <termref def="dt-implementation-defined"/> mechanisms
+                <item><p><rfc2119>Must</rfc2119> provide <termref def="dt-implementation-defined"/> mechanisms
                 enabling predictable results from the invocation of functions with
                 side-effects: see <specref ref="functional-purity"/>.</p></item>
+                
+                <item><p><rfc2119>Must not</rfc2119> include in the static context any function in the namespace 
+                        <code>http://expath.org/ns/file</code> other than a function defined in the cited specification.</p></item>
             </olist>
             
             <p>An implementation that does not claim conformance to this feature:</p>
             
             <olist>
-                <item><p><rfc2119>May</rfc2119> provide a subset of the functions;</p></item>
+                <item><p><rfc2119>May</rfc2119> provide a subset of the functions, provided these conform to the cited specification;</p></item>
                 <item><p><rfc2119>May</rfc2119> predeclare the <code>"file"</code> namespace;</p></item>
-                <item><p><rfc2119>Must not</rfc2119> provide any functions in the <code>"file"</code> namespace
-                        that do not conform to the cited specification;</p></item>
+ 
                 <item><p><rfc2119>Must</rfc2119> return <code>false</code> as the result of the expression
                 <code>fn:system-properties()?#supports-file-library</code>.</p></item>
+                <item><p><rfc2119>Must not</rfc2119> include in the static context any function in the namespace 
+                        <code>http://expath.org/ns/file</code> other than a function defined in the cited specification.</p></item>
             </olist>
 
         </div3>

--- a/specifications/xquery-40/src/conformance.xml
+++ b/specifications/xquery-40/src/conformance.xml
@@ -209,6 +209,9 @@
             <olist>
                 <item><p><rfc2119>Must</rfc2119> include these functions in the static context of every query module;</p></item>
                 
+                <item><p><rfc2119>Must not</rfc2119> include in the static context any function in the namespace 
+                        <code>http://expath.org/ns/binary</code> other than a function defined in the cited specification.</p></item>
+                
                 <item><p><rfc2119>Must</rfc2119> include in the static context of each query module a namespace binding of the
                 prefix <code>"bin"</code> to the namespace URI <code>http://expath.org/ns/binary</code>
                 (subject to the same rules as other predeclared namespace bindings: see 
@@ -217,19 +220,21 @@
                 <item><p><rfc2119>Must</rfc2119> return <code>true</code> as the result of the expression
                 <code>fn:system-properties()?#supports-binary-library</code>.</p></item>
                 
-                <item><p><rfc2119>Must not</rfc2119> include in the static context any function in the namespace 
-                        <code>http://expath.org/ns/binary</code> other than a function defined in the cited specification.</p></item>
+                
             </olist>
             
             <p>An implementation that does not claim conformance to this feature:</p>
             
             <olist>
                 <item><p><rfc2119>May</rfc2119> provide a subset of the functions, provided these conform to the cited specification;</p></item>
+                
+                <item><p><rfc2119>Must not</rfc2119> include in the static context any function in the namespace 
+                        <code>http://expath.org/ns/binary</code> other than a function defined in the cited specification.</p></item>
+                
                 <item><p><rfc2119>May</rfc2119> predeclare the <code>"bin"</code> namespace;</p></item>
                 <item><p><rfc2119>Must</rfc2119> return <code>false</code> as the result of the expression
                 <code>fn:system-properties()?#supports-binary-library</code>.</p></item>
-                <item><p><rfc2119>Must not</rfc2119> include in the static context any function in the namespace 
-                        <code>http://expath.org/ns/binary</code> other than a function defined in the cited specification.</p></item>
+                
             </olist>
 
         </div3>
@@ -248,6 +253,9 @@
             <olist>
                 <item><p><rfc2119>Must</rfc2119> include these functions in the static context of every query module;</p></item>
                 
+                <item><p><rfc2119>Must not</rfc2119> include in the static context any function in the namespace 
+                        <code>http://expath.org/ns/file</code> other than a function defined in the cited specification.</p></item>
+                
                 <item><p><rfc2119>Must</rfc2119> include in the static context of each query module a namespace binding of the
                 prefix <code>"file"</code> to the namespace URI <code>http://expath.org/ns/file</code>
                 (subject to the same rules as other predeclared namespace bindings: see 
@@ -260,20 +268,20 @@
                 enabling predictable results from the invocation of functions with
                 side-effects: see <specref ref="functional-purity"/>.</p></item>
                 
-                <item><p><rfc2119>Must not</rfc2119> include in the static context any function in the namespace 
-                        <code>http://expath.org/ns/file</code> other than a function defined in the cited specification.</p></item>
+               
             </olist>
             
             <p>An implementation that does not claim conformance to this feature:</p>
             
             <olist>
                 <item><p><rfc2119>May</rfc2119> provide a subset of the functions, provided these conform to the cited specification;</p></item>
+                <item><p><rfc2119>Must not</rfc2119> include in the static context any function in the namespace 
+                        <code>http://expath.org/ns/file</code> other than a function defined in the cited specification.</p></item>
                 <item><p><rfc2119>May</rfc2119> predeclare the <code>"file"</code> namespace;</p></item>
  
                 <item><p><rfc2119>Must</rfc2119> return <code>false</code> as the result of the expression
                 <code>fn:system-properties()?#supports-file-library</code>.</p></item>
-                <item><p><rfc2119>Must not</rfc2119> include in the static context any function in the namespace 
-                        <code>http://expath.org/ns/file</code> other than a function defined in the cited specification.</p></item>
+                
             </olist>
 
         </div3>

--- a/specifications/xslt-40/src/function-catalog.xml
+++ b/specifications/xslt-40/src/function-catalog.xml
@@ -2150,15 +2150,15 @@ serialize($input, {
             <item>
                <p>
                   <code>xsl:supports-binary-library</code>, returns the string
-                     <code>"yes"</code> if the processor supports the function library
-                  defined in <specref ref="expath-binary-40"/>: see <specref ref="id-expath-binary-feature"/>.</p>
+                     <code>"yes"</code> if the processor supports the <termref def="dt-binary-library-feature"/>
+                  (see <specref ref="id-expath-binary-feature"/>); otherwise it returns the string <code>"no"</code>.</p>
 
             </item>
             <item>
                <p>
                   <code>xsl:supports-file-library</code>, returns the string
-                     <code>"yes"</code> if the processor supports the function library
-                  defined in <specref ref="expath-file-40"/>: see <specref ref="id-expath-file-feature"/>.</p>
+                     <code>"yes"</code> if the processor supports the <termref def="dt-file-library-feature"/> 
+                  (see <specref ref="id-expath-file-feature"/>); otherwise it returns the string <code>"no"</code>.</p>
 
             </item>
             <item>

--- a/specifications/xslt-40/src/function-catalog.xml
+++ b/specifications/xslt-40/src/function-catalog.xml
@@ -2148,6 +2148,20 @@ serialize($input, {
 
             </item>
             <item>
+               <p>
+                  <code>xsl:supports-binary-library</code>, returns the string
+                     <code>"yes"</code> if the processor supports the function library
+                  defined in <specref ref="expath-binary-40"/>: see <specref ref="id-expath-binary-feature"/>.</p>
+
+            </item>
+            <item>
+               <p>
+                  <code>xsl:supports-file-library</code>, returns the string
+                     <code>"yes"</code> if the processor supports the function library
+                  defined in <specref ref="expath-file-40"/>: see <specref ref="id-expath-file-feature"/>.</p>
+
+            </item>
+            <item>
                <p diff="chg" at="2023-01-29">
                   <code>xsl:supports-higher-order-functions</code>, always returns the string
                   <code>"yes"</code>.</p>
@@ -2231,6 +2245,7 @@ serialize($input, {
       </fos:notes>
       <fos:changes>
          <fos:change issue="1242" PR="1243" date="2024-04-28"><p>Changed as necessary for version 4.0</p></fos:change>
+         <fos:change issue="2602"><p>The EXPath file and binary modules are now categorized as optional features.</p></fos:change>
       </fos:changes>
    </fos:function>
    

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -31537,6 +31537,12 @@ the same group, and the-->
             <item>
                <p>The streaming feature, defined in <specref ref="streaming-feature"/>.</p>
             </item>
+            <item>
+               <p>The <termref def="dt-binary-library-feature"/>, defined in <specref ref="id-expath-binary-feature"/>.</p>
+            </item>
+            <item>
+               <p>The <termref def="dt-file-library-feature"/>, defined in <specref ref="id-expath-file-feature"/>.</p>
+            </item>
            
             
          </olist>
@@ -31888,6 +31894,9 @@ the same group, and the-->
             
             <olist>
                 <item><p><rfc2119>Must</rfc2119> include these functions in the static context of every stylesheet module;</p></item>
+               
+                <item><p><rfc2119>Must not</rfc2119> include in the static context any function in the namespace 
+                        <code>http://expath.org/ns/binary</code> other than a function defined in the cited specification.</p></item>
                 
                 <item><p><rfc2119>Must</rfc2119> add to the set of standard namespaces (see <specref ref="reserved-namespaces"/>) 
                       a namespace binding of the
@@ -31899,14 +31908,17 @@ the same group, and the-->
                 <item><p><rfc2119>Must</rfc2119> return <code>true</code> as the result of the expression
                 <code>fn:system-properties()?#supports-binary-library</code>.</p></item>
                
-               <item><p><rfc2119>Must not</rfc2119> include in the static context any function in the namespace 
-                        <code>http://expath.org/ns/binary</code> other than a function defined in the cited specification.</p></item>
+               
             </olist>
             
             <p>An implementation that does not claim conformance to this feature:</p>
             
             <olist>
                 <item><p><rfc2119>May</rfc2119> provide a subset of the functions, provided they conform to the cited specification;</p></item>
+               
+                <item><p><rfc2119>Must not</rfc2119> include in the static context any function in the namespace 
+                        <code>http://expath.org/ns/binary</code> other than a function defined in the cited specification.</p></item>
+               
                 <item><p><rfc2119>May</rfc2119> predeclare the <code>"bin"</code> namespace;</p></item>
 
                 <item><p><rfc2119>Must</rfc2119> return <code>"no"</code> as the result of the expression
@@ -31915,8 +31927,7 @@ the same group, and the-->
                 <item><p><rfc2119>Must</rfc2119> return <code>false</code> as the result of the expression
                 <code>fn:system-properties()?#supports-binary-library</code>.</p></item>
                
-               <item><p><rfc2119>Must not</rfc2119> include in the static context any function in the namespace 
-                        <code>http://expath.org/ns/binary</code> other than a function defined in the cited specification.</p></item>
+               
             </olist>
 
         </div2>
@@ -31930,20 +31941,25 @@ the same group, and the-->
             
             <p>These functions are defined in <bibref ref="expath-file-40"/>.</p>
             
-            <p>An implementation claiming conformance to this feature <rfc2119>must</rfc2119>:</p>
+            <p>An implementation claiming conformance to this feature:</p>
             
             <olist>
-                <item><p>Include these functions in the static context of every query module;</p></item>
+                <item><p><rfc2119>Must</rfc2119> include these functions in the static context of every query module;</p></item>
+               
+                <item><p><rfc2119>Must not</rfc2119> include in the static context any function in the namespace 
+                        <code>http://expath.org/ns/file</code> other than a function defined in the cited specification.</p></item>
                 
-                <item><p>Add to the set of standard namespaces (see <specref ref="reserved-namespaces"/>) 
+                <item><p><rfc2119>Must</rfc2119> add to the set of standard namespaces (see <specref ref="reserved-namespaces"/>) 
                       a namespace binding of the
                 prefix <code>"file"</code> to the namespace URI <code>http://expath.org/ns/file</code>;</p></item>
 
+                <item><p><rfc2119>Must</rfc2119> return <code>"yes"</code> as the result of the expression
+                <code>fn:system-property(#xsl:supports-file-library)</code>.</p></item>
 
-                <item><p>Return <code>true</code> as the result of the expression
+                <item><p><rfc2119>Must</rfc2119> return <code>true</code> as the result of the expression
                 <code>fn:system-properties()?#supports-file-library</code>.</p></item>
                 
-                <item><p>Provide <termref def="dt-implementation-defined"/> mechanisms
+                <item><p><rfc2119>Must</rfc2119> provide <termref def="dt-implementation-defined"/> mechanisms
                 enabling predictable results from the invocation of functions with
                 side-effects: see <xspecref spec="XP40" ref="functional-purity"/>.</p></item>
             </olist>
@@ -31952,9 +31968,13 @@ the same group, and the-->
             
             <olist>
                 <item><p><rfc2119>May</rfc2119> provide a subset of the functions;</p></item>
+                <item><p><rfc2119>Must not</rfc2119> include in the static context any function in the namespace 
+                        <code>http://expath.org/ns/binary</code> other than a function defined in the cited specification.</p></item>
                 <item><p><rfc2119>May</rfc2119> predeclare the <code>"file"</code> namespace;</p></item>
                 <item><p><rfc2119>Must not</rfc2119> provide any functions in the <code>"file"</code> namespace
                         that do not conform to the cited specification;</p></item>
+                <item><p><rfc2119>Must</rfc2119> return <code>"no"</code> as the result of the expression
+                <code>fn:system-property(#xsl:supports-file-library)</code>.</p></item>
                 <item><p><rfc2119>Must</rfc2119> return <code>false</code> as the result of the expression
                 <code>fn:system-properties()?#supports-file-library</code>.</p></item>
             </olist>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -31514,6 +31514,9 @@ the same group, and the-->
                The dynamic evaluation feature no longer exists; processor are now required
                to support the <elcode>xsl:evaluate</elcode> instruction.
             </change>
+            <change issue="2602">
+               The EXPath binary and file modules are now categorized as optional features.
+            </change>
          </changes>
          
          <p>A <termref def="dt-processor">processor</termref> that claims
@@ -31869,6 +31872,89 @@ the same group, and the-->
 
 
          </div2>
+         
+         
+         <div2 id="id-expath-binary-feature">
+            <head>Binary Library Feature</head>
+            <p>
+                <termdef id="dt-binary-library-feature" term="binary library feature">The
+                        <term>Binary Library Feature</term> provides a set of functions
+                    for manipulating binary data, specifically, atomic values of type
+                    <code>xs:base64Binary</code> and <code>xs:hexBinary</code>.</termdef></p>
+            
+            <p>These functions are defined in <bibref ref="expath-binary-40"/>.</p>
+            
+            <p>An implementation claiming conformance to this feature <rfc2119>must</rfc2119>:</p>
+            
+            <olist>
+                <item><p>Include these functions in the static context of every stylesheet module;</p></item>
+                
+                <item><p>Add to the set of standard namespaces (see <specref ref="reserved-namespaces"/>) 
+                      a namespace binding of the
+                prefix <code>"bin"</code> to the namespace URI <code>http://expath.org/ns/binary</code>;</p></item>
+
+                <item><p>Return <code>"yes"</code> as the result of the expression
+                <code>fn:system-property(#xsl:supports-binary-library)</code>.</p></item>
+
+                <item><p>Return <code>true</code> as the result of the expression
+                <code>fn:system-properties()?#supports-binary-library</code>.</p></item>
+            </olist>
+            
+            <p>An implementation that does not claim conformance to this feature:</p>
+            
+            <olist>
+                <item><p><rfc2119>May</rfc2119> provide a subset of the functions;</p></item>
+                <item><p><rfc2119>May</rfc2119> predeclare the <code>"bin"</code> namespace;</p></item>
+                <item><p><rfc2119>Must not</rfc2119> provide any functions in the <code>"bin"</code> namespace
+                        that do not conform to the cited specification;</p></item>
+                <item><p><rfc2119>Must</rfc2119> return <code>"no"</code> as the result of the expression
+                <code>fn:system-property(#xsl:supports-binary-library)</code>.</p></item>
+
+                <item><p><rfc2119>Must</rfc2119> return <code>false</code> as the result of the expression
+                <code>fn:system-properties()?#supports-binary-library</code>.</p></item>
+            </olist>
+
+        </div2>
+        
+        <div2 id="id-expath-file-feature">
+            <head>File Library Feature</head>
+            <p>
+                <termdef id="dt-file-library-feature" term="file library feature">The
+                        <term>File Library Feature</term> provides a set of functions
+                    for manipulating files in an external filestore.</termdef></p>
+            
+            <p>These functions are defined in <bibref ref="expath-file-40"/>.</p>
+            
+            <p>An implementation claiming conformance to this feature <rfc2119>must</rfc2119>:</p>
+            
+            <olist>
+                <item><p>Include these functions in the static context of every query module;</p></item>
+                
+                <item><p>Add to the set of standard namespaces (see <specref ref="reserved-namespaces"/>) 
+                      a namespace binding of the
+                prefix <code>"file"</code> to the namespace URI <code>http://expath.org/ns/file</code>;</p></item>
+
+
+                <item><p>Return <code>true</code> as the result of the expression
+                <code>fn:system-properties()?#supports-file-library</code>.</p></item>
+                
+                <item><p>Provide <termref def="dt-implementation-defined"/> mechanisms
+                enabling predictable results from the invocation of functions with
+                side-effects: see <xspecref spec="XP40" ref="functional-purity"/>.</p></item>
+            </olist>
+            
+            <p>An implementation that does not claim conformance to this feature:</p>
+            
+            <olist>
+                <item><p><rfc2119>May</rfc2119> provide a subset of the functions;</p></item>
+                <item><p><rfc2119>May</rfc2119> predeclare the <code>"file"</code> namespace;</p></item>
+                <item><p><rfc2119>Must not</rfc2119> provide any functions in the <code>"file"</code> namespace
+                        that do not conform to the cited specification;</p></item>
+                <item><p><rfc2119>Must</rfc2119> return <code>false</code> as the result of the expression
+                <code>fn:system-properties()?#supports-file-library</code>.</p></item>
+            </olist>
+
+        </div2>
          
   
          

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -31514,7 +31514,7 @@ the same group, and the-->
                The dynamic evaluation feature no longer exists; processor are now required
                to support the <elcode>xsl:evaluate</elcode> instruction.
             </change>
-            <change issue="2602">
+            <change issue="2602" PR="2603" date="2026-05-05">
                The EXPath binary and file modules are now categorized as optional features.
             </change>
          </changes>
@@ -31884,34 +31884,39 @@ the same group, and the-->
             
             <p>These functions are defined in <bibref ref="expath-binary-40"/>.</p>
             
-            <p>An implementation claiming conformance to this feature <rfc2119>must</rfc2119>:</p>
+            <p>An implementation claiming conformance to this feature:</p>
             
             <olist>
-                <item><p>Include these functions in the static context of every stylesheet module;</p></item>
+                <item><p><rfc2119>Must</rfc2119> include these functions in the static context of every stylesheet module;</p></item>
                 
-                <item><p>Add to the set of standard namespaces (see <specref ref="reserved-namespaces"/>) 
+                <item><p><rfc2119>Must</rfc2119> add to the set of standard namespaces (see <specref ref="reserved-namespaces"/>) 
                       a namespace binding of the
                 prefix <code>"bin"</code> to the namespace URI <code>http://expath.org/ns/binary</code>;</p></item>
 
-                <item><p>Return <code>"yes"</code> as the result of the expression
+                <item><p><rfc2119>Must</rfc2119> return <code>"yes"</code> as the result of the expression
                 <code>fn:system-property(#xsl:supports-binary-library)</code>.</p></item>
 
-                <item><p>Return <code>true</code> as the result of the expression
+                <item><p><rfc2119>Must</rfc2119> return <code>true</code> as the result of the expression
                 <code>fn:system-properties()?#supports-binary-library</code>.</p></item>
+               
+               <item><p><rfc2119>Must not</rfc2119> include in the static context any function in the namespace 
+                        <code>http://expath.org/ns/binary</code> other than a function defined in the cited specification.</p></item>
             </olist>
             
             <p>An implementation that does not claim conformance to this feature:</p>
             
             <olist>
-                <item><p><rfc2119>May</rfc2119> provide a subset of the functions;</p></item>
+                <item><p><rfc2119>May</rfc2119> provide a subset of the functions, provided they conform to the cited specification;</p></item>
                 <item><p><rfc2119>May</rfc2119> predeclare the <code>"bin"</code> namespace;</p></item>
-                <item><p><rfc2119>Must not</rfc2119> provide any functions in the <code>"bin"</code> namespace
-                        that do not conform to the cited specification;</p></item>
+
                 <item><p><rfc2119>Must</rfc2119> return <code>"no"</code> as the result of the expression
                 <code>fn:system-property(#xsl:supports-binary-library)</code>.</p></item>
 
                 <item><p><rfc2119>Must</rfc2119> return <code>false</code> as the result of the expression
                 <code>fn:system-properties()?#supports-binary-library</code>.</p></item>
+               
+               <item><p><rfc2119>Must not</rfc2119> include in the static context any function in the namespace 
+                        <code>http://expath.org/ns/binary</code> other than a function defined in the cited specification.</p></item>
             </olist>
 
         </div2>


### PR DESCRIPTION
Fix #2602.

The EXPath file and binary modules become optional conformance features in XQuery and XSLT.

Interrogatives for these features are added to the system-property() and system-properties() functions.

Fulfils action QT4CG-158-02