### PR TITLE
1962 fn:map-to-element

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -29061,7 +29061,7 @@ element-to-map-plan((<a><b/><b/></a>, <a><b/><c/></a>))
       <fos:see-also prefix="fn" name="element-to-map"/>
       <fos:see-also prefix="fn" name="element-to-map-plan"/>
       <fos:changes>
-         <fos:change issue="1692" PR="" date="2026-06-24"><p>New in 4.0.</p></fos:change>
+         <fos:change issue="1962" PR="2707" date="2026-06-24"><p>New in 4.0.</p></fos:change>
       </fos:changes>
    </fos:function>
 

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -28968,6 +28968,103 @@ element-to-map-plan((<a><b/><b/></a>, <a><b/><c/></a>))
       </fos:changes>
    </fos:function>
 
+   <fos:function name="map-to-element" prefix="fn">
+      <fos:signatures>
+         <fos:proto name="map-to-element" return-type="element()?">
+            <fos:arg name="map" type="map(*)?" usage="inspection"/>
+            <fos:arg name="options" type="map(*)?" usage="inspection" default="{}" note="default-on-empty"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:summary>
+         <p>Converts a map into an element node.</p>
+      </fos:summary>
+      <fos:rules>
+         <p>This function performs the inverse of <function>element-to-map</function>:
+            it reconstructs an element node from the <termref def="dt-single-entry-map"/>
+            supplied in <code>$map</code>. The key of the entry represents the element name,
+            and the value of the entry represents the element’s attributes and children.</p>
+
+         <p>If <code>$map</code> is the empty sequence, the result is the empty sequence.</p>
+
+         <p>Because <function>element-to-map</function> does not preserve all information present
+            in its input (see <specref ref="id-loss-of-xdm-information"/>), the reconstruction is
+            exact only up to that loss of information, and generally only when the same
+            <code>$options</code> are supplied as were used for the forward conversion.</p>
+
+         <p>The entries that may appear in the <code>$options</code> map are the same as for
+            <function>element-to-map</function> but are interpreted in the reverse direction.</p>
+
+         <p>The rules for converting a map to an element are described in
+            <specref ref="id-converting-maps-to-elements"/>; the rules for selecting a layout from
+            the conversion plan are the inverse of those in <specref ref="id-selecting-element-layout"/>.</p>
+      </fos:rules>
+      <fos:errors>
+         <p>A dynamic error <errorref class="JS" code="0009"/> occurs if <code>$map</code>
+            is not a single-entry map, if a map key or the <code>#processing-instruction</code>
+            structure does not have the form required by the selected layout, if a reconstructed
+            element or attribute name is not a valid <code>xs:QName</code>, or if <code>list</code>
+            layout is selected for an array but the conversion plan supplies no <code>child</code>
+            element name.</p>
+         <p>Any error in the conversion plan is treated as a type error <xerrorref
+               spec="XP" class="TY" code="0004"/>, as for <function>element-to-map</function>.</p>
+      </fos:errors>
+      <fos:examples>
+         <fos:example>
+            <fos:test>
+               <fos:expression>map-to-element(())</fos:expression>
+               <fos:result>()</fos:result>
+            </fos:test>
+            <fos:test spec="XQuery">
+               <fos:expression><![CDATA[map-to-element({ "foo": "bar" })]]></fos:expression>
+               <fos:result><![CDATA[<foo>bar</foo>]]></fos:result>
+            </fos:test>
+            <fos:test spec="XQuery">
+               <fos:expression><eg><![CDATA[map-to-element(
+  { "price": { "@currency": "USD", "#content": 12.16 } }
+)]]></eg></fos:expression>
+               <fos:result><eg><![CDATA[<price currency="USD">12.16</price>]]></eg></fos:result>
+            </fos:test>
+            <fos:test spec="XQuery">
+               <fos:expression><eg><![CDATA[map-to-element({ "name": {
+  "first": "Jane",
+  "middle": [ "Elizabeth", "Mary" ],
+  "last": "Smith"
+} })]]></eg></fos:expression>
+               <fos:result><eg><![CDATA[
+<name>
+  <first>Jane</first>
+  <middle>Elizabeth</middle>
+  <middle>Mary</middle>
+  <last>Smith</last>
+</name>]]></eg></fos:result>
+            </fos:test>
+            <fos:test spec="XQuery">
+               <fos:expression><eg><![CDATA[map-to-element(
+  { "years": [ "2023", "2023" ] },
+  { "plan": { "dates": { "layout": "list", "child": "year" } } }
+)]]></eg></fos:expression>
+               <fos:result><eg><![CDATA[<years><year>2023</year><year>2023</year></years>]]></eg></fos:result>
+            </fos:test>
+            <fos:test spec="XQuery">
+               <fos:expression><eg><![CDATA[map-to-element(
+  { "para": [ { "@id": "x" }, "A ", { "i": "fine" }, " mess!" ] }
+)]]></eg></fos:expression>
+               <fos:result><eg><![CDATA[<para id="x">A <i>fine</i> mess!</para>]]></eg></fos:result>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
+      <fos:see-also prefix="fn" name="element-to-map"/>
+      <fos:see-also prefix="fn" name="element-to-map-plan"/>
+      <fos:changes>
+         <fos:change issue="1692" PR="" date="2026-06-24"><p>New in 4.0.</p></fos:change>
+      </fos:changes>
+   </fos:function>
+
    <fos:function name="parse-csv" prefix="fn">
       <fos:signatures>
          <fos:proto name="parse-csv" return-type-ref="parsed-csv-structure-record" return-type-ref-occurs="?">

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -29102,7 +29102,7 @@ element-to-map-plan((<a><b/><b/></a>, <a><b/><c/></a>))
       <fos:see-also prefix="fn" name="element-to-map"/>
       <fos:see-also prefix="fn" name="element-to-map-plan"/>
       <fos:changes>
