### PR TITLE
2632-6: cross-cutting consistency (automatically generated & reviewed)

### DIFF
--- a/specifications/xquery-40/src/back-matter.xml
+++ b/specifications/xquery-40/src/back-matter.xml
@@ -291,7 +291,7 @@ the value of the component for their subexpressions.</p></item>
 and
 <specref ref="id-schema-import"/> ( (which adds constructor functions for user-defined types)</td>
   <td>no</td>
-  <td>Must be consistent with statically known function signatures</td>
+  <td>Must be consistent with statically known function signatures.</td>
 </tr>
 <tr>
   <td>Current dateTime</td>
@@ -313,42 +313,42 @@ and
   <td>must be initialized <phrase role="xquery">by implementation</phrase></td>
   <td>no</td>
   <td>no</td>
-  <td>None</td></tr>
+  <td>None.</td></tr>
 <tr>
   <td>Available text resources</td>
   <td>none</td>
   <td>must be initialized <phrase role="xquery">by implementation</phrase></td>
   <td>no</td>
   <td>no</td>
-  <td>None</td></tr>
+  <td>None.</td></tr>
 <tr>
   <td>Available collections</td>
   <td>none</td>
   <td>must be initialized <phrase role="xquery">by implementation</phrase></td>
   <td>no</td>
   <td>no</td>
-  <td>None</td></tr>
+  <td>None.</td></tr>
 <tr>
   <td>Default collection</td>
   <td>none</td>
   <td>overwriteable</td>
   <td>no</td>
   <td>no</td>
-  <td>None</td></tr>
+  <td>None.</td></tr>
   <tr>
     <td>Available URI collections</td>
     <td>none</td>
     <td>must be initialized <phrase role="xquery">by implementation</phrase></td>
     <td>no</td>
     <td>no</td>
-    <td>None</td></tr>
+    <td>None.</td></tr>
   <tr>
     <td>Default URI collection</td>
     <td>none</td>
     <td>overwriteable</td>
     <td>no</td>
     <td>no</td>
-    <td>None</td></tr>  
+    <td>None.</td></tr>  
 </tbody>
 </table></div2>
 </div1>
@@ -479,7 +479,7 @@ defined.</p>
 <div1 id="id-impl-defined-items"><head>Implementation-Defined Items</head><p>The following items in this specification 
   are <termref def="dt-implementation-defined">implementation-defined</termref>:</p><olist>
 <item><p>The version of Unicode that is used to construct expressions.</p></item>
-<item><p>The <termref def="dt-static-collations">statically-known collations</termref>.</p></item>
+<item><p>The <termref def="dt-static-collations">statically known collations</termref>.</p></item>
 <item><p>The <termref def="dt-timezone">implicit timezone</termref>.</p></item>
 <item><p>The circumstances in which <termref def="dt-warning">warnings</termref> are raised, and the ways in which warnings are handled.</p></item>
 <item><p>The method by which errors are reported to the external processing environment.</p></item>
@@ -932,7 +932,7 @@ See
     
     <p>The function <function>fn:compare</function> was introduced in XPath 3.0 and XQuery 3.0 for comparing
     strings; in 4.0 it has been extended to handle other data types. Unlike <function>fn:deep-equal</function>
-    and <code>fn:atomic-equal</code> it establishes the order relationship of two atomic items, rather than
+    and <function>fn:atomic-equal</function> it establishes the order relationship of two atomic items, rather than
     simply determining whether they are equal.</p>
     
     <p>Broadly speaking, the <function>fn:compare</function> function establishes the relationship between

--- a/specifications/xquery-40/src/conformance.xml
+++ b/specifications/xquery-40/src/conformance.xml
@@ -50,7 +50,7 @@
       </p>
 
       <p role="xquery">An XQuery processor that claims to conform to
-      this specification <termref def="must" >MUST</termref> include a
+      this specification <termref def="must">MUST</termref> include a
       claim of Minimal Conformance as defined in <specref
       ref="id-minimal-conformance"/>. In addition to a claim of
       Minimal Conformance, it <termref def="may">MAY</termref> claim
@@ -207,17 +207,17 @@
             <p>An implementation claiming conformance to this feature:</p>
             
             <olist>
-                <item><p><rfc2119>Must</rfc2119> include these functions in the static context of every query module;</p></item>
+                <item><p><termref def="must">MUST</termref> include these functions in the static context of every query module;</p></item>
                 
-                <item><p><rfc2119>Must not</rfc2119> include in the static context any function in the namespace 
+                <item><p><termref def="mustnot">MUST NOT</termref> include in the static context any function in the namespace 
                         <code>http://expath.org/ns/binary</code> other than a function defined in the cited specification.</p></item>
                 
-                <item><p><rfc2119>Must</rfc2119> include in the static context of each query module a namespace binding of the
+                <item><p><termref def="must">MUST</termref> include in the static context of each query module a namespace binding of the
                 prefix <code>"bin"</code> to the namespace URI <code>http://expath.org/ns/binary</code>
                 (subject to the same rules as other predeclared namespace bindings: see 
                 <specref ref="id-namespaces-and-qnames"/>);</p></item>
 
-                <item><p><rfc2119>Must</rfc2119> return <code>true</code> as the result of the expression
+                <item><p><termref def="must">MUST</termref> return <code>true</code> as the result of the expression
                 <code>fn:system-properties()?#supports-binary-library</code>.</p></item>
                 
                 
@@ -226,13 +226,13 @@
             <p>An implementation that does not claim conformance to this feature:</p>
             
             <olist>
-                <item><p><rfc2119>May</rfc2119> provide a subset of the functions, provided these conform to the cited specification;</p></item>
+                <item><p><termref def="may">MAY</termref> provide a subset of the functions, provided these conform to the cited specification;</p></item>
                 
-                <item><p><rfc2119>Must not</rfc2119> include in the static context any function in the namespace 
+                <item><p><termref def="mustnot">MUST NOT</termref> include in the static context any function in the namespace 
                         <code>http://expath.org/ns/binary</code> other than a function defined in the cited specification.</p></item>
                 
-                <item><p><rfc2119>May</rfc2119> predeclare the <code>"bin"</code> namespace;</p></item>
-                <item><p><rfc2119>Must</rfc2119> return <code>false</code> as the result of the expression
+                <item><p><termref def="may">MAY</termref> predeclare the <code>"bin"</code> namespace;</p></item>
+                <item><p><termref def="must">MUST</termref> return <code>false</code> as the result of the expression
                 <code>fn:system-properties()?#supports-binary-library</code>.</p></item>
                 
             </olist>
@@ -251,20 +251,20 @@
             <p>An implementation claiming conformance to this feature:</p>
             
             <olist>
-                <item><p><rfc2119>Must</rfc2119> include these functions in the static context of every query module;</p></item>
+                <item><p><termref def="must">MUST</termref> include these functions in the static context of every query module;</p></item>
                 
-                <item><p><rfc2119>Must not</rfc2119> include in the static context any function in the namespace 
+                <item><p><termref def="mustnot">MUST NOT</termref> include in the static context any function in the namespace 
                         <code>http://expath.org/ns/file</code> other than a function defined in the cited specification.</p></item>
                 
-                <item><p><rfc2119>Must</rfc2119> include in the static context of each query module a namespace binding of the
+                <item><p><termref def="must">MUST</termref> include in the static context of each query module a namespace binding of the
                 prefix <code>"file"</code> to the namespace URI <code>http://expath.org/ns/file</code>
                 (subject to the same rules as other predeclared namespace bindings: see 
                 <specref ref="id-namespaces-and-qnames"/>);</p></item>
 
-                <item><p><rfc2119>Must</rfc2119> return <code>true</code> as the result of the expression
+                <item><p><termref def="must">MUST</termref> return <code>true</code> as the result of the expression
                 <code>fn:system-properties()?#supports-file-library</code>.</p></item>
                 
-                <item><p><rfc2119>Must</rfc2119> provide <termref def="dt-implementation-defined"/> mechanisms
+                <item><p><termref def="must">MUST</termref> provide <termref def="dt-implementation-defined">implementation-defined</termref> mechanisms
                 enabling predictable results from the invocation of functions with
                 side-effects: see <specref ref="functional-purity"/>.</p></item>
                 
@@ -274,12 +274,12 @@
             <p>An implementation that does not claim conformance to this feature:</p>
             
             <olist>
-                <item><p><rfc2119>May</rfc2119> provide a subset of the functions, provided these conform to the cited specification;</p></item>
-                <item><p><rfc2119>Must not</rfc2119> include in the static context any function in the namespace 
+                <item><p><termref def="may">MAY</termref> provide a subset of the functions, provided these conform to the cited specification;</p></item>
+                <item><p><termref def="mustnot">MUST NOT</termref> include in the static context any function in the namespace 
                         <code>http://expath.org/ns/file</code> other than a function defined in the cited specification.</p></item>
-                <item><p><rfc2119>May</rfc2119> predeclare the <code>"file"</code> namespace;</p></item>
+                <item><p><termref def="may">MAY</termref> predeclare the <code>"file"</code> namespace;</p></item>
  
-                <item><p><rfc2119>Must</rfc2119> return <code>false</code> as the result of the expression
+                <item><p><termref def="must">MUST</termref> return <code>false</code> as the result of the expression
                 <code>fn:system-properties()?#supports-file-library</code>.</p></item>
                 
             </olist>

--- a/specifications/xquery-40/src/ebnf.xml
+++ b/specifications/xquery-40/src/ebnf.xml
@@ -159,7 +159,7 @@
           <def>
             <p>matches zero or more occurrences of <code>A</code>. Concatenation has higher
               precedence than choice; thus <code>A* | B*</code> is identical to <code>(A*) |
-                (B*)</code></p>
+                (B*)</code>.</p>
           </def>
         </gitem>
         <gitem>
@@ -411,7 +411,7 @@
                 does not explicitly appear on the right-hand side of the grammar (except in its own
                 production). See <specref ref="DefaultWhitespaceHandling"/>. <phrase role="xquery"
                   >Note that comments are not allowed in direct constructor content, though they are
-                  allowed in nested <nt def="EnclosedExpr"> EnclosedExprs</nt>.</phrase></p>
+                  allowed in nested <nt def="EnclosedExpr">EnclosedExprs</nt>.</phrase></p>
               <p>A comment can contain nested comments, as long as all <code>"(:"</code> and <code>":)"</code> patterns are
                 balanced, no matter where they occur within the outer comment.</p>
               <note>
@@ -619,8 +619,8 @@
           the following regular expressions:</p>
             <slist>
               <sitem><code><![CDATA[^<\i\c*\s*>]]></code> (as in <code>&lt;element>...</code>)</sitem>
-              <sitem><code><![CDATA[^<\i\c*\s*/>]]></code>(as in <code>&lt;element/></code>)</sitem>
-              <sitem><code><![CDATA[^<\i\c*\s+\i\c*\s*=]]></code>(as in <code>&lt;element att=...</code>)</sitem>
+              <sitem><code><![CDATA[^<\i\c*\s*/>]]></code> (as in <code>&lt;element/></code>)</sitem>
+              <sitem><code><![CDATA[^<\i\c*\s+\i\c*\s*=]]></code> (as in <code>&lt;element att=...</code>)</sitem>
             </slist>
             <p>If the content matches one of these regular expressions but further analysis shows that the subsequent
             content does not satisfy the <nt def="DirElemConstructor">DirElemConstructor</nt> production,
@@ -1143,7 +1143,7 @@
       <code>a ⊙ b ⊙ c</code> is evaluated as <code>(a ⊙ b) ⊙ c</code>. As a special case, the operators <code>+</code>
       and <code>*</code> are associative provided they are not mixed with other operators of the same precedence.</p></item>
       <item><p><term>right-to-left</term> is used only for unary operators, and indicates that <code>⊙ ⊙ a</code>
-      is evaluated as <code>⊙ (⊙ a)</code></p></item>
+      is evaluated as <code>⊙ (⊙ a)</code>.</p></item>
     </ulist>
     
     <p>These rules do not constrain the order in which the operands of an expression are evaluated (which might affect

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -702,13 +702,13 @@ The term URI has been retained in preference to IRI to avoid introducing new nam
 
                <item>
                   <p>
-                     <termdef id="dt-xpath-compat-mode" term="XPath 1.0 compatibility     mode">
+                     <termdef id="dt-xpath-compat-mode" term="XPath 1.0 compatibility mode">
                         <term>XPath 1.0 compatibility
 			 mode.</term>
                         <phrase role="xquery"
                               >This
 			 component must be set by all host languages
-			 that include XPath 3.1  as a subset,
+			 that include XPath 3.1 as a subset,
 			 indicating whether rules for compatibility
 			 with XPath 1.0 are in effect.
 			 XQuery sets the value of this component to
@@ -1582,7 +1582,7 @@ the context size cannot be determined without lookahead, so it may be undefined.
                </p>
                <p><termdef id="dt-singleton-focus" term="singleton focus"
                      >A <term>singleton focus</term> is a <termref def="dt-fixed-focus"/> in which the
-                  <termref def="dt-context-value"/> is a <termref def="dt-singleton"/> item.</termdef>.
+                  <termref def="dt-context-value"/> is a <termref def="dt-singleton"/> item.</termdef>
                With a singleton focus, the context value is a single item, the context position is 1, and the context size is 1.
                </p>
             
@@ -18946,8 +18946,8 @@ for member $y in $expr2]]></eg>
                The resulting sequence of variable bindings becomes the initial tuple stream that serves as input to the next clause 
                of the FLWOR expression. The order of tuples in the tuple stream preserves the order of the <termref
                   def="dt-binding-collection">binding collection</termref>.</p>
