### PR TITLE
1949 Refine rules for element-to-map() handling of atomic types

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -114,7 +114,7 @@
             <p>For list layouts, defines the name of the child element type contained in the list.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="type" type="enum('numeric', 'boolean', 'string')" required="false">
+      <fos:field name="type" type="enum('integer', 'decimal', 'double', 'boolean', 'string')" required="false">
          <fos:meaning>
             <p>For elements with simple content, defines whether they should be represented
                as numbers or booleans instead of the default representation as strings.</p>
@@ -127,7 +127,7 @@
          <p>This record type represents a plan for converting attributes
             to atomic items during evaluation of <function>fn:element-to-map</function>.</p>
       </fos:summary>
-      <fos:field name="type" type="enum('numeric', 'boolean', 'string', 'skip')" required="true">
+      <fos:field name="type" type="enum('integer', 'decimal', 'double', 'boolean', 'string', 'skip')" required="true">
          <fos:meaning>
             <p>Defines whether attributes should be represented
                as numbers or booleans instead of the default representation as strings;

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -7162,10 +7162,12 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         <tr>
                            <th>Example output (2)</th>
                            <td><eg>{ "dates": [ 
-    { "year": "2023", "month": "03", "day": "20" },
-    { "year": "2023", "month": "04", "day": "12" },
-    { "year": "2023", "month": "05", "day": "30" }
-  ] }</eg></td>
+    { "year": 2023, "month": "03", "day": 20 },
+    { "year": "2023", "month": "04", "day": 12 },
+    { "year": "2023", "month": "05", "day": 30 }
+  ] }</eg>
+                           <note><p>Leading zeros in the month have been retained, since they could be significant.</p></note>
+                           </td>
                         </tr>
                         <tr>
                            <th>Mapping rules</th>
@@ -7576,6 +7578,11 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                of nodes (which will normally be element or document nodes), and it examines all the elements within
                the trees rooted at these nodes, looking for commonalities among like-named elements.</p>
                
+               <note><p>These rules are written for the general case where a plan is inferred from a collection
+               of element nodes, in the same or in different documents. However, the rules also apply to the simple
+               case where each element node is considered independently of any others: in this case the set of elements
+               being considered is a singleton set.</p></note>
+               
                <p>The output of this function (the conversion plan) holds information about how elements and attributes
                   (identified by name) should be converted.</p>
                
@@ -7594,6 +7601,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                   <item><p>Let <code>$EE</code> be
                   the set of all elements named <var>N</var>, specifically
                   <code>$input/descendant-or-self::*[node-name(.) eq <var>N</var>]</code>. </p>
+                     
+                     <note><p>In trivial cases, <code>$EE</code> is a singleton set.</p></note>
                   </item>
                   
                   <item>
@@ -7613,10 +7622,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                            are no attributes)
                            then the layout is <code>simple</code>: see <specref ref="id-simple-layout"/>.</p></item>
                         <item><p>Otherwise, <code>simple-plus</code>: see <specref ref="id-simple-plus-layout"/>.</p></item>
-                        <item><p>The plan also includes the property <code>type</code>. If all the elements
-                        in <code>$EE</code> are castable as <code>xs:boolean</code>, then the type is <code>boolean</code>;
-                        otherwise, if all the elements in <code>$EE</code> as castable as <code>xs:numeric</code>,
-                        then the type is <code>numeric</code>; otherwise, the type is <code>string</code>.</p></item>
+                        <item><p>The plan also includes the property <code>type</code>, whose value is determined
+                           as described below.</p></item>
                      </olist>
                   </item>
                   <item>
@@ -7652,25 +7659,19 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                
                <p>For elements with simple content (more specifically, elements where the chosen layout is
                <code>simple</code> or <code>simple-plus</code>) the conversion plan also includes an entry indicating