-         <fos:change issue="1692" PR="" date="2026-06-24"><p>New in 4.0.</p></fos:change>
+         <fos:change issue="1962" PR="2707" date="2026-06-24"><p>New in 4.0.</p></fos:change>
       </fos:changes>
    </fos:function>
 

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -29009,6 +29009,103 @@ element-to-map-plan((<a><b/><b/></a>, <a><b/><c/></a>))
       </fos:changes>
    </fos:function>
 
+   <fos:function name="map-to-element" prefix="fn">
+      <fos:signatures>
+         <fos:proto name="map-to-element" return-type="element()?">
+            <fos:arg name="map" type="map(*)?" usage="inspection"/>
+            <fos:arg name="options" type="map(*)?" usage="inspection" default="{}" note="default-on-empty"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:summary>
+         <p>Converts a map into an element node.</p>
+      </fos:summary>
+      <fos:rules>
+         <p>This function performs the inverse of <function>element-to-map</function>:
+            it reconstructs an element node from the <termref def="dt-single-entry-map"/>
+            supplied in <code>$map</code>. The key of the entry represents the element name,
+            and the value of the entry represents the element’s attributes and children.</p>
+
+         <p>If <code>$map</code> is the empty sequence, the result is the empty sequence.</p>
+
+         <p>Because <function>element-to-map</function> does not preserve all information present
+            in its input (see <specref ref="id-loss-of-xdm-information"/>), the reconstruction is
+            exact only up to that loss of information, and generally only when the same
+            <code>$options</code> are supplied as were used for the forward conversion.</p>
+
+         <p>The entries that may appear in the <code>$options</code> map are the same as for
+            <function>element-to-map</function> but are interpreted in the reverse direction.</p>
+
+         <p>The rules for converting a map to an element are described in
+            <specref ref="id-converting-maps-to-elements"/>; the rules for selecting a layout from
+            the conversion plan are the inverse of those in <specref ref="id-selecting-element-layout"/>.</p>
+      </fos:rules>
+      <fos:errors>
+         <p>A dynamic error <errorref class="JS" code="0009"/> occurs if <code>$map</code>
+            is not a single-entry map, if a map key or the <code>#processing-instruction</code>
+            structure does not have the form required by the selected layout, if a reconstructed
+            element or attribute name is not a valid <code>xs:QName</code>, or if <code>list</code>
+            layout is selected for an array but the conversion plan supplies no <code>child</code>
+            element name.</p>
+         <p>Any error in the conversion plan is treated as a type error <xerrorref
+               spec="XP" class="TY" code="0004"/>, as for <function>element-to-map</function>.</p>
+      </fos:errors>
+      <fos:examples>
+         <fos:example>
+            <fos:test>
+               <fos:expression>map-to-element(())</fos:expression>
+               <fos:result>()</fos:result>
+            </fos:test>
+            <fos:test spec="XQuery">
+               <fos:expression><![CDATA[map-to-element({ "foo": "bar" })]]></fos:expression>
+               <fos:result><![CDATA[<foo>bar</foo>]]></fos:result>
+            </fos:test>
+            <fos:test spec="XQuery">
+               <fos:expression><eg><![CDATA[map-to-element(
+  { "price": { "@currency": "USD", "#content": 12.16 } }
+)]]></eg></fos:expression>
+               <fos:result><eg><![CDATA[<price currency="USD">12.16</price>]]></eg></fos:result>
+            </fos:test>
+            <fos:test spec="XQuery">
+               <fos:expression><eg><![CDATA[map-to-element({ "name": {
+  "first": "Jane",
+  "middle": [ "Elizabeth", "Mary" ],
+  "last": "Smith"
+} })]]></eg></fos:expression>
+               <fos:result><eg><![CDATA[
+<name>
+  <first>Jane</first>
+  <middle>Elizabeth</middle>
+  <middle>Mary</middle>
+  <last>Smith</last>
+</name>]]></eg></fos:result>
+            </fos:test>
+            <fos:test spec="XQuery">
+               <fos:expression><eg><![CDATA[map-to-element(
+  { "years": [ "2023", "2023" ] },
+  { "plan": { "dates": { "layout": "list", "child": "year" } } }
+)]]></eg></fos:expression>
+               <fos:result><eg><![CDATA[<years><year>2023</year><year>2023</year></years>]]></eg></fos:result>
+            </fos:test>
+            <fos:test spec="XQuery">
+               <fos:expression><eg><![CDATA[map-to-element(
+  { "para": [ { "@id": "x" }, "A ", { "i": "fine" }, " mess!" ] }
+)]]></eg></fos:expression>
+               <fos:result><eg><![CDATA[<para id="x">A <i>fine</i> mess!</para>]]></eg></fos:result>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
+      <fos:see-also prefix="fn" name="element-to-map"/>
+      <fos:see-also prefix="fn" name="element-to-map-plan"/>
+      <fos:changes>
+         <fos:change issue="1692" PR="" date="2026-06-24"><p>New in 4.0.</p></fos:change>
+      </fos:changes>
+   </fos:function>
+
    <fos:function name="parse-csv" prefix="fn">
       <fos:signatures>
          <fos:proto name="parse-csv" return-type-ref="parsed-csv-structure-record" return-type-ref-occurs="?">

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -8452,6 +8452,14 @@ map( xs:string,
       and <code>name-format</code> options that were used for the forward conversion is generally
       necessary to achieve this round trip.</p>
 
+   <note><p>This function is not intended as a general-purpose converter from arbitrary JSON to
+      XML. It expects the specific structure produced by <function>fn:element-to-map</function>
+      (a single-entry map, attribute keys prefixed with the <code>attribute-marker</code>, arrays
+      of like-named children, and so on), and it raises <errorref class="JS" code="0009"/> for
+      input that does not follow those conventions. To construct XML from arbitrary JSON, use
+      <function>fn:json-to-xml</function>, or <function>fn:parse-json</function> together with a
+      bespoke transformation.</p></note>
+
    <p>The same <code>$options</code> entries as for <function>fn:element-to-map</function> are
       recognized; they are interpreted in the reverse direction:</p>
 

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -8484,7 +8484,8 @@ map( xs:string,
    <p>If the supplied map is not a single-entry map, the function fails with a dynamic error
       <errorref class="JS" code="0009"/>. Otherwise the single entry is processed: its key is
       decoded into the element name, and its value is interpreted as the content of that element,
-      as follows.</p>
+      as follows. A key that does not decode to a valid, non-empty element or attribute name
+      causes the function to fail with <errorref class="JS" code="0009"/>.</p>
 
    <div4 id="id-map-to-element-value">
       <head>Interpreting a map value</head>
@@ -8529,7 +8530,9 @@ map( xs:string,
             a single-entry map with the key equal to <code>content-key</code> and value
             <code>#fn:null</code> indicates a nilled element; and any other single-entry map
             contributes a child element. The <code>sequence</code> and <code>mixed</code> layouts
-            are reconstructed identically.</p>
+            are reconstructed identically. If the array contains two consecutive atomic members and
+            the <code>plan</code> does not select a <code>list</code> layout, the function fails with
+            a dynamic error <errorref class="JS" code="0009"/>.</p>
             <p>If the <code>plan</code> selects <code>list</code> or <code>list-plus</code> layout
             for the element, the array members are instead interpreted as the content of children
             all having the <code>child</code> element name given in the plan. If <code>list</code>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -8467,6 +8467,14 @@ map( xs:string,
          the marker is removed to recover the attribute name.</p></item>
       <item><p>A map key equal to the <code>content-key</code> denotes simple element content
          (when its value is atomic) or, when its value is <code>#fn:null</code>, a nilled element.</p></item>
+      <item><p>If a key both begins with the <code>attribute-marker</code> and equals the
+         <code>content-key</code> or a reserved key (<code>#comment</code>,
+         <code>#processing-instruction</code>), the content or reserved interpretation takes
+         precedence over the attribute interpretation. As a consequence, an empty
+         <code>attribute-marker</code> leaves attributes and child elements indistinguishable, so
+         such a configuration does not round-trip; under <code>name-format</code>
+         <code>lexical</code> a prefixed name is recovered only if its prefix is bound in the
+         static context of the function call.</p></item>
       <item><p>The <code>name-format</code> governs how keys are decoded into names, as the
          inverse of <specref ref="element-and-attribute-names"/>. A key of the form
          <code>Q{uri}local</code> always yields a name in the namespace <code>uri</code>.
@@ -8544,6 +8552,12 @@ map( xs:string,
             containing serialized XML; it is parsed as an XML fragment and the resulting node is
             used as the element content.</p></item>
       </olist>
+
+      <p>In every case the result must be a well-formed element. The function fails with
+         <errorref class="JS" code="0009"/> if a value that contributes attribute, simple, or text
+         content is not a single atomic value, if simple content is combined with child elements, or
+         if a comment or processing instruction reconstructed from the map would not be well-formed
+         (for example, an invalid processing-instruction target).</p>
    </div4>
 </div3>
 

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -8427,14 +8427,134 @@ map( xs:string,
                   <code>&lt;ref name="x"/&gt;</code> could be transformed to <code>&lt;ref&gt;x&lt;/ref&gt;</code>.</p></note>
             </div3>
             
+<div3 id="id-converting-maps-to-elements">
+   <head>Converting maps to elements</head>
+   <changes>
+      <change issue="1962" PR="2707" date="2026-06-24">
+         A new function <function>fn:map-to-element</function> is provided for converting
+         a map produced by <function>fn:element-to-map</function> back to an XML element node.
+      </change>
+   </changes>
+
+   <p>The <function>fn:map-to-element</function> function performs the inverse of
+      <function>fn:element-to-map</function>: it reconstructs an element node from a
+      <termref def="dt-single-entry-map">single-entry map</termref> of the form produced
+      by that function. Because the forward conversion is not lossless (see
+      <specref ref="id-loss-of-xdm-information"/>), the inverse cannot recover all of the
+      original information. However, the function is designed so that for any element
+      <var>E</var> and options map <var>OPTS</var>,</p>
+
+   <eg><var>E</var> => element-to-map(<var>OPTS</var>) => map-to-element(<var>OPTS</var>)</eg>
+
+   <p>reconstructs an element that is <function>fn:deep-equal</function> to <var>E</var>,
+      except for the information identified as lost in <specref ref="id-loss-of-xdm-information"/>.
+      Supplying the same <code>plan</code>, <code>attribute-marker</code>, <code>content-key</code>,
+      and <code>name-format</code> options that were used for the forward conversion is generally
+      necessary to achieve this round trip.</p>
+
+   <p>The same <code>$options</code> entries as for <function>fn:element-to-map</function> are
+      recognized; they are interpreted in the reverse direction:</p>
+
+   <ulist>
+      <item><p>The <code>plan</code> determines, for each element name, the layout (and where
+         applicable the content <code>type</code> and the <code>child</code> element name) that
+         was used in the forward direction, and hence how the corresponding map value is to be
+         interpreted. The rules for selecting a layout are the inverse of those in
+         <specref ref="id-selecting-element-layout"/>. Entries with the layout
+         <code>deep-skip</code> are ignored; the layout <code>error</code> is not relevant
+         to this function.</p></item>
+      <item><p>A map key beginning with the <code>attribute-marker</code> denotes an attribute;
+         the marker is removed to recover the attribute name.</p></item>
+      <item><p>A map key equal to the <code>content-key</code> denotes simple element content
+         (when its value is atomic) or, when its value is <code>#fn:null</code>, a nilled element.</p></item>
+      <item><p>The <code>name-format</code> governs how keys are decoded into names, as the
+         inverse of <specref ref="element-and-attribute-names"/>. A key of the form
+         <code>Q{uri}local</code> always yields a name in the namespace <code>uri</code>.
+         When <code>name-format</code> is <code>default</code>, a key consisting of a local name
+         alone yields a name in no namespace if it is the top-level element, and otherwise a name
+         in the namespace of the parent element; this is the inverse of the rule that omits the
+         namespace for a child in the same namespace as its parent. Namespace prefixes are always
+         synthesized; under <code>name-format</code> <code>local</code> or <code>lexical</code>,
+         namespace URIs cannot be recovered.</p></item>
+   </ulist>
+
+   <p>In the absence of a <code>plan</code>, the layout is inferred from the structure of the
+      map value, as the inverse of the rules in <specref ref="id-creating-a-conversion-plan"/>.</p>
+
+   <p>If the supplied map is not a single-entry map, the function fails with a dynamic error
+      <errorref class="JS" code="0009"/>. Otherwise the single entry is processed: its key is
+      decoded into the element name, and its value is interpreted as the content of that element,
+      as follows.</p>
+
+   <div4 id="id-map-to-element-value">
+      <head>Interpreting a map value</head>
+
+      <p>A value <var>V</var> appearing as element content is interpreted according to its kind:</p>
+
+      <olist>
+         <item><p>If <var>V</var> is an atomic value, it contributes a single text-node child
+            whose string value is the lexical representation of <var>V</var>. (Numeric and boolean
+            values therefore lose their type and reappear as text, just as type annotations are
+            lost in the forward direction.) The zero-length string contributes no child, which is
+            the common inverse of the <code>empty</code> and <code>simple</code> layouts.</p></item>
+
+         <item><p>If <var>V</var> is the value <code>#fn:null</code>, the element is nilled: the
+            attribute <code>xsi:nil="true"</code> is added, together with a declaration of the
+            <code>xsi</code> namespace. This is the inverse of the "Mapping for nilled elements"
+            rules of every layout.</p></item>
+
+         <item><p>If <var>V</var> is a map, each entry contributes to the element as follows:</p>
+            <ulist>
+               <item><p>If the key begins with the <code>attribute-marker</code>, it contributes
+                  an attribute whose name is the decoded key and whose value is the lexical
+                  representation of the entry value.</p></item>
+               <item><p>If the key is equal to the <code>content-key</code>, it contributes simple
+                  text content (atomic value) or a nilled marker (value <code>#fn:null</code>).</p></item>
+               <item><p>Otherwise the key contributes one or more child elements named by the
+                  decoded key: an atomic or map value contributes a single child; an array value
+                  contributes one child per array member, each member being interpreted recursively
+                  as that child's content. This single rule is the common inverse of the
+                  <code>empty-plus</code>, <code>simple-plus</code>, <code>record</code>, and
+                  <code>list-plus</code> layouts.</p></item>
+            </ulist>
+         </item>
+
+         <item><p>If <var>V</var> is an array, its members contribute children (and attributes) in
+            order, as the inverse of the <code>sequence</code> and <code>mixed</code> layouts. A
+            member that is a string contributes a text node; a single-entry map whose key begins
+            with the <code>attribute-marker</code> contributes an attribute; a single-entry map
+            with the key <code>#comment</code> contributes a comment node; a single-entry map with
+            the key <code>#processing-instruction</code> (whose value is a map with keys
+            <code>#target</code> and <code>#data</code>) contributes a processing-instruction node;
+            a single-entry map with the key equal to <code>content-key</code> and value
+            <code>#fn:null</code> indicates a nilled element; and any other single-entry map
+            contributes a child element. The <code>sequence</code> and <code>mixed</code> layouts
+            are reconstructed identically.</p>
+            <p>If the <code>plan</code> selects <code>list</code> or <code>list-plus</code> layout
+            for the element, the array members are instead interpreted as the content of children
+            all having the <code>child</code> element name given in the plan. If <code>list</code>
+            layout applies but no <code>child</code> name is available (the element name is not
+            recoverable from the array alone), the function fails with a dynamic error
+            <errorref class="JS" code="0009"/>.</p></item>
+
+         <item><p>If the <code>plan</code> selects <code>xml</code> layout, <var>V</var> is a string
+            containing serialized XML; it is parsed as an XML fragment and the resulting node is
+            used as the element content.</p></item>
+      </olist>
+   </div4>
+</div3>
+
             <!--<?local-function-index?>-->
-            
+
             <div3 id="func-element-to-map-plan">
                <head><?function fn:element-to-map-plan?></head>
             </div3>
             
             <div3 id="func-element-to-map">
                <head><?function fn:element-to-map?></head>
+            </div3>
+            <div3 id="func-map-to-element">
+               <head><?function fn:map-to-element?></head>
             </div3>
          </div2>
          
@@ -14611,6 +14731,16 @@ ISBN 0 521 77752 6.</bibl>
                   elements of a given name is unsuitable for an element node with that name, or
                   if the conversion plan explicitly defines the processing of a particular
                element as an error.</p>
+            </error>
+
+            <error class="JS" code="0009" label="Cannot convert map to element." type="dynamic">
+               <p>Raised by <function>fn:map-to-element</function> if the supplied map cannot be
+                  converted to an element node. This includes the cases where the map is not a
+                  single-entry map; where a map key or the <code>#processing-instruction</code>
+                  structure does not have the form required by the selected layout; where a
+                  reconstructed element or attribute name is not a valid <code>xs:QName</code>;
+                  or where <code>list</code> layout is selected for an array but the conversion
+                  plan supplies no <code>child</code> element name.</p>
             </error>
             
 

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -8471,7 +8471,7 @@ map( xs:string,
       <item><p>The <code>plan</code> determines, for each element name, the layout (and where
          applicable the content <code>type</code> and the <code>child</code> element name) that
          was used in the forward direction, and hence how the corresponding map value is to be
-         interpreted. The rules for selecting a layout are the inverse of those in
+         interpreted. Each layout is read directly from the <code>plan</code> entry, as recorded by
          <specref ref="id-selecting-element-layout"/>. Entries with the layout
          <code>deep-skip</code> are ignored; the layout <code>error</code> is not relevant
          to this function.</p></item>
@@ -8483,10 +8483,11 @@ map( xs:string,
          <code>content-key</code>, the content interpretation takes precedence over the attribute
          interpretation. (Within an array, the reserved keys <code>#comment</code> and
          <code>#processing-instruction</code> are likewise recognized in preference to an attribute
-         interpretation; they have no special meaning as the key of a child map.) As a consequence,
-         an empty
-         <code>attribute-marker</code> leaves attributes and child elements indistinguishable, so
-         such a configuration does not round-trip; under <code>name-format</code>
+         interpretation; they have no special meaning as the key of a child map.) Attributes
+         round-trip as attributes only if the <code>attribute-marker</code> is distinctive, that is,
+         if no genuine child-element key begins with it. An empty
+         <code>attribute-marker</code> leaves attributes and child elements
+         indistinguishable, so such a configuration does not round-trip; under <code>name-format</code>
          <code>lexical</code> a prefixed name is recovered only if its prefix is bound in the
          static context of the function call.</p></item>
       <item><p>The <code>name-format</code> governs how keys are decoded into names, as the
@@ -8502,8 +8503,10 @@ map( xs:string,
          namespace URIs cannot be recovered.</p></item>
    </ulist>
 
-   <p>In the absence of a <code>plan</code>, the layout is inferred from the structure of the
-      map value, as the inverse of the rules in <specref ref="id-creating-a-conversion-plan"/>.</p>
+   <p>In the absence of a <code>plan</code>, the value is interpreted directly from its structure,
+      by the rules in <specref ref="id-map-to-element-value"/>. A <code>plan</code> is consulted only
+      where the structure alone is ambiguous: to supply the <code>child</code> element name for
+      <code>list</code> layout, and to request <code>xml</code>-layout parsing.</p>
 
    <p>If the supplied map is not a single-entry map, the function fails with a dynamic error
       <errorref class="JS" code="0009"/>. Otherwise the single entry is processed: its key is
@@ -8514,7 +8517,8 @@ map( xs:string,
    <div4 id="id-map-to-element-value">
       <head>Interpreting a map value</head>
 
-      <p>A value <var>V</var> appearing as element content is interpreted according to its kind:</p>
+      <p>A map value <var>V</var> is interpreted according to its kind, contributing to the
+         element's content:</p>
 
       <olist>
          <item><p>If <var>V</var> is an atomic value, it contributes a single text-node child

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -8450,7 +8450,11 @@ map( xs:string,
       except for the information identified as lost in <specref ref="id-loss-of-xdm-information"/>.
       Supplying the same <code>plan</code>, <code>attribute-marker</code>, <code>content-key</code>,
       and <code>name-format</code> options that were used for the forward conversion is generally
-      necessary to achieve this round trip.</p>
+      necessary to achieve this round trip. In particular, <code>list</code> layout (requested
+      explicitly, or selected automatically when an element's children all share a name) does not
+      preserve the child element names; reconstructing them requires an explicit <code>plan</code>
+      supplying the <code>child</code> name, failing which the function raises
+      <errorref class="JS" code="0009"/>.</p>
 
    <note><p>This function is not intended as a general-purpose converter from arbitrary JSON to
       XML. It expects the specific structure produced by <function>fn:element-to-map</function>
@@ -8476,9 +8480,11 @@ map( xs:string,
       <item><p>A map key equal to the <code>content-key</code> denotes simple element content
          (when its value is atomic) or, when its value is <code>#fn:null</code>, a nilled element.</p></item>
       <item><p>If a key both begins with the <code>attribute-marker</code> and equals the
-         <code>content-key</code> or a reserved key (<code>#comment</code>,
-         <code>#processing-instruction</code>), the content or reserved interpretation takes
-         precedence over the attribute interpretation. As a consequence, an empty
+         <code>content-key</code>, the content interpretation takes precedence over the attribute
+         interpretation. (Within an array, the reserved keys <code>#comment</code> and
+         <code>#processing-instruction</code> are likewise recognized in preference to an attribute
+         interpretation; they have no special meaning as the key of a child map.) As a consequence,
+         an empty
          <code>attribute-marker</code> leaves attributes and child elements indistinguishable, so
          such a configuration does not round-trip; under <code>name-format</code>
          <code>lexical</code> a prefixed name is recovered only if its prefix is bound in the
@@ -8489,8 +8495,10 @@ map( xs:string,
          When <code>name-format</code> is <code>default</code>, a key consisting of a local name
          alone yields a name in no namespace if it is the top-level element, and otherwise a name
          in the namespace of the parent element; this is the inverse of the rule that omits the
-         namespace for a child in the same namespace as its parent. Namespace prefixes are always
-         synthesized; under <code>name-format</code> <code>local</code> or <code>lexical</code>,
+         namespace for a child in the same namespace as its parent. When <code>name-format</code>
+         is <code>eqname</code>, a key consisting of a local name alone always yields a name in no
+         namespace, since names in a namespace are invariably encoded as <code>Q{uri}local</code>.
+         Namespace prefixes are always synthesized; under <code>name-format</code> <code>local</code> or <code>lexical</code>,
          namespace URIs cannot be recovered.</p></item>
    </ulist>
 

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -8164,6 +8164,11 @@ map( xs:string,
                then the element <code><![CDATA[<data x:val="3" y:val="4"/>]]></code> becomes either
                <code>{ "data": { "@val": ["3", "4"] } }</code> or (because attribute order is unpredictable)
                <code>{ "data": { "@val": ["4", "3"] } }</code>.</p>
+
+               <p>Where both rules apply, the <code>attribute-marker</code> rule is applied first: a conflict
+               between the names of attributes and child elements reverts the marker to <code>"@"</code>,
+               decided separately for each element. This preserves the round trip; entries that are combined
+               into an array, by contrast, cannot be reconverted by <function>fn:map-to-element</function>.</p>
                
                
                
@@ -8439,9 +8444,7 @@ map( xs:string,
    <p>The <function>fn:map-to-element</function> function performs the inverse of
       <function>fn:element-to-map</function>: it reconstructs an element node from a
       <termref def="dt-single-entry-map">single-entry map</termref> of the form produced
-      by that function. Because the forward conversion is not lossless (see
-      <specref ref="id-loss-of-xdm-information"/>), the inverse cannot recover all of the
-      original information. However, the function is designed so that for any element
+      by that function. The function is designed so that for any element
       <var>E</var> and options map <var>OPTS</var>,</p>
 
    <eg><var>E</var> => element-to-map(<var>OPTS</var>) => map-to-element(<var>OPTS</var>)</eg>
@@ -8451,7 +8454,7 @@ map( xs:string,
       Supplying the same <code>plan</code>, <code>attribute-marker</code>, <code>content-key</code>,
       and <code>name-format</code> options that were used for the forward conversion is generally
       necessary to achieve this round trip. In particular, <code>list</code> layout (requested
-      explicitly, or selected automatically when an element's children all share a name) does not
+      explicitly, or selected automatically when an element’s children all share a name) does not
       preserve the child element names; reconstructing them requires an explicit <code>plan</code>
       supplying the <code>child</code> name, failing which the function raises
       <errorref class="JS" code="0009"/>.</p>
@@ -8471,10 +8474,9 @@ map( xs:string,
       <item><p>The <code>plan</code> determines, for each element name, the layout (and where
          applicable the content <code>type</code> and the <code>child</code> element name) that
          was used in the forward direction, and hence how the corresponding map value is to be
-         interpreted. Each layout is read directly from the <code>plan</code> entry, as recorded by
-         <specref ref="id-selecting-element-layout"/>. Entries with the layout
-         <code>deep-skip</code> are ignored; the layout <code>error</code> is not relevant
-         to this function.</p></item>
+         interpreted. Layouts are those recorded by <specref ref="id-selecting-element-layout"/>.
+         Entries with the layout <code>deep-skip</code> are ignored; the layout <code>error</code>
+         is not relevant to this function.</p></item>
       <item><p>A map key beginning with the <code>attribute-marker</code> denotes an attribute;
          the marker is removed to recover the attribute name.</p></item>
       <item><p>A map key equal to the <code>content-key</code> denotes simple element content
@@ -8506,7 +8508,8 @@ map( xs:string,
    <p>In the absence of a <code>plan</code>, the value is interpreted directly from its structure,
       by the rules in <specref ref="id-map-to-element-value"/>. A <code>plan</code> is consulted only
       where the structure alone is ambiguous: to supply the <code>child</code> element name for
-      <code>list</code> layout, and to request <code>xml</code>-layout parsing.</p>
+      <code>list</code> layout, wherever the array appears; and to request <code>xml</code>-layout
+      parsing.</p>
 
    <p>If the supplied map is not a single-entry map, the function fails with a dynamic error
       <errorref class="JS" code="0009"/>. Otherwise the single entry is processed: its key is
@@ -8518,7 +8521,7 @@ map( xs:string,
       <head>Interpreting a map value</head>
 
       <p>A map value <var>V</var> is interpreted according to its kind, contributing to the
-         element's content:</p>
+         element’s content:</p>
 
       <olist>
          <item><p>If <var>V</var> is an atomic value, it contributes a single text-node child
@@ -8542,7 +8545,10 @@ map( xs:string,
                <item><p>Otherwise the key contributes one or more child elements named by the
                   decoded key: an atomic or map value contributes a single child; an array value
                   contributes one child per array member, each member being interpreted recursively
-                  as that child's content. This single rule is the common inverse of the
+                  as that child’s content. If, however, the <code>plan</code> assigns
+                  <code>list</code> layout to the decoded key, the array is the content of a single
+                  child, and its members become the children of that child, named by the
+                  <code>child</code> entry of the plan. This single rule is the common inverse of the
                   <code>empty-plus</code>, <code>simple-plus</code>, <code>record</code>, and
                   <code>list-plus</code> layouts.</p></item>
             </ulist>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -8427,14 +8427,134 @@ map( xs:string,
                   <code>&lt;ref name="x"/&gt;</code> could be transformed to <code>&lt;ref&gt;x&lt;/ref&gt;</code>.</p></note>
             </div3>
             
+<div3 id="id-converting-maps-to-elements">
+   <head>Converting maps to elements</head>
+   <changes>
+      <change issue="1962" PR="2707" date="2026-06-24">
+         A new function <function>fn:map-to-element</function> is provided for converting
+         a map produced by <function>fn:element-to-map</function> back to an XML element node.
+      </change>
+   </changes>
+
+   <p>The <function>fn:map-to-element</function> function performs the inverse of
+      <function>fn:element-to-map</function>: it reconstructs an element node from a
+      <termref def="dt-single-entry-map">single-entry map</termref> of the form produced
+      by that function. Because the forward conversion is not lossless (see
+      <specref ref="id-loss-of-xdm-information"/>), the inverse cannot recover all of the
+      original information. However, the function is designed so that for any element
+      <var>E</var> and options map <var>OPTS</var>,</p>
+
+   <eg><var>E</var> => element-to-map(<var>OPTS</var>) => map-to-element(<var>OPTS</var>)</eg>
+
+   <p>reconstructs an element that is <function>fn:deep-equal</function> to <var>E</var>,
+      except for the information identified as lost in <specref ref="id-loss-of-xdm-information"/>.
+      Supplying the same <code>plan</code>, <code>attribute-marker</code>, <code>content-key</code>,
+      and <code>name-format</code> options that were used for the forward conversion is generally
+      necessary to achieve this round trip.</p>
+
+   <p>The same <code>$options</code> entries as for <function>fn:element-to-map</function> are
+      recognized; they are interpreted in the reverse direction:</p>
+
+   <ulist>
+      <item><p>The <code>plan</code> determines, for each element name, the layout (and where
+         applicable the content <code>type</code> and the <code>child</code> element name) that
+         was used in the forward direction, and hence how the corresponding map value is to be
+         interpreted. The rules for selecting a layout are the inverse of those in
+         <specref ref="id-selecting-element-layout"/>. Entries with the layout
+         <code>deep-skip</code> are ignored; the layout <code>error</code> is not relevant
+         to this function.</p></item>
+      <item><p>A map key beginning with the <code>attribute-marker</code> denotes an attribute;
+         the marker is removed to recover the attribute name.</p></item>
+      <item><p>A map key equal to the <code>content-key</code> denotes simple element content
+         (when its value is atomic) or, when its value is <code>#fn:null</code>, a nilled element.</p></item>
+      <item><p>The <code>name-format</code> governs how keys are decoded into names, as the
+         inverse of <specref ref="element-and-attribute-names"/>. A key of the form
+         <code>Q{uri}local</code> always yields a name in the namespace <code>uri</code>.
+         When <code>name-format</code> is <code>default</code>, a key consisting of a local name
+         alone yields a name in no namespace if it is the top-level element, and otherwise a name
+         in the namespace of the parent element; this is the inverse of the rule that omits the
+         namespace for a child in the same namespace as its parent. Namespace prefixes are always
+         synthesized; under <code>name-format</code> <code>local</code> or <code>lexical</code>,
+         namespace URIs cannot be recovered.</p></item>
+   </ulist>
+
+   <p>In the absence of a <code>plan</code>, the layout is inferred from the structure of the
+      map value, as the inverse of the rules in <specref ref="id-creating-a-conversion-plan"/>.</p>
+
+   <p>If the supplied map is not a single-entry map, the function fails with a dynamic error
+      <errorref class="JS" code="0009"/>. Otherwise the single entry is processed: its key is
+      decoded into the element name, and its value is interpreted as the content of that element,
+      as follows.</p>
+
+   <div4 id="id-map-to-element-value">
+      <head>Interpreting a map value</head>
+
+      <p>A value <var>V</var> appearing as element content is interpreted according to its kind:</p>
+
+      <olist>
+         <item><p>If <var>V</var> is an atomic value, it contributes a single text-node child
+            whose string value is the lexical representation of <var>V</var>. (Numeric and boolean
+            values therefore lose their type and reappear as text, just as type annotations are
+            lost in the forward direction.) The zero-length string contributes no child, which is
+            the common inverse of the <code>empty</code> and <code>simple</code> layouts.</p></item>
+
+         <item><p>If <var>V</var> is the value <code>#fn:null</code>, the element is nilled: the
+            attribute <code>xsi:nil="true"</code> is added, together with a declaration of the
+            <code>xsi</code> namespace. This is the inverse of the "Mapping for nilled elements"
+            rules of every layout.</p></item>
+
+         <item><p>If <var>V</var> is a map, each entry contributes to the element as follows:</p>
+            <ulist>
+               <item><p>If the key begins with the <code>attribute-marker</code>, it contributes
+                  an attribute whose name is the decoded key and whose value is the lexical
+                  representation of the entry value.</p></item>
+               <item><p>If the key is equal to the <code>content-key</code>, it contributes simple
+                  text content (atomic value) or a nilled marker (value <code>#fn:null</code>).</p></item>
+               <item><p>Otherwise the key contributes one or more child elements named by the
+                  decoded key: an atomic or map value contributes a single child; an array value
+                  contributes one child per array member, each member being interpreted recursively
+                  as that child's content. This single rule is the common inverse of the
+                  <code>empty-plus</code>, <code>simple-plus</code>, <code>record</code>, and
+                  <code>list-plus</code> layouts.</p></item>
+            </ulist>
+         </item>
+
+         <item><p>If <var>V</var> is an array, its members contribute children (and attributes) in
+            order, as the inverse of the <code>sequence</code> and <code>mixed</code> layouts. A
+            member that is a string contributes a text node; a single-entry map whose key begins
+            with the <code>attribute-marker</code> contributes an attribute; a single-entry map
+            with the key <code>#comment</code> contributes a comment node; a single-entry map with
+            the key <code>#processing-instruction</code> (whose value is a map with keys
+            <code>#target</code> and <code>#data</code>) contributes a processing-instruction node;
+            a single-entry map with the key equal to <code>content-key</code> and value
+            <code>#fn:null</code> indicates a nilled element; and any other single-entry map
+            contributes a child element. The <code>sequence</code> and <code>mixed</code> layouts
+            are reconstructed identically.</p>
+            <p>If the <code>plan</code> selects <code>list</code> or <code>list-plus</code> layout
+            for the element, the array members are instead interpreted as the content of children
+            all having the <code>child</code> element name given in the plan. If <code>list</code>
+            layout applies but no <code>child</code> name is available (the element name is not
+            recoverable from the array alone), the function fails with a dynamic error
+            <errorref class="JS" code="0009"/>.</p></item>
+
+         <item><p>If the <code>plan</code> selects <code>xml</code> layout, <var>V</var> is a string
+            containing serialized XML; it is parsed as an XML fragment and the resulting node is
+            used as the element content.</p></item>
+      </olist>
+   </div4>
+</div3>
+
             <!--<?local-function-index?>-->
-            
+
             <div3 id="func-element-to-map-plan">
                <head><?function fn:element-to-map-plan?></head>
             </div3>
             
             <div3 id="func-element-to-map">
                <head><?function fn:element-to-map?></head>
+            </div3>
+            <div3 id="func-map-to-element">
+               <head><?function fn:map-to-element?></head>
             </div3>
          </div2>
          
@@ -14613,6 +14733,16 @@ ISBN 0 521 77752 6.</bibl>
                   elements of a given name is unsuitable for an element node with that name, or
                   if the conversion plan explicitly defines the processing of a particular
                element as an error.</p>
+            </error>
+
+            <error class="JS" code="0009" label="Cannot convert map to element." type="dynamic">
+               <p>Raised by <function>fn:map-to-element</function> if the supplied map cannot be
+                  converted to an element node. This includes the cases where the map is not a
+                  single-entry map; where a map key or the <code>#processing-instruction</code>
+                  structure does not have the form required by the selected layout; where a
+                  reconstructed element or attribute name is not a valid <code>xs:QName</code>;
+                  or where <code>list</code> layout is selected for an array but the conversion
+                  plan supplies no <code>child</code> element name.</p>
             </error>
             
 


### PR DESCRIPTION
It repeatedly bothered me that we have no reverse counterpart for `fn:element-to-map`, so I finally pulled myself together and wrote a PR for `fn:map-to-element`.

All feedback is much appreciated. While I’m quite confident about the defined rules, I would mostly be interested in grammatical/stylistic advise.

Closes #1962