### PR TITLE
2641 Support comments in csv

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -28863,13 +28863,12 @@ element-to-map-plan((<a><b/><b/></a>, <a><b/><c/></a>))
 
          <p>If <code>$value</code> is the empty sequence, the function returns the empty sequence.</p>
 
-         <p>The input supplied in <code>$value</code> is CSV data, as defined
-            in <bibref ref="rfc4180"/>. The function
-            first parses the input using <function>fn:csv-to-arrays</function>, and then
-            further processes the result. The initial parsing is exactly as defined for
-            <function>fn:csv-to-arrays</function>, and can be controlled using the same options.
-            Additional options are available to control the way in which header information and
-            column names are handled.</p>
+        <p>The input supplied in <code>$value</code> is CSV data, as defined in <bibref
+            ref="rfc4180"/>, extended to permit comments. The function first parses the input
+          using <function>fn:csv-to-arrays</function>, and then further processes the result. The
+          initial parsing is exactly as defined for <function>fn:csv-to-arrays</function>, and can
+          be controlled using the same options. Additional options are available to control the
+          way in which header information and column names are handled.</p>
 
          <p>If the input is the a zero-length string, the function
                returns a <code>parsed-csv-structure-record</code> whose 
@@ -28966,6 +28965,20 @@ element-to-map-plan((<a><b/><b/></a>, <a><b/><c/></a>))
                   </fos:value>
                </fos:values>
             </fos:option>
+         <fos:option key="comment-character">
+               <fos:meaning>The character used to indicate that the remainder of a row, up to a row
+                  delimiter (or end of input, if that occurs first) should not be parsed. An instance 
+                  of <code>xs:string</code> whose length is zero or one. If the option is absent or empty, 
+                  no comments are recognized. If the character immediately following a row delimiter is a 
+                  comment character, then all characters up to and including the following row delimiter 
+                  (or the end of input if that occurs first) are ignored. The comment character is not 
+                  recognized (that is, is treated as a regular textual character) if it occurs (following 
+                  a row delimiter) within a quoted field. A file that consists entirely of comments is 
+                  treated as if it consisted entirely of empty rows separated by row delimiters.</fos:meaning>
+               <!-- Description based on https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html -->
+               <fos:type>xs:string</fos:type>
+               <fos:default>()</fos:default>
+            </fos:option>
          </fos:options>
 
          <p>The result of the function is a <code>parsed-csv-structure-record</code>, as
@@ -28978,12 +28991,13 @@ element-to-map-plan((<a><b/><b/></a>, <a><b/><c/></a>))
          <p>A dynamic error <errorref class="CV" code="0001"/> occurs if the value of
             <code>$csv</code> does not conform to the required grammar.</p>
          <p>A dynamic error <errorref class="CV" code="0002"/> occurs if any of the
-            options <code>field-delimiter</code>, <code>row-delimiter</code>, or <code>quote-character</code>
+            options <code>field-delimiter</code>, <code>row-delimiter</code>,
+               <code>quote-character</code>, or <code>comment-character</code>
             is not a single character.</p>
          <p>A dynamic error <errorref class="CV" code="0003"/> occurs if the same character is used
             for more than one of the options
-            <code>field-delimiter</code>, <code>row-delimiter</code>, and
-            <code>quote-character</code>.</p>
+            <code>field-delimiter</code>, <code>row-delimiter</code>, <code>quote-character</code>, and
+               <code>comment-character</code>.</p>
 
       </fos:errors>
       <fos:notes>
