### PR TITLE
Remove space in function declaration between EQName & params

### DIFF
--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -2416,7 +2416,7 @@ return $box =?> expand(2) =?> perimeter()</eg>
                   </p></item>
                   
                   <item><p>
-                     <eg><![CDATA[declare function my:is-even ($n as xs:integer) as xs:boolean {
+                     <eg><![CDATA[declare function my:is-even($n as xs:integer) as xs:boolean {
     $evens =?> contains($n)
 };]]></eg>
                   </p></item>


### PR DESCRIPTION
While the space is legal, no other function declaration in the spec has one