### PR TITLE
2632-2: fix broken examples in expressions.xml (automatically generated & reviewed)

### DIFF
--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -6015,7 +6015,7 @@ name.</p>
                   </item>
                   <item>
                      <p>
-                        <code>$M instance of map(xs:integer, xs:token))</code>  returns <code>false</code>
+                        <code>$M instance of map(xs:integer, xs:token)</code> returns <code>false</code>
                      </p>
                   </item>
                </ulist>
@@ -6346,11 +6346,11 @@ name.</p>
                   <head>An Arbitrary Tree</head>
                   <p>A record used to represent a node in a tree where each node has an arbitrary number
                      of children might be represented (using XQuery syntax) as:</p>
-                  <eg>declare record t:tree as (value, children as t:tree*);</eg>
+                  <eg>declare record t:tree (value, children as t:tree*);</eg>
                   <p>A function to walk this tree and enumerate all the values in order might be written 
                      as:</p>
                   <eg>declare function t:flatten($tree as t:tree) as item()* {
-  $tree?value, $tree?children ! t:flatten(.))   
+  $tree?value, $tree?children ! t:flatten(.)
 }</eg>
                </example>
                
@@ -12580,7 +12580,7 @@ return if (every $r in $R satisfies $r instance of gnode())
 			 <code>following-sibling</code> axis is
 			 empty.</p>
                      <p>More formally, <code>$node/following-sibling::gnode()</code> delivers the result
-                     of <code>fn:siblings($node)[. >> $node])</code>.</p>
+                     of <code>fn:siblings($node)[. >> $node]</code>.</p>
                   </item>
                   
                   <item>
@@ -12841,7 +12841,7 @@ return if (every $r in $R satisfies $r instance of gnode())
                   <item><p>If the principal node kind of the axis step is <code>element</code>, 
                   using the <termref def="dt-element-name-matching-rule"/>.</p>
                   <note><p>If the <termref def="dt-default-namespace-elements-and-types"/> has the
-                     special value <code>"##any</code>, the result of the expanding an unprefixed name
+                     special value <code>##any</code>, the result of expanding an unprefixed name
                   <var>NN</var> is the wildcard <code>*:<var>NN</var></code>.</p></note></item>
                   <item><p>Otherwise, using the <termref def="dt-no-namespace-rule"/>.</p></item>
                </ulist>
@@ -14089,8 +14089,8 @@ every <code>section</code> element that has a parent that is either a <code>chap
     "occupation": "cook"}, 
   { "first": "Mary", 
     "last": "Smith", 
-    "date of birth": "2006-08-12", 
-    "occupation": "teacher"},                 
+    "date of birth": "2006-08-12",
+    "occupation": "teacher"}
 ]</eg>
             
             <ulist>
@@ -14376,8 +14376,8 @@ the value <code>10.50</code>, the result of this expression is the sequence <cod
                <p>This example selects the first four items from an input sequence:</p>
                <eg role="parse-test">$input[1 to 4]</eg>
                
-               <p>This example returns the sequence <code>(0, 0.1, 0.2, 0.3, 0.5)</code>:</p>
-               <eg role="parse-test">$x = (1 to 5) ! . * 0.1</eg>
+               <p>This example returns the sequence <code>(0.1, 0.2, 0.3, 0.4, 0.5)</code>:</p>
+               <eg role="parse-test">(1 to 5) ! . * 0.1</eg>
                <p>This example constructs a sequence of length one containing the single integer 10.</p>
                <eg role="parse-test">10 to 10</eg>
                <p>The result of this example is a sequence of length zero.</p>