-               whether the content should be represented as a boolean, a number, or a string. If every instance of
-               the element name has content that is castable to <code>xs:boolean</code>, the plan indicates
-               <code>"type": "boolean"</code>. If every instance of
-               the element name has content that is castable to <code>xs:numeric</code>, the plan indicates
-               <code>"type": "numeric"</code>. In other cases, the plan indicates <code>"type": "string"</code>; however,
-               this may be omitted because it is the default.</p>
+               how the content should be represented. The rules in <specref ref="id-inferring-data-type"/> are applied
+                  to the string values of the elements in <code>$EE</code> to infer a type <var>T</var>
+                  which will be one of <code>"integer"</code>, <code>"decimal"</code>, <code>"double"</code>,
+                  <code>"boolean"</code>, or <code>"string"</code>, and the plan will indicate the selected
+                  type with the property <code>"type": <var>T</var></code>. The value <code>"type": "string"</code>
+                  is the default, and can be omitted.</p>
                
-               <p>For attributes, the conversion plan identifies whether attributes (with a given name)
-               should be represented as booleans, numbers, or strings; alternatively, it may indicate
+               <p>Similarly, for attributes, the conversion plan identifies whether attributes (with a given name)
+               should be represented as booleans, integers, decimals, doubles, or strings; alternatively, it may indicate
                that attributes with a given name should be discarded. For every distinct attribute name present
-               in the input, an entry is output associating the attribute name with one of the types
-               <code>boolean</code> or <code>numeric</code>; the entry is generally omitted when the values are to 
-               be represented as strings, though the type can also be given explicitly as <code>string</code>. 
-               An entry with type <code>boolean</code>
-               is generated for an attribute name if all the attributes with that name are castable as <code>xs:boolean</code>.
-               Similarly, an entry with type <code>numeric</code> is generated for an attribute name if all the 
-               attributes with that name are castable as <code>xs:numeric</code>. In other case, the attributes are
-               treated as being of type <code>string</code>. Entries with type
-               <code>string</code> may be omitted, since that is the default.
+               in the input, an entry is output associating the attribute name with the type selected
+               by applying the rules in <specref ref="id-inferring-data-type"/> to the string values of these attributes; 
+                  the entry <code>"type": "string"</code> is the default and may be omitted. 
                The entry for an attribute may also specify <code>"type": "skip"</code>
                to indicate that the attribute should be discarded.</p>
                
@@ -7691,7 +7692,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                <p>The conversion plan is a map of type <code>map(xs:string, 
                      ( fn:element-conversion-plan-record | fn:attribute-conversion-plan-record ))  </code>.
                   The key is an element or attribute name, representing element names in the form <code>Q{uri}local</code>,
-                  and attributes in the form <code>@Q{uri}local</code>notation: in both cases the <code>Q{uri}</code>
+                  and attributes in the form <code>@Q{uri}local</code>notation: in both cases the <code>Q{uri}</code> 
                   part <rfc2119>must</rfc2119> be omitted for a name in no namespace. Strings
                   are used as keys in preference to <code>xs:QName</code> instances to allow the plan to be serialized
                   in JSON format.</p>
@@ -7706,7 +7707,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
   "book": { "layout": "record" },
   "author": { "layout": "simple" },
   "title": { "layout": "simple" },
-  "price": { "layout": "simple", "type": "numeric" },
+  "price": { "layout": "simple", "type": "decimal" },
   "hardback": { "layout": "simple", "type": "boolean" },
   "@out-of-print": { "type": "boolean" },
   "@Q{http://www.w3.org/2001/XMLSchema-instance}nil": { "type": "skip" }
