### PR TITLE
Try pull_request instead of pull_request_target for PR builds

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,6 +1,6 @@
 name: build-pr
 on:
-  pull_request_target:
+  pull_request:
     types: [assigned, opened, edited, synchronize, reopened]
     branches:
       - master


### PR DESCRIPTION
See https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/