### PR TITLE
2632-1: fix critical bugs and DTD-validity issues (automatically generated & reviewed)

### DIFF
--- a/specifications/xquery-40/src/ebnf.xml
+++ b/specifications/xquery-40/src/ebnf.xml
@@ -317,7 +317,7 @@
         <head>reserved-function-names</head>
         <p>Unprefixed function names spelled the same way as language keywords could make the
           language impossible to parse. For instance, <code>element(foo)</code> could be taken either as
-          a <nt def="FunctionCall">FunctionCall</nt> or as an <nt def="ElementNodeType"/>. 
+          a <nt def="FunctionCall">FunctionCall</nt> or as an <nt def="ElementNodeType">ElementNodeType</nt>.
           Therefore, an unprefixed function name must not be any of the names in
             <specref ref="id-reserved-fn-names"/>.</p>
 
@@ -470,7 +470,7 @@
     <head>Productions Derived from XML</head>
     <p>Some productions are defined by reference to the XML and XML Names specifications (e.g.
       <bibref ref="XML"/> and <bibref ref="XMLNAMES"/>, or <bibref ref="XML1.1"/> and <bibref
-        ref="XMLNAMES11"/>. <phrase role="xpath">A host language may choose</phrase><phrase
+        ref="XMLNAMES11"/>). <phrase role="xpath">A host language may choose</phrase><phrase
           role="xquery">It is implementation-defined</phrase> which version of these specifications is
       used; it is recommended that the latest applicable version be used (even if it is published
       later than this specification).</p>
@@ -894,7 +894,7 @@
     can appear, followed by a left parenthesis, at the start of an XPath or XQuery expression that
     is not a function call.</p>
     
-    <p>Names used in <nt def="TypeTest">NodeKindTests</nt>:</p>
+    <p>Names used in <nt def="TypeTest">TypeTest</nt>:</p>
       
       <slist>
         <sitem>attribute</sitem>

--- a/specifications/xquery-40/src/errors.xml
+++ b/specifications/xquery-40/src/errors.xml
@@ -350,9 +350,9 @@
 </error>
 -->
 
-      <error spec="XQ"  code="0044" class="DY" type="dynamic">
+      <error spec="XQ" code="0044" class="DY" type="dynamic">
          <!-- <change diff="chg" at="XQ.E19"> -->
-         <p>It is a <termref def="dt-dynamic-error">dynamic error</termref> the node-name of a node
+         <p>It is a <termref def="dt-dynamic-error">dynamic error</termref> if the node-name of a node
             constructed by a computed attribute constructor has any of the following properties: </p>
          <ulist>
             <item>
@@ -679,7 +679,7 @@
                def="dt-expanded-qname">expanded QNames</termref>).</p>
       </error>
       
