### PR TITLE
2632-5: refresh stale 4.0 content (automatically generated & reviewed)

### DIFF
--- a/specifications/xquery-40/src/mime-type.xml
+++ b/specifications/xquery-40/src/mime-type.xml
@@ -6,9 +6,9 @@
 
 
 
-  <p>This Appendix 
+  <p>This Appendix
 
-    specifies the media type for XQuery Version 1.0.  XQuery is a language for querying over
+    specifies the media type for XQuery 4.0.  XQuery is a language for querying over
 
     collections of data from XML data sources, as specified in the main body of this document. This media type is being 
 
@@ -30,7 +30,7 @@ Authority.)</p>
 
 	<loc href="http://www.w3.org/TR/xquery/" role="xquery">http://www.w3.org/TR/xquery/</loc>,
 
-	together with its normative references,  defines the language XQuery Version 1.0.  This Appendix
+	together with its normative references,  defines the language XQuery 4.0.  This Appendix
 
       provides information about the <code>application/xquery</code> media type,
 
@@ -173,7 +173,7 @@ declaration</termref> as part of its <termref def="dt-version-declaration">versi
 
     beginning of the document, where <code>"V.V"</code> is a version number.
 
-    Currently the version number, if present, must be <code>"1.0"</code><phrase diff="add" at="2014-12-05">, <code>"3.0"</code>, or <code>"3.1"</code></phrase>.</p></div2>
+    Currently the version number, if present, must be <code>"1.0"</code><phrase diff="add" at="2014-12-05">, <code>"3.0"</code>, <code>"3.1"</code>, or <code>"4.0"</code></phrase>.</p></div2>
 
 
 

--- a/specifications/xquery-40/src/xpath-backwards-compat.xml
+++ b/specifications/xquery-40/src/xpath-backwards-compat.xml
@@ -214,7 +214,7 @@
                     (because the string <code>"+4"</code> converts to <code>NaN</code>),
                     and <code>false = "false"</code> returned <code>false</code> (because the
                     string <code>"false"</code> converts to the boolean <code>true</code>). In XPath
-                    3.0 all these comparisons are type errors.</p>
+                    4.0 all these comparisons are type errors.</p>
             </item>
 
 
@@ -323,12 +323,6 @@
             do the computation in a different way. For example, <code role="parse-test"
                 >substring-after(@temperature, "-")</code> might be rewritten as <code
                 role="parse-test">abs(@temperature)</code>.</p>
-
-        <p>In the case of an XPath 4.0 implementation that provides the static typing feature, many
-            further type errors will be reported in respect of expressions that worked under XPath
-            1.0. For example, an expression such as <code role="parse-test">round(../@price)</code>
-            might lead to a static type error because the processor cannot infer statically that
-                <code role="parse-test">../@price</code> is guaranteed to be numeric.</p>
 
         <p>Schema validation will in many cases perform whitespace normalization on the contents of
             elements (depending on their type). This will change the result of operations such as

--- a/specifications/xquery-40/src/xpath.xml
+++ b/specifications/xquery-40/src/xpath.xml
@@ -53,7 +53,7 @@
 <!ENTITY doc.latestloc-tech "&doc.publoc;">
 <!ENTITY doc.latestloc-tech "&w3c.tr;/&doc.generic-shortname;/">
 
-<!ENTITY doc.w3c-prev-designation "REC-&doc.shortname;">
+<!ENTITY doc.w3c-prev-designation "REC-&doc.generic-shortname;-31">
 <!ENTITY language-tech "XPath">
 <!ENTITY language "XPath &doc.version;">
 <!ENTITY language-major "XPath &doc.major-version;">
@@ -104,7 +104,7 @@
 <!ENTITY implementation-report-location "">
 <!ENTITY implementation-report-availability "">
 <!ENTITY test-suite-location "">
-<!ENTITY Bugzilla-key "XPath31">
+<!ENTITY Bugzilla-key "XPath40">
 <!ENTITY patent-policy-paragraph "&ppp-two;">
 <!ENTITY documents-and-relationships "&set-of-documents-30-preREC;">
 <!ENTITY advancement.statement "&advance.2WGs;">
@@ -119,7 +119,7 @@ for transition to Proposed Recommendation. </p>'>
 <!ENTITY features-at-risk "">
 
 <!ENTITY customized-paragraph '<p diff="chg">This &doc.w3c-doctype-full; specifies XPath
-                               version 4.1, a fully compatible extension of <loc href="https://www.w3.org/TR/xpath-31/">XPath version 3.1</loc>.
+                               version 4.0, a fully compatible extension of <loc href="https://www.w3.org/TR/xpath-31/">XPath version 3.1</loc>.
                                </p>'>
 
 

