### PR TITLE
2664 Allow element-to-map(doc())

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -28628,7 +28628,7 @@ element-to-map-plan((<a><b/><b/></a>, <a><b/><c/></a>))
    <fos:function name="element-to-map" prefix="fn">
       <fos:signatures>
          <fos:proto name="element-to-map" return-type="map(xs:string, item()?)?">
-            <fos:arg name="element" type="element()?" usage="absorption"/>
+            <fos:arg name="element" type="document-node(*)|element()?" usage="absorption"/>
             <fos:arg name="options" type="map(*)?" usage="inspection" default="{}" note="default-on-empty"/>
          </fos:proto>
       </fos:signatures>
@@ -28642,6 +28642,9 @@ element-to-map-plan((<a><b/><b/></a>, <a><b/><c/></a>))
             JSON serialization.</p>
       </fos:summary>
       <fos:rules>
+         <p>Supplying a well-formed document node as the value of the first argument
+         has the same effect as supplying the single element node child of that document node.</p>
+         
          <p>This function returns a map derived from
             the element node supplied in <code>$element</code>. The map is in a form
             that is suitable for JSON serialization, thus providing a mechanism for conversion

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -28822,7 +28822,7 @@ element-to-map-plan((<a><b/><b/></a>, <a><b/><c/></a>))
          </fos:example>
       </fos:examples>
       <fos:changes>
-         <fos:change issue="1797 2661" PR="1906" date="2025-04-29"><p>New in 4.0.</p></fos:change>
+         <fos:change issue="1797 2661 2664" PR="1906 2666 2675" date="2025-04-29"><p>New in 4.0.</p></fos:change>
       </fos:changes>
    </fos:function>
 


### PR DESCRIPTION
Implements one of the suggestions in #2664, allowing element-to-map() to accept a well-formed document node.

I'm not in favour of pursuing the other suggestion in that issue, namely atomizing a map (or a JNode) to extract its string-value (as the concatenation of the map entries).

Fix #2664