### PR TITLE
2655b matching segments empty

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -8323,8 +8323,9 @@ Tak, tak, tak! - da kommen sie.
          </fos:example>
       </fos:examples>
       <fos:see-also prefix="fn" name="analyze-string"/>
+      <fos:see-also prefix="fn" name="regex"/>
       <fos:changes>
-         <fos:change issue="1310 2655" PR="2470" date="2026-04-20"><p>New in 4.0</p></fos:change>
+         <fos:change issue="1310 2655" PR="2470 2657" date="2026-04-20"><p>New in 4.0</p></fos:change>
       </fos:changes>
    </fos:function>
    

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -8190,7 +8190,8 @@ Tak, tak, tak! - da kommen sie.
       </fos:summary>
       <fos:rules>
          
-         <p>If <code>$value</code> is the empty sequence then the function returns the empty sequence.</p>
+         <p>If <code>$value</code> is the empty sequence, it is interpreted as the zero-length
+            string.</p>
          
          <p>The value of <code>$regex</code> must be a regular expression as defined
          in <specref ref="regex-syntax"/>.</p>
@@ -8218,10 +8219,31 @@ Tak, tak, tak! - da kommen sie.
       </fos:errors>
       <fos:notes>
          <p>The information returned by this function is similar to that returned by <function>fn:analyze-string</function>.
-         But because it is returned as a map, it may be easier to process.</p>
+         But because it is returned as a sequence of maps, it may be easier to process.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
+            <fos:test>
+               <fos:expression><eg>matching-segments("a", "b")</eg></fos:expression>
+               <fos:result><eg>()</eg></fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>matching-segments("a", "a")</eg></fos:expression>
+               <fos:result><eg>{ "substring": "a", "position": 1, "groups": {}}</eg></fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>matching-segments("a", "(a)")</eg></fos:expression>
+               <fos:result><eg>{ "substring": "a", "position": 1, 
+        "groups": {1: {"group": "a", "position": 1}}}</eg></fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>matching-segments("", "b?")</eg></fos:expression>
+               <fos:result><eg>{ "substring": "", "position": 1, "groups": {}}</eg></fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>matching-segments((), "b?")</eg></fos:expression>
+               <fos:result><eg>{ "substring": "", "position": 1, "groups": {}}</eg></fos:result>
+            </fos:test>
             <fos:test>
                <fos:expression><eg>matching-segments("The cat sat on the mat.", "\w+")</eg></fos:expression>
                <fos:result><eg>
@@ -8302,7 +8324,7 @@ Tak, tak, tak! - da kommen sie.
       </fos:examples>
       <fos:see-also prefix="fn" name="analyze-string"/>
       <fos:changes>
-         <fos:change issue="1310" PR="2470" date="2026-04-20"><p>New in 4.0</p></fos:change>
+         <fos:change issue="1310 2655" PR="2470" date="2026-04-20"><p>New in 4.0</p></fos:change>
       </fos:changes>
    </fos:function>
    

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -18896,18 +18896,31 @@ Intermediate clauses may be <code>for</code>, <code>let</code>, <code>window</co
          <div3 id="id-binding-rules" role="xquery">
             <head>Variable Bindings</head>
             <p>The following clauses in FLWOR expressions bind values to variables: 
-<code>for</code>, <code>let</code>, <code>window</code>, <code>count</code>, and <code>group by</code>. 
-The binding of variables for <code>for</code>, <code>let</code>, and <code>count</code> is governed by the following rules
-(the binding of variables in <code>group by</code> is discussed in <specref
+<code>for</code>, <code>let</code>, <code>window</code>, <code>count</code>, and <code>group by</code>.
+            These variables are classified as <termref def="dt-range-variable">range variables</termref>
+            or <termref def="dt-positional-variable">positional variables</termref>.</p>
+            
+            <p><termdef id="dt-range-variable" term="range variable">A variable bound in a clause of
+                  a FLWOR expression, other than a <termref def="dt-positional-variable"/>,
+                  is called a <term>range variable</term>.</termdef></p>
+            
+<p>The binding of range variables for <code>for</code>, <code>let</code>, and <code>count</code> is governed by the following rules
+(the binding of range variables in <code>group by</code> is discussed in <specref
                   ref="id-group-by"
                   />,
-the binding of variables in <code>window</code> clauses is discussed in <specref
+the binding of range variables in <code>window</code> clauses is discussed in <specref
                   ref="id-windows"/>):</p>
 
             <olist>
 
                <item>
-                  <p>The scope of a bound variable includes all subexpressions of the containing FLWOR that appear after the variable binding. The scope does not include the expression to which the variable is bound. The following code fragment, containing two <code>let</code> clauses, illustrates how variable bindings may reference variables that were bound in earlier clauses, or in earlier bindings in the same clause:</p>
+                  <p>The scope of a <termref def="dt-range-variable"/> or <termref def="dt-positional-variable"/> 
+                     includes all subexpressions 
+                     of the containing FLWOR that appear after the variable binding. 
+                     The scope does not include the expression to which the variable is bound. 
+                     The following code fragment, containing two <code>let</code> clauses, 
+                     illustrates how variable bindings may reference variables that were bound 
+                     in earlier clauses, or in earlier bindings in the same clause:</p>
                   <eg><![CDATA[let $x := 47, $y := f($x)
 let $z := g($x, $y)]]></eg>
                </item>
@@ -18919,7 +18932,8 @@ let $z := g($x, $y)]]></eg>
                      remainder of the FLWOR expression.</p>
                   <p>For example, it is valid to write:</p>
                   <eg>let $x := 0, $x := $x*2, $x := $x + 1</eg>
-                  <p>This binds three separate variables, each of which happens to have the
+                  <p>This binds three separate <termref def="dt-range-variable">range variables</termref>, 
+                     each of which happens to have the
                   same name. It should not be construed as binding a series of different values
                   to the same variable.</p>
                </item>
@@ -18951,7 +18965,8 @@ let $z := g($x, $y)]]></eg>
                         preceded by the keyword <code>in</code>, the value of that expression is 
                         called a <term>binding collection</term>.</termdef> The collection may be either
                      a sequence, an array, or a map. The <code>for</code>  
-                     clause iterates over its binding collection, producing multiple bindings for one or more variables. 
+                     clause iterates over its binding collection, producing multiple bindings 
+                     for one or more <termref def="dt-range-variable">range variables</termref>. 
                      Details on how binding collections are used in <code>for</code> clauses 
                      are described in the following sections.</p>
                </item>
@@ -18961,7 +18976,8 @@ let $z := g($x, $y)]]></eg>
                            >In a <code>window</code> clause, when an expression is 
                         preceded by the keyword <code>in</code>, the value of that expression is 
                         called a <term>binding sequence</term>.</termdef> The <code>window</code> 
-                     clause iterates over its binding sequence, producing multiple bindings for one or more variables. 
+                     clause iterates over its binding sequence, producing multiple bindings for one or more 
+                     <termref def="dt-range-variable">range variables</termref>. 
                      Details on how binding sequences are used in <code>for</code> and <code>window</code> clauses 
                      are described in the following sections.</p>
                </item>
@@ -18989,8 +19005,8 @@ let $z := g($x, $y)]]></eg>
                <prodrecap ref="ForClause"/>
             </scrap>
             
-            <p>A <code>for</code> clause is used for iteration. Each variable in a <code>for</code> clause iterates over a 
-               sequence, an array, or a map.</p>
+            <p>A <code>for</code> clause is used for iteration. Each <termref def="dt-range-variable"/> 
+               in a <code>for</code> clause iterates over a sequence, an array, or a map.</p>
             
             <p>The expression following the keyword <code>in</code> is evaluated; we refer to the 
                resulting sequence, array, or map generically as the <termref def="dt-binding-collection"/>, and to
