### PR TITLE
2581 XSLT Patterns

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -58,13 +58,14 @@ apply.
     <g:choice>
       <g:ref name="PredicatePattern"/>
       <g:ref name="TypePattern"/>
-      <g:ref name="GNodePattern"/>
+      <g:ref name="XNodePattern"/>
       <g:ref name="MapPattern"/>
       <g:ref name="ArrayPattern"/>
+      <g:ref name="JNodePattern"/>
     </g:choice>   
   </g:production>
   
-  <g:production name="GNodePattern" if="xslt40-patterns">
+  <g:production name="XNodePattern" if="xslt40-patterns">
     <g:ref name="UnionExprP"/>
   </g:production>
   
@@ -320,12 +321,19 @@ apply.
       <g:string>map</g:string>
     </g:optional>
     <g:string>{</g:string>
-    <g:zeroOrMore separator=",">
-      <g:ref name="MapEntryPattern"/>
-    </g:zeroOrMore>
     <g:optional>
-      <g:string>,</g:string>
-      <g:string>*</g:string>
+      <g:choice>
+        <g:sequence>
+          <g:oneOrMore separator=",">
+            <g:ref name="MapEntryPattern"/>
+          </g:oneOrMore>
+          <g:optional>
+            <g:string>,</g:string>
+            <g:string>*</g:string>
+          </g:optional>
+        </g:sequence>
+        <g:string>*</g:string>
+      </g:choice>
     </g:optional>
     <g:string>}</g:string>
     <g:zeroOrMore>
@@ -375,12 +383,12 @@ apply.
     <g:ref name="Pattern"/>
   </g:production>
   
-  <!--<g:production name="JNodePattern" if="xslt40-patterns">
+  <g:production name="JNodePattern" if="xslt40-patterns">
     <g:string>jnode</g:string>
     <g:string>(</g:string>
     <g:ref name="JNodePatternSelector"/>
     <g:string>,</g:string>
-    <g:ref name="JNodePatternContent"/>
+    <g:ref name="SequencePattern"/>
     <g:string>)</g:string>
     <g:zeroOrMore>
       <g:ref name="Predicate"/>
@@ -390,17 +398,10 @@ apply.
   <g:production name="JNodePatternSelector" if="xslt40-patterns">
     <g:choice>
       <g:string>*</g:string>
-      <g:ref name="NCName"/>
       <g:ref name="Constant"/>
     </g:choice>
   </g:production>
   
-  <g:production name="JNodePatternContent" if="xslt40-patterns">
-    <g:choice>
-      <g:string>*</g:string>
-      <g:ref name="SequenceType"/>
-    </g:choice>
-  </g:production>-->
   
   <!-- ] end XSLT 4.0 Patterns -->
 

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -60,6 +60,7 @@ apply.
       <g:ref name="TypePattern"/>
       <g:ref name="GNodePattern"/>
       <g:ref name="MapPattern"/>
+      <g:ref name="ArrayPattern"/>
     </g:choice>   
   </g:production>
   
@@ -322,6 +323,10 @@ apply.
     <g:zeroOrMore separator=",">
       <g:ref name="MapEntryPattern"/>
     </g:zeroOrMore>
+    <g:optional>
+      <g:string>,</g:string>
+      <g:string>*</g:string>
+    </g:optional>
     <g:string>}</g:string>
     <g:zeroOrMore>
       <g:ref name="Predicate"/>
@@ -338,6 +343,16 @@ apply.
   
   <g:production name="MapEntryKey" if="xslt40-patterns">
     <g:ref name="Constant"/>
+  </g:production>
+  
+  <g:production name="ArrayPattern" if="xslt40-patterns">
+    <g:string>array</g:string>   
+    <g:string>(</g:string>
+    <g:ref name="SequencePattern"/>
+    <g:string>)</g:string>
+    <g:zeroOrMore>
+      <g:ref name="Predicate"/>
+    </g:zeroOrMore>
   </g:production>
   
   <g:production name="SequencePattern" if="xslt40-patterns">

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -12533,6 +12533,8 @@ return $tree =?> depth()]]></eg>
                   </item>
                   
                   <item><p>A <code>MapPattern</code> matches maps (including records) based on their content.</p></item>
+                  
+                  <item><p>An <code>ArrayPattern</code> matches arrays based on their content.</p></item>
                   <!--<p>The grammar for <code>XNodePattern</code> also allows a
                   <code>ParenthesizedPattern</code>, which can be used to match items other than
                   XNodes. This allows patterns such as <code><var>P</var> except (<var>Q</var> union <var>R</var>)</code>,
@@ -13019,6 +13021,35 @@ return $tree =?> depth()]]></eg>
             </div5>
                </div4>
                
+               <div4 id="id-sequence-patterns">
+                  <head>Sequence Patterns</head>
+                  
+                  <p>Sequence patterns cannot be used as top-level patterns, but they are used within
+                  map patterns and array patterns.</p>
+                  
+                  <scrap id="SequencePatterns-scrap">
+                     <prodrecap ref="SequencePattern"/>
+                  </scrap>
+                  
+                  <p>A value <var>V</var> matches a <nt def="SequencePattern">SequencePattern</nt> <var>SP</var> if
+                     one of the following conditions applies:</p>
+                  
+                  <olist>
+                     <item><p><var>V</var> is the empty sequence and <var>SP</var> is <code>empty-sequence()</code>.</p></item>
+                     <item><p><var>SP</var> includes an <nt def="ItemPattern">ItemPattern</nt> <var>P</var> and both
+                        the following conditions are true:</p>
+                        <olist>
+                           <item><p>Every item in <var>V</var> matches <var>P</var>.</p></item>
+                           <item><p>Either <var>SP</var> includes no <nt def="OccurrenceIndicator">OccurrenceIndicator</nt>
+                              and the number of items in <var>V</var> is exactly one, or the number of items in
+                              <var>V</var> matches the requirements of the <nt def="OccurrenceIndicator">OccurrenceIndicator</nt>
+                              (<code>?</code> = zero or one, <code>*</code> = zero or more, <code>+</code> = one or more).</p></item>
+                        </olist>
+                     </item>
+                  </olist>
+                  
+               </div4>
+               
                <div4 id="id-map-patterns">
                   <head>Map Patterns</head>
                   <changes>
@@ -13028,12 +13059,22 @@ return $tree =?> depth()]]></eg>
                      <prodrecap ref="MapPattern"/>
                   </scrap>
                   <p>Map patterns are used to match maps, including records.</p>
-                  <p>For example, the pattern <code>{"first", "last"}</code> matches any map (or record)
-                  whose keys include the strings <code>"first"</code> and <code>"last"</code>,
-                  while the pattern <code>{"first":~xs:string+, "last":~enum("Smith", "Smyth")}</code>
-                  matches any map (or record) having an entry with key <code>"first"</code>
-                  whose value is a sequence of one or more strings, and an entry with key
-                  <code>"last"</code> whose value is either <code>"Smith"</code> or <code>"Smyth"</code>.</p>
+                  <p>For example:</p>
+                  
+                  <ulist>
+                     <item><p>The pattern <code>{"first", "last"}</code> matches a map (or record)
+                        with two entries whose keys are the strings <code>"first"</code> and <code>"last"</code></p></item>
+                     <item><p>The pattern <code>{"first", "last", *}</code> matches a map (or record)
+                        whose keys include the strings <code>"first"</code> and <code>"last"</code>; the map may
+                     have other keys in addition.</p></item>
+                     <item><p>The pattern <code>{"first":~xs:string+, "last":~enum("Smith", "Smyth"), *}</code>
+                        matches any map (or record) having an entry with key <code>"first"</code>
+                        whose value is a sequence of one or more strings, and an entry with key
+                        <code>"last"</code> whose value is either <code>"Smith"</code> or <code>"Smyth"</code>;
+                     the map may have other entries in addition.</p></item>
+                  </ulist>
+                     
+                 
                   
                   <note><p>The keyword <code>"map"</code> is optional and does not change the meaning.</p></note>
                   
@@ -13058,6 +13099,8 @@ return $tree =?> depth()]]></eg>
                            matches the <code>SequencePattern</code>, under the rules given below.</p></item>
                         </olist>
                      </item>
+                     <item><p>Either the optional <code>, *</code> is present in the pattern,
+                     or the map has no entries with keys other than those listed.</p></item>
                      <item>
                         <p><var>M</var> satisfies each of the <nt def="Predicate">Predicates</nt>.</p>
                      </item>
@@ -13072,21 +13115,7 @@ return $tree =?> depth()]]></eg>
                   <p>The order of entries in the map has no effect on whether or not the pattern matches, unless
                   one of the predicates takes order into account.</p>
                   
-                  <p>A value <var>V</var> matches a <nt def="SequencePattern">SequencePattern</nt> <var>SP</var> if
-                     one of the following conditions applies:</p>
                   
-                  <olist>
-                     <item><p><var>V</var> is the empty sequence and <var>SP</var> is <code>empty-sequence()</code>.</p></item>
-                     <item><p><var>SP</var> includes an <nt def="ItemPattern">ItemPattern</nt> <var>P</var> and both
-                     the following conditions are true:</p></item>
-                     <olist>
-                        <item>Every item in <var>V</var> matches <var>P</var>.</item>
-                        <item>Either <var>SP</var> includes no <nt def="OccurrenceIndicator">OccurrenceIndicator</nt>
-                        and the number of items in <var>V</var> is exactly one, or the number of items in
-                        <var>V</var> matches the requirements of the <nt def="OccurrenceIndicator">OccurrenceIndicator</nt>
-                        (<code>?</code> = zero or one, <code>*</code> = zero or more, <code>+</code> = one or more).</item>
-                     </olist>
-                  </olist>
                   
                   <example>
                      <head>Map Patterns</head>
@@ -13173,6 +13202,93 @@ return $tree =?> depth()]]></eg>
                               <td><p><code>{}[deep-equal(map:keys(.), ('x', 'y', 'z'))]</code></p></td>
                               <td><p>Any map whose keys are <code>'x'</code>, <code>'y'</code>, and <code>'z'</code>,
                                     in that order.</p></td>
+                           </tr>
+                           
+                        </tbody>
+                     </table>
+                  </example>
+               </div4>
+               
+               <div4 id="id-array-patterns">
+                  <head>Array Patterns</head>
+                  <changes>
+                     <change>Array patterns are new in 4.0.</change>
+                  </changes>
+                  <scrap id="ArrayPatterns-scrap">
+                     <prodrecap ref="ArrayPattern"/>
+                  </scrap>
+                  <p>Array patterns are used to match arrays.</p>
+                  <p>For example:</p>
+                  
+                  <ulist>
+                     <item><p>The pattern <code>array(~xs:integer)</code> matches an array of integers.</p></item>
+                     <item><p>The pattern <code>array(array(~xs:integer))</code> matches an array whose members are arrays of integers.</p></item>
+                     <item><p>The pattern <code>array(~xs:integer*)</code> matches an array each of whose members is a sequence of zero or more integers.</p></item>
+                     <item><p>The pattern <code>array({"first", "last", *})</code> matches an array of maps (or records)
+                        whose keys include the strings <code>"first"</code> and <code>"last"</code>; the maps may
+                        have other keys in addition.</p></item>
+                     <item><p>The pattern <code>array(item())[array:size(.) = 3]</code> an array with three members, each member being a singleton item.</p></item>
+                  </ulist>
+
+                  
+                  <p>More specifically, an array pattern <var>P</var> matches an 
+                     item <var>A</var> if all the following conditions
+                     are satisfied:</p>
+                  
+                  <olist>
+                     <item>
+                        <p>The item <var>A</var> is an array.</p>
+                     </item>
+                     <item>
+                        <p>Every member of <var>A</var> matches the contained <nt def="SequencePattern">SequencePattern</nt></p>
+                     </item>
+                     <item>
+                        <p><var>M</var> satisfies each of the <nt def="Predicate">Predicates</nt>.</p>
+                     </item>
+                  </olist>
+                  
+                  <note>
+                     <p>The type pattern <code>~array(xs:integer)</code> and the array pattern <code>array(~xs:integer)</code>
+                     are interchangeable: both match an array of integers. The difference is that in a type pattern <code>~array(T)</code>,
+                     <var>T</var> must be a SequenceType, whereas in an array pattern <code>array(P)</code>, <var>P</var> must be a pattern.</p>
+                  </note>
+                  
+                  <example>
+                     <head>Array Patterns</head>
+                     <p>The table below gives some examples of array patterns and their meaning.</p>
+                     <table>
+                        <caption>Array Patterns and their Meanings</caption>
+                        <thead>
+                           <tr>
+                              <th>Pattern</th>
+                              <th>Matches</th>
+                           </tr>
+                        </thead>
+                        <tbody>
+                           <tr>
+                              <td><p><code>array(.*)</code></p></td>
+                              <td><p>Any array</p></td>
+                           </tr>
+                           <tr>
+                              <td><p><code>array(.)</code></p></td>
+                              <td><p>Any array whose members are all singleton items</p></td>
+                           </tr>
+                           <tr>
+                              <td><p><code>array({"long", "lat", *})</code></p></td>
+                              <td><p>An array of maps in which the keys <code>"long"</code> and <code>"lat"</code> are present.</p></td>
+                           </tr>
+                           <tr>
+                              <td><p><code>map{"long", "lat"}[empty(?altitude)]</code></p></td>
+                              <td><p>Any map in which the keys <code>"long"</code> and <code>"lat"</code> are present,
+                                 and in which the entry with key <code>"altitude"</code> is either absent or empty.</p></td>
+                           </tr>
+                           <tr>
+                              <td><p><code>array(~xs:numeric)</code></p></td>
+                              <td><p>An array of singleton numeric values.</p></td>
+                           </tr>
+                           <tr>
+                              <td><p><code>array(.)[exists(?1)]</code></p></td>
+                              <td><p>A non-empty array of singleton items.</p></td>
                            </tr>
                            
                         </tbody>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -13065,7 +13065,8 @@ return $tree =?> depth()]]></eg>
                      <item><p>The pattern <code>{"first", "last"}</code> matches a map (or record)
                         with two entries whose keys are the strings <code>"first"</code> and <code>"last"</code></p></item>
                      <item><p>The pattern <code>{"first", "last", *}</code> matches a map (or record)
