### PR TITLE
2536 EXPath modules: handling of default values

### DIFF
--- a/specifications/EXPath/binary/src/binary-functions.xml
+++ b/specifications/EXPath/binary/src/binary-functions.xml
@@ -413,7 +413,16 @@ Michael Sperberg-McQueen (1954–2024).</p>
                     (trailing) optional arguments for functions (introduced in XPath 4.0) are used
                     where appropriate in the signatures, rather than multiple-arity signatures as
                     previously. </p>
-                
+
+                <note>
+                    <p id="default-on-empty">If no argument is supplied for a parameter that has a
+                        default value, the default value is used. If the parameter is marked
+                        <code role="arg-note">(:default-on-empty:)</code>, the default value is also used when the
+                        supplied argument is the empty sequence. Otherwise, the empty sequence is
+                        treated according to the function-specific rules.</p>
+                    <p>The marker is only used on parameters that have default values.</p>
+                </note>
+
                 <p>All the functions defined in this specification are deterministic and independent
                 of the static and dynamic context.</p>
                 

--- a/specifications/EXPath/binary/src/function-catalog.xml
+++ b/specifications/EXPath/binary/src/function-catalog.xml
@@ -604,7 +604,7 @@ $values =!> bin:to-octets() => bin:from-octets()
             <fos:proto name="pad-left" return-type="xs:base64Binary?">
                 <fos:arg name="value" type="(xs:hexBinary | xs:base64Binary)?"/>
                 <fos:arg name="count" type="xs:integer"/>
-                <fos:arg name="octet" type="xs:unsigned-byte?" default="0"/>
+                <fos:arg name="octet" type="xs:unsignedByte?" default="0" note="default-on-empty"/>
             </fos:proto>
         </fos:signatures>
         <fos:properties>
@@ -620,8 +620,7 @@ $values =!> bin:to-octets() => bin:from-octets()
             <p>If the value of <code>$value</code> is the empty sequence, the function returns an empty
                 sequence.</p>
             <p>Otherwise, the function returns a binary value consisting of
-                <code>$count</code> instances of <code>$octet</code>, followed by <code>$value</code>. 
-            The default for <code>$octet</code> is zero (0).</p>
+                <code>$count</code> instances of <code>$octet</code>, followed by <code>$value</code>.</p>
             <p><code>$size</code>
                 <rfc2119>must</rfc2119> be a non-negative integer.</p>
             
@@ -668,7 +667,7 @@ $values =!> bin:to-octets() => bin:from-octets()
             <fos:proto name="pad-right" return-type="xs:base64Binary?">
                 <fos:arg name="value" type="(xs:hexBinary | xs:base64Binary)?"/>
                 <fos:arg name="count" type="xs:integer"/>
-                <fos:arg name="octet" type="xs:unsignedByte?" default="0"/>
+                <fos:arg name="octet" type="xs:unsignedByte?" default="0" note="default-on-empty"/>
             </fos:proto>
         </fos:signatures>
         <fos:properties>
@@ -684,8 +683,7 @@ $values =!> bin:to-octets() => bin:from-octets()
             <p>If the value of <code>$value</code> is the empty sequence, the function returns an empty
                 sequence.</p>
             <p>Otherwise, the function returns a binary value consisting of
-                <code>$value, followed by </code><code>$count</code> instances of <code>$octet</code>. 
-            The default for <code>$octet</code> is zero (0).</p>
+                <code>$value</code>, followed by <code>$count</code> instances of <code>$octet</code>.</p>
             <p><code>$size</code>
                 <rfc2119>must</rfc2119> be a non-negative integer.</p>
             
@@ -1019,7 +1017,7 @@ return bin:decode-string($input, $encoding, $offset)</eg></fos:expression>
         <fos:signatures>
             <fos:proto name="encode-string" return-type="xs:base64Binary?">
                 <fos:arg name="value" type="xs:string?"/>
-                <fos:arg name="encoding" type="xs:string?" default="'UTF-8'"/>
+                <fos:arg name="encoding" type="xs:string?" default="'UTF-8'" note="default-on-empty"/>
             </fos:proto>
         </fos:signatures>
         <fos:properties>