@@ -29221,9 +29235,30 @@ return (
 "11.99"</eg></fos:result>
             </fos:test>
          </fos:example>
+      <fos:example>
+            <p>Specifying a comment character (<code>"#"</code>)</p>
+            <fos:test use="csv-display">
+               <fos:expression><eg>let $input := string-join((
+  "name, city", "Bob, Berlin # Berlin,
+  OH, US not Berlin, Germany", "# Comment line; ignore",
+  "Alice, Aachen"
+), char('\n')),
+let $options := { "trim-whitespace": true(),"comment-character": "#" }
+let $result := parse-csv($input, $options)
+return ($result => $display())</eg></fos:expression>
+               <fos:result><eg>{ 
+   "columns": ("name", "city"),
+   "column-index": { "name": 1, "city": 2 },
+   "rows": (
+      [ "Bob", "Berlin" ], 
+      [ "Alice", "Aachen" ]
+   )
+}</eg></fos:result>
+            </fos:test>
+         </fos:example>
       </fos:examples>
       <fos:changes>
-         <fos:change PR="533 719 834 1066" issue="413 1052" date="2024-03-19"><p>New in 4.0</p></fos:change>
+         <fos:change PR="533 719 834 1066" issue="413 1052 2641" date="2024-06-19"><p>New in 4.0</p></fos:change>
       </fos:changes>
    </fos:function>
 
@@ -29329,6 +29364,20 @@ return (
                   </fos:value>
                </fos:values>
             </fos:option>
+            <fos:option key="comment-character">
+               <fos:meaning>The character used to indicate that the remainder of a row, up to a row
+                  delimiter (or end of input, if that occurs first) should not be parsed. An instance 
+                  of <code>xs:string</code> whose length is zero or one. If the option is absent or empty, 
+                  no comments are recognized. If the character immediately following a row delimiter is a 
+                  comment character, then all characters up to and including the following row delimiter 
+                  (or the end of input if that occurs first) are ignored. The comment character is not 
+                  recognized (that is, is treated as a regular textual character) if it occurs (following 
+                  a row delimiter) within a quoted field. A file that consists entirely of comments is 
+                  treated as if it consisted entirely of empty rows separated by row delimiters.</fos:meaning>
+               <!-- Description based on https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html -->
+               <fos:type>xs:string</fos:type>
+               <fos:default>()</fos:default>
+            </fos:option>
             <!--<fos:option key="normalize-newlines">
                <fos:meaning>Determines whether CR and CRLF character sequences
                   are treated as equivalent to NL characters.</fos:meaning>
@@ -29352,9 +29401,10 @@ return (
          a row delimiter, or the start of <code>$value</code>; or when a row delimiter or the
          end of <code>$value</code> immediately follows a field delimiter.</p>
          
-         <p>A blank row is represented as the empty array (not as an
-            array containing a single empty field). A blank row is deemed to exist when a
-            row delimiter immediately follows either another row delimiter or the start of <code>$value</code>,
+         <p>A blank row is represented as the empty array (not as an array containing a single empty
+            field). A blank row is deemed to exist when a row begins with a specified
+            <code>comment-character</code> or when row delimiter immediately follows either
+            another row delimiter or the start of <code>$value</code>,
          after trimming of whitespace if the <code>trim-whitespace</code> option is <code>true</code>.
          No blank row occurs after the final row delimiter.</p>
          
@@ -29375,8 +29425,8 @@ return (
             <code>quote-character</code> option is not a single character.</p>
          <p>A dynamic error <errorref class="CV" code="0003"/> occurs if the same character
             is used for more than one of the
-            <code>field-delimiter</code>, <code>row-delimiter</code>, and
-            <code>quote-character</code>.</p>
+            <code>field-delimiter</code>, <code>row-delimiter</code>,
+            <code>quote-character</code>, and <code>comment-character</code>.</p>
       </fos:errors>
       <fos:notes>
          <p>The default row delimiter is a single newline character <char>U+000A</char>. 
@@ -29516,9 +29566,29 @@ return csv-to-arrays(
 [ "Alice", "Aachen" ]</eg></fos:result>
             </fos:test>
          </fos:example>
-      </fos:examples>
+         <fos:example>
+               <p>Specified comment character:</p>
+               <fos:test use="escaped-crlf-3">
+                  <fos:expression><eg>csv-to-arrays(
+   string-join(
+      (
+         "name, city", 
+         "Bob, Berlin # Berlin, OH, US not Berlin, Germany", 
+         "# Comment line; ignore", 
+         "Alice, Aachen"
+      ), 
+      char('\n')
+   ), 
+   { "trim-whitespace": true(),"comment-character": "#" }
+)</eg></fos:expression>
+                  <fos:result><eg>[ "name", "city" ],
+[ "Bob", "Berlin"]
+[ "Alice", "Aachen"]</eg></fos:result>
+               </fos:test>
+            </fos:example>
+         </fos:examples>
       <fos:changes>
-         <fos:change PR="533 719 834 1066" issue="413 1052" date="2023-07-25"><p>New in 4.0</p></fos:change>
+         <fos:change PR="533 719 834 1066" issue="413 1052 2641" date="2026-06-19"><p>New in 4.0</p></fos:change>
       </fos:changes>
    </fos:function>
 


### PR DESCRIPTION
Modified `parse-csv()` and `csv-to-arrays()` to add support for comments.