### PR TITLE
2625 Make arguments of fn:substring be xs:numeric

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -5890,8 +5890,8 @@ return normalize-unicode(concat($v1, $v2))</eg>
       <fos:signatures>
          <fos:proto name="substring" return-type="xs:string">
             <fos:arg name="value" type="xs:string?"/>
-            <fos:arg name="start" type="xs:double"/>
-            <fos:arg name="length" type="xs:double?" default="()"/>
+            <fos:arg name="start" type="xs:numeric"/>
+            <fos:arg name="length" type="xs:numeric?" default="()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -5935,9 +5935,21 @@ return normalize-unicode(concat($v1, $v2))</eg>
       </fos:rules>
       <fos:notes>
          <p>The first character of a string is located at position 1, not position 0.</p>
-         <p>The second and third arguments allow <code>xs:double</code> values (rather than
-         requiring <code>xs:integer</code>) in order to achieve compatibility with XPath 1.0.</p>
          <p>A surrogate pair counts as one character, not two.</p>
+         <p>The most common usage pattern is to supply integers as the arguments. In this
+         case the rounding logic is unnecessary: <code>substring($s, $n)</code> returns all
+         characters in the string starting at position <code>$n</code> (one-based), while <code>substring($s, $n, $l)</code>
+         returns the substring starting at position <code>$n</code> and ending at position <code>$n + $l</code>.</p>
+         
+         <p>In earlier versions the second and third arguments were defined to be of type <code>xs:double</code>,
+         but this potentially leads to unnecessary conversions in the common case where the supplied arguments
+         are integers. The reason for the rounding rules is to compensate for any imprecision in the resulting floating-point
+            computations.</p>
+         
+         <p>The second and third arguments allow <code>xs:double</code> values (as an alternative
+         to <code>xs:integer</code>) in order to achieve compatibility with earlier versions.
+         </p>
+         
          <p>The consequences of supplying values such as <code>NaN</code> or positive or negative
          infinity for the <code>$start</code> or <code>$length</code> arguments follow from the
          above rules, and are not always intuitive.</p>
@@ -6039,6 +6051,11 @@ return normalize-unicode(concat($v1, $v2))</eg>
       <fos:changes>
          <fos:change issue="895" PR="901" date="2023-12-16">
             <p>The third argument can now be supplied as the empty sequence.</p>
+         </fos:change>
+         <fos:change issue="2625" PR="2626" date="2026-05-11">
+            <p>The argument type for the second and third arguments has changed from <code>xs:double</code> to <code>xs:numeric</code>. This creates
+               a minor incompatibility: when running in XPath 1.0 compatibility mode, it is no longer possible to
+               supply either of these arguments as a string.</p>
          </fos:change>
       </fos:changes>
    </fos:function>
