### PR TITLE
2565 Absent-vs-Empty fields in dateTime-record

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -11332,7 +11332,6 @@ return ($value - unix-dateTime()) div seconds(0.001)</eg>
          components may be supplied as <code>xs:double</code> values, and the timezone may be
          supplied as an <code>xs:duration</code>. Components that are not required may either be
          absent from the supplied map, or may be set to the empty sequence.</p>
-
       </fos:notes>
       <fos:examples>
          <fos:example>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -381,40 +381,40 @@
             <code>xs:date</code>, <code>xs:time</code>, <code>xs:gYear</code>, <code>xs:gYearMonth</code>,
             <code>xs:gMonth</code>, <code>xs:gMonthDay</code>, or <code>xs:gDay</code>.</p>
       </fos:summary>
-      <fos:field name="year" type="xs:integer" required="false">
+      <fos:field name="year" type="xs:integer?" required="false">
          <fos:meaning>
             <p>The value of the <code>year</code> component. Range is implementation-defined.
             If years less than one are supported, then the integer zero represents the year
             before year one, and the integer -1 represents the year before year zero.</p>
          </fos:meaning>        
       </fos:field>
-      <fos:field name="month" type="xs:integer" required="false">
+      <fos:field name="month" type="xs:integer?" required="false">
          <fos:meaning>
             <p>The value of the <code>month</code> component. A valid value is in the range 1 to 12 inclusive.</p>
          </fos:meaning>        
       </fos:field>
-      <fos:field name="day" type="xs:integer" required="false">
+      <fos:field name="day" type="xs:integer?" required="false">
          <fos:meaning>
             <p>The value of the <code>day</code> component. A valid value is in the range 1 to 31 inclusive.</p>
          </fos:meaning>        
       </fos:field>
-      <fos:field name="hours" type="xs:integer" required="false">
+      <fos:field name="hours" type="xs:integer?" required="false">
          <fos:meaning>
             <p>The value of the <code>hours</code> component. A valid value is in the range 0 to 23 inclusive.</p>
          </fos:meaning>        
       </fos:field>
-      <fos:field name="minutes" type="xs:integer" required="false">
+      <fos:field name="minutes" type="xs:integer?" required="false">
          <fos:meaning>
             <p>The value of the <code>minutes</code> component. A valid value is in the range 0 to 59 inclusive.</p>
          </fos:meaning>        
       </fos:field>
-      <fos:field name="seconds" type="xs:decimal" required="false">
+      <fos:field name="seconds" type="xs:decimal?" required="false">
          <fos:meaning>
             <p>The value of the <code>seconds</code> component. A valid value is in the range 0 (inclusive) to 60 (exclusive).
             (Thus 59.9999999 is valid, but 60 is not.)</p>
          </fos:meaning>        
       </fos:field>
-      <fos:field name="timezone" type="xs:dayTimeDuration" required="false">
+      <fos:field name="timezone" type="xs:dayTimeDuration?" required="false">
          <fos:meaning>
             <p>The timezone offset, if the value has a timezone. A valid value corresponds to an integral number
             of minutes between -840 and +840 inclusive.</p>
@@ -11191,8 +11191,7 @@ return ($value - unix-dateTime()) div seconds(0.001)</eg>
       <fos:rules>
          <p>If <code>$value</code> is the empty sequence, the function returns the empty sequence.</p>
          <p>Otherwise, the function returns a record whose fields are as follows. If a particular component
-         is not present in the value, the corresponding entry will be absent from the map (the returned
-         map will never contain any entry whose value is the empty sequence).</p>
+         is not present in the value, the corresponding field in the returned record will be the empty sequence.</p>
          <table>
             <thead>
                <tr>
@@ -11254,7 +11253,9 @@ return ($value - unix-dateTime()) div seconds(0.001)</eg>
                <fos:expression><eg>parts-of-dateTime(
   xs:time("13:30:04.2678")
 )</eg></fos:expression>
-               <fos:result><eg>{ "hours": 13, "minutes": 30, "seconds": 4.2678 }</eg></fos:result>
+               <fos:result><eg>{ "year": (), "month": (), "day": (),
+  "hours": 13, "minutes": 30, "seconds": 4.2678,
+  "timezone": () }</eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -11262,7 +11263,9 @@ return ($value - unix-dateTime()) div seconds(0.001)</eg>
                <fos:expression><eg>parts-of-dateTime(
   xs:gYearMonth("2007-05Z")
 )</eg></fos:expression>
-               <fos:result><eg>{ "year": 2007, "month": 5, "timezone": xs:dayTimeDuration("PT0S") }</eg></fos:result>
+               <fos:result><eg>{ "year": 2007, "month": 5, "day": (), 
+  "hours": (), "minutes": (), "seconds": (), 
+  "timezone": xs:dayTimeDuration("PT0S") }</eg></fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -11291,11 +11294,9 @@ return ($value - unix-dateTime()) div seconds(0.001)</eg>
          <p>If <code>$value</code> is the empty sequence, the function returns the empty sequence.</p>
          <p>Otherwise, the function returns a <termref def="dt-gregorian"/> value based on the supplied component
             values. The result will be the <termref def="dt-gregorian"/> value <code>$R</code> such that