-            <p>If the <termref def="dt-binding-sequence"
-                  >binding collection</termref> is empty, the output tuple stream depends on whether <code>allowing empty</code> is specified. 
+            <p>If the <termref def="dt-binding-collection"
+                  >binding collection</termref> is empty, the output tuple stream depends on whether <code>allowing empty</code> is specified.
                If <code>allowing empty</code> is specified, the output tuple stream consists of one tuple in which the variable is bound to the empty sequence.
                This option is not available when the keywords <code>member</code>, <code>key</code>, or <code>value</code>
                are used.


### PR DESCRIPTION
ebnf.xml:
* missing trailing period on two list items (A* and the right-to-left precedence note) — neighbouring items end with periods
* leading space inside <nt def="EnclosedExpr"> EnclosedExprs</nt>
* missing space between </code> and "(as in &lt;element/&gt;)" for two direct-element-constructor pattern examples

conformance.xml:
* EXPath Binary and File library sections used <rfc2119>Must</rfc2119>, <rfc2119>Must not</rfc2119>, <rfc2119>May</rfc2119> with title-case variants; the rest of the file uses the <termref def="must">MUST</termref> / def="mustnot" / def="may" pattern. Normalise the EXPath sections to the termref form
* <termref def="must" >MUST</termref> had a stray space before "&gt;"
* empty self-closing <termref def="dt-implementation-defined"/> got display text "implementation-defined" to match the surrounding form

back-matter.xml:
* "statically-known collations" -> "statically known collations" (hyphenless form used by every other occurrence in the corpus)
* dynamic-context table: six "<td>None</td>" cells got trailing periods to match the periods used in the other rows
* static-context table: one "Must be consistent with ..." cell was missing its trailing period
* fn:compare-summary: "fn:atomic-equal" was tagged `<code>`, all surrounding function names use `<function>`; normalise

expressions.xml:
* termdef term="XPath 1.0 compatibility     mode" — collapse the five-space
  block in the @term attribute (significant when terms are matched as
  strings)
* one doubled space ("XPath 3.1  as a subset")
* singleton-focus termdef ended with "</termdef>." — drop the redundant
  trailing period (sentence already ends inside the termdef)
* <termref def="dt-binding-sequence">binding collection</termref> — def and
  display text disagreed; this is the in-the-for-clause "binding collection"
  case, so def is now dt-binding-collection (which is the existing termdef)

Issue: #2632