### PR TITLE
2632-4: logic and semantics (automatically generated & reviewed)

### DIFF
--- a/specifications/xquery-40/src/back-matter.xml
+++ b/specifications/xquery-40/src/back-matter.xml
@@ -454,7 +454,7 @@ defined.</p>
   <td>Variable values</td>
   <td>dynamic; for-expressions, let-expressions, and quantified expressions can bind new variables</td></tr>
 <tr>
-  <td>Current date and time</td>
+  <td>Current dateTime</td>
   <td>global; must be initialized <phrase role="xquery">by implementation</phrase></td></tr>
 <tr>
   <td>Implicit timezone</td>
@@ -463,7 +463,7 @@ defined.</p>
   <td>Available documents</td>
   <td>global; must be initialized <phrase role="xquery">by implementation</phrase></td></tr>
 <tr>
-  <td>Available node collections</td>
+  <td>Available collections</td>
   <td>global; must be initialized <phrase role="xquery">by implementation</phrase></td></tr>
 <tr>
   <td>Default collection</td>
@@ -790,8 +790,8 @@ See
           <item><p>If nodes are supplied, they are atomized. In the absence of schema validation,
           the result of atomizing a node is an untyped atomic value, which is treated as a string.
           Comparison of a node to a value such as a number or a date therefore raises an error.</p></item>
-          <item><p>Numeric values of types <code>xs:integer</code>, <code>xs:decimal</code>, 
-            or <code>xs:float</code> are mutually comparable. Except for the special values <code>NaN</code>
+          <item><p>Numeric values of types <code>xs:integer</code>, <code>xs:decimal</code>,
+            <code>xs:float</code>, or <code>xs:double</code> are mutually comparable. Except for the special values <code>NaN</code>
             and positive and negative infinity, both operands
             are converted to <code>xs:decimal</code>, using an implementation of <code>xs:decimal</code>
           that supports unlimited precision (or at least, sufficient precision to represent every
@@ -950,7 +950,7 @@ See
     <function>fn:sort-by</function>, and <function>fn:sort-with</function> functions, the <function>fn:min</function>
     and <function>fn:max</function> functions, <function>fn:highest</function> and <function>fn:lowest</function>,
     the <code>order by</code> clause in XQuery, and the <code>xsl:sort</code> and <code>xsl:merge</code> instructions
-    in XSLT, are ultimately defined in terms of either <code>fn:compare</code> or the value comparison operators
+    in XSLT) are ultimately defined in terms of either <code>fn:compare</code> or the value comparison operators
     <code>eq</code> and <code>lt</code>.</p>
   </div2>
   

--- a/specifications/xquery-40/src/errors.xml
+++ b/specifications/xquery-40/src/errors.xml
@@ -400,8 +400,8 @@
       </error>
 
       <error spec="XQ" role="xquery" code="0048" class="ST" type="static">
-         <p> It is a <termref def="dt-static-error"/> if a function, variable,
-            or item type declared in a <termref def="dt-library-module"/> is not 
+         <p> It is a <termref def="dt-static-error"/> if a public function, public variable,
+            or item type declared in a <termref def="dt-library-module"/> is not
             in the <termref def="dt-target-namespace"/> of the library module.</p>
       </error>
 

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -5815,7 +5815,6 @@ name.</p>
                   >TypedFunctionType</nt>.</p>
                
 
-               <note><p>The keywords <code>function</code> and <code>fn</code> are synonymous.</p></note>
 
                <p>If parameter names are included in a <nt def="TypedFunctionType">TypedFunctionType</nt>,
                they are purely documentary and have no semantic effect. In particular, they
@@ -5852,10 +5851,6 @@ name.</p>
                         because the signature of the function item <code>fn:count#1</code>
                         is a subtype of <code>function(xs:string*) as item()</code>.
                      </p>
-
-                     <note><p>The same type might also be written 
-                        <code>fn($x as xs:int, $y as xs:int) as xs:int</code>.</p></note>
-
                   </item>
                   <item role="xquery">
                      <p>
