### PR TITLE
2661 Add content-key option for fn:element-to-map

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -28643,6 +28643,17 @@ element-to-map-plan((<a><b/><b/></a>, <a><b/><c/></a>))
                <fos:type>xs:string</fos:type>
                <fos:default>"@"</fos:default>
             </fos:option>
+            <fos:option key="content-key">
+               <fos:meaning>For layouts that by default use the key value <code>#content</code>
+               to identify content derived from the children of an input element, this
+               option substitutes a different string in place of <code>#content</code>.
+               If the selected value would result in a generated map having duplicate key
+               values, then as many <code>#</code> characters as are needed to make the
+               key unique are prepended to the requested string.
+               </fos:meaning>
+               <fos:type>xs:string</fos:type>
+               <fos:default>"#content"</fos:default>
+            </fos:option>
             <fos:option key="name-format">
                <fos:meaning>Indicates how the names of element and attribute nodes are handled.</fos:meaning>
                <fos:type>xs:string</fos:type>
@@ -28702,6 +28713,11 @@ element-to-map-plan((<a><b/><b/></a>, <a><b/><c/></a>))
             <fos:test spec="XQuery">
                <fos:expression><![CDATA[element-to-map(<foo>bar</foo>)]]></fos:expression>
                <fos:result>{ "foo": "bar" }</fos:result>
