### PR TITLE
2632-3: typos and grammar (automatically generated & reviewed)

### DIFF
--- a/specifications/xquery-40/src/back-matter.xml
+++ b/specifications/xquery-40/src/back-matter.xml
@@ -289,7 +289,7 @@ the value of the component for their subexpressions.</p></item>
  <specref ref="FunctionDeclns"/>, 
 <specref ref="id-module-import"/>,
 and
-<specref ref="id-schema-import"/> ( (which adds constructor functions for user-defined types)</td>
+<specref ref="id-schema-import"/> (which adds constructor functions for user-defined types)</td>
   <td>no</td>
   <td>Must be consistent with statically known function signatures</td>
 </tr>
@@ -500,10 +500,10 @@ defined.</p>
       <termref def="dt-option-declaration">option declarations</termref> 
       recognized by the implementation.</p></item><item role="xquery">
         <p>Protocols (if any) by which parameters can be passed to an external function,
-          and the result of the function can returned to the invoking query.</p></item>
+          and the result of the function can be returned to the invoking query.</p></item>
     <item role="xquery"><p>The process by which the specific modules to be imported by a
 <termref def="dt-module-import">module import</termref> are identified 
-      (includes processing of location hints, if any.)</p></item>
+      (includes processing of location hints, if any).</p></item>
 
 <item role="xquery"><p>The means by which serialization is invoked, if the <termref def="dt-serialization-feature">Serialization Feature</termref> is supported.</p></item><item role="xquery"><p>The default values for the <code>byte-order-mark</code>, <code>encoding</code>, <code>html-version</code>, <code>item-separator</code>, <code>media-type</code>, <code>normalization-form</code>, <code>omit-xml-declaration</code>, <code>standalone</code>, and <code>version</code> parameters, if the <termref def="dt-serialization-feature">Serialization Feature</termref> is supported.</p></item><item role="xquery"><p>The result of an unsuccessful call to an external function (for example,
 if the function implementation cannot be found or does not return a value
@@ -765,7 +765,7 @@ See
     of atomic items, with some background on the history and rationale.</p>
   
     <p>In &language; there are several ways of comparing two atomic items for equality or ordering.
-    The rules for each are summarized in the following sections</p>
+    The rules for each are summarized in the following sections.</p>
     
     <div2 id="value-comparisons-summary">
       <head>Value Comparisons</head>
@@ -881,7 +881,7 @@ See
           <item><p>If nodes are supplied, they are not atomized; they are compared as nodes.</p></item>
           <item><p>Strings can be compared using the default collation or using an explicitly specified collation;
             there are also options to compare after normalizing whitespace or Unicode.</p></item>
-          <item><p>Comparisons of dates and times lacking a timezone uses the implicit timezone from the dynamic
+          <item><p>Comparisons of dates and times lacking a timezone use the implicit timezone from the dynamic
             context.</p></item>
           <item><p>To ensure that every value is equal to itself, comparing NaN to NaN returns true.</p></item>        
           <item><p>In all other cases comparison between numeric values, including comparison of mixed

--- a/specifications/xquery-40/src/conformance.xml
+++ b/specifications/xquery-40/src/conformance.xml
@@ -137,7 +137,7 @@
             <p>
                 <termdef id="dt-typed-data-feature" term="typed data feature">The
                         <term>Typed Data Feature</term> permits an XDM instance to contain element
-                    node types other than <code>xs:untyped</code> and attributes node types other
+                    node types other than <code>xs:untyped</code> and attribute node types other
                     than <code>xs:untypedAtomic</code>.</termdef>
             </p>
 
@@ -348,7 +348,7 @@
                 >implementation-defined</termref>. The effect of syntactic extensions, including
             their error behavior, is <termref def="dt-implementation-defined"
                 >implementation-defined</termref>. Syntactic extensions <termref def="may">MAY</termref> be used without
-            restriction to modify the semantics of a XQuery expression.</p>
+            restriction to modify the semantics of an XQuery expression.</p>
 
     </div2>
 </div1>

--- a/specifications/xquery-40/src/ebnf.xml
+++ b/specifications/xquery-40/src/ebnf.xml
@@ -489,7 +489,7 @@
     
   </div2>
   <div2 id="lexical-structure">
-    <head>Lexical structure</head>
+    <head>Lexical Structure</head>
     
     <changes>
       <change issue="327" PR="519" date="2023-05-30">
@@ -525,7 +525,7 @@
           does not qualify because it appears only in <nt def="URIQualifiedName">URIQualifiedName</nt>, and <code>"0x"</code> does not qualify
         because it appears only in <nt def="HexIntegerLiteral">HexIntegerLiteral</nt>.</phrase>
           <phrase role="xpath">For example, <nt def="BracedURILiteral">BracedURILiteral</nt>
-            does not quality because it appears only in <nt def="URIQualifiedName">URIQualifiedName</nt>, and <code>"0x"</code> does not qualify
+            does not qualify because it appears only in <nt def="URIQualifiedName">URIQualifiedName</nt>, and <code>"0x"</code> does not qualify
             because it appears only in <nt def="HexIntegerLiteral">HexIntegerLiteral</nt>.</phrase></p></note>
       
         <p>

--- a/specifications/xquery-40/src/errors.xml
+++ b/specifications/xquery-40/src/errors.xml
@@ -409,7 +409,7 @@
          <p>It is a <termref def="dt-static-error"/> if two or more variables
             declared or imported by a <termref def="dt-module"/> have equal <termref
                def="dt-expanded-qname">expanded QNames</termref> (as defined by the <code>eq</code>
-            operator.)</p>
+            operator).</p>
       </error>
 
       <error spec="XP" code="0050" class="DY" type="type">
@@ -1087,7 +1087,7 @@ It is a static error if the name of a feature in
          <p>It is a <termref def="dt-static-error">static error</termref> if two or more item types
             declared or imported by a <termref def="dt-module">module</termref> have equal <termref
                def="dt-expanded-qname">expanded QNames</termref> (as defined by the <code>eq</code>
-            operator.)</p>
+            operator).</p>
       </error>
       
       <!--<error spec="XP" code="0147" class="ST" type="static">

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -459,7 +459,7 @@ return namespace {$k}{$v}
          <item role="xquery">
             <p>
                <code>local</code>: <code>http://www.w3.org/2005/xquery-local-functions</code>