@@ -18999,20 +19015,20 @@ let $z := g($x, $y)]]></eg>
             <ulist>
                <item><p>When a <nt def="ForItemBinding">ForItemBinding</nt> is used (that is, when none of the
                   keywords <code>member</code>, <code>key</code>, or <code>value</code> is used), 
-                  the range variable is bound in turn to each item in the <termref def="dt-binding-collection"/>,
+                  the <termref def="dt-range-variable"/> is bound in turn to each item in the <termref def="dt-binding-collection"/>,
                   which is treated as a sequence of items.</p></item>
                <item><p>When a <nt def="ForItemBinding">ForMemberBinding</nt> is used (that is, when the
                keyword <code>member</code> is used), 
-               the range variable is bound in turn to each member of the array.</p>
+               the <termref def="dt-range-variable"/> is bound in turn to each member of the array.</p>
                   <p>In this case the corresponding <code>ExprSingle</code>
                   must evaluate to a single array, otherwise a type error is raised <errorref
                   class="TY" code="0141"/>. However, the coercion rules also allow a JNode
                   whose <term>·jvalue·</term> is an array to be supplied.</p></item>
-               <item><p>When a <nt def="ForItemBinding">ForEntryBinding</nt> is used (that is, when either
+               <item><p>When a <nt def="ForEntryBinding">ForEntryBinding</nt> is used (that is, when either
                   or both of the keywords <code>key</code> and <code>value</code> are used), 
-                  the <code>key</code> range variable (if present) is bound in turn to each key in the map 
+                  the <code>key</code> <termref def="dt-range-variable"/> (if present) is bound in turn to each key in the map 
                   (in <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref>), and the <code>value</code>
-                  range variable (if present) is bound to the corresponding value.</p>
+                  <termref def="dt-range-variable"/> (if present) is bound to the corresponding value.</p>
                   <p>In this case the corresponding <code>ExprSingle</code>
                   must evaluate to a single map, otherwise a type error is raised <errorref
                   class="TY" code="0141"/>. However, the coercion rules also allow a JNode
@@ -19050,12 +19066,13 @@ for member $y in $expr2]]></eg>
             
            
 
-            <p>In the remainder of this section, we define the semantics of a <code>for</code> clause containing 
-               a single variable and an associated expression 
-               (following the keyword <code>in</code>) whose value is the <termref
-                  def="dt-binding-collection">binding collection</termref> for that variable.</p>
-            <p>If a single-variable <code>for</code> clause is the initial clause in a FLWOR expression, it iterates over its <termref
-               def="dt-binding-collection">binding collection</termref>, binding the variable(s) to each component in turn. 
+            <p>In the remainder of this section, we define the semantics of a <code>for</code> clause 
+               after performing this expansion: that is, a <code>for</code> clause with a single
+               <termref def="dt-binding-collection"/>.</p>
+               
+            <p>If such a <code>for</code> clause is the initial clause in a FLWOR expression, it iterates over its <termref
+               def="dt-binding-collection">binding collection</termref>, binding the <termref def="dt-range-variable"/>
+               (or pair of variables, if the <code>for key $K value $V</code> form is used) to each component in turn. 
                The resulting sequence of variable bindings becomes the initial tuple stream that serves as input to the next clause 
                of the FLWOR expression. The order of tuples in the tuple stream preserves the order of the <termref
                   def="dt-binding-collection">binding collection</termref>.</p>
@@ -19118,17 +19135,30 @@ for member $y in $expr2]]></eg>
             <p>
                <termdef term="positional variable" id="dt-positional-variable">A <term>positional variable</term> 
                   is a variable that is preceded by the keyword <code>at</code>.</termdef> A positional variable 
-               may be associated with the range variable(s) that are bound in a <code>for</code> clause. In this case, as 
-               the main range variable(s) iterate over the components of its <termref def="dt-binding-collection" diff="chg" at="A">binding collection</termref>, 
-               the positional variable iterates over the integers that represent the ordinal numbers of these component in the 
+               may be associated with a <termref def="dt-range-variable"/>
+               that is bound in a <code>for</code> clause, or with a pair of range variables when the
+               <nt def="ForEntryBinding">ForEntryBinding</nt> form is used. In this case, as 
+               the range variable(s) iterate over the components of its <termref def="dt-binding-collection" diff="chg" at="A">binding collection</termref>, 
+               the positional variable iterates over the integers that represent the ordinal numbers of these components in the 
                <termref def="dt-binding-collection" diff="chg" at="A">binding collection</termref>, starting with one. Each tuple in the output 
-               tuple stream contains bindings for both the main variable and the positional variable. If the 
+               tuple stream contains bindings for both the <termref def="dt-range-variable">range variable(s)</termref> and the positional variable. If the 
                <termref def="dt-binding-collection" diff="chg" at="A">binding collection</termref> is empty and <code>allowing empty</code> is 
                specified, the positional variable in the output tuple is bound to the integer zero. Positional variables  
                have the implied type <code>xs:integer</code>.</p>
+            
+            <p>Note that, since the <termref
+                  def="dt-positional-variable"/> represents a position within a <termref
+                     def="dt-binding-collection"/>, the output tuples corresponding to each input tuple are independently numbered, 
+               starting with one. For a given input tuple, if the <termref
+                     def="dt-binding-collection"  diff="chg" at="A"
+                  >binding collection</termref> is empty and <code>allowing empty</code> is specified, the <termref
+                  def="dt-positional-variable"/> in the output tuple is bound to the integer zero.</p>
+            
+            
+            
             <p>The <termref def="dt-expanded-qname">expanded
 			        QName</termref> of a positional variable must be distinct from the <termref def="dt-expanded-qname"
-                  >expanded QName</termref> of the main variable with which it is associated <errorref
+                  >expanded QName(s)</termref> of the associated <termref def="dt-range-variable">range variable(s)</termref> <errorref
                   class="ST" code="0089"/>.</p>
             <p>The following  examples illustrate how a positional variable would have affected the results of the previous examples that generated tuples:</p>
             <ulist>
@@ -19187,24 +19217,7 @@ for member $y in $expr2]]></eg>
             should include an occurrence indicator of <code>"?"</code> to indicate that the variable may be bound to an
             empty sequence.</p></note>
             
-            <p>If the new variable introduced by a <code>for</code> clause has an associated <termref
-                  def="dt-positional-variable"
-                  >positional variable</termref>, the output tuples generated by the <code>for</code> clause  also contain bindings for the <termref
-                  def="dt-positional-variable"
-                  >positional variable</termref>. In this case, as the new variable is bound to each item in its <termref
-                     def="dt-binding-collection" diff="chg" at="A">binding collection</termref>, the <termref
-                  def="dt-positional-variable"
-                  >positional variable</termref> is bound to the ordinal position of that item within the <termref
-                     def="dt-binding-collection" diff="chg" at="A"
-                  >binding collection</termref>, starting with one. Note that, since the <termref
-                  def="dt-positional-variable"
-                  >positional variable</termref> represents a position within a <termref
-                     def="dt-binding-collection" diff="chg" at="A"
-                  >binding collection</termref>, the output tuples corresponding to each input tuple are independently numbered, starting with one. For a given input tuple, if the <termref
-                     def="dt-binding-collection"  diff="chg" at="A"
-                  >binding collection</termref> is empty and <code>allowing empty</code> is specified, the <termref
-                  def="dt-positional-variable"
-               >positional variable</termref> in the output tuple is bound to the integer zero.</p>
+            
             <p>The tuples in the output tuple stream are ordered primarily by the order of the 
                input tuples from which they are derived, and secondarily by the order of the <termref
                   def="dt-binding-sequence"
