### PR TITLE
2257 Record declarations without namespace

### DIFF
--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -4937,8 +4937,8 @@ types</term> (such as <code>xs:integer</code>) and function types
                   <p>Some consequences of these rules may not be immediately apparent.</p>
                   <p>Suppose that an XQuery query contains the declarations:</p>
                   <eg>
-declare type my:color := enum("red", "green", "orange");
-declare type my:fruit := enum("apple", "orange", "banana");
+declare type my:color as enum("red", "green", "orange");
+declare type my:fruit as enum("apple", "orange", "banana");
 declare variable $orange-color as my:color := "orange";
 declare variable $orange-fruit as my:fruit := "orange";
                   </eg>

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -2105,10 +2105,13 @@ local:depth(doc("partlist.xml"))
       <termref def="dt-library-module"/> <errorref class="ST" code="0048"/>.
       </p></item>
       <item><p>The name of a <termref def="dt-private-item-type"/>, or of a <termref def="dt-public-item-type"/> declared
-      in a <termref def="dt-main-module"/>, must be in a namespace, which may be any namespace
-        that is not a <termref def="dt-reserved-namespaces">reserved namespace</termref>.</p>
+      in a <termref def="dt-main-module"/>, <phrase diff="chg" at="issue2257">must not be in a
+        <termref def="dt-reserved-namespaces">reserved namespace</termref>; it may be in any other namespace,
+        or in no namespace.</phrase></p>
       <note><p>Writing the name as an unprefixed NCName is generally possible, except when the
-      <termref def="dt-default-namespace-elements-and-types"/> is a reserved namespace.</p></note></item>
+      <termref def="dt-default-namespace-elements-and-types"/> is a reserved namespace.<phrase diff="add" at="issue2257">
+        With no <termref def="dt-default-namespace-elements-and-types"/> in force, an unprefixed name denotes an
+        item type in no namespace.</phrase></p></note></item>
     </ulist>
     
     <p>The declaration of an item type is available throughout the containing module; if it is
@@ -2230,6 +2233,11 @@ local:depth(doc("partlist.xml"))
             Extensible map types are dropped; instead, the coercion rules cause undefined
             map entries to be discarded.
          </change>
+         <change issue="2257" date="2026-06-25">
+            A named record declaration whose name is unprefixed and expands to no namespace is no
+            longer an error; its constructor function is then a no-namespace function, callable by an
+            unprefixed name.
+         </change>
       </changes>
    
        <p>The construct:</p>
@@ -2287,9 +2295,15 @@ local:depth(doc("partlist.xml"))
      <ulist>
        <item><p>The function annotations are the annotations on the named record declaration.</p></item>
        <item><p>The function name is the QName of the named record declaration, expanded using
-         the <termref def="dt-default-type-namespace-rule"/>. The resulting QName must be the same as the
-       module namespace if the declaration appears in a library module, and in any event, it must be in some
-       namespace.</p></item>
+         the <termref def="dt-default-type-namespace-rule"/>. <phrase diff="chg" at="issue2257">If the
+       declaration appears in a library module, the resulting QName must be in the
+       <termref def="dt-target-namespace"/> of that module; otherwise it may be in any namespace, or
+       in no namespace.</phrase></p></item>
+       <item><p>When the name is unprefixed and no <termref def="dt-default-namespace-elements-and-types"/>
+         is in force, both the record type and its constructor function are in no namespace.
+         An unprefixed call resolves to the constructor by the first step of the
+         <termref def="dt-default-function-namespace-rule"/>, which searches no-namespace functions
+         before the <termref def="dt-default-function-namespace"/>.</p></item>
        <item><p>The parameters of the function declaration are derived from the fields of the named record
        declaration, in order.</p>
        <ulist>
@@ -2298,16 +2312,14 @@ local:depth(doc("partlist.xml"))
              <code>item()*</code>.</p></item>
          <item><p>The default value for the parameter is given by the initializing expression in
          the <nt def="ExtendedFieldDeclaration">ExtendedFieldDeclaration</nt>, if present.</p></item>
-       </ulist></item>
-       
-       
+       </ulist>
+       </item>
        
        <item><p>The return type of the function is the <termref def="dt-record-type"/> being declared, with no occurrence
        indicator.</p></item>
        <item><p>The body of the function is a <nt def="MapConstructor">MapConstructor</nt>
            containing one <nt def="MapConstructorEntry">MapConstructorEntry</nt> for each field of the record type,
-           in the form <code>"<var>N</var>" : $<var>N</var></code>, where <var>N</var> is the field name.</p>
-         
+           in the form <code>"<var>N</var>": $<var>N</var></code>, where <var>N</var> is the field name.</p>
        </item>  
  
  

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -2074,8 +2074,11 @@ local:depth(doc("partlist.xml"))
       
     </example>
     
-    <p>If the name of the item type being declared is written as an (unprefixed) NCName, then 
-      it is interpreted as being in the <termref def="dt-default-namespace-elements-and-types"/>.</p>
+    <p>If the name of the item type being declared is written as an (unprefixed) NCName, then
+      it is interpreted as being in the <termref def="dt-default-namespace-elements-and-types"/>.
+      <phrase diff="add" at="issue2257">With no <termref def="dt-default-namespace-elements-and-types"/>
+      in force, the name is in no namespace:</phrase></p>
+    <eg>declare type color as enum("red", "green", "blue");</eg>
     
     
     


### PR DESCRIPTION
This solution aims to provide a solution for the vast majority of use cases where the default function and element namespaces remain untouched, and where people write simple one-file scripts. I think I have found a good compromise:

* Unprefixed records are allowed: `declare record coord(x, y); coord(1, 3)`
* Name keeps the default-type-namespace rule; drops "must be in some namespace."
* No default element namespace → record and constructor in no namespace; unprefixed call resolves via no-namespace-first
* Default element namespace → call constructor prefixed

Closes #2257