+            </fos:test>
+            <fos:test spec="XQuery">
+               <fos:expression><![CDATA[element-to-map(<price currency="USD">12.16</price>,
+    { 'attribute-marker': '', 'content-key': 'value' })]]></fos:expression>
+               <fos:result>{ "price": {'currency': 'USD', 'value': 12.16 }}</fos:result>
             </fos:test>
             <fos:test spec="XQuery">
                <fos:expression><eg><![CDATA[element-to-map(
@@ -28769,7 +28785,7 @@ element-to-map-plan((<a><b/><b/></a>, <a><b/><c/></a>))
          </fos:example>
       </fos:examples>
       <fos:changes>
-         <fos:change issue="1797" PR="1906" date="2025-04-29"><p>New in 4.0.</p></fos:change>
+         <fos:change issue="1797 2661" PR="1906" date="2025-04-29"><p>New in 4.0.</p></fos:change>
       </fos:changes>
    </fos:function>
 
@@ -30313,316 +30329,6 @@ return document {
       
    </fos:function>
    
-   <!--<fos:function name="json" prefix="fn">
-      <fos:signatures>
-         <fos:proto name="json" return-type="xs:string">
-            <fos:arg name="input" type="xs:string?"/>
-            <fos:arg name="options" type="map(*)?" usage="inspection" default="{}" note="default-on-empty"/>
-         </fos:proto>
-      </fos:signatures>
-      <fos:properties>
-         <fos:property>deterministic</fos:property>
-         <fos:property>context-independent</fos:property>
-         <fos:property>focus-independent</fos:property>
-      </fos:properties>
-      <fos:summary>
-         <p>Creates a JSON representation of an arbitrary XDM value.</p>
-      </fos:summary>
-      <fos:rules>
-         <p>This function returns a string, in JSON format, containing a representation of the
-         supplied input <code>$input</code>. The function is error-free (it accepts any input sequence
-         whatsoever), but it is not lossless: there are cases when two different XDM values will
-         have the same JSON representation. For example, the sequence <code>(1, 2)</code>
-            and the array <code>[ 1, 2 ]</code> are both output as <code>[ 1, 2 ]</code>.</p>
-         
-         <p>The entries that may appear in the <code>$options</code> map are as follows:</p>
-         
-         <fos:options>
-            <fos:option key="indent">
-               <fos:meaning>Determines whether additional whitespace should be added to the output to improve readability.</fos:meaning>
-               <fos:type>xs:boolean</fos:type>
-               <fos:default>false</fos:default>
-               <fos:values>
-                  <fos:value value="false">
-                     The processor must not insert any insignificant whitespace between JSON tokens.
-                  </fos:value>
-                  <fos:value value="true">
-                     The processor <rfc2119>may</rfc2119> insert whitespace between JSON tokens in order to improve readability.
-                     The specification imposes no constraints on how this is done.
-                  </fos:value>
-               </fos:values>
-            </fos:option>
-            <fos:option key="element-map">
-               <fos:meaning>Determines whether elements whose children are element nodes with distinct
-                  names should be treated specially.</fos:meaning>
-               <fos:type>xs:boolean</fos:type>
-               <fos:default>true</fos:default>
-               <fos:values>
-                  <fos:value value="false">
-                     The processor treats such elements in the same way as any other element.
-                  </fos:value>
-                  <fos:value value="true">
-                     The processor generates a JSON object in which the child element names are used
-                     as JSON property names.
-                  </fos:value>
-               </fos:values>
-            </fos:option>
-         </fos:options>
-         
-         
-         <p>An input sequence is handled as follows:</p>
-         <ulist>
-            <item><p>An empty sequence is output as the JSON value null.</p></item>
-            <item><p>A singleton sequence is output following the rules for processing items, below.</p></item>
-            <item><p>A sequence of two or more items results in a JSON array, whose members are constructed
-            from the items by applying the rules below.</p></item>
-         </ulist>
-         
-         <p>Items are processed as follows:</p>
-         
-         <ulist>
-            <item>
-               <p><emph>atomic items</emph></p>
-               <ulist>
-                  <item><p>An <code>xs:boolean</code> value is output as the JSON value <code>true</code> or <code>false</code>.</p></item>
-                  <item><p>A numeric value, other than <code>INF</code>, <code>-INF</code>, or <code>NaN</code>,
-                  is output as a JSON number.</p></item>
-                  <item><p>Any other atomic item is cast to <code>xs:string</code>, and the result is output as a JSON string,
-                  escaped as described below.</p></item>
-               </ulist>
-            </item>
-            <item>
-               <p><emph>Nodes</emph></p>
-               <ulist>
-                  <item>
-                     <p><emph>Document nodes</emph></p>
-                     <p>A document node is output as a JSON object with two properties, in order:</p>
-                     <ulist>
-                        <item><p>A property <code>#document</code> set to the value of the base URI of the document
-                           if available, or an empty string otherwise..</p></item>
-                        <item><p>A property <code>#content</code> whose value follows the rules for
-                        outputting the content of an element node, given below.</p></item>                       
-                     </ulist>
-                  </item>
-                  <item>
-                     <p><emph>Element nodes</emph></p>
-                     <p>An element node is output as a JSON object with the following properties, in order:</p>
-                     <ulist>
-                        <item>
-                           <p><code>#element</code> set to the local name of the element.</p>
-                        </item>
-                        <item>
-                           <p>If the element name has a prefix, <code>#prefix</code>, set to the value of the prefix.</p>
-                        </item>
-                     
-                        <item>
-                           <p>If the element name is in a namespace, <code>#namespace</code>, set to the value of the 
-                           namespace URI.</p>
-                        </item>
-                        <item>
-                           <p>For each attribute of the element, in arbitrary order, a property whose
-                              name is derived from the attribute name as follows:</p>
-                                 <ulist>
-                                    <item><p>If the attribute name is in no namespace, then <code>"@"</code> followed
-                                    by the local name.</p></item>
-                                    <item><p>If the attribute name is in the XML namespace, then <code>"@xml:"</code> followed
-                                       by the local name.</p></item>
-                                    <item><p>Otherwise <code>"@Q{uri}local"</code> where <code>uri</code> is the namespace
-                                       URI and <code>local</code> is the local name.</p></item>
-                                 </ulist>
-                              
-                                 <p>The property value is the result of atomizing the attribute node and applying the
-                                 <function>fn:json</function> function to the result. (For untyped attributes, the result
-                                 will always be a single string.)</p>
-                              
-                           
-                        </item>
-                        <item>
-                           <p>The children of the element are processed as follows:</p>
-                           <ulist>
-                              <item>
-                                 <p>If there are no children, nothing is output.</p>
-                              </item>
-                              <item>
-                                 <p>If the element has a type annotation that is a simple type, or if its content
-                                 comprises a single text node, then a property <code>#value</code> set to the result
-                                 of atomizing the element node and applying the <function>fn:json</function> function
-                                 to the result.</p>
-                              </item>
-                              <item>
-                                 <p>If (a) the children consist exclusively of elements and whitespace-only
-                                 text nodes, and (b) the child element nodes are all in the same namespace, or all in no
-                                 namespace, and (c) each child element has a local name that is distinct from the local
-                                 name of any other child, and (d) the <code>element-map</code> option is not
-                                    present in <code>$options</code> with the value <code>false</code>,
-                                    then a property <code>#content</code> whose value is a JSON
-                                 object having one property for each child element node. The name of this property
-                                 is the local name of the element, and the value of the property is obtained by applying
-                                 these rules recursively, except that for an empty element, the value is represented
-                                 as JSON <code>null</code>.</p>
-                              </item>
-                              <item><p>Otherwise, a property <code>#content</code> whose value is an array, with
-                              one member for each child node (including whitespace-only text nodes), obtained
-                              by applying the <function>fn:json</function> function to that child node.</p></item>
-                           </ulist>
-                        </item>
-                     </ulist>
-                  </item>
-                  <item>
-                     <p><emph>Text nodes</emph></p>
-                     <p>A JSON object with a single property <code>#text</code> whose value is the
-                        string value of the text node.</p>
-                  </item>
-                  <item>
-                     <p><emph>Comment nodes</emph></p>
-                     <p>A JSON object with a single property <code>#comment</code> whose value is the
-                        string value of the comment.</p>
-                  </item>
-                  <item>
-                     <p><emph>Processing instruction nodes</emph></p>
-                     <p>A JSON object with a two properties (in order): <code>#processing-instruction</code> set to the
-                        name of the processing instruction, and <code>#data</code> set to the
-                        string value of the processing instruction node.</p>
-                  </item>
-                  <item>
-                     <p><emph>Attribute nodes</emph></p>
-                     <p>Attribute nodes that are reached via an element node are output as described
-                        under “element nodes”, above.</p>
-                     <p>Free-standing attribute nodes are output as JSON objects with properties
-                     <code>#attribute</code> set to the local name of the attribute, <code>#prefix</code>
-                     (if non-empty) set to the prefix of the attribute’s name, <code>#namespace</code>
-                     (if non-empty) set to the namespace URI, and <code>#value</code> set to
-                        the result of atomizing the attribute value and applying the
-                        <function>fn:json</function> function to the result.</p>
-                  </item>
-                  <item><p><emph>Namespace nodes</emph></p></item>
-                  <item><p>Namespace nodes that are reached via an element node result in no output.</p></item>
-                  <item><p>Free-standing namespace nodes are output as JSON objects with properties
-                  <code>#namespace</code> set to the namespace prefix (<code>""</code> for the default
-                  namespace) and <code>#uri</code> set to the namespace URI.</p></item>
-               </ulist>            
-            </item>
-            <item>
-               <p><emph>Maps</emph></p>
-               <p>An XDM map is output as a JSON object with one property for each entry in the map.</p>
-               <p>The property name is derived from the key value by converting the value to a string
-               and applying escaping rules. If the property name thus generated is the same as a previously output
-               property name, then it is made unique by appending <code>"(N)"</code> where <var>N</var> is the smallest
-               positive integer that makes the resulting value unique.</p>
-               <p>The property value is derived by applying the <function>fn:json</function> function to the value in the map entry.</p>
-               
-               <note><p>Conflicts between property names can arise because the XDM model allows keys of different types,
-                  for example the <code>xs:date</code> value <code>2020-12-31</code> and the string value 
-                  <code>"2020-12-31"</code> can co-exist. The map <code>{ xs:duration('PTD'): 20, "P1D": 30 }</code>
-                  is converted to the JSON string <code>{ "P1D": 20, "P1D(1)": 30 }</code> or 
-                  <code>{ "P1D": 30, "P1D(1)": 20 }</code>, depending on the (unpredictable) order in which the
-               entries in the map are processed.</p></note>
-               <note><p>Because the order of entries in a map is unpredictable, the order in which the
-               properties are listed in the JSON output is also unpredictable.</p></note>
-               </item>
-            <item>
-               <p><emph>Arrays</emph></p>
-               <p>An XDM array is output as a JSON array. Each member of the XDM array generates one entry in the
-                  JSON array, in order, obtained by applying the <function>fn:json</function> function to the XDM array member.</p>              
-            </item>
-            <item>
-               <p><emph>Functions</emph></p>
-               <p>An XDM function, other than a map or array, is output as a JSON object with the following
-               properties:</p>
-               <ulist>
-                  <item><p><code>#function</code>, set to the local name of the function
-                  if it has a name, or the empty string otherwise.</p></item>
-                  <item><p><code>#namespace</code>, set to the namespace URI of the function. The property
-                  is omitted for an anonymous function.</p></item>
-                  <item><p><code>#arity</code>, set to the arity of the function as a JSON number.</p></item>
-                  <item><p><code>#arguments</code> whose value is an array
-                  of strings, which identify the names and types of the function arguments,
-                  in the format <code>$Q{uri}local as SequenceType</code>: for example 
-                     <code>[ "$x as double", "$y as string" ]</code>. Namespace prefixes must not be used:
-                     unprefixed element names and variable names are taken to be in no namespace, and unprefixed
-                     type names are taken to be in the namespace <code>http://www.w3.org/2001/XMLSchema</code>.
-                  </p></item>
-                  <item><p><code>#result</code> whose value is a string 
-                     identifying the type of the function result, using the same conventions as for <code>#arguments</code>.</p></item>
-                  <item><p>Optionally at implementer discretion, <code>#implementation</code> whose value is a string 
-                     representing the function’s implementation in implementation-defined format.</p></item>
-               </ulist>
-               <p>Strings are escaped as follows:</p>
-               <olist>
-                  <item>
-                     <p>Any occurrence of backslash is replaced by <code>\\</code></p>
-                  </item>
-                  
-                  <item>
-                     <p>Any occurrence of quotation mark, backspace, form-feed, newline, carriage return, or tab is 
-                        replaced by <code>\"</code>, <code>\b</code>, <code>\f</code>, <code>\n</code>, <code>\r</code>, or <code>\t</code> respectively; </p>
-                  </item>
-                  
-                  <item>
-                     <p>Any other codepoint in the range 1-31 or 127-159 is replaced by an escape in 
-                        the form <code>\uHHHH</code> where <code>HHHH</code> is the upper-case hexadecimal representation of the codepoint value.</p>
-                  </item>
-               </olist>
-            </item>
-         </ulist>        
-      </fos:rules>
-      <fos:notes>
-         <p>In the JSON output, names of properties defined in this specification are prefixed with <code>#</code>;
-         names not so prefixed are derived from names appearing in the input.</p>
-         <p>Namespace information may be lost (specifically, namespaces that are declared but not used are
-         not retained in the output).</p>
-         <p>The distinction between sequences and arrays is lost.</p>
-         <p>The distinction between different atomic types is lost, except for the boolean / number / string
-         distinction present in JSON.</p>
-         <p>In elements whose children are elements with distinct names, whitespace text nodes are lost,
-         and the namespace URIs and prefixes of the child elements are lost.</p>
-      </fos:notes>
-      <fos:examples>
-         <fos:example>
-            <fos:test>
-               <fos:expression>json(())</fos:expression>
-               <fos:result>'null'</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>json(12)</fos:expression>
-               <fos:result>'12'</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>json((12, "December"))</fos:expression>
-               <fos:result>'[12,"December"]'</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>json(true())</fos:expression>
-               <fos:result>'true'</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>json({ "a": 1,"b": number('NaN'), "c": (1, 2, 3) })</fos:expression>
-               <fos:result>'{"a":1,"b":"NaN","c":[1,2,3]}'</fos:result>
-               <fos:postamble>(or some permutation thereof)</fos:postamble>
-            </fos:test>
-            <fos:test>
-               <fos:expression><![CDATA[json(<a x="2">banana</a>)]]></fos:expression>
-               <fos:result>'{"#element":"a","@x":"2","#value":"banana"}'</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression><![CDATA[json(<a><b/><c>2</c></a>)]]></fos:expression>
-               <fos:result>'{"#element":"a","#content":{"b":null,"c":"2"}}'</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression><![CDATA[json(<a><b/><b/><c/></a>)]]></fos:expression>
-               <fos:result>'{"#name":"a","#content":[{"#name":"b"},{"#name":"b"},{"#name":"c}]}'</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression><![CDATA[json(<a>A <i>nice</i> one!</a>)]]></fos:expression>
-               <fos:result>'{"#name":"a","#content":["A ",{"#name":"i", "#value":"nice"}," one!"]}'</fos:result>
-            </fos:test>
-         </fos:example>
-      </fos:examples>
-      <fos:history>
-         <fos:version version="4.0">Proposed for 4.0; not yet reviewed.</fos:version>
-      </fos:history>
-   </fos:function>
--->
 
    <fos:function name="size" prefix="array">
       <fos:signatures>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -7018,6 +7018,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         </tr>
                      </tbody>
                   </table>
+                  <note><p>In all cases where the string <code>"#content"</code> is used by default as a map key
+                  in a generated map, a different string may be substituted using the <code>content-key</code> option.</p></note>
                </div4>
                <div4 id="id-simple-layout">
                   <head>Layout: Simple Content</head>
@@ -7123,6 +7125,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         </tr>
                      </tbody>
                   </table>
+                  <note><p>In all cases where the string <code>"#content"</code> is used by default as a map key
+                  in a generated map, a different string may be substituted using the <code>content-key</code> option.</p></note>
                </div4>
                <div4 id="id-list-layout">
                   <head>Layout: Simple List</head>


### PR DESCRIPTION
Fix #2661

Provides an option to `element-to-map()` to replace the string "#content" with one of the user's choosing.