-                  (see <specref ref="FunctionDeclns"/>.)
+                  (see <specref ref="FunctionDeclns"/>).
             </p>
          </item>
          <item>
@@ -484,7 +484,7 @@ return namespace {$k}{$v}
 
       <p>
          <termdef term="URI" id="dt-URI"
-               >Within this specification, the term <term>URI</term> refers to a Universal Resource Identifier as defined in <bibref
+               >Within this specification, the term <term>URI</term> refers to a Uniform Resource Identifier as defined in <bibref
                ref="RFC3986"/> and extended in <bibref ref="RFC3987"
                /> with the new name <term>IRI</term>.</termdef>
 The term URI has been retained in preference to IRI to avoid introducing new names for concepts such as “Base URI” that are defined or referenced across the whole family of XML specifications.</p>
@@ -532,7 +532,7 @@ The term URI has been retained in preference to IRI to avoid introducing new nam
                      namespace, then a function call using the unprefixed function name invokes the user-defined
                      function in preference to the system-defined function.</p>
                      <p>It is generally advisable to avoid any danger of user confusion by keeping the names
-                        of user-defined functions noticably distinct from the names of system-defined functions,
+                        of user-defined functions noticeably distinct from the names of system-defined functions,
                         for example by using different naming conventions (for example, leading upper-case letters
                         leading underscores, or <code>camelCase</code>).</p>
                      <p>There may however be cases where a user-defined function deliberately has the same local name
@@ -1401,7 +1401,7 @@ constructor, as described in <specref
                                  ten Unicode characters that are used to represent the values 0
                                  to 9 in the function output: Unicode is organized so that each
                                  set of decimal digits forms a contiguous block of characters in
-                                 numerical sequence. Within the picture string any of these ten character 
+                                 numerical sequence. Within the picture string any of these ten characters
                                  can be used (interchangeably) as a place-holder for a mandatory digit.
                                  Within the final result string, these ten characters are used to represent
                                  the digits zero to nine.</termdef>
@@ -2049,7 +2049,7 @@ comparison or arithmetic operation. The implicit timezone is an  <termref
          <ulist>
             <item><p>Functions such as <function>doc</function>, <function>doc-available</function>,
             <function>unparsed-text</function>, <function>unparsed-text-lines</function>, 
-               <function>unparsed-text-available</function>, <function>collection</function>
+               <function>unparsed-text-available</function>, <function>collection</function>,
             <function>uri-collection</function>, and <function>unparsed-binary</function>, and in XSLT,
             the <code>document</code> function and the <code>xsl:source-document</code>
             and <code>xsl:merge</code> instructions.</p></item>
@@ -2070,7 +2070,7 @@ comparison or arithmetic operation. The implicit timezone is an  <termref
             as <function>environment-variable</function>, <function>available-environment-variables</function>,
             and (in XSLT) <code>system-property</code>.</p></item>
             <item><p>Static inclusion of XSD schemas and schema documents using 
-               <code>import schema</code>in XQuery or <code>xsl:import-schema</code> in XSLT,
+               <code>import schema</code> in XQuery or <code>xsl:import-schema</code> in XSLT,
             or indirectly using <code>xs:import</code>, <code>xs:include</code>,
             <code>xs:redefine</code>, or <code>xs:override</code> in XSD schema documents.</p></item>
             <item><p>Dynamic loading of XSD schema documents (directly or indirectly) 
@@ -3035,7 +3035,7 @@ numbers or sizes of various objects.
 
                      <item>
                         <p>
-                           <code>XP</code> denotes an error defined by XPath. Such an error may also occur XQuery since XQuery  includes XPath as a subset.</p>
+                           <code>XP</code> denotes an error defined by XPath. Such an error may also occur in XQuery since XQuery includes XPath as a subset.</p>
                      </item>
 
                      <item>
@@ -3461,7 +3461,7 @@ would raise an error because it has an <code>id</code> child whose value is not 
             that would be classed as errors in a language with stricter static typing rules.</p></note>
             
             <note><p>In many cases the classification of constructs as implausible is designed to protect users
-            from usability problems that have been found with earlier versions of the language. without
+            from usability problems that have been found with earlier versions of the language, without
             introducing backwards incompatibilities.</p></note>
             
          </div3> 
@@ -3687,8 +3687,8 @@ tree <var>T2</var>.</p>
                   <p>Example: A2 is an attribute with type
                      annotation <code>xs:IDREFS</code>, which is a list datatype whose item type is the atomic datatype <code>xs:IDREF</code>. Its string value is
                      <code>"bar baz faz"</code>. The typed value of A2 is a sequence of
