### PR TITLE
2652 Clarify lax validation

### DIFF
--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -8726,7 +8726,7 @@ map( xs:string,
                   <change issue="2029" PR="2030" date="2025-05-28">
                      This description of the XSD validation process was previously found (with some duplication)
                      in the XQuery and XSLT specifications; those specifications now reference this description.
-                     As a side-effects, the descriptions of the process in XQuery and XSLT are better aligned.
+                     As a side-effect, the descriptions of the process in XQuery and XSLT are better aligned.
                   </change>
                </changes>
                
@@ -8760,6 +8760,17 @@ map( xs:string,
                   but this does not invoke validation (instead, it invokes stripping of
                   existing type annotations and re-annotation of nodes as untyped.)</p></note></item>
                </ulist>
+               
+               <p>Host languages may define a conformance level in which validation is not supported.
+               If the processor does not support validation, then any attempt to invoke validation
+               results in a static or dynamic error.</p>
+               
+               <note>
+                  <p>In XSLT, requesting <code>validation="lax"</code> with a non-schema-aware processor
+                  does not result in an error, it is treated as <code>validation="strip"</code>. Other
+                  constructs that request validation, such as the option <code>{'xsd-validation':'lax'}</code>
+                  on a call to <function>fn:doc</function>, result in a dynamic error.</p>
+               </note>
                
                <p>The output of the validation process comprises one or more of the following:</p>
                
@@ -8797,6 +8808,11 @@ map( xs:string,
                the schema that is used is the set of schema components found in the <xtermref
                spec="XP40" ref="dt-issd">in-scope schema definitions</xtermref>, but this is not the only
                possibility.</p>
+               
+               <note><p>Validation against an empty schema, that is, a schema containing only
+               the built-in components such as <code>xs:integer</code>, is well defined. For example,
+               validating the element <code>&lt;a xsi:type="xs:integer">42&lt;/a></code> against
+               the empty schema produces an element with a type annotation of <code>xs:integer</code>.</p></note>
                
                
                
@@ -8943,7 +8959,7 @@ map( xs:string,
                        top-level element declaration in the effective schema, or</p></item>
                            <item><p>have an <code>xsi:type</code> attribute
                            whose value matches the name of a top-level type definition
-                           in the effective schema</p>
+                           in the effective schema.</p>
                            </item>
                         </olist>
                         

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -24894,12 +24894,9 @@ return string-join($chopped, '; ')
             </tbody>
          </table>
             
-
+         <p>For the effect of the <code>validate</code> expression when the processor is not schema-aware,
+         see <specref ref="id-schema-aware-feature"/>.</p>
         
-
-
-
-       
          
          <note diff="add" at="Issue451">
             <p>A query might take as its primary input a document conforming to schema <var>X</var>,
@@ -24910,6 +24907,13 @@ return string-join($chopped, '; ')
                if the validation occurs within a module that imports both <var>X</var>
             and <code>Y</code>, the outcome of validation might differ because of the
             differences between the two schemas.</p>
+         </note>
+         
+         <note>
+            <p>The effect of a <code>validate</code> expression is well defined even if no schema
+            has been imported. For example, the expression <code><![CDATA[validate type xs:integer {<a>42</a>}]]></code>
+            returns an element with type annotation <code>xs:integer</code> regardless of the schema used
+            for validation.</p>
          </note>
 
       </div2>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -30353,17 +30353,12 @@ the same group, and the-->
                <termref def="dt-literal-result-element">literal result elements</termref>,
                <phrase diff="chg" at="2022-01-01">appearing as descendants of the element 
                   on which the attribute appears, unless there is an inner element that defines 
-                  a different default</phrase>. <phrase diff="del" at="2022-01-01">It also determines
-               the validation applied to the implicit <termref def="dt-final-result-tree">final
-                  result tree</termref> created in the absence of an
-                  <elcode>xsl:result-document</elcode> instruction.</phrase> This default <phrase diff="del" at="2022-01-01">applies within the
-               containing <termref def="dt-stylesheet-module">stylesheet module</termref> or
-                  <termref def="dt-package"/>: it</phrase> does not extend to included or imported stylesheet
+                  a different default</phrase>.  This default does not extend to included or imported stylesheet
                modules or used packages. If the attribute is omitted, the default is
                   <code>strip</code>. The permitted values are <code>preserve</code> and
                   <code>strip</code>.</p>
             
-            <p diff="add" at="2022-01-01">
+            <p>
                The <code>default-validation</code> attribute on the outermost element of the principal
                stylesheet module of the <termref def="dt-top-level-package"/> also determines the validation 
                applied to the implicit final result tree created in the absence of an 
@@ -30398,9 +30393,16 @@ the same group, and the-->
                   and <code>Y</code>, the outcome of validation might differ because of the
                   differences between the two schemas.</p>
             </note>
+            <note>
+               <p>The schema used for validation might be empty, that is, it might contain only the built-in components
+               that are present in every schema, such as the type <code>xs:integer</code>. Validation against an empty
+               schema is well defined: for example, validation of the element <code><![CDATA[<a xsi:type="xs:integer">42</a>]]></code>
+               delivers an element whose type annotation is <code>xs:integer</code>, regardless of the schema that is used.</p>
+            </note>
             
             <p>The detailed rules for validation vary depending on the kind of node being validated.
-               The rules for element and attribute nodes are given in <specref ref="validating-constructed-nodes"/>, while those for document nodes are given in
+               The rules for element and attribute nodes are given in <specref ref="validating-constructed-nodes"/>, 
+               while those for document nodes are given in
                   <specref ref="validating-document-nodes"/>.</p>
             <div3 id="validating-constructed-nodes">
                <head>Validating Constructed Elements and Attributes</head>
@@ -31871,6 +31873,11 @@ the same group, and the-->
                      <code>[xsl:]validation</code> attribute or the <code>type</code> attribute,
                   indicates that the stylesheet is expecting to deal with typed data, and therefore
                   cannot be processed without performing the validation.</p>
+               <p>The rule that a non-schema-aware processor treats <code>validation="lax"</code>
+               as if <code>validation="strip"</code> were specified is retained for backwards compatibility
+               reasons. However, other constructs that request lax validation, for example in the options
+               to the <function>doc</function> or <function>xsd-validator</function> functions,
+               typically result in a dynamic error if the processor is not schema-aware.</p>
             </note>
             <p>
                <error spec="XT" type="static" class="SE" code="1660">


### PR DESCRIPTION
Clarifies the effect of lax validation, especially (a) when no schema has been imported, and (b) when the processor is not schema-aware.