-            <code>deep-equal( $significant(parts-of-dateTime($R)), $significant($value) )</code>,
-            where <code>$significant</code> is the function <code>map:filter(?, fn($K, $V){$K eq "timezone" or exists($V)})</code>,
-         that is, a function that discards entries in a map whose value is the empty sequence, other than the entry
-         with key <code>"timezone"</code>.</p>
-         <p>If all seven components are present (year, month, day, hours, minutes, seconds, and timezone)
+            <code>deep-equal( parts-of-dateTime($R), $value )</code> is true, where <code>$value</code>
+            is the result of coercing the supplied argument to the required type <code>fn:dateTime-record</code>.</p>
+         <p>If all seven components are non-empty (year, month, day, hours, minutes, seconds, and timezone)
          then the result will be of type <code>xs:dateTimeStamp</code>.</p>
          <p>The range of years supported is <termref def="implementation-defined"/>. If years earlier than
          0001 CE are supported then the numbering follows the proleptic Gregorian calendar as defined
@@ -11304,7 +11305,7 @@ return ($value - unix-dateTime()) div seconds(0.001)</eg>
       </fos:rules>
       <fos:errors>
          <p>A dynamic error is raised <errorref class="DT" code="0005"/> if the set of fields
-         that are present and non-empty in <code>$value</code> is not one of the sets:</p>
+         that are non-empty in <code>$value</code> is not one of the sets:</p>
          <ulist>
             <item><p>year, month, day, hours, minutes, seconds, and optional timezone (delivering an <code>xs:dateTime</code>)</p></item>
             <item><p>year, month, day, and optional timezone (delivering an <code>xs:date</code>)</p></item>
@@ -11315,18 +11316,23 @@ return ($value - unix-dateTime()) div seconds(0.001)</eg>
             <item><p>day, and optional timezone (delivering an <code>xs:gDay</code>)</p></item>
             <item><p>hours, minutes, seconds, and optional timezone (delivering an <code>xs:time</code>)</p></item>
          </ulist>
-      	<p>A dynamic error is raised <errorref class="DT" code="0003" /> if the timezone component of <code>$value</code> is outside the range <code>-PT14H</code> to <code>PT14H</code></p>
-        <p>A dynamic error is raised <errorref class="RG" code="0001" /> if any other component of <code>$value</code> is outside the permitted range specified by the target date/time datatype, for example: if <code>minutes</code> is less than zero or greater than 59; or if <code>day</code> is 30 and <code>month</code> is 2.  See <xspecref spec="DM31" ref="dates-and-times" />.</p>
+      	<p>A dynamic error is raised <errorref class="DT" code="0003" /> if the timezone 
+      	   component of <code>$value</code> is outside the range <code>-PT14H</code> to <code>PT14H</code></p>
+        <p>A dynamic error is raised <errorref class="RG" code="0001" /> if any other 
+           component of <code>$value</code> is outside the permitted range specified by 
+           the target date/time datatype, for example: if <code>minutes</code> is less 
+           than zero or greater than 59; or if <code>day</code> is 30 and <code>month</code> is 2.  
+           See <xspecref spec="DM31" ref="dates-and-times" />.</p>
       </fos:errors>
       <fos:notes>
-         <p>Components that are present in <code>$value</code> but with an empty value are treated
-         as if they were absent.</p>
-         <p>The timezone, if present, must correspond to an integral number of minutes in the range
+         <p>The timezone, if non-empty, must correspond to an integral number of minutes in the range
          -840 to +840.</p>
          <p>Midnight must be expressed with the <code>hours</code> value set to zero, not 24.</p>
          <p>The standard <xtermref spec="XP40" ref="dt-coercion-rules"/> apply, so (for example) the integral 
          components may be supplied as <code>xs:double</code> values, and the timezone may be
-         supplied as an <code>xs:duration</code>.</p>
+         supplied as an <code>xs:duration</code>. Components that are not required may either be
+         absent from the supplied map, or may be set to the empty sequence.</p>
+
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -11341,12 +11347,18 @@ build-dateTime({
   "seconds": 0, 
   "timezone": xs:dayTimeDuration("-PT5H")
 })</eg></fos:expression>
-               <fos:result><eg>xs:dateTime("1999-05-31T13:20:00-05:00")</eg></fos:result>
+               <fos:result><eg>xs:dateTimeStamp("1999-05-31T13:20:00-05:00")</eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
                <fos:expression><eg>build-dateTime({ "hours": 13, "minutes": 30, "seconds": 4.2678 })</eg></fos:expression>
+               <fos:result><eg>xs:time("13:30:04.2678")</eg></fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>build-dateTime({ "days": (), "hours": 13, "minutes": 30, "seconds": 4.2678 })</eg></fos:expression>
                <fos:result><eg>xs:time("13:30:04.2678")</eg></fos:result>
             </fos:test>
          </fos:example>


### PR DESCRIPTION
PR #2566 clarified and expanded the rules for records and record types; one of the effects is that in a record, all fields are present, but may be empty. This resolves the issues raised in issue #2565 concerning absent-vs-empty fields in a dateTime-record. This PR changes the description of the build-dateTime and parts-of-dateTime functions to reflect these changes.

Fix #2565