-                     three atomic items (<code>"bar"</code>, <code>"baz"</code>",
-                     <code>"faz"</code>"), each of type <code>xs:IDREF</code>. The typed
+                     three atomic items (<code>"bar"</code>, <code>"baz"</code>,
+                     <code>"faz"</code>), each of type <code>xs:IDREF</code>. The typed
                      value of a node is never treated as an instance of a named list
                      type. Instead, if the type annotation of a node is a list type (such
                      as <code>xs:IDREFS</code>), its typed value is treated as a sequence
@@ -4612,7 +4612,7 @@ types</term> (such as <code>xs:integer</code>) and function types
                      <p>A <nt def="ChoiceItemType"
                         >ChoiceItemType</nt> lists a number of alternative item types in parentheses,
                         separated by <code>"|"</code>. An item matches a <code>ChoiceItemType</code>
-                        it if matches any of the alternatives.</p>
+                        if it matches any of the alternatives.</p>
                      <p>For example, <code>(map(*) | array(*))</code> matches any item that
                      is a map or an array.</p>
                       <note><p>If there is only one alternative, the <code>ChoiceItemType</code>
@@ -4704,7 +4704,7 @@ types</term> (such as <code>xs:integer</code>) and function types
                      <p>Example: Suppose <nt def="ItemType">ItemType</nt>
                         <code>dress-size</code> is a union type that allows
     either <code>xs:decimal</code> values for numeric sizes (for example: 4, 6, 10, 12),
-    or one of an enumerated set of <code>xs:strings</code>
+    or one of an enumerated set of <code>xs:string</code> values
     (for example: <code>small</code>, <code>medium</code>, <code>large</code>). The <nt
                            def="ItemType">ItemType</nt>
                         <code>dress-size</code> matches any of these values.</p>
@@ -5393,8 +5393,8 @@ matches any nilled or non-nilled element node whose type annotation is
     has its prefixes expanded to a namespace URI by means of the
     <termref
                      def="dt-static-namespaces"
-                     >statically known namespaces</termref>, or if unprefixed, the
-                  is interpreted according to the
+                     >statically known namespaces</termref>, or, if unprefixed, the name is
+                  interpreted according to the
                   <termref def="dt-default-namespace-elements-and-types"/>. If this has the special
                   value <code>"##any"</code>, an unprefixed name represents a name in no namespace.
 
@@ -5517,7 +5517,7 @@ matches any nilled or non-nilled element node whose type annotation is
                   but not necessarily in <var>Y</var>. However, <var>ET</var> will 
                   necessarily be present in both; and because the two schemas
                   must be <xtermref spec="DM40" ref="dt-schema-compatible">compatible</xtermref>,
-                  <var>ET</var> will be the present in both schemas, will have the same
+                  <var>ET</var> will be present in both schemas, will have the same
                   definition in both, and will be the declared type of <var>N</var> in both.
                   The test can therefore be applied from knowledge of type <var>AT</var>
                   as defined in schema <var>X</var>.</p></item>
@@ -5944,7 +5944,7 @@ name.</p>
 
                <p role="xquery">
     Implementations must not define function assertions in <termref
-                     def="dt-reserved-namespaces">reserved namespaces</termref>; it is is a <termref
+                     def="dt-reserved-namespaces">reserved namespaces</termref>; it is a <termref
                      def="dt-static-error">static error</termref>
                   <errorref class="ST" code="0045"
                      /> for a user to define a function assertion  in a <termref
@@ -5989,7 +5989,7 @@ name.</p>
                
                <p>For example, given a map <code>$M</code> whose keys are integers and whose
   results are strings, such as <code>{ 0: "no", 1: "yes" }</code>,
-  the following following expressions deliver the result shown:
+  the following expressions deliver the result shown:
   </p>
 
                <ulist>
@@ -8231,7 +8231,7 @@ declare record Particle (
                   </item>
                   
                   <item>
-                     <p>If <var>R</var> is an <termref def="dt-singleton-enumeration-type"/>
+                     <p>If <var>R</var> is a <termref def="dt-singleton-enumeration-type"/>
                      and <var>J</var> is an instance of <code>xs:untypedAtomic</code>
                         or <code>xs:anyURI</code>, then <var>J</var> is cast to
                         type <code>xs:string</code>.</p>
@@ -8274,7 +8274,7 @@ declare record Particle (
                         the datum is within the value space of <code>xs:unsignedByte</code>.</p>
                      <note><p>Relabeling is not the same as casting. For example, the <code>xs:decimal</code> value 10.1
                         can be cast to <code>xs:integer</code>, but it cannot be relabeled as <code>xs:integer</code>,
-                        because its datum not within the value space of <code>xs:integer</code>.</p></note>
+                        because its datum is not within the value space of <code>xs:integer</code>.</p></note>
                   
                      <note><p>The effect of this rule is that if, for example, a function parameter is declared
                         with an expected type of <code>xs:positiveInteger</code>, then a call that supplies the literal
@@ -8618,7 +8618,7 @@ declare record Particle (
            </item>
            <item>
               <p>When the coerced function is called, the supplied arguments must match the parameter
-              typed defined in <var>T</var>; it is not sufficient to match the parameter types defined
+              types defined in <var>T</var>; it is not sufficient to match the parameter types defined
               in <var>F</var>.</p>
            </item>
            
@@ -9024,9 +9024,9 @@ return $f(12.3)]]></eg>
                </example>
                
                <example id="eg-coercion-to-positive-integer">
-                  <head>Coercion to <code>xs:positive-integer</code></head>
+                  <head>Coercion to <code>xs:positiveInteger</code></head>
                   <p>Consider the case where the required type (of a variable, or a function argument)
-                     is <code>xs:positive-integer</code>. The table below illustrates the values that might be supplied, and
+                     is <code>xs:positiveInteger</code>. The table below illustrates the values that might be supplied, and
                      the coercions that are applied.</p>
                   
                   <table role="medium">
@@ -9074,7 +9074,7 @@ return $f(12.3)]]></eg>
                   <head>Coercion to a union type</head>
                   <p>Consider the first parameter of the function <function>fn:char</function>, whose declared
                   type is <code>(xs:string | xs:positiveInteger)</code>. The rules are the same