@@ -19359,7 +19372,7 @@ Specifically, any separating comma is replaced by <code>let</code>.</p>
                <p>In a <nt def="LetValueBinding">LetValueBinding</nt>
                   such as <code>let $<var>V</var> as <var>T</var> := <var>EXPR</var></code>:</p>
                   <olist>
-                     <item><p>The variable <var>V</var> is declared as a <term>range variable</term>.</p></item>
+                     <item><p>The variable <var>V</var> is declared as a <termref def="dt-range-variable"/>.</p></item>
                      <item><p>The sequence type <var>T</var> is called the <term>declared type</term>.
                      If there is no declared type, then <code>item()*</code> is assumed.</p></item>
                      <item><p>The expression <var>EXPR</var> is evaluated, and its value is converted
@@ -19380,7 +19393,7 @@ Specifically, any separating comma is replaced by <code>let</code>.</p>
                      <item><p>Each variable <var>A/i</var> (for <var>i</var> in 1 to <var>n</var>-1)
                      is effectively replaced by a <nt def="LetValueBinding">LetValueBinding</nt>
                         of the form <code>let <var>A/i</var> as <var>T/i</var> := items-at(<var>V</var>, <var>i</var>)</code>.
-                     That is, a <term>range variable</term> named <var>A/i</var> is declared, whose <term>binding sequence</term>
+                     That is, a <termref def="dt-range-variable"/> named <var>A/i</var> is declared, whose <term>binding sequence</term>
                      is the item <var>V[ i ]</var>, after coercion to the type <var>T/i</var> if specified.
                      If <var>T/i</var> is absent, no further coercion takes place (the default is effectively
                      <code>item()?</code>).</p></item>
@@ -19495,7 +19508,7 @@ local:grouped-moves(tokenize("Nf3 Nf6 c4 g6 Nc3 Bg7 d4 O-O Bf4 d5"))</eg>
                      <item><p>Each variable <var>A/i</var> (for <var>i</var> in 1 to <var>n</var>)
                      is effectively replaced by a <nt def="LetValueBinding">LetValueBinding</nt>
                         of the form <code>let <var>A/i</var> as <var>T/i</var> := array:get(<var>V</var>, <var>i</var>)</code>.
-                     That is, a <term>range variable</term> named <var>A/i</var> is declared, whose <term>binding sequence</term>
+                     That is, a <termref def="dt-range-variable"/> named <var>A/i</var> is declared, whose <term>binding sequence</term>
                      is the array member <var>V ? i</var>, after coercion to the type <var>T/i</var> if specified.
                      If <var>T/i</var> is absent, no further coercion takes place (the default is effectively
                      <code>item()*</code>).</p>
@@ -19544,7 +19557,7 @@ return $a + $b + $local:c</eg>
                      is effectively replaced by a <nt def="LetValueBinding">LetValueBinding</nt>
                         of the form <code>let <var>A/i</var> as <var>T/i</var> := map:get(<var>V</var>, "<var>N/i</var>", ())</code>,
                         where <var>N/i</var> is the local part of the name of the variable <var>A/i</var>.
-                     That is, a <term>range variable</term> named <var>A/i</var> is declared, whose <term>binding sequence</term>
+                     That is, a <termref def="dt-range-variable"/> named <var>A/i</var> is declared, whose <term>binding sequence</term>
                      is the value of the map entry in <var>V</var> whose key is an <code>xs:string</code> (or <code>xs:anyURI</code> or <code>xs:untypedAtomic</code>)
                         equal to the local part of the variable name, after coercion to the type <var>T/i</var> if specified.
                      If <var>T/i</var> is absent, no further coercion takes place (the default is effectively
@@ -19581,7 +19594,7 @@ return $a + $b + $local:c</eg>
                         
              <item><p>The effect of the <nt def="LetClause">LetClause</nt> is to add
              one or more variable bindings to the tuple stream. Specifically, each
-             <term>range variable</term> declared within the <code>LetClause</code>
+             <termref def="dt-range-variable"/> declared within the <code>LetClause</code>
              is bound to its corresponding <term>binding sequence</term>, and 
              the resulting variable binding is added to the current tuple, replacing
              any existing variable binding with the same variable name.</p>
@@ -21058,26 +21071,32 @@ return ($i, $j)]]></eg>
             </item>
             
             <item>
-               <p>Having performed this expansion, 
-                  variables bound in the <nt def="ForClause">ForClause</nt>
-                  are called the <term>range variables</term>,
-                  the variable named in the <nt def="PositionalVar">PositionalVar</nt> (if present)
-                  is called the <term>position variable</term>,
-                  the expression that follows the <code>in</code> keyword is called the <term>binding expression</term>, 
-                  and the expression in the <nt def="ForLetReturn">ForLetReturn</nt> part 
+               <p>Having performed this expansion:</p>
+               <ulist>
+                  <item><p><termdef id="dt-positional-variable-xp" term="positional variable">The
+                      variable named in the <nt def="PositionalVar">PositionalVar</nt> (if present)
+                      is called the <term>positional variable</term>.</termdef></p></item>
+                  <item><p><termdef id="dt-range-variable-xp" term="range variable">Variables other than
+                  positional variables are referred to as <term>range variables</term>.</termdef></p></item>
+                  <item><p><termdef id="dt-binding-expression-xp" term="binding expression">The expression 
+                           that follows the <code>in</code> keyword is called the <term>binding expression</term>.</termdef></p></item>
+                  <item><p><termdef id="dt-return-expression-xp" term="return expression">The expression 
+                           in the <nt def="ForLetReturn">ForLetReturn</nt> part 
                   (that is, the following <nt def="LetExpr">LetExpr</nt> or
                   <nt def="ForExpr">ForExpr</nt>, or the <nt def="ExprSingle">ExprSingle</nt> 
-                  that follows the <code>return</code> keyword) is called the <term>return expression</term>. 
-               </p>
-               <p><termdef id="dt-binding-collection-xp" term="binding collection">The 
-                  result of evaluating the <term>binding expression</term> in a 
+                  that follows the <code>return</code> keyword) is called the <term>return expression</term>.</termdef></p></item>
+                  <item><p><termdef id="dt-binding-collection-xp" term="binding collection">The 
+                  result of evaluating the <termref def="dt-binding-expression-xp"/> in a 
                   <code>for</code> expression is called the 
-                  <term>binding collection</term></termdef>.</p>
+                  <term>binding collection</term></termdef>.</p></item>
+               </ulist>
+                  
+               
             </item>
             <item>
-               <p>If a <term>position variable</term> is declared, its type is implicitly
+               <p>If a <termref def="dt-positional-variable-xp"/> is declared, its type is implicitly
                   <code>xs:integer</code>. Its name (as an <termref def="dt-expanded-qname"/>) must be
-               different from the name of a <term>range variable</term> declared in the same
+               different from the name of a <termref def="dt-range-variable-xp"/> declared in the same
                 <nt def="ForBinding">ForBinding</nt>.  
                   <errorref spec="XQ" class="ST" code="0089"/>.
                </p>
@@ -21090,14 +21109,14 @@ return ($i, $j)]]></eg>
                      <item><p>If a <nt def="TypeDeclaration">TypeDeclaration</nt>
                         is present then each item in the <termref def="dt-binding-collection-xp"/>
                         is converted to the specified type by applying the <termref def="dt-coercion-rules"/>.</p></item>
-                     <item><p>The <term>return expression</term> is evaluated once 
+                     <item><p>The <termref def="dt-return-expression-xp"/> is evaluated once 
                         for each item in the <termref def="dt-binding-collection-xp"/>, with a dynamic context in which
-                        the <term>range variable</term> is bound to that item, and the <term>position variable</term> 
+                        the <termref def="dt-range-variable-xp"/> is bound to that item, and the <termref def="dt-positional-variable-xp"/> 
                         (if present) is bound to the one-based position of that item in the 
                         <termref def="dt-binding-collection-xp"/>, as an instance of type 
                         <code>xs:integer</code>.</p></item>
                      <item><p>The result of the <code>for</code> expression is the <termref def="dt-sequence-concatenation"/>