@@ -16466,7 +16466,7 @@ character (that is, the pair <code>"{{"</code> represents the
                   <item>
                      <p>Example:</p>
                      <eg role="parse-test">&lt;chapter ref="[ { 1, 5 to 7, 9 } ]"/&gt;</eg>
-                     <p>The string value of the <code>ref</code> attribute is <code>"[1 5 6 7 9]"</code>.</p>
+                     <p>The string value of the <code>ref</code> attribute is <code>"[ 1 5 6 7 9 ]"</code>.</p>
                   </item>
 
                   <item>
@@ -17387,15 +17387,15 @@ same result as the first example in <specref
                         <sitem><code>element #table {}</code></sitem>
                         <sitem><code>element #html:table {}</code></sitem>
                         <sitem><code>element #Q{}table {}</code></sitem>
-                        <sitem><code>element #Q{http://http://www.w3.org/1999/xhtml}table {}</code></sitem>
-                        <sitem><code>element #Q{http://http://www.w3.org/1999/xhtml}html:table {}</code></sitem>
+                        <sitem><code>element #Q{http://www.w3.org/1999/xhtml}table {}</code></sitem>
+                        <sitem><code>element #Q{http://www.w3.org/1999/xhtml}html:table {}</code></sitem>
                      </slist>
                      <p>A QName literal written as an unprefixed <termref def="dt-qname">lexical QName</termref>
                      (the first form above) is resolved using the 
                      <termref def="dt-constructed-element-namespace-rule"/>. This differs from the normal rules for evaluating
                      a QName literal as an atomic item of type <code>xs:QName</code>.</p>
                      <p>Note that the third and fourth examples (<code>#Q{}table</code> and 
-                        <code>#Q{http://http://www.w3.org/1999/xhtml}table</code>) will result in the name of the
+                        <code>#Q{http://www.w3.org/1999/xhtml}table</code>) will result in the name of the
                      constructed element having no prefix, which may in turn trigger the generation of a default
                      namespace declaration.</p>
                   </item>
@@ -17406,8 +17406,8 @@ same result as the first example in <specref
                         <sitem><code>element table {}</code></sitem>
                         <sitem><code>element html:table {}</code></sitem>
                         <sitem><code>element Q{}table {}</code></sitem>
-                        <sitem><code>element Q{http://http://www.w3.org/1999/xhtml}table {}</code></sitem>
-                        <sitem><code>element Q{http://http://www.w3.org/1999/xhtml}html:table {}</code></sitem>
+                        <sitem><code>element Q{http://www.w3.org/1999/xhtml}table {}</code></sitem>
+                        <sitem><code>element Q{http://www.w3.org/1999/xhtml}html:table {}</code></sitem>
                      </slist>
                      <p>In &language; the first form (using an unprefixed <termref def="dt-qname">lexical QName</termref>)
                      is allowed only if the element name is not a reserved keyword (such as <code>div</code> or <code>case</code>): see
@@ -18289,7 +18289,7 @@ attribute {
                   </item>
                </olist>
                <p>The following example illustrates a computed processing instruction constructor:</p>
-               <eg role="parse-test"><![CDATA[let $target := "audio-output",
+               <eg role="parse-test"><![CDATA[let $target := "audio-output"
 return processing-instruction { $target } { "beep" }]]></eg>
                <p>The processing instruction node constructed by this example might be serialized as follows:</p>
                <eg>&lt;?audio-output beep?&gt;</eg>
@@ -18985,7 +18985,7 @@ for member $y in $expr2]]></eg>
                   <p>Output tuple stream:</p>
                   <eg><![CDATA[($x = (1))
 ($x = (2))
-($x = (5, 6, 7, 8, 9, 10)]]></eg>
+($x = (5, 6, 7, 8, 9, 10))]]></eg>
                </item>
                
                <item diff="add" at="A">
@@ -19031,7 +19031,7 @@ for member $y in $expr2]]></eg>
                
                <item diff="add" at="A">
                   <p>Initial clause:</p>
-                  <eg><![CDATA[for $x at $i in [1 to 3, 11 to 13, 21 to 23]]></eg>
+                  <eg><![CDATA[for member $x at $i in [1 to 3, 11 to 13, 21 to 23]]></eg>
                   <p>Output tuple stream:</p>
                   <eg><![CDATA[($x = (1, 2, 3), $i = 1)
 ($x = (11, 12, 13), $i = 2)
@@ -19165,7 +19165,7 @@ for member $y in $expr2]]></eg>
 ($x = 2)
 ($x = 3)]]></eg>
                   <p>Intermediate <code>for</code> clause:</p>
-                  <eg><![CDATA[for member $y in [[$x+1, $x+2], [[$x+3, $x+4]] ]]></eg>
+                  <eg><![CDATA[for member $y in [[$x+1, $x+2], [$x+3, $x+4]] ]]></eg>
                   <p>Output tuple stream:</p>
                   <eg><![CDATA[($x = 1, $y = [ 2, 3 ])
 ($x = 1, $y = [ 4, 5 ])
@@ -19353,12 +19353,12 @@ return $a + $b + $local:c</eg>
                      <head>Example:</head>
                      <p>Consider transforming the string <code>"Nf3 Nf6 c4 g6 Nc3 Bg7 d4 O-O Bf4 d5"</code>
                      (notation for the start of a chess game) to the form 
-                     <code>(["Nf3", "Nf6",] ["c4", "g6"], [ "Nc3", "Bg7"], [ "d4", "O-O"], ["Bf4", "d5"])</code>.
+                     <code>(["Nf3", "Nf6"], ["c4", "g6"], [ "Nc3", "Bg7"], [ "d4", "O-O"], ["Bf4", "d5"])</code>.
                      This can be achieved as follows:</p>
                      <eg>declare function local:grouped-moves($moves) {
    if (exists($moves)) {
      let $($m1, $m2, $rest) := $moves
-     return [$m1, $m2], local:grouped-moves($rest)
+     return ([$m1, $m2], local:grouped-moves($rest))
   }
 };
 local:grouped-moves(tokenize("Nf3 Nf6 c4 g6 Nc3 Bg7 d4 O-O Bf4 d5"))</eg>
@@ -19402,9 +19402,9 @@ local:grouped-moves(tokenize("Nf3 Nf6 c4 g6 Nc3 Bg7 d4 O-O Bf4 d5"))</eg>
 return $a + $b + $local:c</eg>
                      <p>is expanded to:</p>
                      <eg>let $temp := [ 2, 4, 6 ]
-let $a := array:get($temp, 1, ())
+let $a := array:get($temp, 1)
 let $b as xs:integer := array:get($temp, 2)
-let $local:c := array:get($temp, 3, ())
+let $local:c := array:get($temp, 3)
 return $a + $b + $local:c</eg>
                      <p>where <code>$temp</code> is some variable name that is otherwise unused.</p>
                   </example>
@@ -19836,7 +19836,7 @@ return <window>{ $w }</window>]]></eg>
 
 
                   <item>
-                     <p>Show non-overlapping sequences starting with a number divisible by 3.</p>
+                     <p>Show non-overlapping sequences starting with a number that has remainder 2 when divided by 3.</p>
 
                      <eg role="parse-test"><![CDATA[for tumbling window $w in (2, 4, 6, 8, 10, 12, 14)
   start $first when $first mod 3 = 2
@@ -20614,7 +20614,7 @@ return &lt;category name="{ $category }"&gt;{
   count($p) || ' products have price greater than ' || $high-price || '.'
 }&lt;/category&gt;</eg>
                   <p>If three products in the “Men’s Wear” category have prices greater than 1000, the result of this query might look (in part) like this:</p>
-                  <eg>&lt;category name="Men’s Wear"&gt;
+                  <eg>&lt;category name="Men's Wear"&gt;
   3 products have price greater than 1000 1000 1000.
 &lt;/category&gt;</eg>
                   <p>The repetition of "1000" in this query result is due to the fact that <code>$high-price</code> is not a <termref
@@ -20642,7 +20642,7 @@ return (
                
                <eg role="parse-test">for $p in $products
 group by collation-key($p/description, $collation)
-return $product/@code</eg>
+return $p/@code</eg>
                
                <p>Note however that the <function>fn:collation-key</function> function might not work
                   for all collations.</p>
@@ -20801,7 +20801,7 @@ return $e/name]]></eg>
                <p>If a collation name is specified, it must be supplied as a literal string; it cannot
                   be computed dynamically. Two possible workarounds are to use the <function>fn:sort-by</function> function
                or the <function>fn:collation-key</function> function.</p>
-               <p>Using <function>fn:sort</function> the expression</p>
+               <p>Using <function>fn:sort-by</function> the expression</p>
                <eg role="parse-test">for $b in $books/book[price &lt; 100]
 order by $b/title
 return $b</eg>
@@ -22011,7 +22011,7 @@ return { $persons/*/* }
 
     
     If <code>$array</code> is an array and <code>$index</code> is an integer corresponding to a position in the array,
-    then <code>$array($key)</code> is equivalent to <code>array:get($array, $key)</code>.
+    then <code>$array($index)</code> is equivalent to <code>array:get($array, $index)</code>.
     The semantics of such a function call are formally defined in
     <xspecref
                      spec="FO40" ref="func-array-get"/>.
@@ -22207,7 +22207,7 @@ return { $persons/*/* }
                               <var>KS</var> is an <code>NCName</code>, then the result
                               is the same as if it were written in quotes as
                               a <code>StringLiteral</code>: for example <code>$map?name</code>
-                           returns the same result as <code>map?"name"</code>.</p>
+                           returns the same result as <code>$map?"name"</code>.</p>
                         </item>
                         
                         <item>
@@ -23058,7 +23058,7 @@ one <code>employee</code> element satisfies the given comparison expression:</p>
 )]]></eg>
                <note diff="add" at="A"><p>Like many quantified expressions, this can be simplified. This example can be written
                   <code>every $emp in /emps/employee satisfies $emp/salary[@current = 'true']</code>, or even
-                  more concisely as <code>empty(/emps/employee[not(salary/@current = 'true')]</code>.</p>
+                  more concisely as <code>empty(/emps/employee[not(salary/@current = 'true')])</code>.</p>
                <p>Another alternative in &language; is to use the higher-order functions <function>fn:some</function> and <function>fn:every</function>.
                This example can be written <code diff="chg" at="2023-04-25">every(/emps/employee, fn { salary/@current = 'true' })</code></p>
                </note>
@@ -23794,7 +23794,7 @@ mechanism such as a data dictionary.-->
                   
 
                   <note diff="add" at="issue688"><p>Casting to an enumeration type relies on the fact that an enumeration type
-                  is a generalized atomic type. So the expression <code>cast $x as enum("red", "green")</code> 
+                  is a generalized atomic type. So the expression <code>$x cast as enum("red", "green")</code>
                   has the following effect:</p>
                      <ulist>
                         <item><p>If <code>$x</code> is an instance of <code>xs:string</code>,
@@ -24278,7 +24278,7 @@ return string-join($chopped, '; ')
             expression invites syntax errors due to misplaced parentheses:
          </p>
          
-         <eg role="parsetest"
+         <eg role="parse-test"
             ><![CDATA[tokenize((normalize-unicode(upper-case($string))),"\s+")]]></eg>
          
          <p>In the following reformulation, it is easier to see that the parentheses are balanced:</p>
@@ -24478,8 +24478,8 @@ return string-join($chopped, '; ')
             <p>Given a  <nt def="UnaryExpr">UnaryExpr</nt>
                <var>U</var>, and a <nt def="RestrictedDynamicCall">RestrictedDynamicCall</nt>
                <code><var>E</var>(<var>A</var>, <var>B</var>, <var>C</var>...)</code>, the expression 
-               <code><var>U</var> => <var>E</var>(<var>A</var>, <var>B</var>, <var>C</var>...)</code> is equivalent to the
-               expression <code>for $u in U return <var>E</var>(<var>$u</var>, <var>A</var>, <var>B</var>, <var>C</var>...)</code>.</p></item>
+               <code><var>U</var> =!> <var>E</var>(<var>A</var>, <var>B</var>, <var>C</var>...)</code> is equivalent to the
+               expression <code>for $u in <var>U</var> return <var>E</var>(<var>$u</var>, <var>A</var>, <var>B</var>, <var>C</var>...)</code>.</p></item>
        
      
             


### PR DESCRIPTION
Path expressions:
* fn:siblings example: stray closing parenthesis
* "##any" example: unbalanced quote and extra "the"

SequenceType / records:
* "$M instance of map(xs:integer, xs:token))": extra closing paren
* t:flatten recursion example: extra closing paren
* "declare record t:tree as (...)": drop "as" (not part of record syntax)

Sequence example:
* "$x = (1 to 5) ! . * 0.1" returning (0, 0.1, 0.2, 0.3, 0.5): both the expression (had stray "$x =") and the claimed result were wrong; fixed to "(1 to 5) ! . * 0.1" yielding (0.1, 0.2, 0.3, 0.4, 0.5)

Element / attribute constructors:
* five occurrences of doubled "http://http://" in Q{...} URIs
* attribute-value normalisation example: claimed "[1 5 6 7 9]" but with the literal " [ " / " ] " in the source the value is "[ 1 5 6 7 9 ]"

Computed PI constructor:
* `let $target := "audio-output", return ...`: stray comma made the example unparseable despite role="parse-test"

FLWOR:
* tuple-stream example missing closing parenthesis "($x = (5, 6, 7, 8, 9, 10)"
* "for $x at $i in [1 to 3, ...]" with array-member tuple output: requires the "member" keyword (without it the array is a single item)
* nested-array example "[[$x+1, $x+2], [[$x+3, $x+4]] ]": extra "[" "]" around the second pair
* chess example: "return [$m1, $m2], local:grouped-moves($rest)" placed the recursive call outside the FLWOR (where $rest is not in scope); also fixed the matching prose
* JSON-style array literal also corrected
* group-by example used $product instead of the bound $p
* note about workarounds said "using fn:sort" but used fn:sort-by

Maps and arrays:
* array lookup paragraph mixed $index and $key
* postfix lookup example "$map?name" vs "map?\"name\"": missing leading "$"
* let-destructure expansion: three array:get calls were inconsistently 2-arg vs. 3-arg; align with the 2-arg form in the prose definition

Window expression:
* description "starting with a number divisible by 3" did not match the predicate "$first mod 3 = 2"; reword to "remainder 2 when divided by 3"

Other:
* group-by "Men's Wear" example: typographic vs. ASCII apostrophe mismatch; prose keeps typographic “Men’s Wear”, both <eg> blocks use ASCII
* trailing comma in JSON array example
* role="parsetest" -> role="parse-test" on one arrow-operator example
* cast example "cast $x as enum(...)" used wrong keyword order
* mapping-arrow rewrite used "=>" instead of "=!>"; also wrap U in <var>

Issue: #2632