### PR TITLE
2659 bin:count-ones, bin:rotate, bin:is-bit-set, bin:sets-bits

### DIFF
--- a/specifications/EXPath/binary/src/binary-functions.xml
+++ b/specifications/EXPath/binary/src/binary-functions.xml
@@ -906,8 +906,8 @@ Michael Sperberg-McQueen (1954–2024).</p>
             <div2 id="func-bin-set-bits">
                 <head><?function bin:set-bits?></head>
             </div2>
-            <div2 id="func-bin-count-ones">
-                <head><?function bin:count-ones?></head>
+            <div2 id="func-bin-count-bits-set">
+                <head><?function bin:count-bits-set?></head>
             </div2>
         </div1>
 

--- a/specifications/EXPath/binary/src/binary-functions.xml
+++ b/specifications/EXPath/binary/src/binary-functions.xml
@@ -897,6 +897,18 @@ Michael Sperberg-McQueen (1954–2024).</p>
             <div2 id="func-bin-shift">
                 <head><?function bin:shift?></head>
             </div2>
+            <div2 id="func-bin-rotate">
+                <head><?function bin:rotate?></head>
+            </div2>
+            <div2 id="func-bin-is-bit-set">
+                <head><?function bin:is-bit-set?></head>
+            </div2>
+            <div2 id="func-bin-set-bits">
+                <head><?function bin:set-bits?></head>
+            </div2>
+            <div2 id="func-bin-count-ones">
+                <head><?function bin:count-ones?></head>
+            </div2>
         </div1>
 
     </body>