@@ -1043,9 +1041,7 @@ return bin:decode-string($input, $encoding, $offset)</eg></fos:expression>
                 most significant byte first).
             </p>
             <p>The function returns the binary value obtained by encoding the string <code>$value</code> using
-                the specified <code>$encoding</code> name.</p>
-            <p>If <code>$encoding</code> is omitted, <code>UTF-8</code> encoding is assumed.</p>
-            <p>The function does not add a byte order mark to the data. 
+                the specified <code>$encoding</code> name.</p>            <p>The function does not add a byte order mark to the data. 
                 But if <code>$value</code> includes a byte order mark (<char>U+FEFF</char>) then it is encoded in the same
             way as any other character.</p>
             
@@ -1088,7 +1084,7 @@ return bin:decode-string($input, $encoding, $offset)</eg></fos:expression>
                 <fos:arg name="value" type="xs:integer"/>
                 <fos:arg name="size" type="xs:integer"/>
                 <fos:arg name="order" type="enum('least-significant-first', 'little-endian', 'LE',
-                    'most-significant-first', 'big-endian', 'BE')?" default="'most-significant-first'"/>
+                    'most-significant-first', 'big-endian', 'BE')?" default="'most-significant-first'" note="default-on-empty"/>
             </fos:proto>
         </fos:signatures>
         <fos:properties>
@@ -1105,9 +1101,7 @@ return bin:decode-string($input, $encoding, $offset)</eg></fos:expression>
             representation of <code>$value mod math:pow(256, $size)</code>, padded on the
             left to <code>$size</code> octets with zero bits if the value is positive,
             or one bits if it is negative.</p>
-            <p>The order of octets in the result is most-significant-first unless
-                <code>$order</code> specifies otherwise.
-            Acceptable values for <code>$order</code> are described in <specref ref="endianness"/>.
+            <p>Acceptable values for <code>$order</code> are described in <specref ref="endianness"/>.
             If least-significant-first ordering is requested then the order of octets
             in the result is reversed.</p>
             <p>Specifying a <code>$size</code> of zero yields a <termref def="dt-zero-length"/>
@@ -1170,7 +1164,7 @@ return bin:decode-string($input, $encoding, $offset)</eg></fos:expression>
                 <fos:arg name="offset" type="xs:integer"/>
                 <fos:arg name="size" type="xs:integer"/>
                 <fos:arg name="order" type="enum('least-significant-first', 'little-endian', 'LE',
-                    'most-significant-first', 'big-endian', 'BE')?" default="'most-significant-first'"/>
+                    'most-significant-first', 'big-endian', 'BE')?" default="'most-significant-first'" note="default-on-empty"/>
             </fos:proto>
         </fos:signatures>
         <fos:properties>
@@ -1185,8 +1179,7 @@ return bin:decode-string($input, $encoding, $offset)</eg></fos:expression>
         <fos:rules>
             <p>The function produces an integer represented by the binary value
                 <code>bin:part($value, $offset, $size)</code>. This is interpreted
-            as a twos-complement representation of a signed integer, with the most significant
-            octet first unless the <code>$order</code> option specifies otherwise.</p>
+            as a twos-complement representation of a signed integer.</p>
             <p>Acceptable values for <code>$order</code> are described in <specref ref="endianness"/>.
             If least-significant-first ordering is requested then the order of octets
             in the input is reversed.</p>
@@ -1240,7 +1233,7 @@ return bin:decode-string($input, $encoding, $offset)</eg></fos:expression>
                 <fos:arg name="offset" type="xs:integer"/>
                 <fos:arg name="size" type="xs:integer"/>
                 <fos:arg name="order" type="enum('least-significant-first', 'little-endian', 'LE',
-                    'most-significant-first', 'big-endian', 'BE')?" default="'most-significant-first'"/>
+                    'most-significant-first', 'big-endian', 'BE')?" default="'most-significant-first'" note="default-on-empty"/>
             </fos:proto>
         </fos:signatures>
         <fos:properties>
@@ -1255,8 +1248,7 @@ return bin:decode-string($input, $encoding, $offset)</eg></fos:expression>
         <fos:rules>
             <p>The function produces an integer represented by the binary value
                 <code>bin:part($value, $offset, $size)</code>. This is interpreted