@@ -16383,22 +16400,29 @@ filter(
             No error occurs if <code>$start</code> is zero or negative, or if <code>$start</code> 
             plus <code>$length</code> exceeds the number of items in the sequence, or if 
             <code>$length</code> is negative.</p>
-
-
-         <p>As a consequence of the general rules, if <code>$start</code> is
-               <code>-INF</code> and <code>$length</code> is <code>+INF</code>, then
-               <code>fn:round($start) + fn:round($length)</code> is <code>NaN</code>; since
-               <code>position() lt NaN</code> always returns <code>false</code>, the result is the empty sequence.</p>
-
-         <p>The reason the function accepts arguments of type <code>xs:numeric</code> rather than
-            <code>xs:integer</code> is historic; in XPath 1.0 it was possible to achieve effects
-            by supplying NaN or Infinity that were difficult to achieve in any other way. The reason for
-            the rounding rules is to compensate for any imprecision in the resulting floating-point
-            computations.</p>
+         
+         <p>The first character of a string is located at position 1, not position 0.</p>
+         <p>A surrogate pair counts as one character, not two.</p>
+         <p>The most common usage pattern is to supply integers as the arguments. In this
+         case the rounding logic is unnecessary: <code>substring($s, $n)</code> returns all
+         characters in the string starting at position <code>$n</code> (one-based), while <code>substring($s, $n, $l)</code>
+         returns the substring starting at position <code>$n</code> and ending at position <code>$n + $l</code>.</p>
          
          <p>In earlier versions the second and third arguments were defined to be of type <code>xs:double</code>,
          but this potentially leads to unnecessary conversions in the common case where the supplied arguments
          are integers.</p>
+         
+         <p>The second and third arguments allow <code>xs:double</code> values (as an alternative
+         to <code>xs:integer</code>) in order to achieve compatibility with earlier versions.
+            The reason for the rounding rules is to compensate for any imprecision in the resulting floating-point
+            computations.
+         </p>
+         
+         <p>The consequences of supplying values such as <code>NaN</code> or positive or negative
+         infinity for the <code>$start</code> or <code>$length</code> arguments follow from the
+         above rules, and are not always intuitive.</p>
+
+
       </fos:notes>
 
       <fos:examples>
@@ -16427,8 +16451,9 @@ filter(
             <p>The optional third argument can now be supplied as the empty sequence.</p>
          </fos:change>
          <fos:change issue="2542" PR="2543" date="2026-03-20">
-            <p>The type of the second and third arguments is now <code>xs:numeric</code> rather
-               than <code>xs:double</code>, to prevent unnecessary conversions when integers are supplied.</p>
+            <p>The argument type for the second and third arguments has changed from <code>xs:double</code> to <code>xs:numeric</code>. This creates
+               a minor incompatibility: when running in XPath 1.0 compatibility mode, it is no longer possible to
+               supply either of these arguments as a string.</p>
          </fos:change>
       </fos:changes>
    </fos:function>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -5937,18 +5937,16 @@ return normalize-unicode(concat($v1, $v2))</eg>
          <p>The first character of a string is located at position 1, not position 0.</p>
          <p>A surrogate pair counts as one character, not two.</p>
          <p>The most common usage pattern is to supply integers as the arguments. In this
-         case the rounding logic is unnecessary: <code>substring($s, $n)</code> returns all
-         characters in the string starting at position <code>$n</code> (one-based), while <code>substring($s, $n, $l)</code>
-         returns the substring starting at position <code>$n</code> and ending at position <code>$n + $l</code>.</p>
+         case the rounding logic is unnecessary: <code>substring($value, $start)</code> returns all
+         characters in <code>$value</code> starting at position <code>$start</code> (one-based), 
+            while <code>substring($value, $start, $length)</code>
+         returns the substring starting at position <code>$start</code> 
+            and ending at position <code>$start + $length - 1</code>.</p>
          
          <p>In earlier versions the second and third arguments were defined to be of type <code>xs:double</code>,
          but this potentially leads to unnecessary conversions in the common case where the supplied arguments
          are integers. The reason for the rounding rules is to compensate for any imprecision in the resulting floating-point
             computations.</p>
-         
-         <p>The second and third arguments allow <code>xs:double</code> values (as an alternative
-         to <code>xs:integer</code>) in order to achieve compatibility with earlier versions.
-         </p>
          
          <p>The consequences of supplying values such as <code>NaN</code> or positive or negative
          infinity for the <code>$start</code> or <code>$length</code> arguments follow from the
@@ -16380,7 +16378,8 @@ filter(
   if (empty($length)) then (
     fn($item, $pos) { round($start) le $pos }
   ) else (
-    fn($item, $pos) { round($start) le $pos and $pos lt round($start) + round($length) }
+    fn($item, $pos) { round($start) le $pos 
+                      and $pos lt round($start) + round($length) }
   )
 )
       </fos:equivalent>
@@ -16401,22 +16400,17 @@ filter(
             plus <code>$length</code> exceeds the number of items in the sequence, or if 
             <code>$length</code> is negative.</p>
          
-         <p>The first character of a string is located at position 1, not position 0.</p>
-         <p>A surrogate pair counts as one character, not two.</p>
+       
          <p>The most common usage pattern is to supply integers as the arguments. In this
-         case the rounding logic is unnecessary: <code>substring($s, $n)</code> returns all
-         characters in the string starting at position <code>$n</code> (one-based), while <code>substring($s, $n, $l)</code>
-         returns the substring starting at position <code>$n</code> and ending at position <code>$n + $l</code>.</p>
+         case the rounding logic is unnecessary: <code>subsequence($input, $start)</code> returns all
+         items in <code>$input</code> starting at position <code>$start</code> (one-based), 
+            while <code>substring($input, $start, $length)</code>
+         returns the all items starting at position <code>$start</code> and 
+            ending at position <code>$start + $length - 1</code>.</p>
          
          <p>In earlier versions the second and third arguments were defined to be of type <code>xs:double</code>,
          but this potentially leads to unnecessary conversions in the common case where the supplied arguments
          are integers.</p>
-         
-         <p>The second and third arguments allow <code>xs:double</code> values (as an alternative
-         to <code>xs:integer</code>) in order to achieve compatibility with earlier versions.
-            The reason for the rounding rules is to compensate for any imprecision in the resulting floating-point
-            computations.
-         </p>
          
          <p>The consequences of supplying values such as <code>NaN</code> or positive or negative
          infinity for the <code>$start</code> or <code>$length</code> arguments follow from the

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -15081,11 +15081,13 @@ ISBN 0 521 77752 6.</bibl>
               mode is in force) an instance of <code>xs:boolean</code> or <code>xs:duration</code>.</p>
            </item>
 
-           <item diff="add" at="issue1725">
+           <item>
               <p>When <function>map:put</function> replaces an entry in a map with a new value for an
               existing key, in the case where the existing key and the new key differ (for example,
               if they have different type annotations), it is no longer guaranteed that the new
-              entry includes the new key rather than the existing key.</p>
+              entry includes the new key rather than the existing key. (This is relevant when the new
+              key is equal to an existing key, but different from it in some way: for example, an
+              <code>xs:QName</code> using a different namespace prefix.)</p>
 		   </item>
 
            <item>
@@ -15098,14 +15100,15 @@ ISBN 0 521 77752 6.</bibl>
            </item>
            
            <item>
-              <p>The <function>fn:index-of</function> now treats <code>NaN</code> as equal to <code>NaN</code>.</p>
+              <p>The <function>fn:index-of</function> function now treats <code>NaN</code> as equal to <code>NaN</code>.</p>
            </item>
            
            <item>
-              <p>The second and third arguments of <function>fn:subsequence</function> are now of type
+              <p>The second and third arguments of the functions <function>fn:substring</function>
+                 and <function>fn:subsequence</function> are now of type
               <code>xs:numeric</code> rather than <code>xs:double</code>. This means that in 1.0 compatibility mode,
-              it is no longer acceptable to supply a string or boolean. The 1.0 compatibility rules allow a string or boolean to be
-              supplied where the required type is <code>xs:double</code>, but not where it is <code>xs:numeric</code>.</p>
+              it is no longer acceptable to supply a string or boolean. (The 1.0 compatibility rules allow a string or boolean to be
+              supplied where the required type is <code>xs:double</code>, but not where it is <code>xs:numeric</code>.)</p>
            </item>
            
            <item>


### PR DESCRIPTION
Fix #2625