-                        whose keys include the strings <code>"first"</code> and <code>"last"</code>; the map may
+                        whose keys include the strings <code>"first"</code> and <code>"last"</code>; the trailing
+                        wildcard <code>, *</code> indicates that the map may
                      have other keys in addition.</p></item>
                      <item><p>The pattern <code>{"first":~xs:string+, "last":~enum("Smith", "Smyth"), *}</code>
                         matches any map (or record) having an entry with key <code>"first"</code>
@@ -13099,7 +13100,7 @@ return $tree =?> depth()]]></eg>
                            matches the <code>SequencePattern</code>, under the rules given below.</p></item>
                         </olist>
                      </item>
-                     <item><p>Either the optional <code>, *</code> is present in the pattern,
+                     <item><p>Either the optional wildcard <code>, *</code> is present in the pattern,
                      or the map has no entries with keys other than those listed.</p></item>
                      <item>
                         <p><var>M</var> satisfies each of the <nt def="Predicate">Predicates</nt>.</p>
@@ -13124,8 +13125,8 @@ return $tree =?> depth()]]></eg>
                         <caption>Map Patterns and their Meanings</caption>
                         <thead>
                            <tr>
-                              <th>Pattern</th>
-                              <th>Matches</th>
+                              <th width="50%">Pattern</th>
+                              <th width="50%">Matches</th>
                            </tr>
                         </thead>
                         <tbody>
@@ -13138,63 +13139,68 @@ return $tree =?> depth()]]></eg>
                               <td><p>Any map</p></td>
                            </tr>
                            <tr>
-                              <td><p><code>{"long", "lat"}</code></p></td>
+                              <td><p><code>{"long", "lat", *}</code></p></td>
                               <td><p>Any map in which the keys <code>"long"</code> and <code>"lat"</code> are present.</p></td>
                            </tr>
                            <tr>
-                              <td><p><code>map{"long", "lat"}[empty(?altitude)]</code></p></td>
+                              <td><p><code>{"long", "lat"}</code></p></td>
+                              <td><p>Any map in which the keys <code>"long"</code> and <code>"lat"</code> are present, and no other keys are present.</p></td>
+                           </tr>
+                           <tr>
+                              <td><p><code>map{"long", "lat", *}[empty(?altitude)]</code></p></td>
                               <td><p>Any map in which the keys <code>"long"</code> and <code>"lat"</code> are present,
                               and in which the entry with key <code>"altitude"</code> is either absent or empty.</p></td>
                            </tr>
                            <tr>
                               <td><p><code>{"long": ~xs:double, "lat": ~xs:double[. gt 0]}</code></p></td>
-                              <td><p>Any map in which the keys <code>"long"</code> and <code>"lat"</code> are present,
+                              <td><p>Any map exclusively containing the two keys <code>"long"</code> and <code>"lat"</code>,
                              both having values of type <code>xs:double</code>, and where the value of <code>"lat"</code>
                               is greater than zero.</p></td>
                            </tr>
                            <tr>
-                              <td><p><code>{"dimensions": ~xs:numeric+}</code></p></td>
+                              <td><p><code>{"dimensions": ~xs:numeric+, *}</code></p></td>
                               <td><p>Any map having an entry with key <code>"dimensions"</code> whose
                                     value is a sequence of one or more numeric values.</p></td>
                            </tr>
                            <tr>
+                              <td><p><code>{"dimensions": array(~xs:numeric), *}</code></p></td>
+                              <td><p>Any map having an entry with key <code>"dimensions"</code> whose
+                                 value is an array of numeric values.</p></td>
+                           </tr>
+                           <tr>
                               <td><p><code>{true(), false()}</code></p></td>
-                              <td><p>Any map in which the boolean keys <code>true</code> and <code>false</code>
-                              are present.</p></td>
+                              <td><p>A map exclusively containing the two boolean keys <code>true</code> and <code>false</code>.</p></td>
                            </tr>
                            <tr>
                               <td><p><code>{#my:first, #my:second}</code></p></td>
-                              <td><p>Any map in which the QName-valued keys <code>#my:first</code> and <code>#my:second</code>
-                              are present.</p></td>
+                              <td><p>A map exclusively containing the QName-valued keys <code>#my:first</code> and <code>#my:second</code>.</p></td>
                            </tr>
                            <tr>
-                              <td><p><code>{"root": doc}</code></p></td>
+                              <td><p><code>{"root": doc, *}</code></p></td>
                               <td><p>Any map having an entry with the key <code>"root"</code> whose value
                               is an element node named <code>"doc"</code>.</p></td>
                            </tr>
                            <tr>
-                              <td><p><code>{"elements": **}</code></p></td>
+                              <td><p><code>{"elements": **, *}</code></p></td>
                               <td><p>Any map having an entry with the key <code>"elements"</code> whose value
-                              is a sequence of zero or more element nodes.</p></td>
+                              is a sequence of zero or more element nodes.</p>
+                              <note><p>The first <code>*</code> is a pattern that matches element nodes. The second
+                              <code>*</code> is an occurrence indicator meaning "zero or more". The third <code>*</code>
+                              is a wildcard indicating that additional entries may appear.</p></note></td>
                            </tr>
                            <tr>
-                              <td><p><code>{"name", "address":{"city", "postcode"}}</code></p></td>
+                              <td><p><code>{"name", "address":{"city", "postcode", *}}</code></p></td>
                               <td><p>Any map having an entry with the key <code>"name"</code>, and an entry
                               with the key <code>"address"</code> whose value matches the map pattern
-                              <code>{"city", "postcode"}</code>.</p></td>
-                           </tr>
-                           <tr>
-                              <td><p><code>{"long", "lat"}[map:size(.) = 2]</code></p></td>
-                              <td><p>Any map in which the keys <code>"long"</code> and <code>"lat"</code> are present,
-                              and no other entries are present.</p></td>
+                              <code>{"city", "postcode", *}</code>.</p></td>
                            </tr>
                            <tr>
                               <td><p><code>{"x", "y"}[?x = ?y]</code></p></td>
-                              <td><p>Any map having entries with keys <code>"x"</code> and <code>"y"</code>
+                              <td><p>Any map having two entries with keys <code>"x"</code> and <code>"y"</code>
                                     in which both of these entries have the same value.</p></td>
                            </tr>
                            <tr>
-                              <td><p><code>{"area":fn(*)}[?area(.) lt 10]</code></p></td>
+                              <td><p><code>{"area":fn(*), *}[?area(.) lt 10]</code></p></td>
                               <td><p>Any map having an <code>"area"</code> method where the computed
                                     area is less than 10.</p></td>
                            </tr>
@@ -13227,7 +13233,8 @@ return $tree =?> depth()]]></eg>
                      <item><p>The pattern <code>array({"first", "last", *})</code> matches an array of maps (or records)
                         whose keys include the strings <code>"first"</code> and <code>"last"</code>; the maps may
                         have other keys in addition.</p></item>
-                     <item><p>The pattern <code>array(item())[array:size(.) = 3]</code> an array with three members, each member being a singleton item.</p></item>
+                     <item><p>The pattern <code>array(item())[array:size(.) = 3]</code> matches an array with three members, 
+                        each member being a singleton item.</p></item>
                   </ulist>
 
                   
@@ -13260,8 +13267,8 @@ return $tree =?> depth()]]></eg>
                         <caption>Array Patterns and their Meanings</caption>
                         <thead>
                            <tr>
-                              <th>Pattern</th>
-                              <th>Matches</th>
+                              <th width="50%">Pattern</th>
+                              <th width="50%">Matches</th>
                            </tr>
                         </thead>
                         <tbody>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -12106,7 +12106,7 @@ return $tree =?> depth()]]></eg>
                attribute. The <elcode>xsl:apply-templates</elcode> instruction is described in the
                next section. If several template rules match a selected item, only one of them is evaluated, as described in <specref ref="conflict"/>.</p>
          </div2>
-         <div2 id="patterns">
+         <div2>
             <head>Patterns</head>
 
             <p>In XSLT 4.0, patterns can match any kind of item: atomic items and
@@ -12122,219 +12122,438 @@ return $tree =?> depth()]]></eg>
 
             <p>There are several kinds of pattern:</p>
 
-            <ulist diff="chg" at="2022-01-01">
-               <item>
-                  <p><termdef id="dt-predicate-pattern" term="predicate pattern">A <term>predicate pattern</term> is written as
-                           <code>.</code> (dot) followed by zero or more predicates in square
-                        brackets, and it matches any item for which each of the predicates evaluates
-                        to <code>true</code>.</termdef></p>
-                  
-                  <p>The detailed semantics are given in <specref ref="predicate-patterns"/>. This construct can be used to match items of any
-                     kind (nodes, atomic items, and function items). For example, the pattern
-                     <code>.[starts-with(., '$')]</code> matches any string that starts with the
-                     character <code>$</code>, or a node whose atomized value starts with 
-                     <code>$</code>. This example shows a predicate pattern with a single
-                     predicate, but the grammar allows any number of predicates (zero or more).</p>
-               </item>
-               <item>
-                  <p><termdef id="dt-type-pattern" term="type pattern">A <term>type pattern</term> is written as
-                     <code>~T</code> (where <var>T</var> is an <xnt spec="XP40" ref="prod-xpath40-ItemType">ItemType</xnt>)
-                     followed by zero or more predicates in square
-                     brackets, and it matches any item that is coercible to type <var>T</var> for which each of the predicates evaluates
-                     to <code>true</code>.</termdef></p>
-                  <p>The parameter <var>T</var> can also be a <xtermref spec="XP40" ref="dt-choice-item-type"/>, 
-                     consisting of a parenthesized sequence of item types separated by <code>"|"</code>.
-                  For example, <code>~(array(*) | map(*))</code> matches arrays and maps, while 
-                  <code>~(text() | comment())</code> matches text nodes and comment nodes.</p>
-                  <!--<p>The most commonly used type patterns can be abbreviated. For example, <code>match="type(record(F1, F2, *))"</code> 
-                     can be abbrevated to <code>match="record(F1, F2, *)"</code>, while <code>match="type(array(xs:string))"</code>
-                     can be abbreviated to <code>match="array(xs:string)"</code>. The main case where such abbreviation is
-                  not possible is with atomic items: <code>match="type(xs:date)"</code> cannot be abbreviated because
-                  a bare QName is interpreted as a node pattern, matching elements named <code>xs:date</code>.</p>-->
-                  
-                  <p>The type pattern <code>match="~(text() | comment())"</code> has almost the same effect as
-                  the <termref def="dt-gnode-pattern"/> <code>match="text() | comment()"</code>, 
-                     but the rules for calculating a default priority
-                  are different: see <specref ref="default-priority"/>.</p>
-                  
-          
-                  
-               </item>
-               <item>
-                  <p><termdef id="dt-gnode-pattern" term="GNode pattern">An <term>GNode pattern</term> uses a subset of
-                        the syntax for path expressions, and is defined to match a GNode if the
-                        corresponding path expression would select the GNode.</termdef></p>
-                  <p>The syntax for GNode patterns
-                        (<nt def="GNodePattern">GNodePattern</nt> in the grammar:
-                        see <specref ref="pattern-syntax"/>) is a subset of the syntax for
-                        <termref def="dt-expression">expressions</termref>. GNode patterns
-                        are used only for matching nodes, and the same syntax may match either
-                        an XNode or a JNode.
-                     As explained in detail below, a GNode matches a GNode pattern if the
-                     equivalent XPath expression selects the GNode when evaluated with respect
-                     to some appropriate context.</p>
-               </item>
+            <ulist>
+               <item><p>Predicate patterns can match any kind of item: see <specref ref="predicate-patterns"/>.</p></item>
+               
+               <item><p>Type patterns can match items against an item type: see <specref ref="type-patterns"/>.</p></item>
+               
+               <item><p>XNode patterns match nodes using their name, content, and/or ancestry. These
+                  are the traditional kind of pattern available since XSLT 1.0: see <specref ref="node-patterns"/>.</p></item>
+               
+               
+               <item><p>Map patterns match maps and records: see <specref ref="id-map-patterns"/>.</p></item>
+               
+               <item><p>Array patterns match arrays: see <specref ref="id-array-patterns"/>.</p></item>
+               
+               <item><p>JNode patterns match JNodes: see <specref ref="id-jnode-patterns"/>.</p></item>
                
             </ulist>
 
-            <!--<p>Patterns may be combined using the <code>union</code>, <code>intersect</code>, and
-            <code>except</code> operators. If <var>P</var> and <var>Q</var> are patterns, then:</p>
             
-            <ulist>
-               <item><p><code><var>P</var> union <var>Q</var></code> (which can also be written
-               <code><var>P</var> | <var>Q</var></code>) matches an item if either or both
-               of <var>P</var> and <var>Q</var> match the item.</p></item>
-               <item><p><code><var>P</var> intersect <var>Q</var></code> matches an item if 
-               <var>P</var> and <var>Q</var> both match the item.</p></item>
-               <item><p><code><var>P</var> except <var>Q</var></code> matches an item if 
-               <var>P</var> matches the item and <var>Q</var> does not.</p></item>
-               <item>Parentheses can be used, for example <code><var>P</var> except (<var>Q</var>
-               union <var>R</var>)</code>, by virtue of the fact that an <code>XNodePattern</code>
-               may be a <code>ParenthesizedPattern</code>.</item>
-            </ulist>-->
-            
-            <!--<note>
-               <p>The meaning of a top-level <code>union</code>, <code>intersect</code>, or
-               <code>except</code> operator has changed in XSLT 4.0. Previously these operators were 
-               defined in terms of the corresponding XPath operators applied to sets of nodes,
-               which meant they could not be used when matching items other than nodes.</p>
-            </note>
--->
 
             <note>
                <p>The specification uses the phrases <emph>an item matches a pattern</emph> and
                      <emph>a pattern matches an item</emph> interchangeably. They are equivalent: an
                   item matches a pattern if and only if the pattern matches the item.</p>
             </note>