--- a/specifications/xquery-40/src/xquery.xml
+++ b/specifications/xquery-40/src/xquery.xml
@@ -41,7 +41,7 @@
 <!ENTITY doc.generic-shortname "xquery">
 <!ENTITY doc.shortname "&doc.generic-shortname;-&doc.version-code;">
 <!ENTITY doc.w3c-designation "&doc.stage;-&doc.shortname;">
-<!ENTITY doc.w3c-prev-designation "REC-&doc.shortname;">
+<!ENTITY doc.w3c-prev-designation "REC-&doc.generic-shortname;-31">
 
 <!ENTITY doc.publoc "https://qt4cg.org/specifications/&doc.shortname;/">
 <!ENTITY doc.publoc "&w3c.tr;/&date.year;/&doc.w3c-designation;-&doc.date;/">
@@ -102,7 +102,7 @@
 <!ENTITY implementation-report '&implementation-report-exists;'>
 <!ENTITY implementation-report-location "&xquery-impl-report;">
 <!ENTITY implementation-report-availability "&report-public;">
-<!ENTITY Bugzilla-key "XQuery31">
+<!ENTITY Bugzilla-key "XQuery40">
 <!ENTITY patent-policy-paragraph "&ppp-one;">
 <!ENTITY documents-and-relationships "&set-of-documents-30-preREC;">
 <!ENTITY advancement.statement "&advance.1WG;">
@@ -112,18 +112,17 @@
 <!ENTITY PR-entrance-criteria '<p>This document will be
 considered ready for transition to Proposed Recommendation
 when there are two independent implementations of Minimal Conformance
-(see <specref ref="id-minimal-conformance"/>) to this specification,
-at least one of them using the human-readable syntax and at least
-one of them using the XML syntax and there are two independent implementations
-of each optional feature (see <specref ref="id-conform-optional-features"/>) using either syntax. 
+(see <specref ref="id-minimal-conformance"/>) to this specification
+and there are two independent implementations
+of each optional feature (see <specref ref="id-conform-optional-features"/>).
 The implementations of each optional feature need not necessarily conform
 to the Minimal Conformance requirements. </p>'>
 <!ENTITY features-at-risk-para "&no-features-at-risk;">
 <!ENTITY features-at-risk "">
 
 <!ENTITY customized-paragraph '<p diff="chg">This &doc.w3c-doctype-full; specifies XQuery
-                               version 3.1, a fully compatible extension of
-                               <loc href="https://www.w3.org/TR/xquery-30/">XQuery version 3.0</loc>.
+                               version 4.0, a fully compatible extension of
+                               <loc href="https://www.w3.org/TR/xquery-31/">XQuery version 3.1</loc>.
                                </p>'>
 
 <!ENTITY status-section SYSTEM "../../../etc/status-general.xml">


### PR DESCRIPTION
xpath.xml:
* customized-paragraph: "XPath version 4.1" -> "4.0"
* doc.w3c-prev-designation: was "REC-&doc.shortname;" which expands to "REC-xpath-40" (the current designation); fix to "REC-xpath-31"
* Bugzilla-key: "XPath31" -> "XPath40"

xquery.xml:
* customized-paragraph: still announced "XQuery version 3.1, a fully compatible extension of XQuery 3.0"; update to 4.0 / 3.1
* doc.w3c-prev-designation: as above, fix to "REC-xquery-31"
* Bugzilla-key: "XQuery31" -> "XQuery40"
* PR-entrance-criteria mentioned "human-readable syntax" and "XML syntax" (the XQueryX flavour). XQueryX is no longer maintained in 4.0 (introduction.xml 98-99); drop the syntax-specific criteria so the paragraph just requires two independent implementations of Minimal Conformance and of each optional feature

xpath-backwards-compat.xml:
* "In XPath 3.0 all these comparisons are type errors" -> "In XPath 4.0" (parallels the surrounding "not allowed in XPath 4.0" wording)
* drop the paragraph about "an XPath 4.0 implementation that provides the static typing feature": the static-typing feature was dropped from 4.0 (conformance.xml 9-11), so this paragraph no longer describes any conforming implementation

mime-type.xml:
* "specifies the media type for XQuery Version 1.0" -> "XQuery 4.0"
* "defines the language XQuery Version 1.0" -> "XQuery 4.0"
* allowed `xquery version` literal list: add "4.0" alongside "1.0"/"3.0"/"3.1"

Issue: #2632