-      <error spec="XQ" role="xpath" code="0089" class="ST" type="static">
+      <error spec="XP" role="xpath" code="0089" class="ST" type="static">
          <p> It is a <termref def="dt-static-error">static error</termref> if a variable bound in a
             <code>for</code> expression, and its
             associated positional variable, do not have distinct names (<termref
@@ -945,8 +945,7 @@ if the value bound to a grouping  variable consists of a sequence of more than o
          <!-- Bug 28588 -->
          <p>When applying the <termref def="dt-coercion-rules"/>, if an item is of type <code>xs:untypedAtomic</code> and the
             expected type is <termref def="dt-namespace-sensitive">namespace-sensitive</termref>, a
-               <termref def="dt-type-error">type error</termref>
-            <errorref class="TY" code="0117"/> is raised. </p>
+               <termref def="dt-type-error">type error</termref> is raised. </p>
       </error>
 
       <error spec="XQ" role="xquery" code="0118" class="ST" type="static">

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -5172,7 +5172,7 @@ declare variable $orange-fruit as my:fruit := "orange";
                   within the <code>NameTestUnion</code> is expanded using the
                   <termref def="dt-element-name-matching-rule"/>.
                   The name need not be present in the <termref
-                     def="dt-is-attrs">in-scope element declarations</termref>.
+                     def="dt-is-elems">in-scope element declarations</termref>.
                </p>
                <note><p>This means that when the 
                   <termref def="dt-default-namespace-elements-and-types"/>
@@ -5635,7 +5635,7 @@ regardless of its name or type annotation.</p>
 
                   <item diff="add" at="A">
                      <p><code role="parse-test"
-                           >element(Q{http://www.w3.org/2000/svg}*)</code> matches any attribute node whose name is in the SVG namespace.</p>
+                           >attribute(Q{http://www.w3.org/2000/svg}*)</code> matches any attribute node whose name is in the SVG namespace.</p>
                   </item>
 
                   <item diff="add" at="A">
@@ -6770,9 +6770,9 @@ declare record Particle (
                   match the empty sequence as their only instance.</p></item>
                   <item><p>The category <code>void</code> includes the sequence types <code>xs:error</code> and <code>xs:error+</code>,
                   which have no instances (not even the empty sequence).</p></item>
-                  <item><p>The categories <code>X?</code>, <code>X*</code>, <code>X</code> and <code>X+</code> includes all sequence types 
-                     having an item type <code>X</code> other than <code>xs:error</code>, together with an occurrence indicator of 
-                     <code>?</code> (zero or more), <code>*</code> (one or more), absent (exactly one), or <code>+</code> (one or more)
+                  <item><p>The categories <code>X?</code>, <code>X*</code>, <code>X</code> and <code>X+</code> include all sequence types
+                     having an item type <code>X</code> other than <code>xs:error</code>, together with an occurrence indicator of
+                     <code>?</code> (zero or one), <code>*</code> (zero or more), absent (exactly one), or <code>+</code> (one or more)
                      respectively. We use the notation <var>X/i</var> to indicate the item type of such a sequence type.</p></item>
                </ulist>
                
@@ -9407,7 +9407,7 @@ and <nt def="OrExpr"
          </scrap>
          <p>These namespace declarations are added to the <termref def="dt-static-context"/> of the expression, overriding any namespace bindings
          initialized by the host language.</p>
-         <p>Specifically, if there is a <nt def="DefaultElementNamespaceDecl">DefaultNamespaceDecl</nt> then
+         <p>Specifically, if there is a <nt def="DefaultElementNamespaceDecl">DefaultElementNamespaceDecl</nt> then
          the relevant URI is set in the <termref def="dt-static-context"/> as the <termref def="dt-default-namespace-elements-and-types"/>,
          while a <nt def="NamespaceDecl">NamespaceDecl</nt> establishes a namespace binding from
          the given prefix to the given URI in the <termref def="dt-static-namespaces"/>.</p>
@@ -12034,7 +12034,7 @@ return $incrementors[2](4)]]></eg>
          
          <p>An expression of the form <code>/<var>PP</var></code> (that is, a <termref def="dt-path-expression"/>
             with a leading <code>/</code>) is treated as an abbreviation for
-	 the expression <code>./(fn:root(.) treat as (document-node()|jnode())/<var>PP</var></code>. 
+	 the expression <code>./(fn:root(.) treat as (document-node()|jnode()))/<var>PP</var></code>.
             The effect of this expansion is that every item <var>N</var> 
             in the context value <var>V</var> is processed as follows, depending on its type:</p>
             
@@ -12128,7 +12128,7 @@ return $incrementors[2](4)]]></eg>
 
          <p>An expression of the form <code>//<var>PP</var></code> (that is, an <termref def="dt-absolute-path-expression"/>
             with a leading <code>//</code>) is treated as an abbreviation for
-            the expression <code>./(fn:root(.) treat as (document-node()|jnode())/descendant-or-self::gnode()/<var>PP</var></code>. 
+            the expression <code>./(fn:root(.) treat as (document-node()|jnode()))/descendant-or-self::gnode()/<var>PP</var></code>.
             The effect of this expansion is that every item <var>N</var> 
             in the context value <var>V</var> is processed as follows, depending on its type:</p>
 
@@ -19387,7 +19387,7 @@ local:grouped-moves(tokenize("Nf3 Nf6 c4 g6 Nc3 Bg7 d4 O-O Bf4 d5"))</eg>
                      If <var>T/i</var> is absent, no further coercion takes place (the default is effectively
                      <code>item()*</code>).</p>
                         <note><p>If <var>i</var> exceeds the length of the array <var>V</var>, then
-                        an error <xerrorref spec="FO" class="AR" code="0001"/> is raised.</p></note>
+                        a dynamic error <xerrorref spec="FO40" class="AY" code="0001"/> is raised.</p></note>
                         <note><p>It is permissible to bind several variables with the same name;
                         all but the last are occluded. A useful convention is therefore to bind
                         items in the sequence that are of no interest to the variable <code>$_</code>:

--- a/specifications/xquery-40/src/ns-local.xml
+++ b/specifications/xquery-40/src/ns-local.xml
@@ -15,7 +15,7 @@
 <!ENTITY xq.spec.ver "31">
 <!ENTITY xq.spec.doctype "REC">
 <!ENTITY xq.spec.name "xquery">
-<!ENTITY xq.loc     "https://www.w3.org/TR/&xq.spec.name;-&spec.ver;">
+<!ENTITY xq.loc     "https://www.w3.org/TR/&xq.spec.name;-&xq.spec.ver;">
 <!ENTITY xq.loc.dated     "https://www.w3.org/TR/&xq.spec.date.year;/&xq.spec.doctype;-&xq.spec.name;-&xq.spec.ver;-&xq.spec.date.year;&xq.spec.date.MM;&xq.spec.date.day;/">
 ]>
 <spec w3c-doctype="rec" status="ext-review">

--- a/specifications/xquery-40/src/ns-xquery.xml
+++ b/specifications/xquery-40/src/ns-xquery.xml
@@ -15,7 +15,7 @@
 <!ENTITY xq.spec.ver "31">
 <!ENTITY xq.spec.doctype "REC">
 <!ENTITY xq.spec.name "xquery">
-<!ENTITY xq.loc     "https://www.w3.org/TR/&xq.spec.name;-&spec.ver;">
+<!ENTITY xq.loc     "https://www.w3.org/TR/&xq.spec.name;-&xq.spec.ver;">
 <!ENTITY xq.loc.dated     "https://www.w3.org/TR/&xq.spec.date.year;/&xq.spec.doctype;-&xq.spec.name;-&xq.spec.ver;-&xq.spec.date.year;&xq.spec.date.MM;&xq.spec.date.day;/">
 ]>
 <spec w3c-doctype="rec" status="ext-review">
@@ -83,7 +83,7 @@
 
 
 
-    <div1 id="features" class="resource">
+    <div1 id="annotations" class="resource">
       <head>XQuery Annotations</head>
 
       <rddl:resource xlink:title="XQuery Annotations" xlink:role="http://www.rddl.org/natures#term"


### PR DESCRIPTION
* ns-local.xml, ns-xquery.xml: undefined entity &spec.ver; -> &xq.spec.ver;
* ns-xquery.xml: duplicate xml:id "features"; rename first to "annotations" (already referenced as #id-annotations via xlink:href)
* errors.xml XQDY0044: insert missing "if"; fix doubled space in attribute list
* errors.xml: second XQST0089 entry was actually XPST0089 (role="xpath"); change spec attribute from "XQ" to "XP"
* errors.xml XPTY0117: remove self-referential <errorref>
* expressions.xml: dt-is-attrs -> dt-is-elems in the NameTestUnion paragraph
* expressions.xml DefaultElementNamespaceDecl: align display text with def
* expressions.xml: attribute-test example accidentally used "element(...)"
* expressions.xml: occurrence-indicator cardinalities for ?, * were wrong (had "zero or more"/"one or more"; correct: "zero or one"/"zero or more")
* expressions.xml: unbalanced parentheses in the /PP and //PP expansions
* expressions.xml: FOAR0001 ("division by zero") -> FOAY0001 ("out of bounds") for the array:get out-of-range note; spec also changed from "FO" to "FO40"
* ebnf.xml: ElementNodeType <nt> was self-closing without display text
* ebnf.xml: TypeTest <nt> display text said "NodeKindTests" (stale name)
* ebnf.xml: unclosed parenthesis after "XMLNAMES11"

Issue: #2632