-            <div3 id="pattern-examples">
-               <head>Examples of Patterns</head>
-               <example id="pattern-examples-1">
-                  <head>Patterns</head>
-                  <p>Here are some examples of patterns:</p>
-                  <ulist>
-                     <item>
-                        <p><emph>Predicate Patterns:</emph></p>
-                        <olist>
-                           <item>
-                              <p><code>.</code> matches any item.</p>
-                           </item>
-                           <item>
-                              <p><code>.[. castable as xs:date]</code> matches any item
-                                 that can be successfully cast to <code>xs:date</code>: for example,
+            
+            <div3 id="pattern-syntax">
+               <head>Syntax of Patterns</head>
+               <p>
+                  <error spec="XT" type="static" class="SE" code="0340">
+                     <p>Where an attribute is defined to contain a <termref def="dt-pattern">pattern</termref>, it is a <termref def="dt-static-error">static
+                           error</termref> if the pattern does not match the production <nt def="Pattern">Pattern</nt>.</p>
+                  </error></p>
+               <p>The complete grammar for patterns is listed in <specref ref="pattern-syntax-summary"/>. 
+                  It uses the notation defined in <xspecref spec="XP40" ref="EBNFNotation">Notation</xspecref>. </p>
+               <p>The lexical rules for patterns are the same as the lexical rules
+                  for XPath expressions, as defined in <xspecref spec="XP40" ref="lexical-structure">Lexical structure</xspecref>. Comments are permitted between tokens, using the
+                  syntax <code>(: ... :)</code>. All other provisions of the XPath grammar apply
+                  where relevant, for example the rules for whitespace handling and
+                  extra-grammatical constraints.</p>
+               
+               <scrap headstyle="show" id="Patterns-scrap" >
+                  <prodrecap ref="Pattern"/>
+               </scrap>
+               
+               <!--<p>Patterns fall into several groups:</p>
+               
+               <ulist diff="add" at="2022-01-01">
+                  <item><p>A <code>PredicatePattern</code> matches items according to conditions that the item must
+                  satisfy: for example <code>.[. castable as xs:integer]</code> matches any value (it might
+                  be an atomic item, a node, or an array) that is castable as an integer.</p></item>
+                  
+                  <item><p>A <code>TypePattern</code> matches items according to their type. For example
+                  <code>~xs:integer</code> matches an atomic item that is an instance of <code>xs:integer</code>,
+                  while <code>~record(longitude, latitude)</code> matches a map that has exactly two entries, with
+                  keys <code>"longitude"</code> and <code>"latitude"</code></p></item>
+                  
+                  <item><p>An <code>GNodePattern</code> matches GNodes in a GTree (for example, a tree
+                     representing the contents of an XML or JSON document), by specifying a path that
+                  can be used to locate the nodes: for example <code>order</code> matches an element node
+                  named <code>order</code> within an XTree, or a JNode with ·jkey· <code>"order"</code>
+                        within a JTree; similarly, <code>billing-address/city</code> matches an element node named <code>city</code>
+                  whose parent node is an element named <code>billing-address</code>, or a JNode with ·jkey· <code>"city"</code>
+                  whose parent is a JNode with ·jkey· <code>"billing-address"</code>.</p>
+                  </item>
+                  
+                  <item><p>A <code>MapPattern</code> matches maps (including records) based on their content.</p></item>
+                  
+                  <item><p>An <code>ArrayPattern</code> matches arrays based on their content.</p></item>
+                  
+               </ulist>-->
+               
+               
+               
+               <p>The following sections define the rules for each kind of pattern.</p>
+            </div3>
+               
+               <div3 id="predicate-patterns">
+                  <head>Predicate Patterns</head>
+                  
+                  <p><termdef id="dt-predicate-pattern" term="predicate pattern">A <term>predicate pattern</term> is written as
+                     <code>.</code> (dot) followed by zero or more predicates in square
+                     brackets, and it matches any item for which each of the predicates evaluates
+                     to <code>true</code>.</termdef></p>
+                  
+                  <scrap headstyle="show" id="PredicatePatterns-scrap">
+                     <prodrecap ref="PredicatePattern"/>
+                  </scrap>
+                  
+                 
+                     
+                     
+                     
+                     <p>This construct can be used to match items of any
+                        kind (nodes, atomic items, and function items). For example, the pattern
+                        <code>.[starts-with(., '$')]</code> matches any string that starts with the
+                        character <code>$</code>, or a node whose atomized value starts with 
+                        <code>$</code>. This example shows a predicate pattern with a single
+                        predicate, but the grammar allows any number of predicates (zero or more).</p>
+                  
+                  
+                  <p>A <nt def="PredicatePattern">PredicatePattern</nt>
+                     <var>PP</var> matches an item <var>J</var> if and only if the XPath expression taking
+                     the same form as <var>PP</var> returns a non-empty sequence when evaluated with a
+                     <termref def="dt-singleton-focus"/> based on <var>J</var>.</p>
+                  
+                  
+                  
+                  <note>
+                     <p>The pattern <code>.</code>, which is a <code>PredicatePattern</code> with no predicates,
+                        matches every item.</p>
+                     <p>A predicate with the numeric value 1 (one) always matches, and a predicate with
+                        any other numeric value never matches. Numeric predicates in a
+                        <code>PredicatePattern</code> are therefore not useful, but are defined this
+                        way in the interests of consistency with XPath.</p>
+                     <p>The predicate pattern <code>.[<var>P1</var>][<var>P2</var>][<var>P3</var>]</code>
+                     is equivalent to the type pattern <code>~item()[<var>P1</var>][<var>P2</var>][<var>P3</var>]</code>.</p>
+                  </note>
+                  
+                  <p>For example, the pattern <code>.[contains(., "XSLT")]</code>
+                  matches any item whose atomized value contains <code>"XSLT"</code> as a substring. 
+                  It matches values such as the string <code>"XSLT Transformations"</code>, the
+                     <code>xs:anyURI</code> value
+                     <code>http://www.w3.org/TR/XSLT</code>, the attribute node 
+                     <code>class="XSD XSLT XPath"</code>, and the singleton array <code>[ "XSLT 4.0" ]</code>.</p>
+                  
+                  <note><p>
+                     Evaluation of this example pattern may fail with a dynamic error if the item in question
+                     has an atomized value that is not a string, or that is a sequence of strings: an example might
+                     be the array <code>[ "XSLT", 1999 ]</code>. It will also fail if the item cannot be atomized,
+                     for example if it is a map. The rules in <specref ref="pattern-errors"/> cause these errors
+                     to be masked: they simply result in the pattern being treated as non-matching.
+                  </p></note>
+                  
+                  <example>
+                     <head>Examples of Predicate Patterns</head>
+                     
+                     
+                     <ulist>
+                        <item>
+                           <p><code>.</code> matches any item.</p>
+                        </item>
+                        <item>
+                           <p><code>.[. castable as xs:date]</code> matches any item
+                              that can be successfully cast to <code>xs:date</code>: for example,
                               an <code>xs:date</code> or <code>xs:dateTime</code> value, or a string
                               in the lexical form of a date, or a node whose typed value is an <code>xs:date</code>
                               or a string in the form of a date.</p>
-                           </item>
-                           <item>
-                              <p><code>.[string() => matches('^[0-9]$')]</code> matches any
-                                 item whose string value is a sequence of digits.</p>
-                           </item>
-                           <item>
-                              <p><code>.[. castable as xs:date][xs:date(.) le current-date()]</code> matches any
-                                 item that is castable to <code>xs:date</code> provided that the result of casting
-                                 the value to <code>xs:date</code> is a date in the past.</p>
-                           </item>
-                        </olist>
-                     </item>
-                     <item diff="add" at="2022-01-01">
-                        <p><emph>Type Patterns</emph></p>
-                        <olist>
-                           <item>
-                              <p><code>~item()</code> matches any item.</p>
-                           </item>
-                           <item>
-                              <p><code>~node()</code> matches any XNode.
-                                 (Note the distinction from the pattern <code>node()</code>.)</p>
-                           </item>
-                           <item>
-                              <p><code>~xs:date</code> matches any
-                                 atomic item of type <code>xs:date</code> (or a type derived by
-                                 restriction from <code>xs:date</code>).</p>
-                           </item>
-                           <item>
-                              <p><code>~xs:date[. gt current-date()]</code> matches any date in
-                                 the future.</p>
-                           </item>
-                           <item>
-                              <p><code>~xs:string[starts-with(., 'e')]</code> matches any <code>xs:string</code>
-                                 value that starts with the letter <code>e</code>. Note there is no type conversion; the pattern
+                        </item>
+                        <item>
+                           <p><code>.[string() => matches('^[0-9]$')]</code> matches any
+                              item whose string value is a sequence of digits.</p>
+                        </item>
+                        <item>
+                           <p><code>.[. castable as xs:date][xs:date(.) le current-date()]</code> matches any
+                              item that is castable to <code>xs:date</code> provided that the result of casting
+                              the value to <code>xs:date</code> is a date in the past.</p>
+                        </item>
+                     </ulist>
+                  </example>
+                  
+               </div3>
+               
+               <div3 id="type-patterns">
+                  <head>Type Patterns</head>
+                  
+                  <changes>
+                     <change issue="400" PR="401" date="2023-03-21">
+                        Patterns (especially those used in template rules) can now be defined
+                        by reference to item types, so any item type can be used as a match
+                        pattern. For example <code>match="~record(longitude, latitude)"</code>
+                        matches any map that includes the key values <code>"longitude"</code>
+                        and <code>"latitude"</code>.
+                     </change>
+                     <change issue="2365" PR="2413" date="2026-01-28">
+                        Extensible map types are dropped; instead, the coercion rules cause undefined
+                        map entries to be discarded.
+                     </change>
+                  </changes>
+                  
+                  <p><termdef id="dt-type-pattern" term="type pattern">A <term>type pattern</term> is written as
+                     <code>~T</code> (where <var>T</var> is an <xnt spec="XP40" ref="prod-xpath40-ItemType">ItemType</xnt>)
+                     followed by zero or more predicates in square
+                     brackets, and it matches any item that is coercible to type <var>T</var> for which each of the predicates evaluates
+                     to <code>true</code>.</termdef></p>
+                  
+                  
+                  <scrap headstyle="show" id="TypePatterns-scrap">
+                     <prodrecap ref="TypePattern"/>
+                  </scrap>
+                  
+      
+                  
+                  <p>A type pattern matches an item if both the following conditions are true:</p>
+                  
+                  <ulist>
+                     <item><p>The item matches the item type according to the 
+                           rules of <xspecref spec="XP40" ref="id-matching-item"/>.</p></item>
+                     <item><p>The item satisfies each of the predicates.</p></item>
+                  </ulist>
+                  
+                  <p>More formally, an item <var>$J</var> matches a pattern <code>~<var>T</var>[<var>P1</var>][<var>P2</var>][<var>P3</var>]</code> if
+                     the XPath expression <code>$J instance of <var>T</var> and exists($JJ[<var>P1</var>][<var>P2</var>][<var>P3</var>])</code> is true.</p>
+                  
+                  
+                  <p>Note that no coercion is applied.</p>
+                  
+                  <p>The parameter <var>T</var> can be a <xtermref spec="XP40" ref="dt-choice-item-type"/>, 
+                     consisting of a parenthesized sequence of item types separated by <code>"|"</code>.
+                     For example, <code>~(array(*) | map(*))</code> matches arrays and maps, while 
+                     <code>~(text() | comment())</code> matches text nodes and comment nodes.</p>
+                  
+                  
+                  <p>The type pattern <code>match="~(text() | comment())"</code> has almost the same effect as
+                     the <termref def="dt-xnode-pattern"/> <code>match="text() | comment()"</code>, 
+                     but the rules for calculating a default priority
+                     are different: see <specref ref="default-priority"/>.</p>
+                  
+                  
+                  
+                   
+                  <note><p>As with predicate patterns, numeric predicates are allowed, but serve no useful purpose.</p></note>
+                  
+                  <note><p>An error in evaluating the equivalent expression (for example, when the item
+                        cannot be coerced to the required type) means that the item is treated as not matching the pattern.</p></note>
+                  
+                  
+                  
+                  
+                  <note>
+                     <p>The item type in a pattern can be any <code>ItemType</code>, but patterns that match
+                        XNodes or JNodes can usually be expressed more concisely
+                        as a <code>NodePattern</code> (see <specref ref="node-patterns"/>): 
+                        for example <code>match="~element(PERSON)"</code> has the same meaning as
+                        <code>match="element(PERSON)"</code>, which in turn is usually abbreviated to 
+                        <code>match="PERSON"</code> (although <code>match="PERSON"</code> will also match JNodes).</p>
+                     
+                  </note>
+                  
+                  
+                  <example>
+                     <head>Examples of Type Patterns</head>
+                     
+                     <olist>
+                        <item>
+                           <p><code>~item()</code> matches any item.</p>
+                        </item>
+                        <item><p><code>~node()</code> matches any XNode. (This is not the same as the pattern
+                           <code>node()</code>, which for historical reasons only matches  element, text, comment, 
+                           and processing instruction nodes).</p></item>
+                        <item>
+                           <p><code>~xs:date</code> matches any
+                              atomic item of type <code>xs:date</code> (or a type derived by
+                              restriction from <code>xs:date</code>).</p>
+                        </item>
+                        <item>
+                           <p><code>~xs:date[. gt current-date()]</code> matches any date in
+                              the future.</p>
+                        </item>
+                        <item>
+                           <p><code>~xs:numeric[not(is-NaN(.))]</code> matches any atomic item whose primitive type
+                              is <code>xs:decimal</code>, <code>xs:double</code>, or <code>xs:float</code>, other
+                              than NaN.</p>
+                        </item>
+                        <item><p><code>~(xs:hexBinary | xs:base64Binary)</code> matches any atomic item whose primitive type
+                           is <code>xs:hexBinary</code> or <code>xs:base64Binary</code>.</p>
+                        </item>
+                        <item>
+                           <p><code>~xs:string[starts-with(., 'e')]</code> matches any <code>xs:string</code>
+                              value that starts with the letter <code>e</code>. Note there is no type conversion; the pattern
                               will not match an <code>xs:untypedAtomic</code> or <code>xs:anyURI</code> value,
                               nor will it match a node.</p>