-                        of the results of the successive evaluations of the <term>return expression</term>.</p></item>
+                        of the results of the successive evaluations of the <termref def="dt-return-expression-xp"/>.</p></item>
                   </olist>
               
                </p>
@@ -21114,15 +21133,15 @@ return ($i, $j)]]></eg>
                         is converted to the specified type by applying the <termref def="dt-coercion-rules"/>.
                         (Recall that this can be any sequence, not necessarily a single item). </p></item>
                      <item><p>The result of the single-variable <code>for member</code> expression is obtained
-                        by evaluating the <term>return expression</term> once 
-                        for each member of that array, with the range variable bound to that member </p></item>
-                     <item><p>The <term>return expression</term> is evaluated once 
+                        by evaluating the <termref def="dt-return-expression-xp"/> once 
+                        for each member of that array, with the <termref def="dt-range-variable-xp"/> bound to that member </p></item>
+                     <item><p>The <termref def="dt-return-expression-xp"/> is evaluated once 
                         for each member of the <termref def="dt-binding-collection-xp"/> array, 
                         with a dynamic context in which
-                        the <term>range variable</term> is bound to that member, and the <term>position variable</term> 
+                        the <termref def="dt-range-variable-xp"/> is bound to that member, and the <termref def="dt-positional-variable-xp"/> 
                         (if present) is bound to the one-based position of that member in the <termref def="dt-binding-collection-xp"/>.</p></item>
                      <item><p>The result of the <code>for</code> expression is the <termref def="dt-sequence-concatenation"/>
-                        of the results of the successive evaluations of the <term>return expression</term>.</p>
+                        of the results of the successive evaluations of the <termref def="dt-return-expression-xp"/>.</p>
                      <p>Note that the result is a sequence, not an array.</p></item>
                   </olist>   
                   
@@ -21155,20 +21174,21 @@ return ($i, $j)]]></eg>
                         is present for the value, then each value is converted to the specified type by 
                         applying the <termref def="dt-coercion-rules"/>.</p></item>
                      <item><p>The result of the single-variable <code>for key/value</code> expression is obtained
-                        by evaluating the <term>return expression</term> once 
-                        for each entry in the map, with the range variables bound to that entry as described.</p></item>
-                     <item><p>The <term>return expression</term> is evaluated once 
+                        by evaluating the <termref def="dt-return-expression-xp"/> once 
+                        for each entry in the map, with the <termref def="dt-range-variable-xp">range variables</termref> 
+                           bound to that entry as described.</p></item>
+                     <item><p>The <termref def="dt-return-expression-xp"/> is evaluated once 
                         for each entry of the <termref def="dt-binding-collection-xp"/> map, 
                         with a dynamic context in which
-                        the <code>key</code> <term>range variable</term> (if present)
+                        the <code>key</code> <termref def="dt-range-variable-xp"/> (if present)
                         is bound to the key part of that entry, 
-                        the <code>value</code> <term>range variable</term> (if present)
+                        the <code>value</code> <termref def="dt-range-variable-xp"/> (if present)
                         is bound to the value part of that entry, and the <term>position variable</term> 
                         (if present) is bound to the one-based position of that entry in the 
                         <termref def="dt-implementation-dependent"/> ordering of the 
                         <termref def="dt-binding-collection-xp"/>.</p></item>
                      <item><p>The result of the <code>for</code> expression is the <termref def="dt-sequence-concatenation"/>
-                        of the results of the successive evaluations of the <term>return expression</term>.</p>
+                        of the results of the successive evaluations of the <termref def="dt-return-expression-xp"/>.</p>
                      <p>Note that the result is a sequence, not a map.</p></item>
                   </olist>   
                </p>
@@ -21233,7 +21253,7 @@ return ($i + $j)</phrase>
          </eg>
          <p>The result of the above expression, expressed as a sequence of numbers, is as follows: <code>11, 12, 21, 22</code>
          </p>
-         <p>The scope of a variable bound in a <code>for</code> expression is the <term>return expression</term>. 
+         <p>The scope of a variable bound in a <code>for</code> expression is the <termref def="dt-return-expression-xp"/>. 
             The scope does not include the expression to which the variable is bound. 
             The following example illustrates how a variable binding may reference another variable 
             bound earlier in the same  <code>for</code> expression:</p>
@@ -21321,7 +21341,7 @@ Specifically, any separating comma is replaced by <code>let</code>.</p>
                <p>In a <nt def="LetValueBinding">LetValueBinding</nt>
                   such as <code>let $<var>V</var> as <var>T</var> := <var>EXPR</var></code>:</p>
                   <olist>
-                     <item><p>The variable <var>V</var> is called the <term>range variable</term>.</p></item>
+                     <item><p>The variable <var>V</var> is called the <termref def="dt-range-variable-xp"/>.</p></item>
                      <item><p>The sequence type <var>T</var> is called the <term>declared type</term>.
                      If there is no declared type, then <code>item()*</code> is assumed.</p></item>
                      <item><p>The expression <var>EXPR</var> is evaluated, and its value is converted
@@ -21342,7 +21362,7 @@ Specifically, any separating comma is replaced by <code>let</code>.</p>
                      <item><p>Each variable <var>A/i</var> (for <var>i</var> in 1 to <var>n</var>-1)
                      is effectively replaced by a <nt def="LetValueBinding">LetValueBinding</nt>
                         of the form <code>let <var>A/i</var> as <var>T/i</var> := items-at(<var>V</var>, <var>i</var>)</code>.
-                     That is, a <term>range variable</term> named <var>A/i</var> is declared, whose <term>binding sequence</term>
+                     That is, a <termref def="dt-range-variable-xp"/> named <var>A/i</var> is declared, whose <term>binding sequence</term>
                      is the item <var>V[ i ]</var>, after coercion to the type <var>T/i</var> if specified.
                      If <var>T/i</var> is absent, no further coercion takes place (the default is effectively
                      <code>item()?</code>).</p></item>
@@ -21441,7 +21461,7 @@ return $a + $b + $local:c</eg>
                      <item><p>Each variable <var>A/i</var> (for <var>i</var> in 1 to <var>n</var>)
                      is effectively replaced by a <nt def="LetValueBinding">LetValueBinding</nt>
                         of the form <code>let <var>A/i</var> as <var>T/i</var> := array:get(<var>V</var>, <var>i</var>)</code>.
-                     That is, a <term>range variable</term> named <var>A/i</var> is declared, whose <term>binding sequence</term>
+                     That is, a <termref def="dt-range-variable-xp"/> named <var>A/i</var> is declared, whose <term>binding sequence</term>
                      is the array member <var>V ? i</var>, after coercion to the type <var>T/i</var> if specified.
                      If <var>T/i</var> is absent, no further coercion takes place (the default is effectively
                      <code>item()*</code>).</p>
@@ -21490,7 +21510,7 @@ return $a + $b + $local:c</eg>
                      is effectively replaced by a <nt def="LetValueBinding">LetValueBinding</nt>
                         of the form <code>let <var>A/i</var> as <var>T/i</var> := map:get(<var>V</var>, "<var>N/i</var>", ())</code>,
                         where <var>N/i</var> is the local part of the name of the variable <var>A/i</var>.