@@ -7714,6 +7715,39 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                </eg>
                
                
+            </div3>
+            
+            <div3 id="id-inferring-data-type">
+               <head>Inferring a data type</head>
+               
+               <p>The rules in this section apply when selecting a data type for a set (potentially a singleton set) of
+               strings in the input, these strings being the content of element or attribute nodes. The rules are 
+               as follows, and are applied in order:</p>
+               
+               <olist>
+                  <item><p>If each of the strings is castable as <code>xs:double</code>, and if none of them
+                  is positive infinity, negative infinity, or NaN, then:</p>
+                     <olist>
+                        <item><p>If each of the strings, after trimming leading and trailing whitespace, is in the lexical space of <code>xs:integer</code>,
+                           then:</p>
+                           <olist>
+                              <item><p>If any of the strings starts with a leading zero followed by another digit, select type <code>string</code>.</p>
+                                 <note><p>It is unsafe to treat such values as numeric because leading zeros are significant in some contexts: examples include
+                                 phone numbers and Belgian VAT numbers.</p></note>
+                              </item>
+                              <item><p>Otherwise, select type <code>integer</code>.</p></item>
+                           </olist>
+                        </item>
+                        <item><p>Otherwise, if each of the strings, after trimming leading and trailing whitespace, is in the lexical space of <code>xs:decimal</code>,
+                           then select type <code>decimal</code>.</p></item>
+                        <item><p>Otherwise, select type <code>double</code>.</p></item>
+                     </olist>
+                  </item>
+                  <item><p>Otherwise, if each of the strings, after trimming leading and trailing whitespace, is in the lexical space
+                     of <code>xs:boolean</code> (that is, if it is <code>"0"</code>, <code>"1"</code>, <code>"false"</code>, or <code>"true"</code>),
+                  then select type <code>boolean</code>.</p></item>
+                  <item><p>Otherwise, select type <code>string</code>.</p></item>
+               </olist>
             </div3>
             
             <div3 id="id-xsi-attributes">