-                  as if it were a union typed declared in an imported schema.</p>
+                  as if it were a union type declared in an imported schema.</p>
                   
                   <table role="medium">
                      <thead>
@@ -9431,7 +9431,7 @@ and <nt def="OrExpr"
             <item><p>The string <code>"##any"</code>. In this case an unprefixed name appearing
               as a <nt def="NameTest">NameTest</nt> in an axis step whose principal node kind is element
               is interpreted as a wildcard (the unprefixed name <code>N</code> is treated as equivalent
-              to the wildcard <code>*:N</code>); an unprefixed name used appearing where an item type name
+              to the wildcard <code>*:N</code>); an unprefixed name appearing where an item type name
               is expected is interpreted as a local name in namespace <code>http://www.w3.org/2001/XMLSchema</code>,
               while an unprefixed name appearing in any other context
               where an element or type name is expected is treated as being in no namespace.</p>
@@ -9763,7 +9763,7 @@ and <nt def="OrExpr"
                expressions, such as <code>`Jamaica`</code> evaluates to the same value as
                the string literals <code>"Jamaica"</code> or <code>'Jamaica'</code>. 
                A string template can contain both single and double quotation marks:
-               <code>`He said: "I don't like it"`</code>. However, there there are
+               <code>`He said: "I don't like it"`</code>. However, there are
                some subtle differences:</p>
                <ulist>
                   <item><p>In string literals, the treatment of character and entity references
@@ -10526,7 +10526,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                         </item>-->
                         <item><p>Any keyword arguments in <var>FC</var> are then matched to
                            parameters (whether required or optional) in <var>FD</var> by comparing the keyword
-                           used in <var>FC</var> with the paramater name declared in <var>FD</var>.
+                           used in <var>FC</var> with the parameter name declared in <var>FD</var>.
                            Each keyword must match the name of a declared parameter <errorref class="ST" code="0017"/>, 
                            and this must be one that has not already
                            been matched to a positional argument. <errorref class="ST" code="0017"/>.</p></item>
@@ -11295,7 +11295,7 @@ return $sum-of-squares(1 to 3)]]></eg>
                   
                   <item>
                      <p>The result of the dynamic function call is the <termref def="dt-sequence-concatenation"/>
-                        of the results of partial applying each function item, retaining order. That is, the
+                        of the results of partially applying each function item, retaining order. That is, the
                         result of <code><var>F</var>(<var>X</var>, <var>Y</var>, ...)</code> is 
                         <code>for $FI in <var>F</var> return <var>$FI</var>(<var>X</var>, <var>Y</var>, ...)</code>.
                         The result of a dynamic function call applied to a single function item <var>FI</var> is defined
@@ -11481,7 +11481,7 @@ return $a("A")]]></eg>
           the static and dynamic context of the named function reference.</p>
             
             <note diff="chg" at="2023-03-11"><p>In practice, it is necessary to retain only those
-            parts of the static and dynamic context that can affect the outcome. These means it is 
+            parts of the static and dynamic context that can affect the outcome. This means it is
             unnecessary to retain parts of the context that no <termref def="dt-system-function"/>
             depends on (for example, local variables), or parts that are invariant within an
             execution scope (for example, the implicit timezone).</p></note>
@@ -11853,7 +11853,7 @@ return $incrementors[2](4)]]></eg>
                For example, <code>$s => tokenize() =!> fn { `"{.}"` }()</code> first tokenizes the string <code>$s</code>,
                then wraps each token in double quotation marks.</p>
                <p>The result of calling the <code>function { EXPR }</code> (or <code>fn { EXPR }</code>), with
-                  a single argument whose value is <var>$Z</var> arguments, is obtained by evaluating <code>EXPR</code>
+                  a single argument whose value is <var>$Z</var>, is obtained by evaluating <code>EXPR</code>
                   with a <termref def="dt-fixed-focus"/> in which the context value is <var>$Z</var>, the context position is 1 (one),
                   and the context size is 1 (one).</p>
                
@@ -13080,7 +13080,7 @@ return <var>Axis</var>::*[some($selector, atomic-equal(?, jkey()))]
         <ulist>    
                <item><p><code>element(N)</code> (short for <code>child::element(N)</code>) selects
                elements named <var>N</var>.</p></item>
-               <item><p><code>attribute(*, xs:integer)</code>selects
+               <item><p><code>attribute(*, xs:integer)</code> selects
                attribute nodes whose type annotation is <code>xs:integer</code>.</p></item>
                <item><p><code>text()</code> selects text nodes.</p></item>
                <item><p><code>jnode("id")</code> selects JNodes having the <term>·jkey·</term> property <code>"id"</code>.</p></item>
@@ -13273,7 +13273,7 @@ return <var>Axis</var>::*[some($selector, atomic-equal(?, jkey()))]
 
                </ulist>
                
-               <p>The following examples show type type tests that might
+               <p>The following examples show type tests that might
 		  be used in path expressions selecting within a JTree:</p>
                <ulist>
 
@@ -13368,7 +13368,7 @@ return <var>Axis</var>::*[some($selector, atomic-equal(?, jkey()))]
                is intended. The first expression, <code>//a[1]</code>, selects every descendant 
                   <code>a</code> element that is the first child of its parent (it expands
                   to <code>/descendant-or-self::node()/child::a[1]</code>), whereas 
