### PR TITLE
2612 fn:char: Support \b and \f

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -34272,7 +34272,8 @@ return every($dl/*, fn($elem, $pos) {
             <item><p>A Unicode codepoint, supplied as an integer. For example <code>fn:char(9)</code>
             returns the tab character.</p></item>
             <item><p>An HTML5 character reference name (often referred to as an entity name) as defined
-               at <loc href="https://html.spec.whatwg.org/multipage/named-characters.html">https://html.spec.whatwg.org/multipage/named-characters.html</loc>. The name is
+                  in <bibref ref="html5"/> (see  
+               <loc href="https://html.spec.whatwg.org/multipage/named-characters.html">§13.5, Named character references</loc>). The name is
                written with no leading ampersand and no trailing semicolon.
                For example <code>fn:char("pi")</code> represents the character
                <char>U+03C0</char> and <code>fn:char("nbsp")</code> returns 
@@ -34281,10 +34282,13 @@ return every($dl/*, fn($elem, $pos) {
                   other versions of HTML. Character reference names are case-sensitive.</p>
                <p>In the event that the HTML5 character reference name identifies a string
                comprising multiple codepoints, that string is returned.</p>
-               <p>[TODO: add a proper bibliographic reference.]</p></item>
+            </item>
             <item><p>A backslash-escape sequence from the set <code>\n</code> (<char>U+000A</char>), 
                <code>\r</code> (<char>U+000D</char>),
-               or <code>\t</code> (<char>U+0009</char>).</p></item>
+               <code>\t</code> (<char>U+0009</char>),
+                  <code>\b</code> (<char>U+0008</char>),
+                  or <code>\f</code> (<char>U+000C</char>)
+                  .</p></item>
             
             
          </olist>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -13807,12 +13807,12 @@ If <var>SV</var> is an instance of <code>xs:string</code> or <code>xs:untypedAto
                <bibl id="html5" key="HTML: Living Standard">
                   <titleref href="https://html.spec.whatwg.org/">HTML: Living Standard</titleref>.
                   WHATWG,
-                  18 November 2022.</bibl>
+                  7 May 2026.</bibl>
 
                <bibl id="dom-ls" key="DOM: Living Standard">
                   <titleref href="https://dom.spec.whatwg.org/">DOM: Living Standard</titleref>.
                   WHATWG,
-                  26 October 2022.</bibl>
+                  15 March 2026.</bibl>
 
                <bibl id="olson" key="IANA Timezone Database">
                   The <emph>tz</emph> timezone database, available at 


### PR DESCRIPTION
Fix #2612