-                           </item>
-                           <item>
-                              <p><code>~fn(*)</code> matches any
-                                 function item.</p>
-                           </item>
-                           <item>
-                              <p><code>~(fn($x as xs:integer) as xs:boolean)[.(42)]</code> matches any function that
-                                 accepts an <code>xs:integer</code> argument and returns a boolean result, provided
-                                 that the result of calling the function with the argument value <code>42</code> is <code>true</code>.</p>
-                           </item>
-                           <item>
-                              <p><code>~(xs:date | xs:dateTime | xs:time)</code> matches any atomic item
-                                 that is an instance of <code>xs:date</code>, <code>xs:dateTime</code>, or <code>xs:time</code>.</p>
-                           </item>
-                           <item>
-                              <p><code>~(array(xs:date) | array(xs:dateTime) | array(xs:time))</code> matches any array whose
-                                 members are all of type <code>xs:date</code>, any array whose
-                                 members are all of type <code>xs:dateTime</code>, or any array whose
-                                 members are all of type <code>xs:time</code>. Contrast 
+                        </item>
+                        <item>
+                           <p><code>~fn(*)</code> matches any
+                              function item.</p>
+                        </item>
+                        <item>
+                           <p><code>~(fn($x as xs:integer) as xs:boolean)[.(42)]</code> matches any function that
+                              accepts an <code>xs:integer</code> argument and returns a boolean result, provided
+                              that the result of calling the function with the argument value <code>42</code> is <code>true</code>.</p>
+                        </item>
+                        <item>
+                           <p><code>~(xs:date | xs:dateTime | xs:time)</code> matches any atomic item
+                              that is an instance of <code>xs:date</code>, <code>xs:dateTime</code>, or <code>xs:time</code>.</p>
+                        </item>
+                        <item>
+                           <p><code>~(array(xs:date) | array(xs:dateTime) | array(xs:time))</code> matches any array whose
+                              members are all of type <code>xs:date</code>, any array whose
+                              members are all of type <code>xs:dateTime</code>, or any array whose
+                              members are all of type <code>xs:time</code>. Contrast 
                               <code>~array(xs:date | xs:dateTime | xs:time)</code> which allows
                               the three types to be mixed within a single array.</p>
-                           </item>
-                           <item>
-                              <p><code>~map((xs:string | xs:untypedAtomic), *)</code> matches any map
-                                 whose keys are all instances of <code>xs:string</code> or <code>xs:untypedAtomic</code>.</p>
-                           </item>
-                           <item>
-                              <p><code>~enum("red", "green", "blue")</code> matches any one of the three strings
-                                 <code>"red"</code>, <code>"green"</code>, or <code>"blue"</code>.</p>
-                           </item>
-                           <item>
-                              <p><code>~record(longitude, latitude)</code> matches any record with exactly two entries,
-                                 whose keys are the strings <code>"longitude"</code>
-                                 and <code>"latitude"</code>.</p>
-                           </item>
-                           <item>
-                              <p><code>~record(longitude, latitude)[?latitude gt 0]</code> matches any record with exactly two entries,
-                                 whose keys are the strings <code>"longitude"</code>
-                                 and <code>"latitude"</code>, where the value of <code>latitude</code> is greater than zero.</p>
-                           </item>
-        
-                           <item>
-                              <p><code>~array(xs:integer)[array:size(.) eq 4]</code> matches any array of four integers.</p>
-                           </item>
-                           <item>
-                              <p><code>~array(record(first, last))</code> matches any array of maps where each map
-                                 contains entries with keys <code>"first"</code> and <code>"last"</code>. Note that
+                        </item>
+                        <item>
+                           <p><code>~map((xs:string | xs:untypedAtomic), *)</code> matches any map
+                              whose keys are all instances of <code>xs:string</code> or <code>xs:untypedAtomic</code>.</p>
+                        </item>
+                        <item>
+                           <p><code>~enum("red", "green", "blue")</code> matches any one of the three strings
+                              <code>"red"</code>, <code>"green"</code>, or <code>"blue"</code>.</p>
+                        </item>
+                        <item>
+                           <p><code>~record(longitude, latitude)</code> matches any record with exactly two entries,
+                              whose keys are the strings <code>"longitude"</code>
+                              and <code>"latitude"</code>.</p>
+                        </item>
+                        <item>
+                           <p><code>~record(longitude, latitude)[?latitude gt 0]</code> matches any record with exactly two entries,
+                              whose keys are the strings <code>"longitude"</code>
+                              and <code>"latitude"</code>, where the value of <code>latitude</code> is greater than zero.</p>
+                        </item>
+                        
+                        <item>
+                           <p><code>~array(xs:integer)[array:size(.) eq 4]</code> matches any array of four integers.</p>
+                        </item>
+                        <item>
+                           <p><code>~array(record(first, last))</code> matches any array of maps where each map
+                              contains entries with keys <code>"first"</code> and <code>"last"</code>. Note that
                               this includes the empty array.</p>
-                           </item>
-                           <item>
-                              <p><code>~array(record(first, last))[array:size(.) gt 0]</code> matches any non-empty array of maps where each map
-                                 contains entries with keys <code>"first"</code> and <code>"last"</code>. </p>
-                           </item>
-                           <item>
-                              <p><code>~complex</code> matches any value that is an instance of the item type 
-                                 declared in an <elcode>xsl:item-type</elcode> or <elcode>xsl:record-type</elcode>
-                                 declaration with name <code>"complex"</code></p>
-                           </item>
-                           <item>
-                              <p><code>~complex[?i eq 0]</code> matches any value that is an instance of the 
-                                 item type declared in an <elcode>xsl:item-type</elcode> or <elcode>xsl:record-type</elcode>
-                                 declaration with name <code>"complex"</code> and that is a map with an entry having key <code>i</code> and value zero.</p>
-                           </item>
-                           <item>
-                              <p><code>~jnode("date of birth", xs:date)</code> matches a JNode that encapsulates a map entry
+                        </item>
+                        <item>
+                           <p><code>~array(record(first, last))[array:size(.) gt 0]</code> matches any non-empty array of maps where each map
+                              contains entries with keys <code>"first"</code> and <code>"last"</code>. </p>
+                        </item>
+                        <item>
+                           <p><code>~complex</code> matches any value that is an instance of the item type 
+                              declared in an <elcode>xsl:item-type</elcode> or <elcode>xsl:record-type</elcode>
+                              declaration with name <code>"complex"</code></p>
+                        </item>
+                        <item>
+                           <p><code>~complex[?i eq 0]</code> matches any value that is an instance of the 
+                              item type declared in an <elcode>xsl:item-type</elcode> or <elcode>xsl:record-type</elcode>
+                              declaration with name <code>"complex"</code> and that is a map with an entry having key <code>i</code> and value zero.</p>
+                        </item>
+                        <item>
+                           <p><code>~jnode("date of birth", xs:date)</code> matches a JNode that encapsulates a map entry
                               whose key is the string <code>"date of birth"</code> and whose associated value is an atomic item
                               of type <code>xs:date</code>.</p>