-                     That is, a <term>range variable</term> named <var>A/i</var> is declared, whose <term>binding sequence</term>
+                     That is, a <termref def="dt-range-variable-xp"/> named <var>A/i</var> is declared, whose <term>binding sequence</term>
                      is the value of the map entry in <var>V</var> whose key is an <code>xs:string</code> (or <code>xs:anyURI</code> or <code>xs:untypedAtomic</code>)
                         equal to the local part of the variable name, after coercion to the type <var>T/i</var> if specified.
                      If <var>T/i</var> is absent, no further coercion takes place (the default is effectively
@@ -21529,8 +21549,9 @@ return $a + $b + $local:c</eg>
                   (that is, the following <nt def="LetExpr">LetExpr</nt> or
                   <nt def="ForExpr">ForExpr</nt>, or the <nt def="ExprSingle">ExprSingle</nt> 
                   that follows the <code>return</code> keyword) is
-called the <term>return expression</term>. The result of the let expression is obtained
-by evaluating the <term>return expression</term> with a dynamic context in which each range variable is bound to the
+called the <termref def="dt-return-expression-xp"/>. The result of the let expression is obtained
+by evaluating the <termref def="dt-return-expression-xp"/> with a dynamic context in which 
+                   each <termref def="dt-range-variable-xp"/> is bound to the
 corresponding binding sequence. </p>
             </item>
             
@@ -21539,7 +21560,7 @@ corresponding binding sequence. </p>
          </olist>
 
          <p>The scope of a variable bound in a let expression is the
-            <term>return expression</term>.
+            <termref def="dt-return-expression-xp"/>.
 The scope does not include the expression to which the variable is bound.
 The following example illustrates how a variable binding may reference
 another variable bound earlier in the same let expression:</p>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -18896,31 +18896,18 @@ Intermediate clauses may be <code>for</code>, <code>let</code>, <code>window</co
          <div3 id="id-binding-rules" role="xquery">
             <head>Variable Bindings</head>
             <p>The following clauses in FLWOR expressions bind values to variables: 
-<code>for</code>, <code>let</code>, <code>window</code>, <code>count</code>, and <code>group by</code>.
-            These variables are classified as <termref def="dt-range-variable">range variables</termref>
-            or <termref def="dt-positional-variable">positional variables</termref>.</p>
-            
-            <p><termdef id="dt-range-variable" term="range variable">A variable bound in a clause of
-                  a FLWOR expression, other than a <termref def="dt-positional-variable"/>,
-                  is called a <term>range variable</term>.</termdef></p>
-            
-<p>The binding of range variables for <code>for</code>, <code>let</code>, and <code>count</code> is governed by the following rules
-(the binding of range variables in <code>group by</code> is discussed in <specref
+<code>for</code>, <code>let</code>, <code>window</code>, <code>count</code>, and <code>group by</code>. 
+The binding of variables for <code>for</code>, <code>let</code>, and <code>count</code> is governed by the following rules
+(the binding of variables in <code>group by</code> is discussed in <specref
                   ref="id-group-by"
                   />,
-the binding of range variables in <code>window</code> clauses is discussed in <specref
+the binding of variables in <code>window</code> clauses is discussed in <specref
                   ref="id-windows"/>):</p>
 
             <olist>
 
                <item>
-                  <p>The scope of a <termref def="dt-range-variable"/> or <termref def="dt-positional-variable"/> 
-                     includes all subexpressions 
-                     of the containing FLWOR that appear after the variable binding. 
-                     The scope does not include the expression to which the variable is bound. 
-                     The following code fragment, containing two <code>let</code> clauses, 
-                     illustrates how variable bindings may reference variables that were bound 
-                     in earlier clauses, or in earlier bindings in the same clause:</p>
+                  <p>The scope of a bound variable includes all subexpressions of the containing FLWOR that appear after the variable binding. The scope does not include the expression to which the variable is bound. The following code fragment, containing two <code>let</code> clauses, illustrates how variable bindings may reference variables that were bound in earlier clauses, or in earlier bindings in the same clause:</p>
                   <eg><![CDATA[let $x := 47, $y := f($x)
 let $z := g($x, $y)]]></eg>
                </item>
@@ -18932,8 +18919,7 @@ let $z := g($x, $y)]]></eg>
                      remainder of the FLWOR expression.</p>
                   <p>For example, it is valid to write:</p>
                   <eg>let $x := 0, $x := $x*2, $x := $x + 1</eg>
-                  <p>This binds three separate <termref def="dt-range-variable">range variables</termref>, 
-                     each of which happens to have the
+                  <p>This binds three separate variables, each of which happens to have the
                   same name. It should not be construed as binding a series of different values
                   to the same variable.</p>
                </item>
@@ -18965,8 +18951,7 @@ let $z := g($x, $y)]]></eg>
                         preceded by the keyword <code>in</code>, the value of that expression is 
                         called a <term>binding collection</term>.</termdef> The collection may be either
                      a sequence, an array, or a map. The <code>for</code>  
-                     clause iterates over its binding collection, producing multiple bindings 
-                     for one or more <termref def="dt-range-variable">range variables</termref>. 
+                     clause iterates over its binding collection, producing multiple bindings for one or more variables. 
                      Details on how binding collections are used in <code>for</code> clauses 
                      are described in the following sections.</p>
                </item>
@@ -18976,8 +18961,7 @@ let $z := g($x, $y)]]></eg>
                            >In a <code>window</code> clause, when an expression is 
                         preceded by the keyword <code>in</code>, the value of that expression is 
                         called a <term>binding sequence</term>.</termdef> The <code>window</code> 
-                     clause iterates over its binding sequence, producing multiple bindings for one or more 
-                     <termref def="dt-range-variable">range variables</termref>. 
+                     clause iterates over its binding sequence, producing multiple bindings for one or more variables. 
                      Details on how binding sequences are used in <code>for</code> and <code>window</code> clauses 
                      are described in the following sections.</p>
                </item>
@@ -19005,8 +18989,8 @@ let $z := g($x, $y)]]></eg>
                <prodrecap ref="ForClause"/>
             </scrap>
             
-            <p>A <code>for</code> clause is used for iteration. Each <termref def="dt-range-variable"/> 
-               in a <code>for</code> clause iterates over a sequence, an array, or a map.</p>
+            <p>A <code>for</code> clause is used for iteration. Each variable in a <code>for</code> clause iterates over a 
+               sequence, an array, or a map.</p>
             
             <p>The expression following the keyword <code>in</code> is evaluated; we refer to the 
                resulting sequence, array, or map generically as the <termref def="dt-binding-collection"/>, and to
@@ -19015,20 +18999,20 @@ let $z := g($x, $y)]]></eg>
             <ulist>
                <item><p>When a <nt def="ForItemBinding">ForItemBinding</nt> is used (that is, when none of the
                   keywords <code>member</code>, <code>key</code>, or <code>value</code> is used), 
-                  the <termref def="dt-range-variable"/> is bound in turn to each item in the <termref def="dt-binding-collection"/>,
+                  the range variable is bound in turn to each item in the <termref def="dt-binding-collection"/>,
                   which is treated as a sequence of items.</p></item>
                <item><p>When a <nt def="ForItemBinding">ForMemberBinding</nt> is used (that is, when the
                keyword <code>member</code> is used), 
-               the <termref def="dt-range-variable"/> is bound in turn to each member of the array.</p>
+               the range variable is bound in turn to each member of the array.</p>
                   <p>In this case the corresponding <code>ExprSingle</code>
                   must evaluate to a single array, otherwise a type error is raised <errorref
                   class="TY" code="0141"/>. However, the coercion rules also allow a JNode
                   whose <term>·jvalue·</term> is an array to be supplied.</p></item>