-            as a representation of an unsigned integer, with the most significant
-            octet first unless the <code>$order</code> option specifies otherwise.</p>
+            as a representation of an unsigned integer.</p>
             <p>Acceptable values for <code>$order</code> are described in <specref ref="endianness"/>.
             If least-significant-first ordering is requested then the order of octets
             in the input is reversed.</p>
@@ -1311,7 +1303,7 @@ return bin:decode-string($input, $encoding, $offset)</eg></fos:expression>
                 <fos:arg name="value" type="(xs:hexBinary | xs:base64Binary)"/>
                 <fos:arg name="offset" type="xs:integer"/>
                 <fos:arg name="order" type="enum('least-significant-first', 'little-endian', 'LE',
-                    'most-significant-first', 'big-endian', 'BE')?" default="'most-significant-first'"/>
+                    'most-significant-first', 'big-endian', 'BE')?" default="'most-significant-first'" note="default-on-empty"/>
             </fos:proto>
         </fos:signatures>
         <fos:properties>
@@ -1327,8 +1319,7 @@ return bin:decode-string($input, $encoding, $offset)</eg></fos:expression>
             <p>Extract the <loc href="http://www.w3.org/TR/xmlschema-2/#double">double</loc> value
                 stored in the 8 successive octets from the <code>$offset</code> octet of the binary
                 data of <code>$value</code>.</p>
-            <p>Most-significant-first number representation is assumed unless the
-                <code>$order</code> parameter specifies otherwise. Acceptable values for
+            <p>Acceptable values for
                 <code>$order</code> are described in <specref ref="endianness"/>.</p>
             <p>The value of <code>$offset</code>
                 <rfc2119>must</rfc2119> be a non-negative integer.</p>
@@ -1351,7 +1342,7 @@ return bin:decode-string($input, $encoding, $offset)</eg></fos:expression>
                 <fos:arg name="value" type="(xs:hexBinary | xs:base64Binary)"/>
                 <fos:arg name="offset" type="xs:integer"/>
                 <fos:arg name="order" type="enum('least-significant-first', 'little-endian', 'LE',
-                    'most-significant-first', 'big-endian', 'BE')?" default="'most-significant-first'"/>
+                    'most-significant-first', 'big-endian', 'BE')?" default="'most-significant-first'" note="default-on-empty"/>
             </fos:proto>
         </fos:signatures>
         <fos:properties>
@@ -1367,8 +1358,7 @@ return bin:decode-string($input, $encoding, $offset)</eg></fos:expression>
             <p>Extract the <loc href="http://www.w3.org/TR/xmlschema-2/#float">float</loc> value
                 stored in the 4 successive octets from the <code>$offset</code> octet of the binary
                 data of <code>$value</code>.</p>
-            <p>Most-significant-octet-first number representation is assumed unless the
-                <code>$order</code> parameter specifies otherwise. Acceptable values for
+            <p>Acceptable values for
                 <code>$order</code> are described in <specref ref="endianness"/>.</p>
             <p>The value of <code>$offset</code>
                 <rfc2119>must</rfc2119> be a non-negative integer.</p>
@@ -1390,7 +1380,7 @@ return bin:decode-string($input, $encoding, $offset)</eg></fos:expression>
             <fos:proto name="pack-double" return-type="xs:base64Binary">
                 <fos:arg name="value" type="xs:double"/>
                 <fos:arg name="order" type="enum('least-significant-first', 'little-endian', 'LE',
-                    'most-significant-first', 'big-endian', 'BE')?" default="'most-significant-first'"/>
+                    'most-significant-first', 'big-endian', 'BE')?" default="'most-significant-first'" note="default-on-empty"/>
             </fos:proto>
         </fos:signatures>
         <fos:properties>
@@ -1402,8 +1392,7 @@ return bin:decode-string($input, $encoding, $offset)</eg></fos:expression>
             <p>Returns the 8-octet binary representation of an <code>xs:double</code> value.</p>
         </fos:summary>
         <fos:rules>
