### PR TITLE
2613b Additional notes, examples, and clarifications for xsl:array-member

### DIFF
--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -28875,7 +28875,7 @@ the same group, and the-->
                         
                      </olist>
                            <note><p>It is only necessary to use the <elcode>xsl:array-member</elcode> instruction
-                           when the required array member is not a <termref def="dt-singleton"/>.</p></note>
+                           when the required array member is not an <xtermref spec="DM40" ref="dt-singleton"/>.</p></note>
                            <note><p>When the <code>for-each</code> attribute is present, then it is never necessary
                            to use the <code>xsl:array-member</code> instruction, since each evaluation
                            of the <code>select</code> attribute or the containing sequence constructor

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -28783,12 +28783,15 @@ the same group, and the-->
                   <p>An array can be constructed by selecting members of an existing array, and appending
                   additional members:</p>
                <eg><![CDATA[<xsl:array>
-   <xsl:array-member select="'start'"/               
+   <xsl:array-member select="'start'"/>               
    <xsl:sequence select="[ 1 to 10 ]/*[. mod 2 = 0]"/>
-   <xsl:array-member select="'end'"/   
+   <xsl:array-member select="'end'"/>   
 </xsl:array>                 
                   ]]></eg>
-                  <p>This returns the array <code>[ "start", 2, 4, 6, 8, 10, "end" ]</code>.</p>
+                  <p>This returns the array <code>[ "start", 2, 4, 6, 8, 10, "end" ]</code>. (Note that the expression 
+                  <code>[ 1 to 10 ]/*</code> implicitly wraps the array <code>[ 1 to 10 ]</code> in a root JNode, and then
+                  selects the children of this root JNode as a sequence of ten JNodes, five of which satisfy the predicate
+                  <code>[. mod 2 = 0]</code>.)</p>
                </item>
             </olist>
          
@@ -28796,30 +28799,32 @@ the same group, and the-->
             <p>The detailed rules follow.</p>
             
             <olist>
-               <!--<item><p>In these rules, the term <term>parcel</term> denotes a function item
-               with arity zero having an implementation-defined 
-                  <xtermref spec="DM40" ref="dt-function-annotation">function annotation</xtermref> that identifies
-               it as having been constructed by the <elcode>xsl:array-member</elcode> instruction.
-               The implementation-defined function annotation should use a reserved namespace such
-               that functions with this annotation can be created only by using the
-               <elcode>xsl:array-member</elcode> instruction.</p> 
-                  <p>A parcel encapsulates a value,
-               which may be any sequence; the value of the parcel is the result of calling the
-               corresponding function item with no arguments.</p></item>-->
+               
                <item><p>The effect of the <elcode>xsl:array-member</elcode> instruction is to return
                a <xtermref spec="DM40" ref="dt-JNode">JNode</xtermref> that encapsulates the sequence obtained by evaluating its
                <code>select</code> attribute or its contained sequence constructor.</p>
-               <p>More specifically, the instruction first produces a sequence <var>V</var> by following
-               the same rules as the <elcode>xsl:sequence</elcode> instruction, and then returns
-               a JNode <var>J</var> whose properties are as follows:</p>
-               <ulist>
-                  <item><p><term>·jvalue·</term> = <var>V</var></p></item>
-                  <item><p><term>·jkey·</term> = absent</p></item>
-                  <item><p><term>·jposition·</term> = absent</p></item>
-                  <item><p><term>·jparent·</term> = absent</p></item>
-               </ulist>
-               
-               </item>
+               <p>More specifically, the instruction is evaluated as follows:</p>
+                  <olist>
+                     <item><p>The <code>select</code> attribute or the contained sequence constructor is evaluated
+                     in the same way as for the <elcode>xsl:sequence</elcode> instruction (see <specref ref="constructing-sequences"/>)
+                           to produce a value <var>V0</var>.</p></item>
+                     <item><p>Sequence <var>V1</var> is obtained by replacing any JNode in <var>V0</var> with its
+                           <term>·jvalue·</term> property, recursively.</p>
+                        <note><p>It is not good practice for the <elcode>xsl:array-member</elcode> instruction to
+                        select JNodes, but this rule is designed to avoid problems that might occur when this is done
+                        inadvertently.</p></note>
+                     </item>
+                     <item><p>The instruction returns
+                        a JNode <var>J</var> whose properties are as follows:</p>
+                        <ulist>
+                           <item><p><term>·jvalue·</term> = <var>V1</var></p></item>
+                           <item><p><term>·jkey·</term> = absent</p></item>
+                           <item><p><term>·jposition·</term> = absent</p></item>
+                           <item><p><term>·jparent·</term> = absent</p></item>
+                        </ulist>
+                        </item>
+                  </olist>
+               </item>   
                <item><p>The <elcode>xsl:array</elcode> instruction is evaluated as follows.</p>
                <olist>
                   <item><p>If the <code>for-each</code> attribute is absent, then:</p>
@@ -28869,7 +28874,9 @@ the same group, and the-->
                            <item>Otherwise, the array member is the sequence <var>S</var>.</item>
                         
                      </olist>
-                           <note><p>When the <code>for-each</code> attribute is present, then it is not necessary
+                           <note><p>It is only necessary to use the <elcode>xsl:array-member</elcode> instruction
+                           when the required array member is not a <termref def="dt-singleton"/>.</p></note>
+                           <note><p>When the <code>for-each</code> attribute is present, then it is never necessary
                            to use the <code>xsl:array-member</code> instruction, since each evaluation
                            of the <code>select</code> attribute or the containing sequence constructor
                            generates one array member. However, use of <code>xsl:array-member</code>


### PR DESCRIPTION
Following the discussion of PR #2614 (which was accepted), this PR provides additional notes, clarifications, and examples.

The only substantive change is to deal with the case where the xsl:array-member instruction inadvertently selects JNodes; it avoids double-wrapping these in further JNodes.