-                           </item>
-                        </olist>
-                     </item>
-                     <item>
-                        <p><emph>Patterns Matching XNodes</emph></p>
-                        
-                        <olist>
-                           <item>
+                        </item>
+                        <item><p><code>~fn:dateTime-record</code> matches an instance of the system-defined record type
+                           <code>fn:dateTime-record</code> (produced typically as the result of the function <function>parse-dateTime</function>).</p></item>
+                        <item><p><code>~my:custom-record</code> matches an instance of the user-defined record type
+                           <code>my:custom-record</code>, defined in an <elcode>xsl:record-type</elcode> declaration.</p></item>
+                     </olist>
+                  </example>
+                  
+               </div3>
+               
+               <div3 id="node-patterns">
+                  <head>XNode Patterns</head>
+                  
+                  <changes>
+                     <change issue="1375 1522" PR="1378" date="2024-10-15">
+                        A function call at the outermost level can now be named using any valid <code>EQName</code>
+                        (for example <xfunction>fn:doc</xfunction>) provided it binds to one of the permitted functions
+                        <xfunction>fn:doc</xfunction>, <xfunction>fn:id</xfunction>, <xfunction>fn:element-with-id</xfunction>, 
+                        <function>fn:key</function>, or <xfunction>fn:root</xfunction>. 
+                        If two functions are called, for example <code>doc('a.xml')/id('abc')</code>,
+                        it is no longer necessary to put the second call in parentheses.
+                     </change>
+                    
+                  </changes>
+               
+                  <p>XNode patterns are used to match XNodes (often simply referred to as <term>nodes</term>).</p>
+                  
+
+               <scrap id="NodePatterns-scrap">
+                  <prodrecap ref="XNodePattern"/>
+               </scrap>
+                  
+                 
+                     <p><termdef id="dt-xnode-pattern" term="XNode pattern">An <term>XNode pattern</term> uses a subset of
+                        the syntax for path expressions, and is defined to match an XNode if the
+                        corresponding path expression would select the XNode.</termdef></p>
+                     <p>The syntax for XNode patterns
+                        (<nt def="XNodePattern">XNodePattern</nt> in the grammar:
+                        see <specref ref="pattern-syntax"/>) is a subset of the syntax for
+                        <termref def="dt-expression">expressions</termref>, and the semantics are defined by reference to the semantics
+                        of XPath expressions. XNode patterns
+                        are used only for matching XNodes.</p>
+                  
+               
+               
+               <p>Many of the constructs within an XNode pattern have names that are chosen to align 
+                  with the XPath 4.0 grammar.
+                  Constructs whose names are suffixed with <code>P</code> are restricted forms of
+                  the corresponding XPath 4.0 construct without the suffix: for example,
+                  <code>StepExprP</code> is a restricted form of <code>StepExpr</code>. Constructs labeled with
+                  the supercript “XP” are defined in <bibref ref="xpath-40"/>.</p>
+
+               
+                  
+                  <note><p>In XPath 4.0, path expressions of the form <code>booklist/book/author</code>
+                  can select either XNodes or JNodes. As an XSLT pattern, however, such a path will only
+                  match XNodes. The difference is that in XPath, it will usually be clear from the context
+                  which interpretation of the path is intended, while in XSLT, patterns in template
+                  rules provide no such context. An ambiguous interpretation would not only complicate
+                  implementations, it would also make the code less readable, and create the risk
+                  of subtle bugs, especially as it would change the meaning of existing XSLT 3.0
+                  template rules in unexpected ways.</p></note>
+                  
+               
+
+               <p>In a <nt def="FunctionCallP">FunctionCallP</nt>, the
+                     <code>EQName</code> used for the function name must bind to
+                  one of the functions <xfunction>fn:doc#1</xfunction>, <xfunction>fn:id#1</xfunction>, 
+                  <xfunction>fn:id#2</xfunction>, <xfunction>fn:element-with-id#1</xfunction>,
+                  <xfunction>fn:element-with-id#2</xfunction>
+                  <function>fn:key#2</function>, <function>fn:key#3</function>
+                  or <xfunction>fn:root#0</xfunction>, and the arguments (if any) must
+                  either be variable references or constants.</p>
+                  
+                 
+               <note><p>In the case of a call to the
+                     <xfunction>fn:root</xfunction> function, the argument list must be empty: that is,
+                  only the zero-arity form of the function is allowed.</p></note>
+
+               <note>
+                  <p>As with XPath expressions, the pattern <code>/ union /*</code> can be parsed in
+                     two different ways, and the chosen interpretation is to treat
+                        <code>union</code> as an element name rather than as an operator. The other
+                     interpretation can be achieved by writing <code>(/) union (/*)</code></p>
+               </note>
+               <div4 id="examples-of-xnode-patterns">
+                  <head>Examples of XNode Patterns</head>
+             
+                  
+                  <example>
+                     <head>Examples of XNode Patterns</head>
+                     
+                     <olist>
+                        <item>
                            <p><code>*</code> matches any element node.</p>
                         </item>
                         <item>
@@ -12344,11 +12563,11 @@ return $tree =?> depth()]]></eg>
                            <p><code>chapter|appendix</code> matches any <code>chapter</code> element
                               and any <code>appendix</code> element.</p>
                         </item>
-                           <item diff="add" at="2022-12-13">
-                              <p><code>child::(chapter|appendix)</code> matches any <code>chapter</code> element
-                                 and any <code>appendix</code> element. Note that although the <code>child</code> axis
+                        <item diff="add" at="2022-12-13">
+                           <p><code>child::(chapter|appendix)</code> matches any <code>chapter</code> element
+                              and any <code>appendix</code> element. Note that although the <code>child</code> axis
                               is explicitly written, an element can match even though it has no parent.</p>
-                           </item>
+                        </item>
                         <item>
                            <p><code>olist/entry</code> matches any <code>entry</code> element with an
                               <code>olist</code> parent.</p>
@@ -12357,11 +12576,11 @@ return $tree =?> depth()]]></eg>
                            <p><code>appendix//para</code> matches any <code>para</code> element with an
                               <code>appendix</code> ancestor element.</p>
                         </item>
-                           <item diff="add" at="2022-12-13">
-                              <p><code>appendix/descendant::(para|table)</code> matches any <code>para</code> 
-                                 or <code>table</code>element with an
-                                 <code>appendix</code> ancestor element.</p>
-                           </item>
+                        <item diff="add" at="2022-12-13">
+                           <p><code>appendix/descendant::(para|table)</code> matches any <code>para</code> 
+                              or <code>table</code>element with an
+                              <code>appendix</code> ancestor element.</p>
+                        </item>
                         <item>
                            <p><code>schema-element(us:address)</code> matches any element that is
                               annotated as an instance of the type defined by the schema element
@@ -12413,7 +12632,7 @@ return $tree =?> depth()]]></eg>
                               element that is an even-numbered <code>bullet</code> child of its
                               parent.</p>
                         </item>
-                           
+                        
                         <item>
                            <p><code>div[@class="appendix"]//p</code> matches any <code>p</code> element
                               with a <code>div</code> ancestor element that has a <code>class</code>
@@ -12446,324 +12665,32 @@ return $tree =?> depth()]]></eg>
                            <p><code>doc('product.xml')//*</code> matches any element
                               within the document whose document URI is <code>product.xml</code>.</p>
                         </item>
-                    </olist>
-                    
-                 </item>
-                     <item>
-                        <p><emph>Patterns matching JNodes</emph></p>
-                        <olist>
-                           <item>
-                              <p>The patterns <code>jnode()</code>, <code>jnode(*)</code>, and <code>jnode(*, item()*)</code> 
-                                 are equivalent, and match any JNode.</p>
-                           </item>
-                           <item>
-                              <p><code>jnode("date of birth")</code> matches any JNode representing a map
-                                 entry with key <code>"date of birth"</code>.</p>
-                           </item>
-                           <item>
-                              <p><code>jnode(*, array(xs:integer))</code> matches any JNode representing a map
-                                 entry or array item whose value is an array of integers.</p>
-                           </item>
-                           <item>
-                              <p><code>jnode(books, array(record(Author, Title)))</code> 
-                                 matches any JNode representing a map
-                                 entry whose key is <code>"books"</code> and whose content is an array of records,
-                                 each record having entries named <code>"Author"</code> and <code>"Title"</code> (with no other
-                                 entries allowed).</p>
-                           </item>
-                           <item>
-                              <p><code>jnode(*, record(Author as enum("Dickens"), Title))</code> 
-                                 matches any JNode whose content is a map
-                                 having an entry with key <code>"Author"</code> and value <code>"Dickens"</code>,
-                                 plus an entry with key <code>"Title"</code> (with no other
-                                 entries allowed).</p>
-                           </item>
-                           <item>
-                              <p><code>jnode(())</code> matches any root JNode (that is, a JNode whose <term>·jkey·</term> property
-                              is absent).</p>
-                           </item>
-                           <item>
-                              <p><code>jnode((), array(map(*)))</code> matches any root JNode whose <term>·jvalue·</term> property
-                                 is an array of maps.</p>
-                           </item>
-                        </olist>
-                     </item>
-                  </ulist>       
-                  
-               </example>
-            </div3>
-            <div3 id="pattern-syntax">
-               <head>Syntax of Patterns</head>
-               <p>
-                  <error spec="XT" type="static" class="SE" code="0340">
-                     <p>Where an attribute is defined to contain a <termref def="dt-pattern">pattern</termref>, it is a <termref def="dt-static-error">static
-                           error</termref> if the pattern does not match the production <nt def="Pattern">Pattern</nt>.</p>
-                  </error></p>
-               <p>The complete grammar for patterns is listed in <specref ref="pattern-syntax-summary"/>. 
-                  It uses the notation defined in <xspecref spec="XP40" ref="EBNFNotation">Notation</xspecref>. </p>
-               <p>The lexical rules for patterns are the same as the lexical rules
-                  for XPath expressions, as defined in <xspecref spec="XP40" ref="lexical-structure">Lexical structure</xspecref>. Comments are permitted between tokens, using the
-                  syntax <code>(: ... :)</code>. All other provisions of the XPath grammar apply
-                  where relevant, for example the rules for whitespace handling and
-                  extra-grammatical constraints.</p>
-               
-               <scrap headstyle="show" id="Patterns-scrap" >
-                  <prodrecap ref="Pattern"/>
-               </scrap>
-               
-               <p>Patterns fall into several groups:</p>
-               
-               <ulist diff="add" at="2022-01-01">
-                  <item><p>A <code>PredicatePattern</code> matches items according to conditions that the item must
-                  satisfy: for example <code>.[. castable as xs:integer]</code> matches any value (it might
-                  be an atomic item, a node, or an array) that is castable as an integer.</p></item>
-                  
-                  <item><p>A <code>TypePattern</code> matches items according to their type. For example
-                  <code>~xs:integer</code> matches an atomic item that is an instance of <code>xs:integer</code>,
-                  while <code>~record(longitude, latitude)</code> matches a map that has exactly two entries, with
-                  keys <code>"longitude"</code> and <code>"latitude"</code></p></item>
-                  
-                  <item><p>An <code>GNodePattern</code> matches GNodes in a GTree (for example, a tree
-                     representing the contents of an XML or JSON document), by specifying a path that
-                  can be used to locate the nodes: for example <code>order</code> matches an element node
-                  named <code>order</code> within an XTree, or a JNode with ·jkey· <code>"order"</code>
-                        within a JTree; similarly, <code>billing-address/city</code> matches an element node named <code>city</code>
-                  whose parent node is an element named <code>billing-address</code>, or a JNode with ·jkey· <code>"city"</code>
-                  whose parent is a JNode with ·jkey· <code>"billing-address"</code>.</p>
-                  </item>
-                  
-                  <item><p>A <code>MapPattern</code> matches maps (including records) based on their content.</p></item>
-                  
-                  <item><p>An <code>ArrayPattern</code> matches arrays based on their content.</p></item>
-                  <!--<p>The grammar for <code>XNodePattern</code> also allows a
-                  <code>ParenthesizedPattern</code>, which can be used to match items other than
-                  XNodes. This allows patterns such as <code><var>P</var> except (<var>Q</var> union <var>R</var>)</code>,
-                  where <var>P</var>, <var>Q</var>, and <var>R</var> are arbitrary patterns.</p>
-                  </item>
-                  <item><p>A <code>JNodePattern</code> matches JNodes in a JTree (a tree of maps and arrays,
-                     often representing the contents of a JSON document), by specifying constraints on
-                     the properties of the JNode, notably its ·jkey· and ·jvalue· properties.
-                   For example the pattern <code>jnode(order, *)</code> matches a JNode corresponding
-                     to a map entry with the key <code>"order"</code>.</p></item>-->
-               </ulist>
-               
-               <!--<p>The four kinds of primary pattern listed above may be combined using the <code>union</code>
-               (or <code>|</code>), <code>intersect</code>, and <code>except</code> operators.
-               By virtue of the fact that the grammar for <code>XNodePattern</code> allows a parenthesized
-               pattern, they can also be combined using parentheses.</p>-->
-               
-               <p>The following sections define the rules for each of these groups.</p>
-               
-               <div4 id="predicate-patterns">
-                  <head>Predicate Patterns</head>
-                  
-                  <scrap headstyle="show" id="PredicatePatterns-scrap">
-                     <prodrecap ref="PredicatePattern"/>
-                  </scrap>
-                  
-                  <p>A <nt def="PredicatePattern">PredicatePattern</nt>
-                     <var>PP</var> matches an item <var>J</var> if and only if the XPath expression taking
-                     the same form as <var>PP</var> returns a non-empty sequence when evaluated with a
-                     <termref def="dt-singleton-focus"/> based on <var>J</var>.</p>
-                  
-                  
-                  
-                  <note>
-                     <p>The pattern <code>.</code>, which is a <code>PredicatePattern</code> with no predicates,
-                        matches every item.</p>
-                     <p>A predicate with the numeric value 1 (one) always matches, and a predicate with
-                        any other numeric value never matches. Numeric predicates in a
-                        <code>PredicatePattern</code> are therefore not useful, but are defined this
-                        way in the interests of consistency with XPath.</p>
-                     <p>The predicate pattern <code>.[<var>P1</var>][<var>P2</var>][<var>P3</var>]</code>
-                     is equivalent to the type pattern <code>~item()[<var>P1</var>][<var>P2</var>][<var>P3</var>]</code>.</p>
-                  </note>
-                  
-                  <p>For example, the pattern <code>.[contains(., "XSLT")]</code>
-                  matches any item whose atomized value contains <code>"XSLT"</code> as a substring. 
-                  It matches values such as the string <code>"XSLT Transformations"</code>, the
-                     <code>xs:anyURI</code> value
-                     <code>http://www.w3.org/TR/XSLT</code>, the attribute node 
-                     <code>class="XSD XSLT XPath"</code>, and the singleton array <code>[ "XSLT 4.0" ]</code>.</p>
-                  
-                  <note><p>
-                     Evaluation of this example pattern may fail with a dynamic error if the item in question
-                     has an atomized value that is not a string, or that is a sequence of strings: an example might
-                     be the array <code>[ "XSLT", 1999 ]</code>. It will also fail if the item cannot be atomized,
-                     for example if it is a map. The rules in <specref ref="pattern-errors"/> cause these errors
-                     to be masked: they simply result in the pattern being treated as non-matching.
-                  </p></note>
+                     </olist>
+                  </example>
                   
                </div4>
                
-               <div4 id="type-patterns">
-                  <head>Type Patterns</head>
-                  
-                  <changes>
-                     <change issue="400" PR="401" date="2023-03-21">
-                        Patterns (especially those used in template rules) can now be defined
-                        by reference to item types, so any item type can be used as a match
-                        pattern. For example <code>match="~record(longitude, latitude)"</code>
-                        matches any map that includes the key values <code>"longitude"</code>
-                        and <code>"latitude"</code>.
-                     </change>
-                     <change issue="2365" PR="2413" date="2026-01-28">
-                        Extensible map types are dropped; instead, the coercion rules cause undefined
-                        map entries to be discarded.
-                     </change>
-                  </changes>
-                  
-                  <scrap headstyle="show" id="TypePatterns-scrap">
-                     <prodrecap ref="TypePattern"/>
-                  </scrap>
-                  
-      
-                  
-                  <p>A type pattern matches an item if both the following conditions are true:</p>
-                  
-                  <ulist>
-                     <item><p>The item matches the item type according to the 
-                           rules of <xspecref spec="XP40" ref="id-matching-item"/>.</p></item>
-                     <item><p>The item satisfies each of the predicates.</p></item>
-                  </ulist>
-                  
-                  
-                  <p>For example:</p>
-                  <ulist>
-                     <item><p><code>~xs:integer</code> matches any instance of
-                        <code>xs:integer</code></p></item>
-                     <item><p><code>~xs:integer[. gt 0]</code> matches
-                        any positive integer.</p></item>
-                     <item><p><code>~(xs:string | xs:untypedAtomic)[matches(., '[0-9]+')]</code> matches
-                        any instance of <code>xs:string</code> or <code>xs:untypedAtomic</code> that
-                        contains a sequence of decimal digits.</p></item>
-                     <item><p><code>~node()</code> matches any XNode. (This is not the same as the pattern
-                        <code>node()</code>, which for historical reasons only matches  element, text, comment, 
-                        and processing instruction nodes).</p></item>
-                     <item><p><code>~record(first as enum("Sharon"), last)</code>
-                        matches any record having entries with the string-valued keys <code>"first"</code> and <code>"last"</code>,
-                        where the entry for the key <code>"first"</code> is equal to the string <code>"Sharon"</code>.
-                        The record must not have any additional entries.</p>
-                        <note><p>A more flexible way to match records, if required, is to use a map pattern:
-                        see <specref ref="id-map-patterns"/>. Map patterns unlike record type patterns,
-                        do not require all the fields to be enumerated.</p></note>
-                     </item>
-                     <item><p><code>~jnode(address, record(address-line-1, address-line-2))</code> matches a JNode whose
-                     ·jkey· property is the string <code>"address"</code>, and whose content matches the given record type.</p></item>
-                     <item><p><code>~fn:dateTime-record</code> matches an instance of the system-defined record type
-                     <code>fn:dateTime-record</code> (produced typically as the result of the function <function>parse-dateTime</function>).</p></item>
-                     <item><p><code>~my:custom-record</code> matches an instance of the user-defined record type
-                     <code>my:custom-record</code>, defined in an <elcode>xsl:record-type</elcode> declaration.</p></item>
-                  </ulist>
-                  
-                  
-                  <p>More formally, an item <var>$J</var> matches a pattern <code>~<var>T</var>[<var>P1</var>][<var>P2</var>][<var>P3</var>]</code> if
-                  the XPath expression <code>let $JJ as <var>T</var> := J return exists($JJ[<var>P1</var>][<var>P2</var>][<var>P3</var>])</code> is true.</p>
-                  
-                  <note><p>As with predicate patterns, numeric predicates are allowed, but serve no useful purpose.</p></note>
-                  
-                  <note><p>An error in evaluating the equivalent expression (for example, when the item
-                        cannot be coerced to the required type) means that the item is treated as not matching the pattern.</p></note>
-                  
-                  
-                  
-                  
-                  <note>
-                     <p>The item type in a pattern can be any <code>ItemType</code>, but patterns that match
-                        XNodes or JNodes can usually be expressed more concisely
-                        as a <code>NodePattern</code> (see <specref ref="node-patterns"/>): 
-                        for example <code>match="~element(PERSON)"</code> has the same meaning as
-                        <code>match="element(PERSON)"</code>, which in turn is usually abbreviated to 
-                        <code>match="PERSON"</code> (although <code>match="PERSON"</code> will also match JNodes).</p>
-                     
-                  </note>
-                  
-               </div4>
                
-               <div4 id="node-patterns">
-                  <head>GNode Patterns</head>
-                  
-                  <changes>
-                     <change issue="1375 1522" PR="1378" date="2024-10-15">
-                        A function call at the outermost level can now be named using any valid <code>EQName</code>
-                        (for example <xfunction>fn:doc</xfunction>) provided it binds to one of the permitted functions
-                        <xfunction>fn:doc</xfunction>, <xfunction>fn:id</xfunction>, <xfunction>fn:element-with-id</xfunction>, 
-                        <function>fn:key</function>, or <xfunction>fn:root</xfunction>. 
-                        If two functions are called, for example <code>doc('a.xml')/id('abc')</code>,
-                        it is no longer necessary to put the second call in parentheses.
-                     </change>
-                     <!--<change issue="402">
-                        The semantics of patterns using the <code>intersect</code> and <code>except</code>
-                        operators have been changed to reflect the intuitive meaning: for example
-                        a node now matches <code>A except B</code> if it matches <code>A</code>
-                        and does not match <code>B</code>.
-                     </change>-->
-                  </changes>
-               
-
-               <scrap id="NodePatterns-scrap">
-                  <prodrecap ref="GNodePattern"/>
-               </scrap>
-               
-               <p>GNode patterns are used to match GNodes: that is, XNodes or JNodes.</p>
-
-               <p>Many of the constructs within a GNode pattern have names that are chosen to align 
-                  with the XPath 4.0 grammar.
-                  Constructs whose names are suffixed with <code>P</code> are restricted forms of
-                  the corresponding XPath 4.0 construct without the suffix: for example,
-                  <code>StepExprP</code> is a restricted form of <code>StepExpr</code>. Constructs labeled with
-                  the subpercript “XP” are defined in <bibref ref="xpath-40"/>.</p>
-
-               <p>The syntax of a <nt def="GNodePattern">GNodePattern</nt> is a subset of the syntax
-               of an XPath path expression, and the semantics are defined by reference to the semantics
-               of XPath expressions.</p>
-                  
-               
-
-               <p>In a <nt def="FunctionCallP">FunctionCallP</nt>, the
-                     <code>EQName</code> used for the function name must bind to
-                  one of the functions <xfunction>fn:doc#1</xfunction>, <xfunction>fn:id#1</xfunction>, 
-                  <xfunction>fn:id#2</xfunction>, <xfunction>fn:element-with-id#1</xfunction>,
-                  <xfunction>fn:element-with-id#2</xfunction>
-                  <function>fn:key#2</function>, <function>fn:key#3</function>
-                  or <xfunction>fn:root#0</xfunction>, and the arguments (if any) must
-                  either be variable references or constants.</p>
-                  
-                 
-               <note><p>In the case of a call to the
-                     <xfunction>fn:root</xfunction> function, the argument list must be empty: that is,
-                  only the zero-arity form of the function is allowed.</p></note>
-
-               <note>
-                  <p>As with XPath expressions, the pattern <code>/ union /*</code> can be parsed in
-                     two different ways, and the chosen interpretation is to treat
-                        <code>union</code> as an element name rather than as an operator. The other
-                     interpretation can be achieved by writing <code>(/) union (/*)</code></p>
-               </note>
-                  
-            
-               
-               
-            <div5 id="pattern-semantics">
-               <head>The Meaning of a GNode Pattern</head>
-               <p>This section defines the formal meaning of a <nt def="GNodePattern">GNodePattern</nt>.</p>
+            <div4 id="pattern-semantics">
+               <head>The Meaning of an XNode Pattern</head>
+               <p>This section defines the formal meaning of a <nt def="XNodePattern">XNodePattern</nt>.</p>
 
                
   
 
                
                
-         <p>The process for determining whether a GNode matches a 
-            <nt def="GNodePattern"/> is as follows:</p>
+         <p>The process for determining whether an XNode matches an 
+            <nt def="XNodePattern"/> is as follows:</p>
          
          <olist>
             
             
-            <item><p>The <nt def="GNodePattern"/> is converted to an 
+            <item><p>The <nt def="XNodePattern"/> is converted to an 
                <termref def="dt-expression">expression</termref>, 
                called the <term>equivalent expression</term>. The
-               equivalent expression to a <nt def="GNodePattern"/> is the XPath
-               expression that takes the same lexical form as the <nt def="GNodePattern"/> as
+               equivalent expression to a <nt def="XNodePattern"/> is the XPath
+               expression that takes the same lexical form as the <nt def="XNodePattern"/> as
                written, except that two adjustments are made to any
                <nt def="AxisStepP"/> that is a <termref def="dt-leading-step"/>.</p>
                
@@ -12777,26 +12704,11 @@ return $tree =?> depth()]]></eg>
                <note><p>An <xnt spec="XP40" ref="AxisStep">AxisStep</xnt>
                within a predicate is unaffected, since it is not an <nt def="AxisStepP"/>.</p></note>
                
-               <p>The adjustments that are made to a <termref def="dt-leading-step"/> are:</p>
-                  <olist>
-                     <item>
-                        <p>The <code>NodeTest</code> is adjusted to ensure that the pattern will (in most cases) match
-                           XNodes or JNodes but not both. Specifically, if the principal node kind of the
-                           axis is <code>element</code>, then any <code>Selector</code> within the <code>NodeTest</code>
-                           that takes the form of an <code>EQName</code> or <code>Wildcard</code> is wrapped in an <nt def="ElementNodeType"/> 
-                           so it only selects element nodes. For example, <code>match="*"</code> is interpreted as
-                           <code>match="element(*)"</code>, and <code>match="employee"</code> is interpreted
-                           as <code>match="element(employee)"</code>.</p>
-                           
-                           <note><p>The rationale for this is firstly, that it improves the clarity of the code
-                           if it is clear whether patterns are intended to match XNodes or JNodes; and secondly,
-                           that it enables pattern matching to be optimized and simplifies streamability analysis.</p></note>
-                     </item>
-                     <item>
-                        <p>In addition, the axis is adjusted to allow the step to match a parentless GNode. The
-                        adjustment depends on the axis used in this step, whether it appears
-                        explicitly or implicitly (according to the rules of <xspecref spec="XP40" ref="abbrev"/>), 
-                        and is made as follows:</p>
+            </item><item>
+                  <p>The axis of a <termref def="dt-leading-step"/> <var>PS</var> is adjusted to allow the step to match a parentless XNode. The
+                  adjustment depends on the axis used in this step, whether it appears
+                  explicitly or implicitly (according to the rules of <xspecref spec="XP40" ref="abbrev"/>), 
+                  and is made as follows:</p>
                      <olist>
                         <item>
                            <p>If the <code>NodeTest</code> in <var>PS</var> is
@@ -12856,27 +12768,24 @@ return $tree =?> depth()]]></eg>
                            if they have one. To match any XNode at all,
                               XSLT 4.0 allows the pattern <code>~node()</code> to be
                               used.</p>
-                        <p>The adjustment is not necessary in the case of JNodes, because a JNode
-                        with ·jkey· value <code>"person"</code> will necessarily have a parent JNode.</p>
+                        
                      </note>
-   
-                  </item>
-                  </olist>
             </item>
-                <item>
+            <item>
+                 
 
                   <p>The meaning of the pattern is then defined in terms of the semantics of the
                      equivalent expression, denoted below as <code>EE</code>.</p>
    
-                  <p>Specifically, an item <var>N</var> matches a <nt def="GNodePattern">GNodePattern</nt>
+                  <p>Specifically, an item <var>N</var> matches a <nt def="XNodePattern">XNodePattern</nt>
                       <var>P</var> if and only if the following applies, where
                         <code>EE</code> is the <term>equivalent expression</term> to <var>P</var>:</p>
                   <ulist>
    
                      <item>
-                        <p><var>N</var> is a GNode, and the result of evaluating the expression
+                        <p><var>N</var> is an XNode, and the result of evaluating the expression
                               <code>root(.)//(EE)</code> with a <termref def="dt-singleton-focus">singleton focus</termref> 
-                           based on <var>N</var> is a sequence that includes the GNode <var>N</var>.
+                           based on <var>N</var> is a sequence that includes the XNode <var>N</var>.
                         </p>
                      </item>
                      
@@ -12893,11 +12802,31 @@ return $tree =?> depth()]]></eg>
                 </item>
                </olist>
 
-
+            </div4>
+                  <div4 id="xnode-pattern-matching-process">
+                     <head>The Pattern Matching Process</head>
+                     
+                     <p>Although the semantics of <termref def="dt-xnode-pattern">XNode patterns</termref> are
+                        specified formally in terms of expression evaluation, it is possible to understand
+                        pattern matching using a different model. A <termref def="dt-xnode-pattern"/> such as
+                        <code>book/chapter/section</code> can be examined from right to left. A node
+                        will only match this pattern if it is a <code>section</code> element; and then,
+                        only if its parent is a <code>chapter</code>; and then, only if the parent of that
+                        <code>chapter</code> is a <code>book</code>. When the pattern uses the
+                        <code>//</code> operator, one can still read it from right to left, but this
+                        time testing the ancestors of a node rather than its parent. For example
+                        <code>appendix//section</code> matches every <code>section</code> element that
+                        has an ancestor <code>appendix</code> element.</p>
+                     <p>The formal definition, however, is useful for understanding the meaning of a
+                        pattern such as <code>para[1]</code>. This matches any node selected by the
+                        expression <code>root(.)//(child-or-top::para[1])</code>: that is, any
+                        <code>para</code> element that is the first <code>para</code> child of its
+                        parent, or a <code>para</code> element that has no parent.</p>
+                     
 
                <example>
                   <head>Matching XNodes</head>
-                  <p>The <termref def="dt-gnode-pattern"/>
+                  <p>The <termref def="dt-xnode-pattern"/>
                      <code>p</code> matches any <code>p</code> element. The equivalent expression,
                      after adjustment, is <code>child-or-top::element(p)</code>, and the pattern matches because a <code>p</code>
                      element will always be present in the result of evaluating the 
@@ -12909,7 +12838,7 @@ return $tree =?> depth()]]></eg>
                      of the equivalent <termref def="dt-expression">expression</termref>
                      <code>root(.)//(self::document-node())</code> returns the root node of the tree containing the
                      context node if and only if it is a document node.</p>
-                  <p>The <termref def="dt-gnode-pattern"/>
+                  <p>The <termref def="dt-xnode-pattern"/>
                      <code>node()</code> matches all XNodes selected by the expression
                         <code>root(.)//(child-or-top::node())</code>, that is, all element, text,
                      comment, and processing instruction nodes, whether or not they have a parent.
@@ -12920,70 +12849,24 @@ return $tree =?> depth()]]></eg>
                   <note>
                      <p>The pattern <code>~node()</code> matches all XNodes.</p>
                   </note>
-                  <p>The <termref def="dt-gnode-pattern"/>
+                  <p>The <termref def="dt-xnode-pattern"/>
                      <code>$V</code> matches all XNodes selected by the expression
                         <code>root(.)//($V)</code>, that is, all XNodes in the value of $V (which
                      will typically be a global variable, though when the pattern is used in
                      contexts such as the <elcode>xsl:number</elcode> or
                         <elcode>xsl:for-each-group</elcode> instructions, it can also be a local
                      variable).</p>
-                  <p>The <termref def="dt-gnode-pattern"/>
+                  <p>The <termref def="dt-xnode-pattern"/>
                      <code>doc('product.xml')//product</code> matches all XNodes selected by the
                      expression <code>root(.)//(doc('product.xml')//product)</code>, that is, all
                         <code>product</code> elements in the document whose URI is
                         <code>product.xml</code>.</p>
-                  <p>The <termref def="dt-gnode-pattern"/>
+                  <p>The <termref def="dt-xnode-pattern"/>
                      <code>root(.)/self::E</code> matches an <code>E</code> element that is the root
                      of a tree (that is, an <code>E</code> element with no parent node).</p>
                </example>
-               <p>Although the semantics of <termref def="dt-gnode-pattern">GNode patterns</termref> are
-                  specified formally in terms of expression evaluation, it is possible to understand
-                  pattern matching using a different model. A <termref def="dt-gnode-pattern"/> such as
-                     <code>book/chapter/section</code> can be examined from right to left. A node
-                  will only match this pattern if it is a <code>section</code> element; and then,
-                  only if its parent is a <code>chapter</code>; and then, only if the parent of that
-                     <code>chapter</code> is a <code>book</code>. When the pattern uses the
-                     <code>//</code> operator, one can still read it from right to left, but this
-                  time testing the ancestors of a node rather than its parent. For example
-                     <code>appendix//section</code> matches every <code>section</code> element that
-                  has an ancestor <code>appendix</code> element.</p>
-               <p>The formal definition, however, is useful for understanding the meaning of a
-                  pattern such as <code>para[1]</code>. This matches any node selected by the
-                  expression <code>root(.)//(child-or-top::para[1])</code>: that is, any
-                     <code>para</code> element that is the first <code>para</code> child of its
-                  parent, or a <code>para</code> element that has no parent.</p>
                
-               <example>
-                  <head>Matching JNodes</head>
-                  <ulist>
-                  <item><p>The pattern <code>jnode(code, xs:string)</code> matches any
-                     JNode whose ·jkey· is the string <code>"code"</code> and whose ·jvalue·
-                     is an instance of <code>xs:string</code>.</p></item>
-                  <item><p>The pattern <code>jnode("date of birth", xs:date)</code> matches any
-                     JNode whose ·jkey· is the string <code>"date of birth"</code> and whose ·jvalue·
-                     is an instance of <code>xs:date</code>.</p></item>
-                  <item><p>The pattern <code>jnode(*, array(*))</code> matches any
-                     JNode whose ·jvalue· is an array, regardless of its ·jkey· property.</p></item>
-                  <item><p>The pattern <code>jnode(*, record(Author, Title))[ancestor::books]</code> matches any
-                     JNode whose ·jvalue· is an instance of the type <code>record(Author, Title)</code>, 
-                     provided it has an ancestor with the ·jkey· value <code>"books"</code>.</p></item>
-                  <item><p>The pattern <code>jnode(*, record(Author as enum("Dickens"), Title))</code> matches any
-                     JNode whose ·jvalue· is a map having an <code>Author</code> entry with the value
-                     <code>"Dickens"</code>, a <code>Title</code> entry with any value, and optionally
-                     other entries.</p></item>
-                  <item><p>The pattern <code>jnode(*)[jkey() = current-date()]</code> matches any
-                     JNode whose ·jkey· property is an <code>xs:date</code> value equal to the current date.
-                     The comparison uses the implicit timezone from the dynamic context. The rules for error
-                  handling in patterns ensure that any JNode whose ·jkey· value is of a type other
-                  than <code>xs:date</code> does not match, because evaluation of the predicate raises an error.</p></item>
-               </ulist>
-                  
-                  <ednote>
-                     <edtext>It would be useful to be able to use a map pattern within a JNode pattern,
-                     for example <code>match="jnode(*, {'first', 'middle', "last'})"</code>.</edtext>
-                  </ednote>
-                  
-               </example>
+               
                
                <note>
                   <p>The <code>intersect</code> and <code>except</code> operators
@@ -13018,14 +12901,14 @@ return $tree =?> depth()]]></eg>
                      result would probably be very inefficient.</p>
                </note>
                
-            </div5>
-               </div4>
+            </div4>
+               </div3>
                
-               <div4 id="id-sequence-patterns">
+               <div3 id="id-sequence-patterns">
                   <head>Sequence Patterns</head>
                   
                   <p>Sequence patterns cannot be used as top-level patterns, but they are used within
-                  map patterns and array patterns.</p>
+                  map patterns, array patterns, and JNode patterns.</p>
                   
                   <scrap id="SequencePatterns-scrap">
                      <prodrecap ref="SequencePattern"/>
@@ -13039,7 +12922,8 @@ return $tree =?> depth()]]></eg>
                      <item><p><var>SP</var> includes an <nt def="ItemPattern">ItemPattern</nt> <var>P</var> and both
                         the following conditions are true:</p>
                         <olist>
-                           <item><p>Every item in <var>V</var> matches <var>P</var>.</p></item>
+                           <item><p>Every item in <var>V</var> matches <var>P</var>.</p>
+                           <note><p>This is always true if <var>V</var> is the empty sequence.</p></note></item>
                            <item><p>Either <var>SP</var> includes no <nt def="OccurrenceIndicator">OccurrenceIndicator</nt>
                               and the number of items in <var>V</var> is exactly one, or the number of items in
                               <var>V</var> matches the requirements of the <nt def="OccurrenceIndicator">OccurrenceIndicator</nt>
@@ -13048,20 +12932,23 @@ return $tree =?> depth()]]></eg>
                      </item>
                   </olist>
                   
-               </div4>
+               </div3>
                
-               <div4 id="id-map-patterns">
+               <div3 id="id-map-patterns">
                   <head>Map Patterns</head>
                   <changes>
                      <change issue="2580" PR="2596" date="2026-04-28">Map patterns are new in 4.0.</change>
                   </changes>
+                  <p>Map patterns are used to match maps, including records.</p>
+                  
                   <scrap id="MapPatterns-scrap">
                      <prodrecap ref="MapPattern"/>
                   </scrap>
-                  <p>Map patterns are used to match maps, including records.</p>
                   <p>For example:</p>
                   
                   <ulist>
+                     <item><p>The pattern <code>{}</code> matches an empty map.</p></item>
+                     <item><p>The pattern <code>{*}</code> matches any map.</p></item>
                      <item><p>The pattern <code>{"first", "last"}</code> matches a map (or record)
                         with two entries whose keys are the strings <code>"first"</code> and <code>"last"</code></p></item>
                      <item><p>The pattern <code>{"first", "last", *}</code> matches a map (or record)
@@ -13079,7 +12966,7 @@ return $tree =?> depth()]]></eg>
                   
                   <note><p>The keyword <code>"map"</code> is optional and does not change the meaning.</p></note>
                   
-                  <p>More specifically, a map pattern <var>P</var> matches an 
+                  <p>More specifically, a map pattern <var>P</var> (other than <code>{}</code> or <code>{*}</code>) matches an 
                      item <var>M</var> if all the following conditions
                   are satisfied:</p>
                   
@@ -13131,11 +13018,11 @@ return $tree =?> depth()]]></eg>
                         </thead>
                         <tbody>
                            <tr>
-                              <td><p><code>{}</code></p></td>
-                              <td><p>Any map</p></td>
+                              <td><p><code>{}</code> or <code>map{}</code></p></td>
+                              <td><p>An empty map</p></td>
                            </tr>
                            <tr>
-                              <td><p><code>map{}</code></p></td>
+                              <td><p><code>{*}</code> or <code>map{*}</code></p></td>
                               <td><p>Any map</p></td>
                            </tr>
                            <tr>
@@ -13200,12 +13087,12 @@ return $tree =?> depth()]]></eg>
                                     in which both of these entries have the same value.</p></td>
                            </tr>
                            <tr>
-                              <td><p><code>{"area":fn(*), *}[?area(.) lt 10]</code></p></td>
+                              <td><p><code>{"area": ~fn(*), *}[?area(.) lt 10]</code></p></td>
                               <td><p>Any map having an <code>"area"</code> method where the computed
                                     area is less than 10.</p></td>
                            </tr>
                            <tr>
-                              <td><p><code>{}[deep-equal(map:keys(.), ('x', 'y', 'z'))]</code></p></td>
+                              <td><p><code>{'x', 'y', 'z'}[deep-equal(map:keys(.), ('x', 'y', 'z'))]</code></p></td>
                               <td><p>Any map whose keys are <code>'x'</code>, <code>'y'</code>, and <code>'z'</code>,
                                     in that order.</p></td>
                            </tr>
@@ -13213,17 +13100,19 @@ return $tree =?> depth()]]></eg>
                         </tbody>
                      </table>
                   </example>
-               </div4>
+               </div3>
                
-               <div4 id="id-array-patterns">
+               <div3 id="id-array-patterns">
                   <head>Array Patterns</head>
                   <changes>
                      <change>Array patterns are new in 4.0.</change>
                   </changes>
+                  
+                  <p>Array patterns are used to match arrays.</p>
+                  
                   <scrap id="ArrayPatterns-scrap">
                      <prodrecap ref="ArrayPattern"/>
                   </scrap>
-                  <p>Array patterns are used to match arrays.</p>
                   <p>For example:</p>
                   
                   <ulist>
@@ -13274,36 +13163,47 @@ return $tree =?> depth()]]></eg>
                         <tbody>
                            <tr>
                               <td><p><code>array(.*)</code></p></td>
-                              <td><p>Any array</p></td>
+                              <td><p>Any array.</p></td>
                            </tr>
                            <tr>
                               <td><p><code>array(.)</code></p></td>
-                              <td><p>Any array whose members are all singleton items</p></td>
+                              <td><p>Any array whose members are all singleton items.</p></td>
+                           </tr>
+                           <tr>
+                              <td><p><code>array({*})</code></p></td>
+                              <td><p>Any array whose members are arbitrary maps.</p></td>
+                           </tr>
+                           <tr>
+                              <td><p><code>array(array(.*))</code></p></td>
+                              <td><p>Any array whose members are arbitrary arrays.</p></td>
+                           </tr>
+                           <tr>
+                              <td><p><code>array(array(*))</code></p></td>
+                              <td><p>Any array whose members are all element nodes (the pattern <code>*</code> matches an element node).</p></td>
                            </tr>
                            <tr>
                               <td><p><code>array({"long", "lat", *})</code></p></td>
                               <td><p>An array of maps in which the keys <code>"long"</code> and <code>"lat"</code> are present.</p></td>
                            </tr>
                            <tr>
-                              <td><p><code>map{"long", "lat"}[empty(?altitude)]</code></p></td>
-                              <td><p>Any map in which the keys <code>"long"</code> and <code>"lat"</code> are present,
-                                 and in which the entry with key <code>"altitude"</code> is either absent or empty.</p></td>
-                           </tr>
-                           <tr>
                               <td><p><code>array(~xs:numeric)</code></p></td>
                               <td><p>An array of singleton numeric values.</p></td>
                            </tr>
                            <tr>
-                              <td><p><code>array(.)[exists(?1)]</code></p></td>
-                              <td><p>A non-empty array of singleton items.</p></td>
+                           <td><p><code>array(book/author/@name)</code></p></td>
+                           <td><p>An array of attribute nodes, each of which matches the pattern <code>book/author/@name</code>.</p></td>
+                           </tr>
+                           <tr>
+                              <td><p><code>array(.+)[array:size() gt 0]</code></p></td>
+                              <td><p>An array having at least one member, with none of its members being the empty sequence.</p></td>
                            </tr>
                            
                         </tbody>
                      </table>
                   </example>
-               </div4>
+               </div3>
                
-            <!--<div4 id="jnode-patterns">
+            <div3 id="id-jnode-patterns">
                <head>JNode Patterns</head>
                <changes>
                   <change issue="2150">JNode Patterns are new in 4.0.</change>
@@ -13311,17 +13211,84 @@ return $tree =?> depth()]]></eg>
                <scrap>
                   <prodrecap ref="JNodePattern"/>
                </scrap>
-               <p>TODO: Merge this section into Node Patterns</p>
+               
                <p>A <nt def="JNodePattern">JNodePattern</nt> matches JNodes. It has three parts:</p>
                <ulist>
                   <item><p>The <nt def="JNodePatternSelector">JNodePatternSelector</nt> defines
                   the required value of the ·jkey· property of the JNode.</p></item>
-                  <item><p>The <nt def="JNodePatternSelector">JNodePatternContent</nt> defines
-                  the required type of the ·jvalue· property of the JNode.</p></item>
-                  <item><p>An optional list of zero or more predicates that the JNode
+                  <item><p>The <nt def="SequencePattern">SequencePattern</nt> matches
+                  the ·jvalue· property of the JNode.</p></item>
+                  <item><p>The optional list of zero or more predicates defines further conditions that the JNode
                   must satisfy.</p></item>
                </ulist>
                <p>Here are some examples of JNode patterns:</p>
+               
+               <example>
+                  <head>Matching JNodes</head>
+                  <ulist>
+                     <item><p>The pattern <code>jnode("code", ~xs:string)</code> matches any
+                        JNode whose ·jkey· is the string <code>"code"</code> and whose ·jvalue·
+                        is an instance of <code>xs:string</code>.</p></item>
+                     <item><p>The pattern <code>jnode("date of birth", ~xs:date)</code> matches any
+                        JNode whose ·jkey· is the string <code>"date of birth"</code> and whose ·jvalue·
+                        is an instance of <code>xs:date</code>.</p></item>
+                     <item><p>The pattern <code>jnode(*, array(.*))</code> matches any
+                        JNode whose ·jvalue· is an array, regardless of its ·jkey· property.</p></item>
+                     <item><p>The pattern <code>jnode(*, {"Author", "Title", *})[ancestor::books]</code> matches any
+                        JNode whose ·jvalue· is a map (or record) that includes the keys <code>"Author"</code> 
+                        and <code>"Title"</code>, 
+                        provided it has an ancestor with the ·jkey· value <code>"books"</code>.</p></item>
+                     <item><p>The pattern <code>jnode(*, {"Author": ~enum("Dickens"), "Title", *))</code> matches any
+                        JNode whose ·jvalue· is a map having an <code>Author</code> entry with the value
+                        <code>"Dickens"</code>, a <code>Title</code> entry with any value, and optionally
+                        other entries.</p></item>
+                     <item><p>The pattern <code>jnode(*, .*)[jkey() = current-date()]</code> matches any
+                        JNode whose ·jkey· property is an <code>xs:date</code> value equal to the current date.
+                        The comparison uses the implicit timezone from the dynamic context. The rules for error
+                        handling in patterns ensure that any JNode whose ·jkey· value is of a type other
+                        than <code>xs:date</code> does not match, because evaluation of the predicate raises an error.</p></item>
+                  </ulist>
+                  
+
+                  
+               </example>
+               
+               <olist>
+                  <item>
+                     <p>The patterns <code>jnode()</code>, <code>jnode(*)</code>, and <code>jnode(*, item()*)</code> 
+                        are equivalent, and match any JNode.</p>
+                  </item>
+                  <item>
+                     <p><code>jnode("date of birth")</code> matches any JNode representing a map
+                        entry with key <code>"date of birth"</code>.</p>
+                  </item>
+                  <item>
+                     <p><code>jnode(*, array(xs:integer))</code> matches any JNode representing a map
+                        entry or array item whose value is an array of integers.</p>
+                  </item>
+                  <item>
+                     <p><code>jnode(books, array(record(Author, Title)))</code> 
+                        matches any JNode representing a map
+                        entry whose key is <code>"books"</code> and whose content is an array of records,
+                        each record having entries named <code>"Author"</code> and <code>"Title"</code> (with no other
+                        entries allowed).</p>
+                  </item>
+                  <item>
+                     <p><code>jnode(*, record(Author as enum("Dickens"), Title))</code> 
+                        matches any JNode whose content is a map
+                        having an entry with key <code>"Author"</code> and value <code>"Dickens"</code>,
+                        plus an entry with key <code>"Title"</code> (with no other
+                        entries allowed).</p>
+                  </item>
+                  <item>
+                     <p><code>jnode(())</code> matches any root JNode (that is, a JNode whose <term>·jkey·</term> property
+                        is absent).</p>
+                  </item>
+                  <item>
+                     <p><code>jnode((), array(map(*)))</code> matches any root JNode whose <term>·jvalue·</term> property
+                        is an array of maps.</p>
+                  </item>
+               </olist>
                
                <p>More specifically, a JNode <var>J</var> matches the pattern if all the following conditions
                are satisfied:</p>
@@ -13329,31 +13296,24 @@ return $tree =?> depth()]]></eg>
                   <item><p>One of the following conditions is satisfied:</p>
                      <olist>
                         <item>The <nt def="JNodePatternSelector">JNodePatternSelector</nt> is <code>*</code>;</item>
-                        <item>The <nt def="JNodePatternSelector">JNodePatternSelector</nt> is an <code>NCName</code>.
-                        and <var>J</var> has a ·jkey· property that is an instance of <code>xs:string</code> 
-                        whose value is equal to the <code>NCName</code> under the rules of the <function>fn:atomic-equal</function>
-                        function.</item>
+                        
                         <item>The <nt def="JNodePatternSelector">JNodePatternSelector</nt> is a <code>Constant</code>.
                         and <var>J</var> has a ·jkey· property that is equal to the value
                            of the constant (evaluated as an XPath expression) under the rules of the 
                               <function>fn:atomic-equal</function> function.</item>
                      </olist>
                   </item>
-                  <item><p>One of the following conditions is satisfied:</p>
-                     <olist>
-                        <item>The <nt def="JNodePatternContent">JNodePatternContent</nt> is <code>*</code>;</item>
-                        <item>The ·jvalue· property of <var>J</var> is an instance of the sequence type
-                        designated by <nt def="JNodePatternContent">JNodePatternContent</nt>.</item>
-                     </olist>
-                  </item>
+                  <item>The ·jvalue· property of <var>J</var> matches the <nt def="SequencePattern">SequencePattern</nt>.</item>
+                     
                   <item><p>All the predicates are satisfied. The predicates are evaluated against the item
                   <var>J</var> in the same way as for a predicate pattern.</p></item>
                         
                </olist>
-            </div4> -->  
-            </div3>
+            </div3> 
             
-            <div3 id="default-priority">
+         </div2>
+            
+            <div2 id="default-priority">
             <head>Default Priority for Patterns</head>
             <changes>
                <change issue="1394" PR="1442" date="2024-09-15">
@@ -13382,7 +13342,7 @@ return $tree =?> depth()]]></eg>
                
             
             
-            <div4 id="default-priority-for-predicate-patterns">
+            <div3 id="default-priority-for-predicate-patterns">
                <head>Default Priority for Predicate Patterns</head>
                
                <p>The default priority for the pattern <code>.</code> (a predicate pattern with
@@ -13390,9 +13350,9 @@ return $tree =?> depth()]]></eg>
                
                <p>For a <nt def="PredicatePattern">PredicatePattern</nt> having one or more
                   predicates, the default priority is +1.</p>
-            </div4>   
+            </div3>   
                
-            <div4 id="default-priority-for-type-patterns">
+            <div3 id="default-priority-for-type-patterns">
                <head>Default Priority for Type Patterns</head>
                
                <p>For a <nt def="TypePattern">TypePattern</nt> with no predicates, the default
@@ -13475,10 +13435,10 @@ return $tree =?> depth()]]></eg>
                the default priority is 0.5</p>
                
                
-            </div4>   
+            </div3>   
                   
-            <div4 id="default-priority-for-gnode-patterns">
-               <head>Default Priority for GNode Patterns</head>
+            <div3 id="default-priority-for-xnode-patterns">
+               <head>Default Priority for XNode Patterns</head>
                <olist>
                   
                   <item>
@@ -13719,35 +13679,7 @@ return $tree =?> depth()]]></eg>
                      −0.5.</p>
                </item>
                   
-                  <item>
-                     <p>The default priority of the pattern <code>jnode(*)</code> is −0.5.</p>
-                     <p>The default priority of the equivalent pattern 
-                        <code>jnode(*, item()*)</code> is also −0.5.</p>
-                  </item>
-                  <item>
-                     <p>The default priority of the pattern <code>jnode(<var>S</var>)</code>,
-                        where <var>S</var> is any constant, is 0 (zero).</p>
-                     <p>The default priority of the equivalent pattern <code>jnode(<var>S</var>, item()*)</code>,
-                        where <var>S</var> is any constant, is also 0 (zero).</p>
-                  </item>
-                  <item>
-                     <p>The default priority of the pattern <code>jnode(())</code> is 0 (zero).</p>
-                     <p>The default priority of the equivalent pattern <code>jnode((), item()*)</code> is also 0 (zero).</p>
-                  </item>
-                  <item>
-                     <p>The default priority of the pattern <code>jnode(*, <var>T</var>)</code>,
-                        where <var>T</var> is any sequence type other than <code>item()*</code>, is 0 (zero).</p>
-                  </item>
-                  <item>
-                     <p>The default priority of the pattern <code>jnode(<var>S</var>, <var>T</var>)</code>,
-                        where <var>S</var> is any constant, and <var>T</var> is any sequence type other 
-                        than <code>item()*</code>, is +0.25.</p>
-                  </item>
-                  <item>
-                     <p>The default priority of the pattern <code>jnode((), <var>T</var>)</code>, 
-                        where <var>T</var> is any sequence type other 
-                        than <code>item()*</code>, is +0.25.</p>
-                  </item>
+                  
                   
                <item>
                   <p>In all other cases, the default priority is +0.5.</p>
@@ -13783,9 +13715,9 @@ return $tree =?> depth()]]></eg>
                Conversely, <code>element(N, xs:anyType)</code> and <code>element(N, xs:anyType?)</code>
                have the same default priority even though the first is more restrictive (it does not match 
                elements that are nilled).</p></note>
-            </div4>
+            </div3>
                
-               <div4 id="id-default-priority-map-patterns">
+               <div3 id="id-default-priority-map-patterns">
                   <head>Default Priority for Map Patterns</head>
                   <changes>
                      <change issue="2580" PR="2596" date="2026-04-28">Map patterns are new in 4.0.</change>
@@ -13796,17 +13728,76 @@ return $tree =?> depth()]]></eg>
                   
                   <olist>
                      <item><p>If the pattern contains at least one predicate, then +0.5.</p></item>
+                     <item><p>For the pattern <code>{}</code> (which matches an empty map), then +0.5.</p></item>
                      <item><p>If the pattern contains at least one <nt def="SequencePattern">SequencePattern</nt>,
                      then +0.25.</p></item>
                      <item><p>If the pattern contains at least one <nt def="MapEntryPattern">MapEntryPattern</nt>,
                      then 0.</p></item>
-                     <item><p>Otherwise (for the pattern <code>{}</code>), -0.25.</p></item>
+                     <item><p>Otherwise (for the pattern <code>{*}</code>), -0.25.</p></item>
                   </olist>
-               </div4>
+               </div3>
+               
+               <div3 id="id-default-priority-array-patterns">
+                  <head>Default Priority for Array Patterns</head>
+                  <changes>
+                     <change>Array patterns are new in 4.0.</change>
+                  </changes>
+                  
+                  <p>The default priority of an array pattern is determined by the first of the 
+                     following rules that applies:</p>
+                  
+                  
+                  <olist>
+                     <item><p>If the pattern contains at least one predicate, then +0.5.</p></item>
+                     <item><p>Otherwise, the default priority of an array pattern is the priority of the contained pattern, ignoring any occurrence indicator.</p>
+                        <p>For example, the default priority of the pattern <code>array(<var>P</var>*)</code> is the default priority of <var>P</var>.</p></item>
+                  </olist>
 
-            </div3>
+                  
+                  
+               </div3>
+               
+               <div3 id="id-default-priority-jnode-patterns">
+                  <head>Default Priority for JNode Patterns</head>
+                  <changes>
+                     <change>JNode patterns are new in 4.0.</change>
+                  </changes>
+                  
+                  <p>The default priority of a JNode pattern is determined by the first of the 
+                     following rules that applies:</p>
+                  
+                  
+                  <olist>
+                     <item><p>If the pattern contains at least one predicate, then +0.5.</p></item>
+                     <item><p>If the <code>JNodeSelectorPattern</code> is <code>*</code>, then
+                        the default priority of the contained pattern, ignoring any occurrence indicator.</p>
+                        <p>For example, the default priority of the pattern <code>jnode(*, <var>P</var>*)</code> is the default priority of <var>P</var>.</p></item>
+                     <item><p>Otherwise, the default priority of the contained pattern, ignoring any occurrence indicator, or zero, whichever is higher.</p></item>
+                  </olist>
+                  
+                  <p>For example:</p>
+                  
+                  <ulist>
+                     <item>
+                        <p>The default priority of the equivalent pattern 
+                           <code>jnode(*, item()*)</code> is also −0.5.</p>
+                     </item>
+                     <item>
+                        <p>The default priority of the pattern <code>jnode(<var>S</var>, {*})</code>,
+                           where <var>S</var> is any constant, is 0 (zero).</p>
+                     </item>
+                     <item>
+                        <p>The default priority of the pattern <code>jnode(())</code> is 0 (zero).</p>
+                     </item>
+                  </ulist>
+                  
+                  
+                  
+               </div3>
+
+            </div2>
             
-            <div3 id="pattern-errors">
+            <div2 id="pattern-errors">
                <head>Errors in Patterns</head>
                <p>A <termref def="dt-dynamic-error">dynamic error</termref> or <termref def="dt-type-error">type error</termref> that occurs during the evaluation of a
                      <termref def="dt-pattern">pattern</termref> against a particular item has the effect that the item being tested is
@@ -13828,9 +13819,9 @@ return $tree =?> depth()]]></eg>
                <p>The requirement to detect and raise a <termref def="dt-circularity"/> as a dynamic error overrides this rule.</p>
 
 
-            </div3>
+            </div2>
             
-         </div2>
+         
          
          <div2 id="applying-templates">
             <head>Applying Template Rules</head>
@@ -14151,7 +14142,6 @@ return $tree =?> depth()]]></eg>
             <p>If a template rule has a <code>test</code> attribute, then its value is an <termref def="dt-expression"/>,
                and the template rule is a candidate for evaluation only if the <code>test</code> condition is true.
                The <code>test</code> condition has access to the values of all the parameters declared in the called template,
-               both tunnel and non-tunnel parameters.</p>
             <p>This mechanism allows the applicability of a template rule to be depend not only on the match pattern applied
                to the item selected for processing, but also on the context in which the evaluation takes place.
                It is especially useful when processing structures derived from JSON (maps and arrays), because unlike
@@ -15755,6 +15745,7 @@ return $tree =?> depth()]]></eg>
                template invocations. They are fully described in <specref ref="tunnel-params"/>.</p>
 
          </div2>
+         
       </div1>
       <div1 id="repetition">
          <head>Repetition</head>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -12288,7 +12288,7 @@ return $tree =?> depth()]]></eg>
                   <head>Type Patterns</head>
                   
                   <changes>
-                     <change issue="400" PR="401" date="2023-03-21">
+                     <change issue="400 2581" PR="401 2678" date="2023-03-21">
                         Patterns (especially those used in template rules) can now be defined
                         by reference to item types, so any item type can be used as a match
                         pattern. For example <code>match="~record(longitude, latitude)"</code>
@@ -12304,7 +12304,7 @@ return $tree =?> depth()]]></eg>
                   <p><termdef id="dt-type-pattern" term="type pattern">A <term>type pattern</term> is written as
                      <code>~T</code> (where <var>T</var> is an <xnt spec="XP40" ref="prod-xpath40-ItemType">ItemType</xnt>)
                      followed by zero or more predicates in square
-                     brackets, and it matches any item that is coercible to type <var>T</var> for which each of the predicates evaluates
+                     brackets, and it matches any instance of type <var>T</var> for which each of the predicates evaluates
                      to <code>true</code>.</termdef></p>
                   
                   
@@ -12323,7 +12323,7 @@ return $tree =?> depth()]]></eg>
                   </ulist>
                   
                   <p>More formally, an item <var>$J</var> matches a pattern <code>~<var>T</var>[<var>P1</var>][<var>P2</var>][<var>P3</var>]</code> if
-                     the XPath expression <code>$J instance of <var>T</var> and exists($JJ[<var>P1</var>][<var>P2</var>][<var>P3</var>])</code> is true.</p>
+                     the XPath expression <code>$J instance of <var>T</var> and exists($J[<var>P1</var>][<var>P2</var>][<var>P3</var>])</code> is true.</p>
                   
                   
                   <p>Note that no coercion is applied.</p>
@@ -12344,8 +12344,7 @@ return $tree =?> depth()]]></eg>
                    
                   <note><p>As with predicate patterns, numeric predicates are allowed, but serve no useful purpose.</p></note>
                   
-                  <note><p>An error in evaluating the equivalent expression (for example, when the item
-                        cannot be coerced to the required type) means that the item is treated as not matching the pattern.</p></note>
+                  <note><p>An error in evaluating a predicate means that the item is treated as not matching the pattern.</p></note>
                   
                   
                   
@@ -12691,8 +12690,8 @@ return $tree =?> depth()]]></eg>
                called the <term>equivalent expression</term>. The
                equivalent expression to a <nt def="XNodePattern"/> is the XPath
                expression that takes the same lexical form as the <nt def="XNodePattern"/> as
-               written, except that two adjustments are made to any
-               <nt def="AxisStepP"/> that is a <termref def="dt-leading-step"/>.</p>
+               written, except that an adjustment is made to any
+               <nt def="AxisStepP"/> that is a <termref def="dt-leading-step"/>, as described below.</p>
                
                <p><termdef id="dt-leading-step" term="leading step">An <nt def="AxisStepP"/>
                within a <termref def="dt-pattern"/> is a <term>leading step</term> if
@@ -12775,16 +12774,16 @@ return $tree =?> depth()]]></eg>
                  
 
                   <p>The meaning of the pattern is then defined in terms of the semantics of the
-                     equivalent expression, denoted below as <code>EE</code>.</p>
+                     equivalent expression, denoted below as <var>EE</var>.</p>
    
                   <p>Specifically, an item <var>N</var> matches a <nt def="XNodePattern">XNodePattern</nt>
                       <var>P</var> if and only if the following applies, where
-                        <code>EE</code> is the <term>equivalent expression</term> to <var>P</var>:</p>
+                        <var>EE</var> is the <term>equivalent expression</term> to <var>P</var>:</p>
                   <ulist>
    
                      <item>
                         <p><var>N</var> is an XNode, and the result of evaluating the expression
-                              <code>root(.)//(EE)</code> with a <termref def="dt-singleton-focus">singleton focus</termref> 
+                              <code>root(.)//(<var>EE</var>)</code> with a <termref def="dt-singleton-focus">singleton focus</termref> 
                            based on <var>N</var> is a sequence that includes the XNode <var>N</var>.
                         </p>
                      </item>
@@ -12937,7 +12936,7 @@ return $tree =?> depth()]]></eg>
                <div3 id="id-map-patterns">
                   <head>Map Patterns</head>
                   <changes>
-                     <change issue="2580" PR="2596" date="2026-04-28">Map patterns are new in 4.0.</change>
+                     <change issue="2580 2581" PR="2596 2678" date="2026-04-28">Map patterns are new in 4.0.</change>
                   </changes>
                   <p>Map patterns are used to match maps, including records.</p>
                   
@@ -12953,7 +12952,7 @@ return $tree =?> depth()]]></eg>
                         with two entries whose keys are the strings <code>"first"</code> and <code>"last"</code></p></item>
                      <item><p>The pattern <code>{"first", "last", *}</code> matches a map (or record)
                         whose keys include the strings <code>"first"</code> and <code>"last"</code>; the trailing
-                        wildcard <code>, *</code> indicates that the map may
+                        wildcard <code>*</code> indicates that the map may
                      have other keys in addition.</p></item>
                      <item><p>The pattern <code>{"first":~xs:string+, "last":~enum("Smith", "Smyth"), *}</code>
                         matches any map (or record) having an entry with key <code>"first"</code>
@@ -13105,7 +13104,7 @@ return $tree =?> depth()]]></eg>
                <div3 id="id-array-patterns">
                   <head>Array Patterns</head>
                   <changes>
-                     <change>Array patterns are new in 4.0.</change>
+                     <change issue="2581" PR="2678" date="2026-06-03">Array patterns are new in 4.0.</change>
                   </changes>
                   
                   <p>Array patterns are used to match arrays.</p>
@@ -13136,7 +13135,8 @@ return $tree =?> depth()]]></eg>
                         <p>The item <var>A</var> is an array.</p>
                      </item>
                      <item>
-                        <p>Every member of <var>A</var> matches the contained <nt def="SequencePattern">SequencePattern</nt></p>
+                        <p>Every member of <var>A</var> matches the contained <nt def="SequencePattern">SequencePattern</nt>.</p>
+                        <note><p>This will always be true if <var>A</var> is an empty array.</p></note>
                      </item>
                      <item>
                         <p><var>M</var> satisfies each of the <nt def="Predicate">Predicates</nt>.</p>
@@ -13206,7 +13206,7 @@ return $tree =?> depth()]]></eg>
             <div3 id="id-jnode-patterns">
                <head>JNode Patterns</head>
                <changes>
-                  <change issue="2150">JNode Patterns are new in 4.0.</change>
+                  <change issue="2150 2581" PR="2678" >JNode Patterns are new in 4.0.</change>
                </changes>
                <scrap>
                   <prodrecap ref="JNodePattern"/>
@@ -13324,6 +13324,9 @@ return $tree =?> depth()]]></eg>
                   The default priority for a template rule using a union pattern has changed.
                   This change may cause incompatible behavior.
                </change>
+               <change issue="2581" PR="2678" date="2026-06-03">
+                  Default priorities are defined for new forms of pattern.
+               </change>
             </changes>
             <p><termdef id="dt-default-priority" term="default priority">If no <code>priority</code>
                   attribute is specified on an <elcode>xsl:template</elcode> element, a
@@ -13334,8 +13337,7 @@ return $tree =?> depth()]]></eg>
                and less than or equal to +1 (plus one). The rules are as follows. </p>
 
                
-               <p>Unless otherwise specified, the default priority for a pattern is +0.5. For some simple patterns,
-               listed below, there is a lower default priority in the range -1 (minus one) to +1.</p>
+               <p>Unless otherwise specified, the default priority for a pattern is +0.5.</p>
                
                <note><p>A higher numeric value denotes a higher priority: a rule with priority 1 is selected
                in preference to a rule with priority 0, which in turn is prefered over one with priority -1.</p></note>


### PR DESCRIPTION
A thorough revision of the section on patterns, based on the whiteboarding done in Prague. The main technical changes are:

* GNodePatterns become XNodePatterns, and apply to XNodes only
* Revise map patterns to distinguish extensible from non-extensible patterns
* Add array patterns
* Reintroduce JNode patterns (which still had a ghostly presence in the spec....)

There's a fair bit of editorial rearrangement as well, so the diffs probably won't be too helpful.