-               <item><p>When a <nt def="ForEntryBinding">ForEntryBinding</nt> is used (that is, when either
+               <item><p>When a <nt def="ForItemBinding">ForEntryBinding</nt> is used (that is, when either
                   or both of the keywords <code>key</code> and <code>value</code> are used), 
-                  the <code>key</code> <termref def="dt-range-variable"/> (if present) is bound in turn to each key in the map 
+                  the <code>key</code> range variable (if present) is bound in turn to each key in the map 
                   (in <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref>), and the <code>value</code>
-                  <termref def="dt-range-variable"/> (if present) is bound to the corresponding value.</p>
+                  range variable (if present) is bound to the corresponding value.</p>
                   <p>In this case the corresponding <code>ExprSingle</code>
                   must evaluate to a single map, otherwise a type error is raised <errorref
                   class="TY" code="0141"/>. However, the coercion rules also allow a JNode
@@ -19066,13 +19050,12 @@ for member $y in $expr2]]></eg>
             
            
 
-            <p>In the remainder of this section, we define the semantics of a <code>for</code> clause 
-               after performing this expansion: that is, a <code>for</code> clause with a single
-               <termref def="dt-binding-collection"/>.</p>
-               
-            <p>If such a <code>for</code> clause is the initial clause in a FLWOR expression, it iterates over its <termref
-               def="dt-binding-collection">binding collection</termref>, binding the <termref def="dt-range-variable"/>
-               (or pair of variables, if the <code>for key $K value $V</code> form is used) to each component in turn. 
+            <p>In the remainder of this section, we define the semantics of a <code>for</code> clause containing 
+               a single variable and an associated expression 
+               (following the keyword <code>in</code>) whose value is the <termref
+                  def="dt-binding-collection">binding collection</termref> for that variable.</p>
+            <p>If a single-variable <code>for</code> clause is the initial clause in a FLWOR expression, it iterates over its <termref
+               def="dt-binding-collection">binding collection</termref>, binding the variable(s) to each component in turn. 
                The resulting sequence of variable bindings becomes the initial tuple stream that serves as input to the next clause 
                of the FLWOR expression. The order of tuples in the tuple stream preserves the order of the <termref
                   def="dt-binding-collection">binding collection</termref>.</p>
@@ -19135,30 +19118,17 @@ for member $y in $expr2]]></eg>
             <p>
                <termdef term="positional variable" id="dt-positional-variable">A <term>positional variable</term> 
                   is a variable that is preceded by the keyword <code>at</code>.</termdef> A positional variable 
-               may be associated with a <termref def="dt-range-variable"/>
-               that is bound in a <code>for</code> clause, or with a pair of range variables when the
-               <nt def="ForEntryBinding">ForEntryBinding</nt> form is used. In this case, as 
-               the range variable(s) iterate over the components of its <termref def="dt-binding-collection" diff="chg" at="A">binding collection</termref>, 
-               the positional variable iterates over the integers that represent the ordinal numbers of these components in the 
+               may be associated with the range variable(s) that are bound in a <code>for</code> clause. In this case, as 
+               the main range variable(s) iterate over the components of its <termref def="dt-binding-collection" diff="chg" at="A">binding collection</termref>, 
+               the positional variable iterates over the integers that represent the ordinal numbers of these component in the 
                <termref def="dt-binding-collection" diff="chg" at="A">binding collection</termref>, starting with one. Each tuple in the output 
-               tuple stream contains bindings for both the <termref def="dt-range-variable">range variable(s)</termref> and the positional variable. If the 
+               tuple stream contains bindings for both the main variable and the positional variable. If the 
                <termref def="dt-binding-collection" diff="chg" at="A">binding collection</termref> is empty and <code>allowing empty</code> is 
                specified, the positional variable in the output tuple is bound to the integer zero. Positional variables  
                have the implied type <code>xs:integer</code>.</p>
-            
-            <p>Note that, since the <termref
-                  def="dt-positional-variable"/> represents a position within a <termref
-                     def="dt-binding-collection"/>, the output tuples corresponding to each input tuple are independently numbered, 
-               starting with one. For a given input tuple, if the <termref
-                     def="dt-binding-collection"  diff="chg" at="A"
-                  >binding collection</termref> is empty and <code>allowing empty</code> is specified, the <termref
-                  def="dt-positional-variable"/> in the output tuple is bound to the integer zero.</p>
-            
-            
-            
             <p>The <termref def="dt-expanded-qname">expanded
 			        QName</termref> of a positional variable must be distinct from the <termref def="dt-expanded-qname"
-                  >expanded QName(s)</termref> of the associated <termref def="dt-range-variable">range variable(s)</termref> <errorref
+                  >expanded QName</termref> of the main variable with which it is associated <errorref
                   class="ST" code="0089"/>.</p>
             <p>The following  examples illustrate how a positional variable would have affected the results of the previous examples that generated tuples:</p>
             <ulist>
@@ -19217,7 +19187,24 @@ for member $y in $expr2]]></eg>
             should include an occurrence indicator of <code>"?"</code> to indicate that the variable may be bound to an
             empty sequence.</p></note>
             
-            
+            <p>If the new variable introduced by a <code>for</code> clause has an associated <termref
+                  def="dt-positional-variable"
+                  >positional variable</termref>, the output tuples generated by the <code>for</code> clause  also contain bindings for the <termref
+                  def="dt-positional-variable"
+                  >positional variable</termref>. In this case, as the new variable is bound to each item in its <termref
+                     def="dt-binding-collection" diff="chg" at="A">binding collection</termref>, the <termref
+                  def="dt-positional-variable"
+                  >positional variable</termref> is bound to the ordinal position of that item within the <termref
+                     def="dt-binding-collection" diff="chg" at="A"
+                  >binding collection</termref>, starting with one. Note that, since the <termref
+                  def="dt-positional-variable"
+                  >positional variable</termref> represents a position within a <termref
+                     def="dt-binding-collection" diff="chg" at="A"
+                  >binding collection</termref>, the output tuples corresponding to each input tuple are independently numbered, starting with one. For a given input tuple, if the <termref
+                     def="dt-binding-collection"  diff="chg" at="A"
+                  >binding collection</termref> is empty and <code>allowing empty</code> is specified, the <termref
+                  def="dt-positional-variable"
+               >positional variable</termref> in the output tuple is bound to the integer zero.</p>
             <p>The tuples in the output tuple stream are ordered primarily by the order of the 
                input tuples from which they are derived, and secondarily by the order of the <termref
                   def="dt-binding-sequence"
@@ -19372,7 +19359,7 @@ Specifically, any separating comma is replaced by <code>let</code>.</p>
                <p>In a <nt def="LetValueBinding">LetValueBinding</nt>
                   such as <code>let $<var>V</var> as <var>T</var> := <var>EXPR</var></code>:</p>
                   <olist>
-                     <item><p>The variable <var>V</var> is declared as a <termref def="dt-range-variable"/>.</p></item>
+                     <item><p>The variable <var>V</var> is declared as a <term>range variable</term>.</p></item>
                      <item><p>The sequence type <var>T</var> is called the <term>declared type</term>.
                      If there is no declared type, then <code>item()*</code> is assumed.</p></item>
                      <item><p>The expression <var>EXPR</var> is evaluated, and its value is converted
@@ -19393,7 +19380,7 @@ Specifically, any separating comma is replaced by <code>let</code>.</p>
                      <item><p>Each variable <var>A/i</var> (for <var>i</var> in 1 to <var>n</var>-1)
                      is effectively replaced by a <nt def="LetValueBinding">LetValueBinding</nt>
                         of the form <code>let <var>A/i</var> as <var>T/i</var> := items-at(<var>V</var>, <var>i</var>)</code>.
-                     That is, a <termref def="dt-range-variable"/> named <var>A/i</var> is declared, whose <term>binding sequence</term>
+                     That is, a <term>range variable</term> named <var>A/i</var> is declared, whose <term>binding sequence</term>
                      is the item <var>V[ i ]</var>, after coercion to the type <var>T/i</var> if specified.
                      If <var>T/i</var> is absent, no further coercion takes place (the default is effectively
                      <code>item()?</code>).</p></item>