@@ -6745,7 +6740,7 @@ declare record Particle (
   
         
             
-            <note diff="add" at="B"><p>The subtype relationship is not acyclic. There are cases where <code>subtype(A, B)</code> and
+            <note diff="add" at="B"><p>The subtype relationship is not antisymmetric. There are cases where <code>subtype(A, B)</code> and
                <code>subtype(B, A)</code> are both true. This implies that <var>A</var> and <var>B</var>
                have the same value space, but they can still be different types. For example this applies when <var>A</var>
                is a union type with member types <code>xs:string</code> and <code>xs:integer</code>, while 
@@ -7181,7 +7176,7 @@ declare record Particle (
                            <example>
                               <head>Examples:</head>
                               <ulist>
-                                 <item><p><code>document-node(a|b) ⊆ document-node(a) | document-node(b)</code></p></item>
+                                 <item><p><code>document-node(a|b) ⊆ (document-node(a) | document-node(b))</code></p></item>
                                  <item><p><code>document-node(a|b) ⊆ document-node(a|b|c)</code></p></item> 
                               </ulist>
                            </example>
@@ -7244,7 +7239,6 @@ declare record Particle (
                                  <item diff="add" at="Issue23"><p><code>element(title|heading, xs:string) ⊆ element(*)</code></p></item>
                                  <item diff="add" at="Issue23"><p><code>element(title, xs:string) ⊆ element(title|heading)</code></p></item>
                                  <item><p><code>element(title, xs:string?) ⊆ element(*)</code></p></item>
-                                 <item diff="add" at="Issue23"><p><code>element(title|heading, xs:string) ⊆ element(*)</code></p></item>
                                  <item><p><code>element(title) ⊆ element(title, xs:anyType?)</code></p></item>
                                  <item><p><code>element(title, xs:integer) ⊆ element(title|heading, xs:anyType?)</code></p></item>
                                  <item><p><code>element(title, xs:string?) ⊆ element(title, xs:anyType?)</code></p></item>
@@ -7376,7 +7370,7 @@ declare record Particle (
                               <item><p><var>A</var> is either <code>attribute(<var>A/n</var>)</code> or 
                                  <code>attribute(<var>A/n</var>, <var>T</var>)</code> 
                                  for any type <var>T</var>.</p></item>
-                              <item><p><var>B</var> is either <code>attribute(Bn)</code> or 
+                              <item><p><var>B</var> is either <code>attribute(<var>B/n</var>)</code> or
                                  <code>attribute(<var>B/n</var>, xs:anyAtomicType)</code></p></item>
                               <item><p><var>A/n</var> <termref def="dt-wildcard-matches"/> <var>B/n</var></p></item>
                               
@@ -8908,7 +8902,7 @@ return $f(12.3)]]></eg>
                         <tr role="xpath">
                            <td valign="top"><code>//author/@id</code></td>
                            <td valign="top"><p>Supplying a sequence of nodes where a single string is expected will raise a type
-                              error unless either there is only one node in the sequence. In this case
+                              error unless there is only one node in the sequence. In this case
                               the typed value of the node will be used (this must be of type
                               <code>xs:string</code>, <code>xs:untypedAtomic</code>, or <code>xs:anyURI</code>).</p>
                               <p role="xpath">If XPath 1.0 compatibility mode is enabled, however, 
@@ -12667,7 +12661,7 @@ return if (every $r in $R satisfies $r instance of gnode())
 			 which are the nodes returned by the
 			 <phrase diff="chg" at="B">
 			 <xspecref spec="DM40" ref="dm-attributes"/></phrase>; the axis will be
-			 empty unless the context node is an
+			 empty unless the origin is an
 			 element.</p>
                      
                      <p>If the <code>attribute</code> axis is applied to a JNode,
@@ -12740,11 +12734,11 @@ return if (every $r in $R satisfies $r instance of gnode())
                </ulist>
                <p>Axes can be categorized as <term>forward axes</term> and
 		  <term>reverse axes</term>. An axis that only ever contains the origin or
-		  nodes that are after the context node in <termref
+		  nodes that are after the origin in <termref
                      def="dt-document-order"
                      >document order</termref> is a forward axis. An
-		  axis that only ever contains the context node or nodes that are before the
-		  context node in <termref
+		  axis that only ever contains the origin or nodes that are before the
+		  origin in <termref
                      def="dt-document-order">document order</termref> is a reverse axis.</p>
                <p>The <code>parent</code>, <code>ancestor</code>, <code>ancestor-or-self</code>, 
                   <code>preceding</code>, <code>preceding-or-self</code>, 
@@ -18170,10 +18164,6 @@ attribute {
                </note>
                <p>The following example illustrates a text node constructor:</p>
                <eg role="parse-test"><![CDATA[text { "Hello" }]]></eg>
-               
-               <note><p>It is possible to construct a text node whose string value is zero-length. The rules 
-                     for constructing element nodes, however, ensure that a zero-length text node will be discarded
-                     if used while forming the content of an element.</p></note>
             </div4>
 
             <div4 id="id-computed-pis">
@@ -23160,23 +23150,23 @@ query using the <code>fn:error()</code> function.</p>
                >dynamic errors</termref> and
                 <termref def="dt-type-error"
                >type errors</termref>
-                raised by the evaluation of the target expression of
-                the <code>try</code>  clause. If the <termref
+                raised by the evaluation of the <termref
                def="dt-content-expression"
-            >content expression</termref> of the try clause does not raise a
+            >content expression</termref> of
+                the <code>try</code>  clause. If the content expression of the try clause does not raise a
                 dynamic error or a type error, the result of the
                 try/catch expression is the result of the content
                 expression.</p>
 
-         <p>If the target expression raises a dynamic error or
+         <p>If the content expression raises a dynamic error or
                 a type error, the result of the try/catch expression
                 is obtained by evaluating the first <code>catch</code>
                 clause that “matches” the error value, as described
-                below.  
+                below.
 
 		If no catch clause “matches” the
 		error value, then the try/catch expression raises the
-		error that was raised by the target
+		error that was raised by the content
 		expression.
 
 		A <code>catch</code> clause with one or more

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -169,7 +169,7 @@
         <errorref class="ST" code="0088"/>. The URILiteral identifies the <termref
         def="dt-target-namespace">target namespace</termref> of the library module, which is the
       namespace for all variables and functions exported by the library module. The name of every
-      variable and function declared in a library module must have a namespace URI that is the same
+      public variable and public function declared in a library module must have a namespace URI that is the same
       as the target namespace of the module; otherwise a <termref def="dt-static-error">static
         error</termref> is raised <errorref class="ST" code="0048"/>. The (prefix,URI) pair is added
       to the set of <termref def="dt-static-namespaces">statically known namespaces</termref>. </p>
@@ -430,7 +430,7 @@ declaration">A
         <errorref class="ST" code="0097"/>.</p></item>
       <item><p>It is a <termref def="dt-static-error">static
         error</termref> if, for any named or unnamed decimal format, the properties identifying
-        <term>marker</term> characters to be used in a picture string do identify distinct values <errorref class="ST"
+        <term>marker</term> characters to be used in a picture string do not identify distinct values <errorref class="ST"
           code="0098"/>.</p> 
         <p>The following properties identify <term>marker</term> characters used in a picture string:
         <termref def="id-static-decimal-format-decimal-separator">decimal-separator</termref>, 
@@ -536,7 +536,7 @@ return (
       import a schema that has no target namespace. Such a schema import must not bind a namespace
       prefix <errorref class="ST" code="0057"/>, but it may set the default element and/or type namespace
       to a zero-length string (representing “no namespace”), thus enabling the definitions in the
-      imported namespace to be referenced. If the <termref def="dt-default-namespace-elements-and-types"/> is not set to "no
+      imported schema to be referenced. If the <termref def="dt-default-namespace-elements-and-types"/> is not set to "no
       namespace", <phrase diff="chg" at="A">the only way to reference the definitions in an imported schema that has no
         target namespace is using the EQName syntax <code>Q{}local-name</code></phrase>.</p>
     
@@ -670,12 +670,12 @@ return (
     </scrap>
     <p>
       <termdef term="module import" id="dt-module-import">A <term>module import</term> imports the
-        public variable declarations, public function declarations<phrase diff="add" at="A">, 
+        public variable declarations, public function declarations<phrase diff="add" at="A">,
           and public item type declarations</phrase> from one or more <termref
           def="dt-library-module">library modules</termref> into the <termref
           def="dt-statically-known-function-definitions"/>, <termref
           def="dt-in-scope-variables">in-scope variables</termref><phrase diff="add" at="A">,
-          or <termref def="dt-in-scope-named-item-types"/></phrase> of the importing <termref
+          and <termref def="dt-in-scope-named-item-types"/></phrase> of the importing <termref
           def="dt-module">module</termref>.</termdef> Each module import names a <termref
         def="dt-target-namespace">target namespace</termref> and imports an <termref
         def="dt-implementation-defined">implementation-defined</termref> set of modules that share
@@ -688,7 +688,7 @@ return (
       <var>A</var> will contain the <termref
         def="dt-statically-known-function-definitions"/>, <termref
           def="dt-in-scope-variables">in-scope variables</termref><phrase diff="add" at="A">,
-            or <termref def="dt-in-scope-named-item-types"/></phrase> of
+            and <termref def="dt-in-scope-named-item-types"/></phrase> of
       module <var>B</var>, and the dynamic context of module <var>A</var> will contain the
         public <termref def="dt-variable-values">variable values</termref> and <termref
         def="dt-dynamically-known-function-definitions"/> of module <var>B</var>. It will
@@ -1616,10 +1616,8 @@ declare context item as element(env:Envelope) external;</eg>
       </item>
       
       <item>
-        <p>Declare a context value, which is collection whose collection URI is supplied as an external
-          parameter to the query. If the
-          system log is in a different location, it can be specified in the external
-          environment:</p>
+        <p>Declare a context value, which is a collection whose collection URI is supplied as an external
+          parameter to the query:</p>
         <eg role="frag-prolog-parse-test">declare variable $uri as xs:string external;
 declare context value as document-node()* := collection($uri); </eg>
         <p>With this declaration, a query body such as <code>//person[name="Mandela"]</code> returns all matching


### PR DESCRIPTION
query-prolog.xml:
* XQST0098 description: inverted polarity — "the properties identifying marker characters ... do identify distinct values" should be "do not"
* module-import termdef: cumulative not alternative ("or" -> "and") in the list of context components imported (in-scope variables, in-scope item types, ...). Same in the "If module A imports module B" paragraph.
* "enabling the definitions in the imported namespace" -> "imported schema" (the imported schema has no target namespace at this point)
* duplicate sentence "If the system log is in a different location, ..." in the context-value example removed; also "which is collection" -> "is a"
* library-module namespace constraint now applies only to *public* variables and functions (private names may be in any namespace since the 2025-04-24 changes — the matching change is already reflected at the specific rules for variables (1318) and functions (1785-1788))

expressions.xml:
* attribute axis: "empty unless the context node is an element" ->
  "empty unless the origin is an element" — matches the rest of the section which speaks of "origin"
* forward/reverse axis: mixed "origin" / "context node"; standardised on "origin" (the surrounding paragraphs use that term consistently)
* coercion table note: "unless either there is only one node" — drop the stranded "either"
* "The subtype relationship is not acyclic" -> "is not antisymmetric" (the following sentences describe an antisymmetry failure, not a cycle)
* subtype example: missing parens around the right-hand alternative "document-node(a|b) ⊆ (document-node(a) | document-node(b))", matching the equivalent examples for elements and attributes
* element-test examples list: "element(title|heading, xs:string) ⊆ element(*)" was listed twice (lines 7244 and 7247); drop the duplicate
* AnyFunctionType: "The keywords function and fn are synonymous" was both in prose (5793) and a note (5818); drop the redundant note
* fn:count#1 instance-of example: a stranded note about "fn($x as xs:int, $y as xs:int) as xs:int" referred to a 2-arity signature in a 1-arity example; remove
* attribute subtype rule: "attribute(Bn)" -> "attribute(<var>B/n</var>)" matching the surrounding var-style notation
* text node constructors: two near-identical notes about constructing zero-length text nodes; keep the more complete one
* try/catch: target expression / content expression were used interchangeably for the same thing; standardise on "content expression" (the defined term)

errors.xml:
* XQST0048 description aligned with the more specific rules: scope is *public* function/variable and item type, not any function/variable

back-matter.xml:
* numeric comparability list: xs:double was missing from "xs:integer, xs:decimal, or xs:float are mutually comparable"; the next sentence ("both operands are converted to xs:decimal ... sufficient precision for the xs:double value space") only made sense with xs:double included
* sort-functions list paragraph: opening "(" never closed before "are ultimately defined ..."
* dynamic-context table:
  - "Current date and time" -> "Current dateTime" (matches the XQuery side and the dt-date-time term)
  - "Available node collections" -> "Available collections" (matches the XQuery side and the function name "fn:collection")

Issue: #2632