### PR TITLE
Reserved constructor names should include `trace`

### DIFF
--- a/specifications/xquery-40/src/ebnf.xml
+++ b/specifications/xquery-40/src/ebnf.xml
@@ -251,7 +251,7 @@
           <code>intersect</code> <code>is</code> <code>is-not</code> <code>le</code> <code>let</code> <code>lt</code> 
           <code>mod</code> <code>ne</code> <code>or</code> <code>otherwise</code> 
           <code>precedes</code> <code>precedes-or-is</code>
-          <code>return</code> <code>satisfies</code> <code>to</code> <code>union</code> 
+          <code>return</code> <code>satisfies</code> <code>to</code> <code>trace</code> <code>union</code> 
           <code>where</code> <code>while</code>
         </p>
           


### PR DESCRIPTION
The recent addition of the `TraceClause` in #2676 caused LALR(2) parser generation to fail (see [GitHub action log](https://github.com/GuntherRademacher/rex-parser-generator/actions/runs/27646655764/job/81760101582)). This is fixed here by adding `trace` to the list of reserved keywords for constraint [unreserved-name](https://qt4cg.org/specifications/xquery-40/xquery-40.html#parse-note-unreserved-name).