### PR TITLE
2684 strip-space - align fn:doc and fn:document

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19349,21 +19349,23 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             </fos:option>
             <fos:option key="strip-space">
                <fos:meaning>Determines whether whitespace-only text nodes are removed
-                  from the resulting document. The default is defined by the host language
-                  or by the implementation. (Note: in XSLT, the <code>xsl:strip-space</code>
-                  and <code>xsl:preserve-space</code> declarations provide detailed control
-                  based on the parent element name.)</fos:meaning>
-               <fos:type>xs:boolean?</fos:type>
-               <fos:default>()</fos:default>
+                  from the resulting document.</fos:meaning>
+               <fos:type>enum("all", "none", "conditional")</fos:type>
+               <fos:default>"conditional"</fos:default>
                <fos:values>
-                  <fos:value value="true">All whitespace-only text nodes are stripped,
+                  <fos:value value="all">All whitespace-only text nodes are stripped,
                   unless either (a) they are within the scope of the attribute <code>xml:space="preserve"</code>,
                   or (b) XSD validation identifies that the parent element has a simple type or a complex
                   type with simple content.
                   </fos:value>
-                  <fos:value value="false">All whitespace-only text nodes are preserved,
+                  <fos:value value="none">All whitespace-only text nodes are preserved,
                   unless either (a) DTD validation marks them as ignorable, or (b) XSD validation recognizes
                   the containing element as having element-only or empty content.
+                  </fos:value>
+                  <fos:value value="conditional">Equivalent to <code>"none"</code>, unless there
+                     is an external control determining how whitespace-only text nodes are to be
+                     handled. An example of such an external control is the set of <code>xsl:strip-space</code>
+                     and <code>xsl:preserve-space</code> declarations in a containing XSLT stylesheet package.
                   </fos:value>
                </fos:values>
             </fos:option>

--- a/specifications/xslt-40/src/function-catalog.xml
+++ b/specifications/xslt-40/src/function-catalog.xml
@@ -1214,19 +1214,22 @@
             </fos:option>
             <fos:option key="strip-space">
                <fos:meaning>Determines whether whitespace-only text nodes are removed
-                  from the resulting document.
-               </fos:meaning>
-               <fos:type>xs:boolean?</fos:type>
-               <fos:default>true</fos:default>
+                  from the resulting document.</fos:meaning>
+               <fos:type>enum("all", "none", "conditional")</fos:type>
+               <fos:default>"conditional"</fos:default>
                <fos:values>
-                  <fos:value value="true">Whitespace stripping is to take place according 
-                     to the <elcode>xsl:strip-space</elcode>
-                  and <elcode>xsl:preserve-space</elcode> declarations of the containing <termref def="dt-package"/>:
-                     see <specref ref="strip"/>.
+                  <fos:value value="all">All whitespace-only text nodes are stripped,
+                     unless either (a) they are within the scope of the attribute <code>xml:space="preserve"</code>,
+                     or (b) XSD validation identifies that the parent element has a simple type or a complex
+                     type with simple content.
                   </fos:value>
-                  <fos:value value="false">All whitespace-only text nodes are preserved,
-                  unless either (a) DTD validation marks them as ignorable, or (b) XSD validation recognizes
-                  the containing element as having element-only or empty content.
+                  <fos:value value="none">All whitespace-only text nodes are preserved,
+                     unless either (a) DTD validation marks them as ignorable, or (b) XSD validation recognizes
+                     the containing element as having element-only or empty content.
+                  </fos:value>
+                  <fos:value value="conditional">Whitespace-only text nodes are stripped or
+                     preserved as defined by the set of <elcode>xsl:strip-space</elcode>
+                     and <elcode>xsl:preserve-space</elcode> declarations in the containing XSLT stylesheet package.
                   </fos:value>
                </fos:values>
             </fos:option>


### PR DESCRIPTION
Proposes that the strip-space option should work the same way across `fn:doc` and `fn:document`, with the option `strip-space="conditional"` taking account of `xsl:strip-space` declarations when running in XSLT, for compatibility.