-            <p>Most-significant-octet-first number representation is assumed unless the
-                <code>$order</code> parameter specifies otherwise. Acceptable values for
+            <p>Acceptable values for
                 <code>$order</code> are described in <specref ref="endianness"/>.</p>
             <p>The binary representation will correspond with that of the IEEE double-precision
                 64-bit floating point type <bibref ref="ieee754"/>. For more details see <specref
@@ -1416,8 +1405,8 @@ return bin:decode-string($input, $encoding, $offset)</eg></fos:expression>
         <fos:signatures>
             <fos:proto name="pack-float" return-type="xs:base64Binary">
                 <fos:arg name="value" type="xs:float"/>
-                <fos:arg name="order" type="xs:enum('least-significant-first', 'little-endian', 'LE',
-                    'most-significant-first', 'big-endian', 'BE')?" default="'most-significant-first'"/>
+                <fos:arg name="order" type="enum('least-significant-first', 'little-endian', 'LE',
+                    'most-significant-first', 'big-endian', 'BE')?" default="'most-significant-first'" note="default-on-empty"/>
             </fos:proto>
         </fos:signatures>
         <fos:properties>
@@ -1430,8 +1419,7 @@ return bin:decode-string($input, $encoding, $offset)</eg></fos:expression>
                     href="http://www.w3.org/TR/xmlschema-2/#float">float</loc> value.</p>
         </fos:summary>
         <fos:rules>
-            <p>Most-significant-octet-first number representation is assumed unless the
-                <code>$order</code> parameter is specified. Acceptable values for
+            <p>Acceptable values for
                 <code>$order</code> are described in <specref ref="endianness"/>.</p>
             <p>The binary representation will correspond with that of the IEEE single-precision
                 32-bit floating point type <bibref ref="ieee754"/>. For more details see <specref

--- a/specifications/EXPath/file/src/file-functions.xml
+++ b/specifications/EXPath/file/src/file-functions.xml
@@ -423,6 +423,15 @@ file:resolve-path($path, file:base-dir())
           (trailing) optional arguments for functions (introduced in XPath 4.0) are used
           where appropriate in the signatures, rather than multiple-arity signatures as
           previously. </p>
+
+        <note>
+          <p id="default-on-empty">If no argument is supplied for a parameter that has a
+            default value, the default value is used. If the parameter is marked
+            <code role="arg-note">(:default-on-empty:)</code>, the default value is also used when the
+            supplied argument is the empty sequence. Otherwise, the empty sequence is
+            treated according to the function-specific rules.</p>
+          <p>The marker is only used on parameters that have default values.</p>
+        </note>
       </div2>
     </div1>
   

--- a/specifications/EXPath/file/src/function-catalog.xml
+++ b/specifications/EXPath/file/src/function-catalog.xml
@@ -198,7 +198,7 @@
     <fos:signatures>
       <fos:proto name="size" return-type="xs:integer">
         <fos:arg type="xs:string" name="path"/>
-        <fos:arg type="xs:boolean?" default="false()" name="recursive"/>
+        <fos:arg type="xs:boolean?" default="false()" name="recursive" note="default-on-empty"/>
       </fos:proto>
     </fos:signatures>
     <fos:properties>
@@ -347,7 +347,7 @@
       <fos:proto name="append-text" return-type="empty-sequence()">
         <fos:arg type="xs:string" name="file"/>
         <fos:arg type="xs:string" name="value"/>
-        <fos:arg type="xs:string?" default="'UTF-8'" name="encoding"/>
+        <fos:arg type="xs:string?" default="'UTF-8'" name="encoding" note="default-on-empty"/>
       </fos:proto>
     </fos:signatures>
     <fos:properties>
@@ -361,9 +361,7 @@
     <fos:rules>
       <p>Appends a string to a file.
         If the file pointed to by <code>$file</code> does not exist, a new file will be
-        created.</p>
-      <p>If no encoding is supplied, <code>UTF-8</code> is used as output encoding.</p>
-      <p>The function returns the empty sequence if the operation is successful.</p>
+        created.</p>      <p>The function returns the empty sequence if the operation is successful.</p>
     </fos:rules>
     <fos:errors>
       <p>