-               <code>(//a)[1]</code> selects the <code>a</code> element in the document.
+               <code>(//a)[1]</code> selects the first <code>a</code> element in the document.
                </p>
             
             </note>
@@ -14114,7 +14114,7 @@ every <code>section</code> element that has a parent that is either a <code>chap
             <head>Comparison with JSONPath</head>
             
             <p>Path expressions applied to a JTree offer similar capability to
-            JSONPath, which is an XPath-like language design for querying JSON.</p>
+            JSONPath, which is an XPath-like language designed for querying JSON.</p>
             
             <example>
             <head>Comparison with JSONPath</head>
@@ -14514,7 +14514,7 @@ the results are the same.
 for $e in $m/child::* except $m/child::xx 
 return ...</eg>
             
-            <note><p>Because the <function>fn:jtree</function> creates a new JTree root,
+            <note><p>Because the <function>fn:jtree</function> function creates a new JTree root,
             calling it twice potentially creates two different trees, in which the JNodes have
             different identity. The expression <code>$map/child::* except $map/child::xx</code>
             might therefore have the wrong effect, because JNodes in two different trees 
@@ -14820,7 +14820,7 @@ course to the use of parentheses. Therefore, the following two examples have dif
          </note>
          <note>
             <p>Negation is not the same as subtraction from zero: if <code>$x</code> is positive zero,
-            then <code>-$x</code> returns negative zero, wheras <code>0 - $x</code> returns positive zero.</p>
+            then <code>-$x</code> returns negative zero, whereas <code>0 - $x</code> returns positive zero.</p>
          </note>
       </div2>
       <div2 id="id-string-expr">
@@ -14854,7 +14854,7 @@ course to the use of parentheses. Therefore, the following two examples have dif
             <p>String templates provide an alternative way of constructing strings. For example,
             the expression <code>`Pi is { round(math:pi(), 4) }`</code> returns the string <code>"Pi is 3.1416"</code>.</p>
             <p>A string template starts and ends with <char>U+0060</char>, popularly known as a back-tick. Between
-               the back-ticks is a string consisting of an sequence of fixed parts and
+               the back-ticks is a string consisting of a sequence of fixed parts and
                variable parts:</p>
             <ulist>
                <item><p>A variable part consists of an optional XPath expression enclosed in curly brackets (<code>{}</code>):
@@ -15087,7 +15087,7 @@ You have just won `{ $a?value }` dollars!
 }`]``
 };]]></eg>
             
-            <p>This is the output of the above function :</p>
+            <p>This is the output of the above function:</p>
             
             <eg><![CDATA[Hello Chris
 You have just won 10000 dollars!
@@ -15107,7 +15107,7 @@ Well, 6000 dollars, after taxes.]]></eg>
 </div>]``
 };]]></eg>
             
-            <p>This is the output of the above function :</p>
+            <p>This is the output of the above function:</p>
             
             <eg>&lt;div&gt;
   &lt;h1&gt;Hello Chris&lt;/h1&gt;
@@ -15132,7 +15132,7 @@ declare function local:prize-message($a) as xs:string {
 }]`` 
 };]]></eg>
             
-            <p>This is the output of the above function :</p>
+            <p>This is the output of the above function:</p>
             
             <eg><![CDATA[{ 
   "name": "Chris",
@@ -18728,7 +18728,7 @@ element #p:a {
                for the prefixes <code>xsi</code> 
                (because it is used in a name) and <code>xml</code> (because it is defined for every 
                constructed element node). During validation of the constructed element, the validator 
-               will be unable to interpret the namespace prefix <code>xs</code> because it is has 
+               will be unable to interpret the namespace prefix <code>xs</code> because it has
                no namespace binding. Validation of this constructed element could be made possible 
                by providing a <termref
                   def="dt-namespace-decl-attr"
@@ -22821,7 +22821,7 @@ else
             <p>The operator is associative (even under error conditions): <code>A otherwise (B otherwise C)</code> returns
          the same result as <code>(A otherwise B) otherwise C</code>.</p>
             <p>The <code>otherwise</code> operator binds more tightly than comparison operators such as
-            <code>=</code>, but less tightly than string concatenation (<code>||</code>) or arithemetic
+            <code>=</code>, but less tightly than string concatenation (<code>||</code>) or arithmetic
             operators. The expression <code>$a = @x otherwise @y + 1</code> parses as 
                <code>$a = (@x otherwise (@y + 1))</code>.</p>
          </note>
@@ -23678,7 +23678,7 @@ atomized value of the input expression is called the <term>input type</term>.
 The target type must be a <termref def="dt-generalized-atomic-type"/>. In practice
                this means it may be any of:</p>
             <ulist>
-               <item diff="add" at="issue688"><p>The name of an <termref def="dt-named-item-type">named item type</termref>
+               <item diff="add" at="issue688"><p>The name of a <termref def="dt-named-item-type">named item type</termref>
                defined in the <termref def="dt-static-context"/>, which in turn must refer to an item
                type in one of the following categories.</p></item>
                <item><p>The name of a type defined in the  <termref def="dt-is-types">in-scope schema types</termref>, 
@@ -23856,9 +23856,9 @@ else $x cast as xs:string]]></eg>
          <div3 id="id-constructor-functions">
             <head>Constructor Functions</head>
             <p>For every simple type in the <termref def="dt-is-types"
-                  >in-scope schema types</termref>  (except <code>xs:NOTATION</code> and 
-               <code>xs:anyAtomicType</code>, and <code>xs:anySimpleType</code>, which 
-               are not instantiable), a <term>constructor function</term> is implicitly defined. 
+                  >in-scope schema types</termref> (except <code>xs:NOTATION</code>,
+               <code>xs:anySimpleType</code>, and <code>xs:anyAtomicType</code>, which
+               are not instantiable), a <term>constructor function</term> is implicitly defined.
                In each case, the name of the constructor function is the same as the name of 
                its target type (including namespace). The signature of the constructor 
                function for  a given type depends on the type that is being constructed, 
@@ -23963,7 +23963,7 @@ usa:zipcode?)</code>.</p>
                <eg role="parse-test"><![CDATA[17 cast as Q{}apple]]></eg>
                <eg role="parse-test"><![CDATA[Q{}apple(17)]]></eg>
                <p diff="chg" at="A">In either context, using an unqualified NCName might not work:
-                  in a cast expression, an unqualified name is it is interpreted
+                  in a cast expression, an unqualified name is interpreted
                   according to the <termref def="dt-default-namespace-elements-and-types"/>,
                   while an unqualified name in a constructor function call is resolved using the
                   <termref def="dt-default-function-namespace"/> which will often be inappropriate.
@@ -24174,7 +24174,7 @@ return string-join($chopped, '; ')
 
          <p>Simple map operators have functionality similar to <specref ref="id-path-operator"
             />.
-  The following table summarizes the differences between these two operators</p>
+  The following table summarizes the differences between these two operators:</p>
 
          <table role="medium" width="100%">
             <thead>
@@ -24399,7 +24399,7 @@ return string-join($chopped, '; ')
          item must be enclosed in parentheses.</p>
          
          <p>Because the semantics of the arrow operator (<code>=></code>) are defined in terms of
-         static and dynamic functions calls, it is possible for the right-hand side to deliver
+         static and dynamic function calls, it is possible for the right-hand side to deliver
          a sequence of functions; the result of the arrow expression is the sequence-concatenation
          of the results of the function calls. For example,</p>
          

--- a/specifications/xquery-40/src/introduction.xml
+++ b/specifications/xquery-40/src/introduction.xml
@@ -27,7 +27,7 @@
 		non-XML syntax, allowing XPath expressions to be embedded within URIs and to be used as 
 		XML attribute values. XPath is designed to be embedded in (or invoked from) other
 		host languages, including both languages specialized towards XML processing (such as <bibref ref="xslt-40"/> and XSD),
-	   and general purpose programming languages such as Java, C#, Python, and Javascript. The interface
+	   and general purpose programming languages such as Java, C#, Python, and JavaScript. The interface
 	   between XPath and its host language is formalized with an abstract definition of a static and dynamic
 	   context, made available by the host language to the XPath processor.</p>
 	

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -270,7 +270,7 @@
         >static error</termref> is raised <errorref class="ST" code="0032"/>.</p>
     <p>In the terminology of <bibref ref="RFC3986"/> Section 5.1, the URILiteral of the base URI
       declaration is considered to be a “base URI embedded in content”. If no base URI declaration
-      is present, <termref def="dt-static-base-uri">Static Base URI</termref> property is
+      is present, the <termref def="dt-static-base-uri">Static Base URI</termref> property is
       established according to the principles outlined in <bibref ref="RFC3986"/> Section
       5.1—that is, it defaults first to the base URI of the encapsulating entity, then to the
       URI used to retrieve the entity, and finally to an implementation-defined default. If the
@@ -508,7 +508,7 @@ return (
       <errorref class="ST" code="0033"/>. </p>
     
     <note diff="add" at="issue647"><p>If schema definitions from the <code>xml</code> namespace
-    are to be used (for example, <code>schema-attribute(xml:space)</code>, then the prolog should
+    are to be used (for example, <code>schema-attribute(xml:space)</code>), then the prolog should
       include a declaration in the form <code>import schema "http://www.w3.org/XML/1998/namespace"</code>.
     No prefix should be supplied (the <code>xml</code> prefix is predeclared), and no location hint
     should be provided (the schema definitions for the namespace are built in, and cannot be varied).</p></note>
@@ -517,7 +517,7 @@ return (
       then the prolog must not contain a <termref def="dt-namespace-declaration">namespace declaration</termref>
       that specifies <code>default element namespace</code> or <code>default type namespace</code>.</p>
     
-    <p diff="add" at="2023-10-16">If the keyword <code>"fixed"</code>, is present, the 
+    <p diff="add" at="2023-10-16">If the keyword <code>"fixed"</code> is present, the
       <termref def="dt-default-namespace-elements-and-types"/> is fixed throughout the module,
       and is not affected by default namespace declarations (<code>xmlns=""</code>) appearing
       on direct element constructors.</p>
@@ -790,7 +790,7 @@ $triangle</eg>
       <p>To maximize interoperability, query authors should use a string that is a valid absolute
         IRI.</p>
 
-      <p>Implementions must accept any string of Unicode characters. Target namespace URIs are
+      <p>Implementations must accept any string of Unicode characters. Target namespace URIs are
         compared using the Unicode codepoint collation rather than any concept of semantic
         equivalence.</p>
 
@@ -853,7 +853,7 @@ $triangle</eg>
         single copy of the resource containing the module is loaded. When different absolutized
         location URIs are used, each results in a single module being loaded, unless the
         implementation is able to determine that the different URIs are references to the same
-        resource. No error due to duplicate variable or functions names should arise from the same
+        resource. No error due to duplicate variable or function names should arise from the same
         module being imported more than once, so long as the absolute location URI is the same in
         each case.</p>
 
@@ -1012,7 +1012,7 @@ return $node/xx:bing]]>
             <item><p>The string <code>"##any"</code>. In this case an unprefixed name appearing
               as a <nt def="NameTest">NameTest</nt> in an axis step whose principal node kind is element
               is interpreted as a wildcard (the unprefixed name <code>N</code> is treated as equivalent
-              to the wildcard <code>*:N</code>); an unprefixed name used appearing where an item type name
+              to the wildcard <code>*:N</code>); an unprefixed name appearing where an item type name
               is expected is interpreted as a local name in namespace <code>http://www.w3.org/2001/XMLSchema</code>,
               while an unprefixed name appearing in any other context
               where an element or type name is expected is treated as being in no namespace.</p>
@@ -1031,7 +1031,7 @@ return $node/xx:bing]]>
         <p>If no default element namespace declaration is present, unprefixed element and type
           names are in no namespace (however, an implementation may define a different default as
           specified in <specref ref="id-xq-static-context-components"/>.)</p>
-        <p diff="add" at="2023-10-16">If the keyword <code>"fixed"</code>, is present, the 
+        <p diff="add" at="2023-10-16">If the keyword <code>"fixed"</code> is present, the
           <termref def="dt-default-namespace-elements-and-types"/> is fixed throughout the module,
           and is not affected by default namespace declarations (<code>xmlns=""</code>) appearing
           on direct element constructors.</p>
@@ -1268,7 +1268,7 @@ return $node/xx:bing]]>
     <p>During static analysis, a variable declaration causes a pair <code>(expanded QName N, type
         T)</code> to be added to the <termref def="dt-in-scope-variables">in-scope
         variables</termref>. The <termref def="dt-expanded-qname"/> N is the <code>VarName</code>. If N is equal (as
-      defined by the eq operator) to the expanded QName of another variable in in-scope variables, a
+      defined by the eq operator) to the expanded QName of another variable in the in-scope variables, a
         <termref def="dt-static-error">static error</termref> is raised <errorref class="ST"
         code="0049"/>.
         
@@ -1301,7 +1301,7 @@ return $node/xx:bing]]>
   variable">A
           <term>private variable</term> is a variable with a <code>%private</code> annotation. A
         private variable is hidden from <termref def="dt-module-import">module import</termref>,
-        which can not import it into the <termref def="dt-in-scope-variables">in-scope
+        which cannot import it into the <termref def="dt-in-scope-variables">in-scope
           variables</termref> of another module.</termdef>
       <termdef id="dt-public-variable" term="public variable">A <term>public variable</term> is a
         variable without a <code>%private</code> annotation. A public variable is accessible to
@@ -1862,7 +1862,7 @@ local:summary(doc("acme_corp.xml")//employee[location = "Denver"])</eg>
     <p>A function declaration includes a list of zero or more function parameters.</p>
       
       <p>The parameters of a function declaration are considered to be variables whose scope is the
-        function body. It is an <termref def="dt-static-error">static error</termref>
+        function body. It is a <termref def="dt-static-error">static error</termref>
         <errorref class="ST" code="0039"/> for a function declaration to have more than one parameter
         with the same name. The type of a function parameter can be any type that can be expressed as
         a <termref def="dt-sequence-type">sequence type</termref>.</p>
@@ -1887,7 +1887,7 @@ local:summary(doc("acme_corp.xml")//employee[location = "Denver"])</eg>
     
     <p>The number of arguments that may be supplied in a call to this family of functions is thus in the range <var>M</var> to <var>N</var>,
     where <var>M</var> is the number of required parameters, and <var>N</var> is the total number of parameters (whether required or optional).
-    This is refered to as the <termref def="dt-arity-range"/> of the <termref def="dt-function-definition"/>.</p>
+    This is referred to as the <termref def="dt-arity-range"/> of the <termref def="dt-function-definition"/>.</p>
       
      <p diff="add" at="2023-05-19">The default value for an optional parameter will often be supplied using a 
        simple literal or constant expression, for example
@@ -1942,7 +1942,7 @@ local:summary(doc("acme_corp.xml")//employee[location = "Denver"])</eg>
       to specify that a function is public or private; if neither of these annotations is used, the
       function is public. <termdef id="dt-private-function" term="private function">A <term>private
           function</term> is a function with a <code>%private</code> annotation. A private function
-        is hidden from <termref def="dt-module-import">module import</termref>, which can not import
+        is hidden from <termref def="dt-module-import">module import</termref>, which cannot import
         it into the <termref def="dt-statically-known-function-definitions"/> of another module. </termdef>
       <termdef id="dt-public-function" term="public function">A <term>public function</term> is a
         function without a <code>%private</code> annotation. A public function is accessible to
@@ -1992,7 +1992,7 @@ function smath:copySign($magnitude, $sign) external;</eg>
       of the function is returned to the invoking query, are <termref
         def="dt-implementation-defined">implementation-defined</termref>. An XQuery implementation
       may augment the type system of <bibref ref="xpath-datamodel-40"/> with additional types that
-      are designed to facilitate exchange of data, or it may provide
+      are designed to facilitate exchange of data, or it may provide a
       mechanism for the user to define such types. For example, a type might be provided that
       encapsulates an object returned by an external function, such as an SQL database connection.
       </p>
@@ -2086,7 +2086,7 @@ local:depth(doc("partlist.xml"))
     <ulist>
       <item><p><termdef id="dt-private-item-type" term="private item type">A <term>private
         item type</term> is a named item type with a <code>%private</code> annotation. A private item type
-        is hidden from <termref def="dt-module-import">module import</termref>, which can not import
+        is hidden from <termref def="dt-module-import">module import</termref>, which cannot import
         it into the <termref def="dt-in-scope-named-item-types"/> of another module. </termdef></p></item>
       <item><p><termdef id="dt-public-item-type" term="public item type">A <term>public item type</term> is an
          item type declaration without a <code>%private</code> annotation. A public item type is accessible to
@@ -2332,7 +2332,7 @@ local:depth(doc("partlist.xml"))
        <ulist>
          <item>
            <p><code>record(longitude, latitude, altitude?)</code></p>
-           <p>Defines a record type in which <code>altitude</code> entry may be absent, and a constructor
+           <p>Defines a record type in which the <code>altitude</code> entry may be absent, and a constructor
            function with three arguments, of which the last is optional; if the function is called
            with two arguments (or with the third argument set to an empty sequence), then there will be no
            <code>altitude</code> entry in the resulting map.</p>
@@ -2541,7 +2541,7 @@ module namespace set = "http://qt4cg.org/atomic-set";
       XQuery does not currently define declaration options in this namespace.</p>
 </note>
     <p>Each implementation recognizes the <code>http://www.w3.org/2012/xquery</code> namespace URI
-      and and all options defined in this namespace in this specification. In addition, each
+      and all options defined in this namespace in this specification. In addition, each
       implementation recognizes an <termref def="dt-implementation-defined"
         >implementation-defined</termref> set of namespace URIs and an implementation-defined set of
       option names defined in those namespaces. If the namespace part of an option declaration's
@@ -2590,8 +2590,7 @@ declare option exq:java-class "smath = java.lang.StrictMath"; </eg>
 of <term>serialization parameters</term> that govern the serialization
 process. If an XQuery implementation provides a serialization
 interface, it may support (and may expose to users) any of the
-serialization parameters listed (with default values) in
-in this section.
+serialization parameters listed (with default values) in this section.
 If an implementation does not support one of these parameters, it must ignore it without raising an error.</p>
 
             <p role="xquery">


### PR DESCRIPTION
expressions.xml:
* "Universal Resource Identifier" -> "Uniform" (per RFC 3986)
* "an unprefixed name used appearing" -> drop "used"
* "ten character" -> "ten characters" (plural)
* "These means" -> "This means"
* "partial applying" -> "partially applying"
* "is `$Z` arguments, is obtained" -> "is `$Z`, is obtained"
* "attribute(*, xs:integer)selects" -> add missing space
* "type type tests" -> drop doubled "type"
* "(//a)[1] selects the a element" -> add "first"
* "language design for querying" -> "designed"
* "Because the fn:jtree creates" -> "fn:jtree function creates"
* "wheras" -> "whereas"
* "an sequence" -> "a sequence"
* "This is the output of the above function :" -> drop space before colon (3x)
* "because it is has no namespace binding" -> drop "is"
* "an named item type" -> "a named"
* constructor exclusion list: drop the second "and" and align order with the matching list in the cast section
* "is it is interpreted" -> drop doubled "is it"
* "summarizes the differences between these two operators" -> add colon
* "static and dynamic functions calls" -> "function calls"
* "arithemetic" -> "arithmetic"
* "be the present" -> "be present"
* "may also occur XQuery" -> "may also occur in XQuery"
* "is is a static error" -> "is a"
* "following following expressions" -> drop doubled "following"
* "typed defined" -> "types defined"
* "union typed declared" -> "union type declared"
* "noticably" -> "noticeably"
* "its datum not within" -> "its datum is not within"
* `xs:positive-integer` -> `xs:positiveInteger` (example head and body)
* ChoiceItemType: "it if matches" -> "if it matches"
* "an enumerated set of xs:strings" -> "an enumerated set of xs:string values"
* "or if unprefixed, the / is interpreted" -> "or, if unprefixed, the name is interpreted"
* "A is an singleton enumeration type" -> "a singleton" (term starts with /s/)
* missing commas in function list and missing space in "import schemain"
* "(see FunctionDeclns.)" -> "(see FunctionDeclns)."
* "of the language. without" -> "of the language, without"
* stray '"' after </code> in IDREFS example

ebnf.xml:
* head "Lexical structure" -> "Lexical Structure"
* "does not quality" -> "qualify"

errors.xml:
* "(as defined by the eq operator.)" -> "operator)." (twice)

query-prolog.xml:
* "Implementions" -> "Implementations"
* "variable or functions names" -> "function names"
* "an unprefixed name used appearing" -> drop "used"
* "another variable in in-scope variables" -> "in the in-scope variables"
* "refered" -> "referred"
* "in which altitude entry may be absent" -> "the altitude entry"
* "and and all options" -> drop doubled "and"
* `"fixed",` -> `"fixed"` (drop stray comma, twice)
* "It is an static error" -> "a static error"
* "Static Base URI property" -> "the Static Base URI property"
* "(for example, schema-attribute(xml:space)," -> close the parenthesis
* "can not import" -> "cannot import" (three occurrences)
* "in / in this section" -> drop the doubled fragment
* "may provide mechanism" -> "may provide a mechanism"

back-matter.xml:
* "( (which adds constructor functions" -> single opening paren
* "can returned to" -> "can be returned to"
* "Comparisons ... lacking a timezone uses" -> "use"
* "in the following sections" -> add trailing period
* "if any.)" -> "if any)." (period outside parenthesis)

conformance.xml:
* "attributes node types" -> "attribute node types"
* "a XQuery expression" -> "an XQuery expression"

introduction.xml:
* "Javascript" -> "JavaScript"

Issue: #2632