@@ -19508,7 +19495,7 @@ local:grouped-moves(tokenize("Nf3 Nf6 c4 g6 Nc3 Bg7 d4 O-O Bf4 d5"))</eg>
                      <item><p>Each variable <var>A/i</var> (for <var>i</var> in 1 to <var>n</var>)
                      is effectively replaced by a <nt def="LetValueBinding">LetValueBinding</nt>
                         of the form <code>let <var>A/i</var> as <var>T/i</var> := array:get(<var>V</var>, <var>i</var>)</code>.
-                     That is, a <termref def="dt-range-variable"/> named <var>A/i</var> is declared, whose <term>binding sequence</term>
+                     That is, a <term>range variable</term> named <var>A/i</var> is declared, whose <term>binding sequence</term>
                      is the array member <var>V ? i</var>, after coercion to the type <var>T/i</var> if specified.
                      If <var>T/i</var> is absent, no further coercion takes place (the default is effectively
                      <code>item()*</code>).</p>
@@ -19557,7 +19544,7 @@ return $a + $b + $local:c</eg>
                      is effectively replaced by a <nt def="LetValueBinding">LetValueBinding</nt>
                         of the form <code>let <var>A/i</var> as <var>T/i</var> := map:get(<var>V</var>, "<var>N/i</var>", ())</code>,
                         where <var>N/i</var> is the local part of the name of the variable <var>A/i</var>.
-                     That is, a <termref def="dt-range-variable"/> named <var>A/i</var> is declared, whose <term>binding sequence</term>
+                     That is, a <term>range variable</term> named <var>A/i</var> is declared, whose <term>binding sequence</term>
                      is the value of the map entry in <var>V</var> whose key is an <code>xs:string</code> (or <code>xs:anyURI</code> or <code>xs:untypedAtomic</code>)
                         equal to the local part of the variable name, after coercion to the type <var>T/i</var> if specified.
                      If <var>T/i</var> is absent, no further coercion takes place (the default is effectively
@@ -19594,7 +19581,7 @@ return $a + $b + $local:c</eg>
                         
              <item><p>The effect of the <nt def="LetClause">LetClause</nt> is to add
              one or more variable bindings to the tuple stream. Specifically, each
-             <termref def="dt-range-variable"/> declared within the <code>LetClause</code>
+             <term>range variable</term> declared within the <code>LetClause</code>
              is bound to its corresponding <term>binding sequence</term>, and 
              the resulting variable binding is added to the current tuple, replacing
              any existing variable binding with the same variable name.</p>
@@ -21071,32 +21058,26 @@ return ($i, $j)]]></eg>
             </item>
             
             <item>
-               <p>Having performed this expansion:</p>
-               <ulist>
-                  <item><p><termdef id="dt-positional-variable-xp" term="positional variable">The
-                      variable named in the <nt def="PositionalVar">PositionalVar</nt> (if present)
-                      is called the <term>positional variable</term>.</termdef></p></item>
-                  <item><p><termdef id="dt-range-variable-xp" term="range variable">Variables other than
-                  positional variables are referred to as <term>range variables</term>.</termdef></p></item>
-                  <item><p><termdef id="dt-binding-expression-xp" term="binding expression">The expression 
-                           that follows the <code>in</code> keyword is called the <term>binding expression</term>.</termdef></p></item>
-                  <item><p><termdef id="dt-return-expression-xp" term="return expression">The expression 
-                           in the <nt def="ForLetReturn">ForLetReturn</nt> part 
+               <p>Having performed this expansion, 
+                  variables bound in the <nt def="ForClause">ForClause</nt>
+                  are called the <term>range variables</term>,
+                  the variable named in the <nt def="PositionalVar">PositionalVar</nt> (if present)
+                  is called the <term>position variable</term>,
+                  the expression that follows the <code>in</code> keyword is called the <term>binding expression</term>, 
+                  and the expression in the <nt def="ForLetReturn">ForLetReturn</nt> part 
                   (that is, the following <nt def="LetExpr">LetExpr</nt> or
                   <nt def="ForExpr">ForExpr</nt>, or the <nt def="ExprSingle">ExprSingle</nt> 
-                  that follows the <code>return</code> keyword) is called the <term>return expression</term>.</termdef></p></item>
-                  <item><p><termdef id="dt-binding-collection-xp" term="binding collection">The 
-                  result of evaluating the <termref def="dt-binding-expression-xp"/> in a 
+                  that follows the <code>return</code> keyword) is called the <term>return expression</term>. 
+               </p>
+               <p><termdef id="dt-binding-collection-xp" term="binding collection">The 
+                  result of evaluating the <term>binding expression</term> in a 
                   <code>for</code> expression is called the 
-                  <term>binding collection</term></termdef>.</p></item>
-               </ulist>
-                  
-               
+                  <term>binding collection</term></termdef>.</p>
             </item>
             <item>
-               <p>If a <termref def="dt-positional-variable-xp"/> is declared, its type is implicitly
+               <p>If a <term>position variable</term> is declared, its type is implicitly
                   <code>xs:integer</code>. Its name (as an <termref def="dt-expanded-qname"/>) must be
-               different from the name of a <termref def="dt-range-variable-xp"/> declared in the same
+               different from the name of a <term>range variable</term> declared in the same
                 <nt def="ForBinding">ForBinding</nt>.  
                   <errorref spec="XQ" class="ST" code="0089"/>.
                </p>
@@ -21109,14 +21090,14 @@ return ($i, $j)]]></eg>
                      <item><p>If a <nt def="TypeDeclaration">TypeDeclaration</nt>
                         is present then each item in the <termref def="dt-binding-collection-xp"/>
                         is converted to the specified type by applying the <termref def="dt-coercion-rules"/>.</p></item>
-                     <item><p>The <termref def="dt-return-expression-xp"/> is evaluated once 
+                     <item><p>The <term>return expression</term> is evaluated once 
                         for each item in the <termref def="dt-binding-collection-xp"/>, with a dynamic context in which
-                        the <termref def="dt-range-variable-xp"/> is bound to that item, and the <termref def="dt-positional-variable-xp"/> 
+                        the <term>range variable</term> is bound to that item, and the <term>position variable</term> 
                         (if present) is bound to the one-based position of that item in the 
                         <termref def="dt-binding-collection-xp"/>, as an instance of type 
                         <code>xs:integer</code>.</p></item>
                      <item><p>The result of the <code>for</code> expression is the <termref def="dt-sequence-concatenation"/>
-                        of the results of the successive evaluations of the <termref def="dt-return-expression-xp"/>.</p></item>
+                        of the results of the successive evaluations of the <term>return expression</term>.</p></item>
                   </olist>
               
                </p>
@@ -21133,15 +21114,15 @@ return ($i, $j)]]></eg>
                         is converted to the specified type by applying the <termref def="dt-coercion-rules"/>.
                         (Recall that this can be any sequence, not necessarily a single item). </p></item>
                      <item><p>The result of the single-variable <code>for member</code> expression is obtained
-                        by evaluating the <termref def="dt-return-expression-xp"/> once 
-                        for each member of that array, with the <termref def="dt-range-variable-xp"/> bound to that member </p></item>
-                     <item><p>The <termref def="dt-return-expression-xp"/> is evaluated once 
+                        by evaluating the <term>return expression</term> once 
+                        for each member of that array, with the range variable bound to that member </p></item>
+                     <item><p>The <term>return expression</term> is evaluated once 
                         for each member of the <termref def="dt-binding-collection-xp"/> array, 
                         with a dynamic context in which
-                        the <termref def="dt-range-variable-xp"/> is bound to that member, and the <termref def="dt-positional-variable-xp"/> 
+                        the <term>range variable</term> is bound to that member, and the <term>position variable</term> 
                         (if present) is bound to the one-based position of that member in the <termref def="dt-binding-collection-xp"/>.</p></item>
                      <item><p>The result of the <code>for</code> expression is the <termref def="dt-sequence-concatenation"/>