@@ -394,7 +392,7 @@
       <fos:proto name="append-text-lines" return-type="empty-sequence()">
         <fos:arg type="xs:string" name="file"/>
         <fos:arg type="xs:string*" name="lines"/>
-        <fos:arg type="xs:string?" default="'UTF-8'" name="encoding"/>
+        <fos:arg type="xs:string?" default="'UTF-8'" name="encoding" note="default-on-empty"/>
       </fos:proto>
     </fos:signatures>
     <fos:properties>
@@ -409,9 +407,7 @@
     <fos:rules>
       <p>Appends a sequence of strings to a file, each followed by the operating-system specific
         newline character.
-        If the file pointed to by <code>$file</code> does not exist, a new file will be created.</p>
-      <p>If no encoding is supplied, <code>UTF-8</code> is used as output encoding.</p>
-      <p>The function returns the empty sequence if the operation is successful.</p>
+        If the file pointed to by <code>$file</code> does not exist, a new file will be created.</p>      <p>The function returns the empty sequence if the operation is successful.</p>
     </fos:rules>
     <fos:errors>
       <p>
@@ -702,7 +698,7 @@ return try {
     <fos:signatures>
       <fos:proto name="delete" return-type="empty-sequence()">
         <fos:arg type="xs:string" name="path"/>
-        <fos:arg type="xs:boolean?" default="false()" name="recursive"/>
+        <fos:arg type="xs:boolean?" default="false()" name="recursive" note="default-on-empty"/>
       </fos:proto>
     </fos:signatures>
     <fos:properties>
@@ -773,7 +769,7 @@ return try {
     <fos:signatures>
       <fos:proto name="list" return-type="xs:string*">
         <fos:arg type="xs:string" name="dir"/>
-        <fos:arg type="xs:boolean?" default="false()" name="recursive"/>
+        <fos:arg type="xs:boolean?" default="false()" name="recursive" note="default-on-empty"/>
         <fos:arg type="xs:string?" default="()" name="pattern"/>
       </fos:proto>
     </fos:signatures>
@@ -1001,7 +997,7 @@ return file:read-text($path)
     <fos:signatures>
       <fos:proto name="read-binary" return-type="xs:base64Binary">
         <fos:arg type="xs:string" name="file"/>
-        <fos:arg type="xs:integer?" default="0" name="offset"/>
+        <fos:arg type="xs:integer?" default="0" name="offset" note="default-on-empty"/>
         <fos:arg type="xs:integer?" default="()" name="length"/>
       </fos:proto>
     </fos:signatures>
@@ -1017,7 +1013,6 @@ return file:read-text($path)
       <p>Returns the content of a file as an <code>xs:base64Binary</code> item.</p>
       <p>Chunks of a file can be read by supplying <code>$offset</code> (0-based) and <code>$length</code>.
         If no value is supplied for <code>$length</code>, all remaining bytes will be read.
-        If only <code>$length</code> is specified, the offset is <code>0</code>.
       </p>
     </fos:rules>
     <fos:errors>
@@ -1308,7 +1303,7 @@ file:write(
       <fos:proto name="write-binary" return-type="empty-sequence()">
         <fos:arg type="xs:string" name="file"/>
         <fos:arg type="xs:base64Binary" name="value"/>
-        <fos:arg type="xs:integer?" default="0" name="offset"/>
+        <fos:arg type="xs:integer?" default="0" name="offset" note="default-on-empty"/>
       </fos:proto>
     </fos:signatures>
     <fos:properties>
@@ -1323,7 +1318,7 @@ file:write(
       <p>Writes the binary data of an <code>xs:base64Binary</code> item to a file.
         If the file pointed to by <code>$file</code> already exists, it will be overwritten;
         otherwise, it will be created.</p>
-      <p>If <code>$offset</code> (0-based) is specified and not an empty sequence, data will be written 
+      <p>If <code>$offset</code> (0-based) is specified, data will be written
         starting at this file position, and existing bytes will be overwritten.
         The operation may resize the existing file.</p>
       <p>The function returns the empty sequence if the operation is successful.</p>
@@ -1366,7 +1361,7 @@ file:write(
       <fos:proto name="write-text" return-type="empty-sequence()">
         <fos:arg type="xs:string" name="file"/>
         <fos:arg type="xs:string" name="value"/>
-        <fos:arg type="xs:string?" default="'UTF-8'" name="encoding"/>
+        <fos:arg type="xs:string?" default="'UTF-8'" name="encoding" note="default-on-empty"/>
       </fos:proto>
     </fos:signatures>
     <fos:properties>
@@ -1379,9 +1374,7 @@ file:write(
     </fos:summary>
     <fos:rules>
       <p>Writes a string to a file.
-        If the file pointed to by <code>$file</code> already exists, it will be overwritten.</p>
-      <p>If no encoding is supplied, <code>UTF-8</code> is used as output encoding.</p>
-      <p>The function returns the empty sequence if the operation is successful.</p>
+        If the file pointed to by <code>$file</code> already exists, it will be overwritten.</p>      <p>The function returns the empty sequence if the operation is successful.</p>
     </fos:rules>
     <fos:errors>
       <p>
@@ -1412,7 +1405,7 @@ file:write(
       <fos:proto name="write-text-lines" return-type="empty-sequence()">
         <fos:arg type="xs:string" name="file"/>
         <fos:arg type="xs:string*" name="values"/>
-        <fos:arg type="xs:string?" default="'UTF-8'" name="encoding"/>
+        <fos:arg type="xs:string?" default="'UTF-8'" name="encoding" note="default-on-empty"/>
       </fos:proto>
     </fos:signatures>
     <fos:properties>
@@ -1426,9 +1419,7 @@ file:write(
     <fos:rules>
       <p>Writes strings to a file, each followed by the operating-system specific newline character.
         If the file pointed to by <code>$file</code> already exists, it will be overwritten;
-        otherwise, it will be created.</p>
-      <p>If no encoding is supplied, <code>UTF-8</code> is used as output encoding.</p>
-      <p>The function returns the empty sequence if the operation is successful.</p>
+        otherwise, it will be created.</p>      <p>The function returns the empty sequence if the operation is successful.</p>
     </fos:rules>
     <fos:errors>
       <p>

--- a/specifications/EXPath/style/expath-functions.xsl
+++ b/specifications/EXPath/style/expath-functions.xsl
@@ -36,7 +36,7 @@
             </div>
         </div>   
     </xsl:template>
-    
+
     <xsl:template
         match="code[matches(., '^(bin|file):[-a-zA-Z0-9]+(#[0-9]+)?$')][not(@role = 'example')]">
         <!--<xsl:variable name="raw-name">

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -614,7 +614,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
                </ulist>
                <note><p id="default-on-empty">
                   If no argument is supplied for a parameter that has a default value, the default
-                  value is used. If the parameter is marked <code>(:default-on-empty:)</code>,
+                  value is used. If the parameter is marked <code role="arg-note">(:default-on-empty:)</code>,
                   the default value is also used when the supplied argument is the empty sequence.
                   Otherwise, the empty sequence is treated according to the function-specific rules.</p>
                   <p>The marker is only used on parameters that have default values.</p>

--- a/specifications/xpath-functions-40/style/xpath-functions.xsl
+++ b/specifications/xpath-functions-40/style/xpath-functions.xsl
@@ -440,7 +440,11 @@
   
   <xsl:template match="var[matches(., '[A-Z]''')]">
     <var><xsl:value-of select="translate(., '''', '&#x2032;')"/></var>
-  </xsl:template>  
+  </xsl:template>
+
+<xsl:template match="code[@role = 'arg-note']">
+  <code class="arg-note"><xsl:apply-templates/></code>
+</xsl:template>
 
 <xsl:template match="code[matches(., '^(fn|op|math|map|array):[-a-zA-Z0-9]+(#[0-9]+)?$')][not(@role=('example','element-name'))]">
   <!-- Simplified 2016-09-20 in response to bug 29825; as a result much of the logic here is redundant -->


### PR DESCRIPTION
* The styling of `(:default-on-empty:)` in the introduction was aligned.
* The `(:default-on-empty:)` comments were added to the Binary and File Module.
* Redundant rules were dropped.
* Minor typos were fixed.

Closes #2536