--- a/specifications/EXPath/binary/src/function-catalog.xml
+++ b/specifications/EXPath/binary/src/function-catalog.xml
@@ -1841,9 +1841,9 @@ fold-left(
         </fos:examples>
     </fos:function>
 
-    <fos:function name="count-ones" prefix="bin">
+    <fos:function name="count-bits-set" prefix="bin">
         <fos:signatures>
-            <fos:proto name="count-ones" return-type="xs:integer?">
+            <fos:proto name="count-bits-set" return-type="xs:integer?">
                 <fos:arg name="value" type="(xs:hexBinary | xs:base64Binary)?"/>
             </fos:proto>
         </fos:signatures>
@@ -1871,16 +1871,16 @@ bin:to-octets($value)
         <fos:notes>
             <p>The result is also known as the <emph>population count</emph>.</p>
             <p>The Hamming distance between two binary values of equal length can be computed as
-                <code>bin:count-ones(bin:xor($value1, $value2))</code>.</p>
+                <code>bin:count-bits-set(bin:xor($value1, $value2))</code>.</p>
         </fos:notes>
         <fos:examples>
             <fos:example>
                 <fos:test>
-                    <fos:expression>bin:count-ones(bin:hex(''))</fos:expression>
+                    <fos:expression>bin:count-bits-set(bin:hex(''))</fos:expression>
                     <fos:result>0</fos:result>
                 </fos:test>
                 <fos:test>
-                    <fos:expression>bin:count-ones(bin:hex('FF_FF_FF_FF'))</fos:expression>
+                    <fos:expression>bin:count-bits-set(bin:hex('FF_FF_FF_FF'))</fos:expression>
                     <fos:result>32</fos:result>
                 </fos:test>
             </fos:example>

--- a/specifications/EXPath/binary/src/function-catalog.xml
+++ b/specifications/EXPath/binary/src/function-catalog.xml
@@ -1667,7 +1667,224 @@ return bin:bin($shifted)
                 <!--<eg xml:space="preserve">bin:shift(bin:hex("000001"), 17) → bin:hex("020000")</eg>-->
             </fos:example>
         </fos:examples>
-    </fos:function>    
-    
+    </fos:function>
+
+    <fos:function name="rotate" prefix="bin">
+        <fos:signatures>
+            <fos:proto name="rotate" return-type="xs:base64Binary?">
+                <fos:arg name="value" type="(xs:hexBinary | xs:base64Binary)?"/>
+                <fos:arg name="by" type="xs:integer"/>
+            </fos:proto>
+        </fos:signatures>
+        <fos:properties>
+            <fos:property>deterministic</fos:property>
+            <fos:property>context-independent</fos:property>
+            <fos:property>focus-independent</fos:property>
+        </fos:properties>
+        <fos:summary>
+            <p>Rotates the bits of a binary value left or right.</p>
+        </fos:summary>
+        <fos:rules>
+            <p>If the value of <code>$value</code> is the empty sequence, the function returns an
+                empty sequence.</p>
+            <p>In other cases the length of the result is always the same as the
+                length of <code>$value</code>.</p>
+            <p>If <code>$by</code> is positive the bits are rotated <code>$by</code> places to the
+                left. The high-order bits shifted out at the front re-enter at the end.</p>
+            <p>If <code>$by</code> is negative then the bits are rotated <code>-$by</code> places to the
+                right.</p>
+            <p>If <code>$by</code> is zero, the result is identical to <code>$value</code>.</p>
+            <p>The rotation is cyclic modulo the bit-length of <code>$value</code>: rotating by the
+                bit-length, or a multiple of it, returns <code>$value</code> unchanged.</p>
+        </fos:rules>
+        <fos:equivalent style="xpath-expression" covers-error-cases="false">
+let $string := (
+  bin:to-octets($value)
+  =!> format-integer('2^xxxxxxxx')
+  =>  string-join()
+)
+let $len := string-length($string)
+let $r := (($by mod $len) + $len) mod $len
+return bin:bin(substring($string, $r + 1) || substring($string, 1, $r))
+        </fos:equivalent>
+        <fos:notes>
+            <p>Like <function>bin:shift</function>, rotation across byte boundaries follows
+                big-endian treatment. Unlike <function>bin:shift</function>, no bits are discarded
+                and no zero bits are injected.</p>
+        </fos:notes>
+        <fos:examples>
+            <fos:example>
+                <fos:test>
+                    <fos:expression>bin:rotate(bin:hex('81'), 1)</fos:expression>
+                    <fos:result>bin:hex('03')</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:rotate(bin:hex('81'), -1)</fos:expression>
+                    <fos:result>bin:hex('C0')</fos:result>
+                </fos:test>
+            </fos:example>
+        </fos:examples>
+    </fos:function>
+
+    <fos:function name="is-bit-set" prefix="bin">
+        <fos:signatures>
+            <fos:proto name="is-bit-set" return-type="xs:boolean?">
+                <fos:arg name="value" type="(xs:hexBinary | xs:base64Binary)?"/>
+                <fos:arg name="index" type="xs:integer"/>
+            </fos:proto>
+        </fos:signatures>
+        <fos:properties>
+            <fos:property>deterministic</fos:property>
+            <fos:property>context-independent</fos:property>
+            <fos:property>focus-independent</fos:property>
+        </fos:properties>
+        <fos:summary>
+            <p>Determines whether a particular bit of a binary value is set.</p>
+        </fos:summary>
+        <fos:rules>
+            <p>If the value of <code>$value</code> is the empty sequence, the function returns an
+                empty sequence.</p>
+            <p>In other cases returns <code>true</code> if the bit at position <code>$index</code> in
+                <code>$value</code> is set, or <code>false</code> otherwise.</p>
+            <p>Bits are numbered from the start of the binary value: index 0 is the most significant
+                bit of the first octet, index 7 its least significant bit, index 8 the most
+                significant bit of the second octet, and so on.</p>
+        </fos:rules>
+        <fos:equivalent style="xpath-expression" covers-error-cases="false">
+let $bits := (
+  bin:to-octets($value)
+  =!> format-integer('2^xxxxxxxx')
+  =>  string-join()
+)
+return substring($bits, $index + 1, 1) = '1'
+        </fos:equivalent>
+        <fos:errors>
+            <p><errorref spec="BIN40" code="index-out-of-range"/> is raised if <code>$index</code> is
+                negative or not less than the number of bits in <code>$value</code>.</p>
+        </fos:errors>
+        <fos:examples>
+            <fos:example>
+                <fos:test>
+                    <fos:expression>bin:is-bit-set(bin:hex('80'), 0)</fos:expression>
+                    <fos:result>true</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:is-bit-set(bin:hex('80'), 7)</fos:expression>
+                    <fos:result>false</fos:result>
+                </fos:test>
+            </fos:example>
+        </fos:examples>
+    </fos:function>
+
+    <fos:function name="set-bits" prefix="bin">
+        <fos:signatures>
+            <fos:proto name="set-bits" return-type="xs:base64Binary?">
+                <fos:arg name="value" type="(xs:hexBinary | xs:base64Binary)?"/>
+                <fos:arg name="indices" type="xs:integer*"/>
+                <fos:arg name="set" type="xs:boolean"/>
+            </fos:proto>
+        </fos:signatures>
+        <fos:properties>
+            <fos:property>deterministic</fos:property>
+            <fos:property>context-independent</fos:property>
+            <fos:property>focus-independent</fos:property>
+        </fos:properties>
+        <fos:summary>
+            <p>Returns a binary value with selected bits set or cleared.</p>
+        </fos:summary>
+        <fos:rules>
+            <p>If the value of <code>$value</code> is the empty sequence, the function returns an
+                empty sequence.</p>
+            <p>In other cases returns a binary value identical to <code>$value</code> with the bit at
+                each position in <code>$indices</code> set to 1 if <code>$set</code> is true,
+                or to 0 otherwise.</p>
+            <p>Bits are numbered as for <function>bin:is-bit-set</function>: index 0 is the most
+                significant bit of the first octet. The order of <code>$indices</code> is
+                insignificant, and repeated indices have no additional effect.</p>
+            <p>The length of the result is always the same as the length of <code>$value</code>. If
+                <code>$indices</code> is empty, the result is identical to <code>$value</code>.</p>
+        </fos:rules>
+        <fos:equivalent style="xpath-expression" covers-error-cases="false">
+fold-left(
+  $indices,
+  $value,
+  fn($result, $index) {
+    let $bits := (
+      bin:to-octets($result)
+      =!> format-integer('2^xxxxxxxx')
+      =>  string-join()
+    )
+    return bin:bin(
+      substring($bits, 1, $index) ||
+      (if ($set) then '1' else '0') ||
+      substring($bits, $index + 2)
+    )
+  }
+)
+        </fos:equivalent>
+        <fos:errors>
+            <p><errorref spec="BIN40" code="index-out-of-range"/> is raised if any value in
+                <code>$indices</code> is negative or not less than the number of bits in
+                <code>$value</code>.</p>
+        </fos:errors>
+        <fos:examples>
+            <fos:example>
+                <fos:test>
+                    <fos:expression>bin:set-bits(bin:hex('00'), (0, 7), true())</fos:expression>
+                    <fos:result>bin:hex('81')</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:set-bits(bin:hex('FF'), (0, 7), false())</fos:expression>
+                    <fos:result>bin:hex('7E')</fos:result>
+                </fos:test>
+            </fos:example>
+        </fos:examples>
+    </fos:function>
+
+    <fos:function name="count-ones" prefix="bin">
+        <fos:signatures>
+            <fos:proto name="count-ones" return-type="xs:integer?">
+                <fos:arg name="value" type="(xs:hexBinary | xs:base64Binary)?"/>
+            </fos:proto>
+        </fos:signatures>
+        <fos:properties>
+            <fos:property>deterministic</fos:property>
+            <fos:property>context-independent</fos:property>
+            <fos:property>focus-independent</fos:property>
+        </fos:properties>
+        <fos:summary>
+            <p>Returns the number of one-bits in a binary value.</p>
+        </fos:summary>
+        <fos:rules>
+            <p>If the value of <code>$value</code> is the empty sequence, the function returns
+                an empty sequence.</p>
+            <p>In other cases the number of bits is returned that are set to <code>1</code> in
+                <code>$value</code>.</p>
+        </fos:rules>
+        <fos:equivalent style="xpath-expression" covers-error-cases="false">
+bin:to-octets($value)
+  =!> format-integer('2^xxxxxxxx')
+  =>  string-join()
+  =>  replace('0')
+  =>  string-length()
+        </fos:equivalent>
+        <fos:notes>
+            <p>The result is also known as the <emph>population count</emph>.</p>
+            <p>The Hamming distance between two binary values of equal length can be computed as
+                <code>bin:count-ones(bin:xor($value1, $value2))</code>.</p>
+        </fos:notes>
+        <fos:examples>
+            <fos:example>
+                <fos:test>
+                    <fos:expression>bin:count-ones(bin:hex(''))</fos:expression>
+                    <fos:result>0</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:count-ones(bin:hex('FF_FF_FF_FF'))</fos:expression>
+                    <fos:result>32</fos:result>
+                </fos:test>
+            </fos:example>
+        </fos:examples>
+    </fos:function>
 
 </fos:functions>


### PR DESCRIPTION
Closes #2659

I have added three other trivial functions for operations that are cumbersome and inefficient to formulate in XPath: `bin:rotate`, `bin:is-bit-set`, `bin:sets-bits`.