-                        of the results of the successive evaluations of the <termref def="dt-return-expression-xp"/>.</p>
+                        of the results of the successive evaluations of the <term>return expression</term>.</p>
                      <p>Note that the result is a sequence, not an array.</p></item>
                   </olist>   
                   
@@ -21174,21 +21155,20 @@ return ($i, $j)]]></eg>
                         is present for the value, then each value is converted to the specified type by 
                         applying the <termref def="dt-coercion-rules"/>.</p></item>
                      <item><p>The result of the single-variable <code>for key/value</code> expression is obtained
-                        by evaluating the <termref def="dt-return-expression-xp"/> once 
-                        for each entry in the map, with the <termref def="dt-range-variable-xp">range variables</termref> 
-                           bound to that entry as described.</p></item>
-                     <item><p>The <termref def="dt-return-expression-xp"/> is evaluated once 
+                        by evaluating the <term>return expression</term> once 
+                        for each entry in the map, with the range variables bound to that entry as described.</p></item>
+                     <item><p>The <term>return expression</term> is evaluated once 
                         for each entry of the <termref def="dt-binding-collection-xp"/> map, 
                         with a dynamic context in which
-                        the <code>key</code> <termref def="dt-range-variable-xp"/> (if present)
+                        the <code>key</code> <term>range variable</term> (if present)
                         is bound to the key part of that entry, 
-                        the <code>value</code> <termref def="dt-range-variable-xp"/> (if present)
+                        the <code>value</code> <term>range variable</term> (if present)
                         is bound to the value part of that entry, and the <term>position variable</term> 
                         (if present) is bound to the one-based position of that entry in the 
                         <termref def="dt-implementation-dependent"/> ordering of the 
                         <termref def="dt-binding-collection-xp"/>.</p></item>
                      <item><p>The result of the <code>for</code> expression is the <termref def="dt-sequence-concatenation"/>
-                        of the results of the successive evaluations of the <termref def="dt-return-expression-xp"/>.</p>
+                        of the results of the successive evaluations of the <term>return expression</term>.</p>
                      <p>Note that the result is a sequence, not a map.</p></item>
                   </olist>   
                </p>
@@ -21253,7 +21233,7 @@ return ($i + $j)</phrase>
          </eg>
          <p>The result of the above expression, expressed as a sequence of numbers, is as follows: <code>11, 12, 21, 22</code>
          </p>
-         <p>The scope of a variable bound in a <code>for</code> expression is the <termref def="dt-return-expression-xp"/>. 
+         <p>The scope of a variable bound in a <code>for</code> expression is the <term>return expression</term>. 
             The scope does not include the expression to which the variable is bound. 
             The following example illustrates how a variable binding may reference another variable 
             bound earlier in the same  <code>for</code> expression:</p>
@@ -21341,7 +21321,7 @@ Specifically, any separating comma is replaced by <code>let</code>.</p>
                <p>In a <nt def="LetValueBinding">LetValueBinding</nt>
                   such as <code>let $<var>V</var> as <var>T</var> := <var>EXPR</var></code>:</p>
                   <olist>
-                     <item><p>The variable <var>V</var> is called the <termref def="dt-range-variable-xp"/>.</p></item>
+                     <item><p>The variable <var>V</var> is called the <term>range variable</term>.</p></item>
                      <item><p>The sequence type <var>T</var> is called the <term>declared type</term>.
                      If there is no declared type, then <code>item()*</code> is assumed.</p></item>
                      <item><p>The expression <var>EXPR</var> is evaluated, and its value is converted
@@ -21362,7 +21342,7 @@ Specifically, any separating comma is replaced by <code>let</code>.</p>
                      <item><p>Each variable <var>A/i</var> (for <var>i</var> in 1 to <var>n</var>-1)
                      is effectively replaced by a <nt def="LetValueBinding">LetValueBinding</nt>
                         of the form <code>let <var>A/i</var> as <var>T/i</var> := items-at(<var>V</var>, <var>i</var>)</code>.
-                     That is, a <termref def="dt-range-variable-xp"/> named <var>A/i</var> is declared, whose <term>binding sequence</term>
+                     That is, a <term>range variable</term> named <var>A/i</var> is declared, whose <term>binding sequence</term>
                      is the item <var>V[ i ]</var>, after coercion to the type <var>T/i</var> if specified.
                      If <var>T/i</var> is absent, no further coercion takes place (the default is effectively
                      <code>item()?</code>).</p></item>
@@ -21461,7 +21441,7 @@ return $a + $b + $local:c</eg>
                      <item><p>Each variable <var>A/i</var> (for <var>i</var> in 1 to <var>n</var>)
                      is effectively replaced by a <nt def="LetValueBinding">LetValueBinding</nt>
                         of the form <code>let <var>A/i</var> as <var>T/i</var> := array:get(<var>V</var>, <var>i</var>)</code>.
-                     That is, a <termref def="dt-range-variable-xp"/> named <var>A/i</var> is declared, whose <term>binding sequence</term>
+                     That is, a <term>range variable</term> named <var>A/i</var> is declared, whose <term>binding sequence</term>
                      is the array member <var>V ? i</var>, after coercion to the type <var>T/i</var> if specified.
                      If <var>T/i</var> is absent, no further coercion takes place (the default is effectively
                      <code>item()*</code>).</p>
@@ -21510,7 +21490,7 @@ return $a + $b + $local:c</eg>
                      is effectively replaced by a <nt def="LetValueBinding">LetValueBinding</nt>
                         of the form <code>let <var>A/i</var> as <var>T/i</var> := map:get(<var>V</var>, "<var>N/i</var>", ())</code>,
                         where <var>N/i</var> is the local part of the name of the variable <var>A/i</var>.
-                     That is, a <termref def="dt-range-variable-xp"/> named <var>A/i</var> is declared, whose <term>binding sequence</term>
+                     That is, a <term>range variable</term> named <var>A/i</var> is declared, whose <term>binding sequence</term>
                      is the value of the map entry in <var>V</var> whose key is an <code>xs:string</code> (or <code>xs:anyURI</code> or <code>xs:untypedAtomic</code>)
                         equal to the local part of the variable name, after coercion to the type <var>T/i</var> if specified.
                      If <var>T/i</var> is absent, no further coercion takes place (the default is effectively
@@ -21549,9 +21529,8 @@ return $a + $b + $local:c</eg>
                   (that is, the following <nt def="LetExpr">LetExpr</nt> or
                   <nt def="ForExpr">ForExpr</nt>, or the <nt def="ExprSingle">ExprSingle</nt> 
                   that follows the <code>return</code> keyword) is
-called the <termref def="dt-return-expression-xp"/>. The result of the let expression is obtained
-by evaluating the <termref def="dt-return-expression-xp"/> with a dynamic context in which 
-                   each <termref def="dt-range-variable-xp"/> is bound to the
+called the <term>return expression</term>. The result of the let expression is obtained
+by evaluating the <term>return expression</term> with a dynamic context in which each range variable is bound to the
 corresponding binding sequence. </p>
             </item>
             
@@ -21560,7 +21539,7 @@ corresponding binding sequence. </p>
          </olist>
 
          <p>The scope of a variable bound in a let expression is the
-            <termref def="dt-return-expression-xp"/>.
+            <term>return expression</term>.
 The scope does not include the expression to which the variable is bound.
 The following example illustrates how a variable binding may reference
 another variable bound earlier in the same let expression:</p>


### PR DESCRIPTION
Fix #2655

Changes the effect of `fn:matching-segments((), "regex")`

Revision of PR #2657, reverts a commit from a different branch.