### PR TITLE
Update deploy plugin for Node deprecation

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Deploy
         if: ${{ env.HAVE_ACCESS_TOKEN == 'true' }}
-        uses: JamesIves/github-pages-deploy-action@v4.6.4
+        uses: JamesIves/github-pages-deploy-action@v4.8.0
         with:
           folder: build/www
           token: ${{ secrets.ACCESS_TOKEN }}
@@ -97,7 +97,7 @@ jobs:
 
       - name: Deploy PR status
         if: ${{ env.HAVE_ACCESS_TOKEN == 'true' }}
-        uses: JamesIves/github-pages-deploy-action@v4.6.4
+        uses: JamesIves/github-pages-deploy-action@v4.8.0
         with:
           folder: build/status
           token: ${{ secrets.ACCESS_TOKEN }}
@@ -125,7 +125,7 @@ jobs:
 
       - name: Deploy PR status
         if: ${{ env.HAVE_ACCESS_TOKEN == 'true' }}
-        uses: JamesIves/github-pages-deploy-action@v4.6.4
+        uses: JamesIves/github-pages-deploy-action@v4.8.0
         with:
           folder: dashboard
           token: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/build-specs.yml
+++ b/.github/workflows/build-specs.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Deploy master to specifications
         if: ${{ env.HAVE_ACCESS_TOKEN == 'true' && github.ref_name == 'master' }}
-        uses: JamesIves/github-pages-deploy-action@v4.6.4
+        uses: JamesIves/github-pages-deploy-action@v4.8.0
         with:
           folder: build/www
           token: ${{ secrets.ACCESS_TOKEN }}
@@ -70,7 +70,7 @@ jobs:
 
       - name: Deploy other branches to branch
         if: ${{ env.HAVE_ACCESS_TOKEN == 'true' && github.ref_name != 'master' }}
-        uses: JamesIves/github-pages-deploy-action@v4.6.4
+        uses: JamesIves/github-pages-deploy-action@v4.8.0
         with:
           folder: build/www
           token: ${{ secrets.ACCESS_TOKEN }}
@@ -101,7 +101,7 @@ jobs:
 
       - name: Deploy the updated tests
         if: ${{ env.UPDATE_TESTS == 'true' && github.ref_name == env.PUBLISH_TESTS_FROM }}
-        uses: JamesIves/github-pages-deploy-action@v4.6.4
+        uses: JamesIves/github-pages-deploy-action@v4.8.0
         with:
           repository-name: ${{ secrets.TEST_REPOSITORY }}
           token: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
We're warned by the build about a deprecated version of Node. That's in the deploy action (I believe).

Updating that to update the version of node.

🤞 