### PR TITLE
Attempt to limit disk space (only checkout 100 revisions)

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 100
 
       - name: Get branch name, etc.
         id: check_step

--- a/.github/workflows/build-specs.yml
+++ b/.github/workflows/build-specs.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Checkout the specifications
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
 
       - name: Setup Saxon EE
         if: ${{ env.HAVE_SAXON_LICENSE == 'true' }}


### PR DESCRIPTION
We check out the full history so that we can make diffs. But now checking out the full history makes us run out of disk space. Try the last 100 revisions. That's a number I totally pulled out of thin air.