@@ -7885,10 +7919,18 @@ map( xs:string,
                         <item>
                            <p>Otherwise, 
                               the selected layout is <code>simple</code> (see <specref ref="id-simple-layout"/>),
-                              and the selected type is <code>boolean</code> if <var>T</var> is derived from
-                              <code>xs:boolean</code>; <code>numeric</code> if <var>T</var> is derived from
-                              <code>xs:decimal</code>, <code>xs:double</code>, or <code>xs:float</code>;
-                              or <code>string</code> otherwise.</p>
+                              and the selected type is as follows (applying the rules in order):</p>
+                           <olist>
+                              <item><p><code>boolean</code> if <var>T</var> is derived from
+                                 <code>xs:boolean</code>;</p></item>
+                              <item><p><code>integer</code> if <var>T</var> is derived from
+                                 <code>xs:integer</code>;</p></item>
+                              <item><p><code>decimal</code> if <var>T</var> is derived from
+                                 <code>xs:decimal</code>;</p></item>
+                              <item><p><code>double</code> if <var>T</var> is derived from
+                                 <code>xs:float</code> or <code>xs:double</code>;</p></item>
+                              <item><p><code>xs:string</code> otherwise.</p></item>
+                           </olist>
                         </item>
                      </olist>
                   </item>
@@ -7932,7 +7974,7 @@ map( xs:string,
                                     <item><p>Otherwise the selected layout is <code>simple-plus</code> 
                                        (see <specref ref="id-simple-plus-layout"/>).</p></item>
                                     <item><p>In both cases the selected type is one of <code>boolean</code>
-                                    <code>numeric</code>, or <code>string</code>, chosen in the same way
+                                       <code>integer</code>, <code>decimal</code>, <code>double</code>, or <code>string</code>, chosen in the same way
                                     as for elements having a simple type.</p></item>
                                  </olist>
                               </item>
@@ -7981,10 +8023,9 @@ map( xs:string,
                   </item>
                </olist>
                
-               <p>For attribute nodes, the selected type is <code>boolean</code> if the type annotation is derived from
-                  <code>xs:boolean</code>; <code>numeric</code> if the type annotation is derived from
-                  <code>xs:decimal</code>, <code>xs:double</code>, or <code>xs:float</code>;
-                  and <code>string</code> otherwise.</p>
+               <p>For attribute nodes, the selected type is one of <code>boolean</code>
+                  <code>integer</code>, <code>decimal</code>, <code>double</code>, or <code>string</code>, chosen in the same way
+                  as for elements having a simple type.</p>
                
                
             </div3>
@@ -8077,22 +8118,28 @@ map( xs:string,
             <div3 id="element-and-attribute-content">
                <head>Element and Attribute Content</head>
                <p>The conversion plan may indicate that element content is to be output
-               as type <code>string</code>, <code>numeric</code>, or <code>boolean</code>: the default
+                  as type <code>string</code>, <code>integer</code>, <code>decimal</code>, 
+                  <code>double</code>, or <code>boolean</code>: the default
                is <code>string</code>. In the case of untyped elements and attributes, the value is
                output as an instance of a string, numeric, or boolean type, according to this
-               prescription. Specifically:</p>
+               prescription. Specifically (applying the rules in order):</p>
                
                <ulist>
                   <item><p>If the prescribed type is <code>boolean</code> and the value is castable
-                  as <code>xs:boolean</code>, then it is output as an instance of <code>xs:boolean</code>.</p></item>
-                  <item><p>If the prescribed type is <code>numeric</code> and the value is castable
-                  as <code>xs:numeric</code>, then it is output as an instance of <code>xs:integer</code>,
-                  <code>xs:decimal</code>, or <code>xs:double</code> depending on the lexical form of the
-                  value, following the same rules as for XPath numeric literals. For example, <code>"-1"</code>
-                  becomes an <code>xs:integer</code>, <code>12.00</code> becomes an <code>xs:decimal</code>,
-                  and <code>1e-3</code> becomes an <code>xs:double</code>. The special <code>xs:double</code>
-                  values <code>NaN</code> and <code>INF</code> (which cannot be used as numeric literals)
-                  are also recognized.</p></item>
+                  as <code>xs:boolean</code>, then it is output as the <code>xs:boolean</code> value 
+                     <code>true</code> or <code>false</code>.</p></item>
+                  
+                  <item><p>If the prescribed type is <code>integer</code> and the value is castable
+                  as <code>xs:integer</code>, then it is output as an instance of <code>xs:integer</code>.</p>
+                  <note><p>Casting to <code>xs:integer</code> may lose precision.</p></note></item>
+                  
+                  <item><p>If the prescribed type is <code>decimal</code> and the value is castable
+                     as <code>xs:decimal</code>, then it is output as an instance of <code>xs:decimal</code>.</p>
+                  <note><p>This does not rule out using a subtype of <code>xs:decimal</code> if appropriate.</p></note></item>
+                  
+                  <item><p>If the prescribed type is <code>double</code> and the value is castable
+                     as <code>xs:double</code>, then it is output as an instance of <code>xs:double</code>.</p></item>
+                  
                   <item><p>In all other cases the value is output as an instance of <code>xs:untypedAtomic</code>,
                      retaining its original lexical form.</p></item>
                </ulist>
@@ -8192,15 +8239,15 @@ map( xs:string,
                      <tr>
                         <td><eg><![CDATA[<a x='1' b='2'/>]]></eg></td>
                         <td><eg><![CDATA[{ "a":{
-    "@x": "1",
-    "@b": "2"
+    "@x": 1,
+    "@b": 2
   } }]]></eg></td>
                      </tr>
                      <tr>
                         <td><eg><![CDATA[<a><x>1</x><y>2</y></a>]]></eg></td>
                         <td><eg><![CDATA[{ "a":{
-    "x": "1",
-    "y": "2"
+    "x": 1,
+    "y": 2
   } }]]></eg></td>
                      </tr>
                      <tr>
@@ -8211,10 +8258,10 @@ map( xs:string,
    <point x='1' y='0'/>
 </polygon>]]></eg></td>
                         <td><eg><![CDATA[{ "polygon":[
-       {"@x": "0", "@y": "0"},
-       {"@x": "0", "@y": "1"},
-       {"@x": "1", "@y": "1"},
-       {"@x": "1", "@y": "0"}
+       {"@x": 0, "@y": 0},
+       {"@x": 0, "@y": 1},
+       {"@x": 1, "@y": 1},
+       {"@x": 1, "@y": 0}
   ] ] }]]></eg></td>
                      </tr>
                      <tr>
@@ -8236,17 +8283,17 @@ map( xs:string,
     {
       "@id": "LDN",
       "name": "London",
-      "size": "18.2"
+      "size": 18.2
     },
     {
       "@id": "PRS",
       "name": "Paris",
-      "size": "19.1"
+      "size": 19.1
     },
     {
       "@id": "BLN",
       "name": "Berlin",
-      "size": "14.6"
+      "size": 14.6
     }
   ] }]]></eg></td>
                      </tr>


### PR DESCRIPTION
Fix #1949 

Refines the rules for inferring boolean and numeric data types.