### PR TITLE
2709 Well-formed sub-documents (2nd attempt)

### DIFF
--- a/schema/xmlspec.dtd
+++ b/schema/xmlspec.dtd
@@ -463,7 +463,7 @@
 
 <!ENTITY % front.element "INCLUDE">
 <![%front.element;[
-<!ELEMENT front (div1+)>
+<!ELEMENT front (fascicle+ | div1+)>
 ]]>
 <!ENTITY % front.attlist "INCLUDE">
 <![%front.attlist;[
@@ -472,7 +472,7 @@
 
 <!ENTITY % body.element "INCLUDE">
 <![%body.element;[
-<!ELEMENT body (div1+)>
+<!ELEMENT body (fascicle+ | div1+)>
 ]]>
 <!ENTITY % body.attlist "INCLUDE">
 <![%body.attlist;[
@@ -485,12 +485,26 @@
 
 <!ENTITY % back.element "INCLUDE">
 <![%back.element;[
-<!ELEMENT back ((div1+, inform-div1*) | inform-div1+)>
+<!ELEMENT back (fascicle+ | (div1+, inform-div1*) | inform-div1+)>
 ]]>
 <!ENTITY % back.attlist "INCLUDE">
 <![%back.attlist;[
 <!ATTLIST back %common.att;>
 ]]>
+
+<!-- 
+#2026-06-06: mhk: added fascicle for a group of top-level (div1 or inform-div1) elements 
+-->
+
+<!ENTITY % fascicle.element "INCLUDE">
+<![%fascicle.element;[
+<!ELEMENT fascicle ((div1 | inform-div1)+)>
+]]>
+<!ENTITY % fascicle.attlist "INCLUDE">
+<![%fascicle.attlist;[
+<!ATTLIST fascicle %common.att;>
+]]>
+
 
 <!ENTITY % div1.element "INCLUDE">
 <![%div1.element;[

--- a/specifications/xquery-40/src/back-matter.xml
+++ b/specifications/xquery-40/src/back-matter.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-
-
+<fascicle>
 <div1 role="xquery" id="id-xq-context-components">
   <head>Context Components</head>
 
@@ -572,7 +571,7 @@ of the declared type).</p></item><item role="xquery"><p>Limits on ranges of valu
       IETF RFC 3987. See <loc href="http://www.ietf.org/rfc/rfc3987.txt">http://www.ietf.org/rfc/rfc3987.txt</loc>.</bibl>
 
 <bibl id="ISO10646" key="ISO/IEC 10646">ISO (International Organization for Standardization).
-      <emph>ISO/IEC 10646:2003. Information technology&mdash;Universal Multiple-Octet Coded Character Set (UCS)</emph>,
+      <emph>ISO/IEC 10646:2003. Information technology—Universal Multiple-Octet Coded Character Set (UCS)</emph>,
       as, from time to time, amended, replaced by a new edition, or expanded by the addition of new parts.
       [Geneva]: International Organization for Standardization.
       (See <loc href="http://www.iso.org">http://www.iso.org</loc> for the latest version.)</bibl>
@@ -712,7 +711,7 @@ Daniela Florescu, Alon Levy, and Dan Suciu.
 </bibl>
 
 <bibl key="SQL" id="SQL" role="xquery">International Organization for
-Standardization (ISO).  <emph>Information Technology &mdash; Database Language
+Standardization (ISO).  <emph>Information Technology — Database Language
 SQL</emph>. Standard No. ISO/IEC 9075:2011.  (Available from American
 National Standards Institute, New York, NY 10036, (212)
 642-4900.)</bibl>
@@ -1236,3 +1235,4 @@ See
   <?change-log?>
 
 </inform-div1>
+</fascicle>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-
+<fascicle>
    <div1 id="id-basics">
       <head>Basics</head>
       
@@ -12,13 +12,13 @@
       such as <code>","</code> as a separator. The notation is borrowed from Invisible XML.</change>
          </changes>
      
-      <p>The basic building block of &language; is the
+      <p>The basic building block of <?inject language?> is the
 	 <term>expression</term>, which is a <xtermref spec="DM40" ref="dt-string"/> of 
          <xtermref spec="DM40" ref="dt-character">characters</xtermref>.</p>
          
 	 <p>The language provides several kinds of expressions which may be constructed
 	 from keywords, symbols, and operands. In general, the operands of an expression
-	 are other expressions. &language; allows expressions to be nested with full
+	 are other expressions. <?inject language?> allows expressions to be nested with full
 generality. <phrase
             role="xquery"
             >(However, unlike a pure functional
@@ -26,8 +26,8 @@ language, it does not allow variable substitution if the variable
 declaration contains construction of new nodes.)</phrase>
       </p>
  
-      <p>Like XML, &language; is a case-sensitive language. Keywords in
-	 &language; use lower-case characters and are not reserved&mdash;that is, names in &language; expressions are allowed to be the same as language keywords, except for certain unprefixed function-names listed in <specref
+      <p>Like XML, <?inject language?> is a case-sensitive language. Keywords in
+	 <?inject language?> use lower-case characters and are not reserved—that is, names in <?inject language?> expressions are allowed to be the same as language keywords, except for certain unprefixed function-names listed in <specref
             ref="id-reserved-fn-names"/>.</p>
          
          
@@ -77,7 +77,7 @@ declaration contains construction of new nodes.)</phrase>
                </change>
             </changes>
             
-            <p>The grammar of &language; is defined using a version of EBNF defined
+            <p>The grammar of <?inject language?> is defined using a version of EBNF defined
             in <specref ref="EBNFNotation"/>. The notation is based on the EBNF dialect used in the
             XML specification, with two notable additions derived from the Invisible XML grammar:</p>
             
@@ -98,9 +98,9 @@ declaration contains construction of new nodes.)</phrase>
             
             <p>EBNF grammar rules appear throughout the specification for ease of reference, and the
             entire grammar is summarized in <specref ref="id-grammar"/>.
-            <phrase role="xpath">For &language;, the top-level production rule is 
+            <phrase role="xpath">For <?inject language?>, the top-level production rule is 
             <nt def="XPath">XPath</nt>, representing an XPath expression.</phrase>
-            <phrase role="xquery">For &language;, the top-level production rule is 
+            <phrase role="xquery">For <?inject language?>, the top-level production rule is 
             <nt def="Module">Module</nt>, representing an XQuery module.</phrase></p>
             
    
@@ -201,7 +201,7 @@ Each XNode has a unique <term>node identity</term>, a <term>typed value</term>, 
          <termdef id="dt-singleton" term="singleton"
                >A sequence containing exactly one item is called a
 	 <term>singleton</term>.</termdef> An item is identical to a singleton sequence
-	 containing that item. Sequences are never nested&mdash;for example, combining the
+	 containing that item. Sequences are never nested—for example, combining the
 	 values 1, (2, 3), and ( ) into a single sequence results in the sequence (1, 2,
 	 3). </p>
          <p><termdef
@@ -229,7 +229,7 @@ Each XNode has a unique <term>node identity</term>, a <term>typed value</term>, 
          <head>Namespaces and QNames</head>
          
          <changes>
-            <change role="xquery" issue="485 2178" PR="487">In &language;, an initial set of
+            <change role="xquery" issue="485 2178" PR="487">In <?inject language?>, an initial set of
             namespace bindings is prescribed for the static context.</change>
             <change issue="2079" PR="2227" date="2025-10-03">A <code>URIQualifiedName</code> may now supply a prefix
             as well as a URI and local name.</change>
@@ -298,7 +298,7 @@ return namespace {$k}{$v}
             the names of constructs such as functions, variables, and types
             that are not themselves atomic items.</p></note>
 
-      <p>In the &language;
+      <p>In the <?inject language?>
       grammar, QNames representing the names of
       elements, attributes, functions, variables, types, or other such
       constructs are written as instances of the grammatical
@@ -474,11 +474,11 @@ return namespace {$k}{$v}
          </item>
       </ulist>
          
-      <p role="xquery">In &language;, the above namespace bindings are by default included
+      <p role="xquery">In <?inject language?>, the above namespace bindings are by default included
       in the <termref def="dt-static-namespaces"/> of the <termref def="dt-static-context"/> 
       of every query module; however, these bindings can be overridden in the query prolog.</p>   
          
-     <p role="xpath">In &language;, the above namespace bindings are not automatically
+     <p role="xpath">In <?inject language?>, the above namespace bindings are not automatically
      included in the <termref def="dt-static-namespaces"/> of the <termref def="dt-static-context"/> 
      of an expression unless the host language chooses to include them.</p>    
 
@@ -500,7 +500,7 @@ The term URI has been retained in preference to IRI to avoid introducing new nam
          <div3 id="id-expanding-unprefixed-qnames">
             <head>Expanding Lexical QNames</head>
             
-            <p>When a <termref def="dt-qname"/> appearing in an &language; expression is expanded, the rules are as follows.</p>
+            <p>When a <termref def="dt-qname"/> appearing in an <?inject language?> expression is expanded, the rules are as follows.</p>
             
             <p>If the name contains a colon, then the prefix (the substring before the colon) is used to establish the 
                corresponding URI by reference to the <termref def="dt-static-namespaces"/>
@@ -657,7 +657,7 @@ The term URI has been retained in preference to IRI to avoid introducing new nam
             <p>The individual components of the <termref def="dt-static-context"
                   >static context</termref> are described below.</p>
             
-            <p role="xpath">In &language;, the static context for an expression is largely defined
+            <p role="xpath">In <?inject language?>, the static context for an expression is largely defined
                by the host language, that is, by the calling environment that causes an XPath
                expression to be evaluated. Most of the static context components are constant
                throughout an expression; the only exception is <termref def="dt-in-scope-variables"/>.
@@ -665,7 +665,7 @@ The term URI has been retained in preference to IRI to avoid introducing new nam
                and <nt def="LetExpr">LetExpr</nt>, that add additional variables to the static context
                of their subexpressions.)</p>
             
-            <p role="xquery">In &language;, the static context for an expression is largely defined
+            <p role="xquery">In <?inject language?>, the static context for an expression is largely defined
                in the query prolog of a module: see <specref ref="id-query-prolog"/>. Declarations in the 
                prolog, such as variable declarations, function declarations, and decimal format declarations
                populate the static context for expressions appearing within the module. In some cases (but
@@ -1521,9 +1521,9 @@ components of the <termref def="dt-dynamic-context"
                   >dynamic context</termref> are described below.</p>
             
             <p>In general, the dynamic context for the outermost expression is supplied externally,
-               often by some kind of application programming interface (API) allowing &language;
+               often by some kind of application programming interface (API) allowing <?inject language?>
                expressions to be invoked from a host language. Application Programming Interfaces
-               are outside the scope of this specification. <phrase role="xquery">In &language;,
+               are outside the scope of this specification. <phrase role="xquery">In <?inject language?>,
                some aspects of the dynamic context (for example, initial values of variables)
                are defined within the query prolog.</phrase> The dynamic context for inner subexpressions
                may be set by their containing expressions: for example in a mapping expression 
@@ -2174,7 +2174,7 @@ comparison or arithmetic operation. The implicit timezone is an  <termref
            </change>
          </changes>
          
-         <p>The semantics of &language; are defined in terms
+         <p>The semantics of <?inject language?> are defined in terms
                          of the <termref
                def="dt-datamodel">data
                          model</termref> and the <termref
@@ -2190,7 +2190,7 @@ comparison or arithmetic operation. The implicit timezone is an  <termref
 
          <p>Figure 1 provides a schematic overview of the processing steps that
 are discussed in detail below. Some of these steps are completely
-outside the domain of &language;; in Figure 1, these are depicted
+outside the domain of <?inject language?>; in Figure 1, these are depicted
 outside the line that represents the boundaries of the language, an
 area labeled <term>external processing</term>. The external processing
 domain includes generation of <termref
@@ -2224,7 +2224,7 @@ analysis and dynamic evaluation phases (see <specref
                   >an expression</phrase> must be represented as one or more <termref
                   def="dt-data-model-instance"
                   >XDM instances</termref>. This process occurs outside
-the domain of &language;, which is why Figure 1 represents it in the
+the domain of <?inject language?>, which is why Figure 1 represents it in the
 external processing domain.</p>
             
             <p>In many cases the input data might originate as XML.
@@ -2264,7 +2264,7 @@ Figure 1)</p>
                   >XDM instance</termref> might be constructed. An XDM instance might
 also be constructed in some other way (see DM3 in Figure 1), for example it might be 
 synthesized directly from a relational database, or
-derived by parsing a JSON text or a CSV file. Whatever the origin, &language; is defined in terms
+derived by parsing a JSON text or a CSV file. Whatever the origin, <?inject language?> is defined in terms
 of the <termref def="dt-datamodel">data model</termref>,
 but it does not place any constraints on how XDM instances are constructed.</p>
             
@@ -2286,7 +2286,7 @@ If the <termref
                   >XDM instance</termref> was derived from a validated XML document as described in <xspecref
                   spec="DM40" ref="const-psvi"
                />, the type annotations of the element and attribute nodes are derived from schema
-validation. &language; does
+validation. <?inject language?> does
 not provide a way to directly access the type annotation of an element
 or attribute node.</p>
             <p>The value of an attribute is represented directly within the
@@ -2335,7 +2335,7 @@ Figure 1) and must satisfy the consistency constraints defined in
          <div3 id="id-expression-processing">
             <head>Expression
 Processing</head>
-            <p>&language; defines two phases of processing called
+            <p><?inject language?> defines two phases of processing called
 the <termref
                   def="dt-static-analysis">static analysis phase</termref>
 and the <termref
@@ -2500,7 +2500,7 @@ data (step DQ4), and on the <termref
                      def="dt-static-context"
                      >static context</termref> (step DQ2). The dynamic evaluation phase may create new data-model values (step DQ4) and it may extend the <termref
                      def="dt-dynamic-context"
-                  >dynamic context</termref> (step DQ5)&mdash;for example, by binding values to variables.</p>
+                  >dynamic context</termref> (step DQ5)—for example, by binding values to variables.</p>
 
                <p diff="chg" at="B">
                   <termdef term="dynamic type" id="dt-dynamic-type">
@@ -2552,7 +2552,7 @@ data (step DQ4), and on the <termref
          <div3 id="id-input-sources">
             <head>Input Sources</head>
             
-            <p>&language; has a set of functions that provide access to XML documents (<function>fn:doc</function>, <function>fn:doc-available</function>), collections (<function>fn:collection</function>, <function>fn:uri-collection</function>), text files (<function>fn:unparsed-text</function>, <function>fn:unparsed-text-lines</function>, <function>fn:unparsed-text-available</function>), and environment variables (<function>fn:environment-variable</function>, <function>fn:available-environment-variables</function>).  These functions are defined in <xspecref
+            <p><?inject language?> has a set of functions that provide access to XML documents (<function>fn:doc</function>, <function>fn:doc-available</function>), collections (<function>fn:collection</function>, <function>fn:uri-collection</function>), text files (<function>fn:unparsed-text</function>, <function>fn:unparsed-text-lines</function>, <function>fn:unparsed-text-available</function>), and environment variables (<function>fn:environment-variable</function>, <function>fn:available-environment-variables</function>).  These functions are defined in <xspecref
                spec="FO40" ref="fns-on-docs"/>.</p>
             
             
@@ -2611,7 +2611,7 @@ used in this specification. Any form of serialization that is
 not based on <bibref
                      ref="xslt-xquery-serialization-40"
                   /> is outside
-the scope of the &language; specification.</p>
+the scope of the <?inject language?> specification.</p>
             </note>
 
             <p role="xpath">Serialization is outside the scope of the XPath specification, except
@@ -2636,14 +2636,14 @@ based on an event stream. </p>
          <div3 id="id-consistency-constraints">
 
             <head>Consistency Constraints</head>
-            <p>In order for &language; to
+            <p>In order for <?inject language?> to
 be well defined, the input <termref
                   def="dt-data-model-instance">XDM instances</termref>, the <termref
                   def="dt-static-context">static context</termref>, and the <termref
                   def="dt-dynamic-context"
                   >dynamic context</termref> must be mutually
 consistent. The consistency constraints listed below are prerequisites
-for correct functioning of an &language; implementation. Enforcement
+for correct functioning of an <?inject language?> implementation. Enforcement
 of these consistency constraints is beyond the scope of this
 specification. This specification does not
 define the result of  <phrase
@@ -2767,7 +2767,7 @@ The prefix <code>xmlns</code> must not be bound to any namespace URI, and no pre
                This section is new; it documents what was largely implicit in previous versions of the specification.
             </change>
          </changes>
-         <p>&language; is designed, as far as possible, to be a pure functional language. This means:</p>
+         <p><?inject language?> is designed, as far as possible, to be a pure functional language. This means:</p>
          <ulist>
             <item><p>The result of evaluating an expression (or a function) depends only on the explicit
             and implicit operands to the expression. (The expression context, described in <specref ref="context"/>,
@@ -2894,7 +2894,7 @@ The prefix <code>xmlns</code> must not be bound to any namespace URI, and no pre
             <head>Kinds of Errors</head>
             <p>
 As described in <specref ref="id-expression-processing"
-                  />, &language;
+                  />, <?inject language?>
 defines a <termref def="dt-static-analysis"
                   >static analysis phase</termref>, which does not depend on input
 data, and a <termref
@@ -2995,7 +2995,7 @@ else 0
                      >static errors</termref>, <termref def="dt-dynamic-error"
                      >dynamic errors</termref>, and <termref def="dt-type-error"
                      >type
-errors</termref>, an &language;
+errors</termref>, an <?inject language?>
 implementation may raise <term>warnings</term>, either during the <termref
                      def="dt-static-analysis">static analysis
 phase</termref> or the
@@ -3439,7 +3439,7 @@ would raise an error because it has an <code>id</code> child whose value is not 
             not <rfc2119>required</rfc2119> to) raise a static error.</p>
             
             <p>For reasons of backwards compatibility and interoperability, and to facilitate
-            automatic generation of &language; code, a processor <rfc2119>must</rfc2119> 
+            automatic generation of <?inject language?> code, a processor <rfc2119>must</rfc2119> 
             provide a mode of operation in which <termref def="dt-implausible"/>
             expressions are not treated as static errors, but are evaluated
             with the defined semantics for the expression.</p>
@@ -3477,7 +3477,7 @@ would raise an error because it has an <code>id</code> child whose value is not 
       <div2 id="id-important-concepts">
          <head>Concepts</head>
 
-         <p>This section explains some concepts that are important to the processing of &language; expressions.</p>
+         <p>This section explains some concepts that are important to the processing of <?inject language?> expressions.</p>
 
          <div3 id="id-document-order">
             <head>Document Order</head>
@@ -3813,7 +3813,7 @@ tree <var>T2</var>.</p>
          <div3 id="id-atomization">
             <head>Atomization</head>
             <p>The semantics of some
-&language; operators depend on a process called <termref
+<?inject language?> operators depend on a process called <termref
                   def="dt-atomization"
                   >atomization</termref>. Atomization is
 applied to a value when the value is used in a context in which a
@@ -4031,7 +4031,7 @@ of applying the <function>fn:boolean</function> function to the value.</termdef>
          <div3 id="id-uri-literals">
             <head>URI Literals</head>
 
-            <p>&language; requires a statically known, valid URI in <phrase role="xquery">a <nt
+            <p><?inject language?> requires a statically known, valid URI in <phrase role="xquery">a <nt
                      def="URILiteral">URILiteral</nt> or
       </phrase>a <nt def="BracedURILiteral"
                   >BracedURILiteral</nt>. 
@@ -4158,17 +4158,17 @@ of applying the <function>fn:boolean</function> function to the value.</termdef>
          that uses XSD 1.0 for validation.</change>
       </changes>
       
-      <p>As noted in <specref ref="id-values"/>, every value in &language; is regarded
+      <p>As noted in <specref ref="id-values"/>, every value in <?inject language?> is regarded
       as a <termref def="dt-sequence"/> of zero, one, or more <termref def="dt-item">items</termref>.
-      The type system of &language;, described in this section, classifies the
+      The type system of <?inject language?>, described in this section, classifies the
       kinds of value that the language can handle, and the operations permitted
       on different kinds of value.</p>
       
-         <p>The type system of &language; is related to the type system of
+         <p>The type system of <?inject language?> is related to the type system of
 		<bibref ref="XMLSchema10"/> or <bibref ref="XMLSchema11"/> in two ways:</p>
       
          <ulist>
-            <item><p>Atomic items in &language; (which are one kind of <termref def="dt-item"/>)
+            <item><p>Atomic items in <?inject language?> (which are one kind of <termref def="dt-item"/>)
                have <termref def="dt-atomic-type">atomic types</termref> such as <code>xs:string</code>,
                <code>xs:boolean</code>, and <code>xs:integer</code>. These types are taken directly
                from their definitions in <bibref ref="XMLSchema11"/>.</p>
@@ -4188,7 +4188,7 @@ of applying the <function>fn:boolean</function> function to the value.</termdef>
             <code><![CDATA[<age>23</age>]]></code> might have been validated against a schema
                that defines this element as having <code>xs:integer</code> content. If this
                is the case, the <termref def="dt-type-annotation"/> of the node will be
-               <code>xs:integer</code>, and in the &language; type system, the node will
+               <code>xs:integer</code>, and in the <?inject language?> type system, the node will
                match the <termref def="dt-item-type"/> <code>element(age, xs:integer)</code>.
             </p></item>
          </ulist>
@@ -4220,14 +4220,14 @@ of applying the <function>fn:boolean</function> function to the value.</termdef>
             <termdef id="dt-sequence-type" term="sequence type"
                   >A <term>sequence type</term> is a type that can be expressed using the <nt
                   def="SequenceType">SequenceType</nt>
-                  syntax. Sequence types are used whenever it is necessary to refer to a type in an &language; expression. 
+                  syntax. Sequence types are used whenever it is necessary to refer to a type in an <?inject language?> expression. 
                   Since all values are sequences, every value matches one or more <term>sequence types</term>.</termdef>
          </p>
       
          
          
          <p>Whenever it is necessary to refer to a <term>sequence type</term> 
-            in an &language; expression, the <nt
+            in an <?inject language?> expression, the <nt
             def="SequenceType">SequenceType</nt> syntax is used.</p>
          <scrap>
             <prodrecap ref="SequenceType"/>
@@ -4271,7 +4271,7 @@ types</term> (such as <code>xs:integer</code>) and function types
 
             <p>Here are some examples of <termref def="dt-sequence-type"
                >sequence types</termref> that
-		  might be used in &language;:</p>
+		  might be used in <?inject language?>:</p>
 
             <ulist>
                <item>
@@ -4354,10 +4354,10 @@ types</term> (such as <code>xs:integer</code>) and function types
                >sequence type</termref>, and <code>false</code> if it does not.</p>
 
 
-            <p>An &language; implementation must be able to determine relationships among the types in type annotations in an <termref
+            <p>An <?inject language?> implementation must be able to determine relationships among the types in type annotations in an <termref
                   def="dt-data-model-instance">XDM instance</termref> and the types in the  <termref
                   def="dt-issd">in-scope schema definitions</termref> (ISSD). <phrase role="xquery"
-                  >An &language; implementation must be able to determine relationships among the types in ISSDs used in different modules of the same query.</phrase>
+                  >An <?inject language?> implementation must be able to determine relationships among the types in ISSDs used in different modules of the same query.</phrase>
             </p>
 
             <p diff="chg" at="B">
@@ -4533,8 +4533,8 @@ types</term> (such as <code>xs:integer</code>) and function types
             syntax. Item types match individual <termref def="dt-item">items</termref>.</termdef></p>
             
             <note><p>While this definition is adequate for the purpose of defining the syntax
-            of &language;, it ignores the fact that there are also item types that cannot be
-            expressed using &language; syntax: specifically, item types that reference
+            of <?inject language?>, it ignores the fact that there are also item types that cannot be
+            expressed using <?inject language?> syntax: specifically, item types that reference
             an anonymous simple type or complex type defined in a schema. Such types 
             can appear as type annotations on nodes following schema validation.</p></note>
          
@@ -4645,7 +4645,7 @@ types</term> (such as <code>xs:integer</code>) and function types
                   that uses XSD 1.0 for validation.</change>
                </changes>
                
-               <p>Atomic types in the &language; type system correspond directly to atomic types
+               <p>Atomic types in the <?inject language?> type system correspond directly to atomic types
                   as defined in the <bibref ref="XMLSchema11"/>
                  type system.</p>
                
@@ -4654,7 +4654,7 @@ types</term> (such as <code>xs:integer</code>) and function types
                by a QName: see <specref ref="id-namespaces-and-qnames"/>.</p>
                
                <note><p>A schema may also include anonymous atomic types. Such types are
-               not usable directly in &language;, though they may appear as the values
+               not usable directly in <?inject language?>, though they may appear as the values
                of <termref def="dt-type-annotation">type annotations</termref> on nodes.</p></note>
                
 
@@ -4798,7 +4798,7 @@ types</term> (such as <code>xs:integer</code>) and function types
                <p>It is not possible to convert between the lexical space and the value space 
                   of a <termref def="dt-namespace-sensitive"/> type without knowledge of 
                   the <termref def="dt-namespace-binding"/> 
-                  that defines the meaning of each namespace prefix used in the value. Therefore, &language; defines 
+                  that defines the meaning of each namespace prefix used in the value. Therefore, <?inject language?> defines 
                   some error conditions that occur only with <termref
                      def="dt-namespace-sensitive"
                      >namespace-sensitive</termref> values. For instance, casting to a <termref
@@ -5906,7 +5906,7 @@ name.</p>
     set of functions matched by a FunctionType. It uses the same
     syntax as <specref
                         ref="id-annotations"
-                  />.</termdef> &language; does not currently
+                  />.</termdef> <?inject language?> does not currently
     define any function assertions, but future versions may. Other
     specifications in the XQuery family may also use function
     assertions in the future.</p>
@@ -6396,12 +6396,12 @@ name.</p>
                
                <p>The data model does not forbid cycles among instances, and indeed, there are functions
                such as <function>fn:schema-type</function> that may return cyclic instances. However, such
-               cycles can only be constructed using mechanisms beyond the capabilities of &language;.
+               cycles can only be constructed using mechanisms beyond the capabilities of <?inject language?>.
                (The structure returned by <function>fn:schema-type</function> carefully uses functions
                to represent references from one value to another, rather than making the 
                references direct. This reduces the danger that
                operations such as serialization will be non-terminating. However, it does not remove
-               the difficulty that the structure cannot be built using &language; alone.)</p></note>
+               the difficulty that the structure cannot be built using <?inject language?> alone.)</p></note>
                
                <example id="e-binary-tree">
                   <head>A Binary Tree</head>
@@ -6435,7 +6435,7 @@ name.</p>
                   <p>The usual textbook example of mutually-recursive types is that of a <emph>forest</emph>
                   consisting of a list of <emph>trees</emph>, where each <emph>tree</emph> is a record 
                   comprising a value and a <emph>forest</emph>.
-                  As the previous example shows, this structure can be defined straightforwardly in &language; without 
+                  As the previous example shows, this structure can be defined straightforwardly in <?inject language?> without 
                   recourse to mutual recursion.</p>
                   <p>A more realistic example where mutual recursion is needed is for the schema component model
                      used in <bibref ref="XMLSchema10"/> or <bibref ref="XMLSchema11"/>. Simplifying greatly,
@@ -6717,7 +6717,7 @@ declare record Particle (
                   
                   
                   It was defined in XML Schema in the interests of making the type system complete and closed, 
-                  and it is also available in &language; for similar reasons.</p>
+                  and it is also available in <?inject language?> for similar reasons.</p>
                
                <note>
                   <p>Even though it cannot occur in an instance, <code>xs:error</code> is a valid type name in a sequence type. The
@@ -8838,7 +8838,7 @@ return local:filter(("Ethel", "Enid", "Gertrude"), $f)
       </p>
                </note>
 
-               <p>Since maps and arrays are also functions in &language;, 
+               <p>Since maps and arrays are also functions in <?inject language?>, 
                   <termref
                      def="dt-function-coercion"
                   >function coercion</termref> applies to them as well.
@@ -9424,11 +9424,11 @@ return $f(12.3)]]></eg>
             </item>
          </olist>
          
-         <p>The relationships among the schema types in the <code>xs</code> namespace are illustrated in Figure 2. A more complete description of the &language; type hierarchy can be found in 
+         <p>The relationships among the schema types in the <code>xs</code> namespace are illustrated in Figure 2. A more complete description of the <?inject language?> type hierarchy can be found in 
             <xspecref
                spec="FO40" ref="datatypes"/>.</p>
          <graphic source="types.jpg" alt="Type Hierarchy Diagram"/>
-         <p>Figure 2: Hierarchy of Schema Types used in &language;.</p>
+         <p>Figure 2: Hierarchy of Schema Types used in <?inject language?>.</p>
          
          
       </div2>
@@ -9441,7 +9441,7 @@ return $f(12.3)]]></eg>
 
    <div1 id="id-expressions">
       <head>Expressions</head>
-      <p>This section discusses each of the basic kinds of expression. Each kind of expression has a name such as <code>PathExpr</code>, which is introduced on the left side of the grammar production that defines the expression. Since &language; is a composable language, each kind of expression is defined in terms of other expressions whose operators have a higher precedence. In this way, the precedence of operators is represented explicitly in the grammar.</p>
+      <p>This section discusses each of the basic kinds of expression. Each kind of expression has a name such as <code>PathExpr</code>, which is introduced on the left side of the grammar production that defines the expression. Since <?inject language?> is a composable language, each kind of expression is defined in terms of other expressions whose operators have a higher precedence. In this way, the precedence of operators is represented explicitly in the grammar.</p>
       <p>The order in which expressions are discussed in this document does not reflect the order of operator precedence. In general, this document introduces the simplest kinds of expressions first, followed by more complex expressions.  For the complete grammar, see Appendix [<specref
             ref="nt-bnf"/>].</p>
       <p>
@@ -9465,7 +9465,7 @@ return $f(12.3)]]></eg>
       <scrap>
          <prodrecap ref="ExprSingle"/>
       </scrap>
-      <p>The &language; operator that has lowest precedence is the <termref def="dt-comma-operator"
+      <p>The <?inject language?> operator that has lowest precedence is the <termref def="dt-comma-operator"
             >comma operator</termref>, which is used to combine two operands to form a sequence. 
          As shown in the grammar, a general expression (<nt
             def="Expr">Expr</nt>) can consist of multiple <nt def="ExprSingle"
@@ -9507,7 +9507,7 @@ and <nt def="OrExpr"
                relying entirely on the host language to declare namespace prefixes.
             </change>
          </changes>
-         <p>An &language; expression may be preceded by a set of namespace declarations: specifically,
+         <p>An <?inject language?> expression may be preceded by a set of namespace declarations: specifically,
          an optional default namespace declaration, followed by zero or more bindings of specific
          namespace prefixes to specific namespace URIs.</p>
          <scrap role="xpath">
@@ -9625,7 +9625,7 @@ and <nt def="OrExpr"
             <p>
                <termdef id="dt-literal" term="literal"
                   >A <term>literal</term> is a direct syntactic representation of an
-		atomic item.</termdef> &language; supports three kinds of literals: numeric literals,
+		atomic item.</termdef> <?inject language?> supports three kinds of literals: numeric literals,
 		string literals, and QName literals.</p>
             
             
@@ -9931,7 +9931,7 @@ and <nt def="OrExpr"
                <note><p>A <code>QNameLiteral</code> is an expression that evaluates to a single
                   item of type <code>xs:QName</code>; it is thus an alternative to calling the
                   <code>xs:QName</code> constructor function with a literal string argument.
-                  This should not be confused with QNames that are used directly in &language; to refer to constructs such as
+                  This should not be confused with QNames that are used directly in <?inject language?> to refer to constructs such as
                functions, variables, and elements.</p>
                   <p>A <code>QName</code> appearing on its own as an expression,
                for example <code>my:invoice</code>, is an abbreviation for the axis step <code>child::my:step</code>,
@@ -10364,7 +10364,7 @@ At evaluation time, the value of a variable reference is the value to which the 
       <div2 id="id-functions">
          <head>Functions</head>
          
-         <p diff="chg" at="B">Functions in &language; arise in two ways:</p>
+         <p diff="chg" at="B">Functions in <?inject language?> arise in two ways:</p>
          
          <ulist diff="chg" at="B">
             <item><p>A <termref def="dt-function-definition"/> contains information
@@ -10800,7 +10800,7 @@ At evaluation time, the value of a variable reference is the value to which the 
             <head>Function Items</head>
 
             <p>A <termref def="dt-function-item"/> is an XDM
-            value that can be bound to a variable, or manipulated in various ways by &language; expressions.
+            value that can be bound to a variable, or manipulated in various ways by <?inject language?> expressions.
             The most significant such expression is a <termref def="dt-dynamic-function-call"/>, which supplies
             values of arguments and evaluates the function to produce a result.</p>
             
@@ -10984,7 +10984,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                                  <p>
                                   If <var>FI</var>’s <phrase diff="chg" at="2023-03-11">body</phrase> is 
                                   
-                                  an &language; expression
+                                  an <?inject language?> expression
                                   
                                     (for example, if <var>FI</var> is
                                     <phrase
@@ -11008,7 +11008,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                                       is evaluated.
                                       
                                         The static context for this evaluation
-                                        is the static context of the &language; expression.
+                                        is the static context of the <?inject language?> expression.
                                       
                                       The dynamic context for this evaluation is obtained
                                       by taking the dynamic context of the
@@ -11103,7 +11103,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                               <item>
                                  <p>                                  
                                   If the body of <var>FI</var> is
-                                  not an &language; expression
+                                  not an <?inject language?> expression
                                   (for example, if <var>FI</var> is
                                   a <termref
                                        def="dt-system-function">system function</termref>
@@ -11829,7 +11829,7 @@ return $a("A")]]></eg>
                <p role="xquery"
                      >An inline function
 	  expression may have
-	  annotations; however, no annotations are defined in &language; 
+	  annotations; however, no annotations are defined in <?inject language?> 
 	  for inline function
 	  expressions.
                   It is a <termref
@@ -14378,9 +14378,9 @@ every <code>section</code> element that has a parent that is either a <code>chap
   }
 }]]></eg>
                   <p>The following table illustrates some queries on this data, expressed
-                  both in JSONPath and in &language;.</p>
+                  both in JSONPath and in <?inject language?>.</p>
                   <table role="small" width="100%">
-                     <caption>JSONPath vs &language; Comparison</caption>
+                     <caption>JSONPath vs <?inject language?> Comparison</caption>
                      <col width="40%"/>
                      <col width="30%"/>
                      <col width="30%"/>
@@ -14388,7 +14388,7 @@ every <code>section</code> element that has a parent that is either a <code>chap
                         <tr>
                            <th>Query</th>
                            <th>JSONPath</th>
-                           <th>&language;</th>
+                           <th><?inject language?></th>
                         </tr>
                      </thead>
                      <tbody>
@@ -14459,11 +14459,11 @@ every <code>section</code> element that has a parent that is either a <code>chap
       </div2>
       <div2 id="id-sequence-expressions">
          <head>Sequence Expressions</head>
-         <p>&language; supports operators to construct, filter,  and combine
+         <p><?inject language?> supports operators to construct, filter,  and combine
 <termref
                def="dt-sequence">sequences</termref> of <termref def="dt-item"
                >items</termref>.
-Sequences are never nested&mdash;for
+Sequences are never nested—for
 example, combining the values <code>1</code>, <code>(2, 3)</code>, and <code>( )</code> into a single sequence results
 in the sequence <code>(1, 2, 3)</code>.</p>
          <div3 id="construct_seq">
@@ -14619,7 +14619,7 @@ the value <code>10.50</code>, the result of this expression is the sequence <cod
             <scrap>
                <prodrecap ref="UnionExpr"/>
             </scrap>
-            <p>&language; provides the following operators for combining sequences of
+            <p><?inject language?> provides the following operators for combining sequences of
 <termref def="dt-GNode">GNodes</termref>:</p>
             <ulist>
 
@@ -14753,7 +14753,7 @@ return ...</eg>
                The symbols <code>×</code> and <code>÷</code> can be used for multiplication and division.
             </change>
          </changes>
-         <p>&language; provides binary arithmetic operators for addition, subtraction,
+         <p><?inject language?> provides binary arithmetic operators for addition, subtraction,
 multiplication, division, and modulus:</p>
          <scrap>
             <prodrecap ref="AdditiveExpr"/>
@@ -14983,7 +14983,7 @@ might result from dividing by zero).</p>
  
          
       <note>
-         <p>&language; provides three division operators:</p>
+         <p><?inject language?> provides three division operators:</p>
          <ulist>
             <item><p>The <code>div</code> and <code>÷</code> operators are synonyms, and implement
                numeric division as well as division of duration values; the semantics are defined in
@@ -15048,7 +15048,7 @@ course to the use of parentheses. Therefore, the following two examples have dif
                <prodrecap ref="StringConcatExpr"/>
             </scrap>
             <p>String concatenation expressions allow the string representations of values to be
-               concatenated. In &language;, <code>$a || $b</code> is equivalent to
+               concatenated. In <?inject language?>, <code>$a || $b</code> is equivalent to
                <code>fn:concat($a, $b)</code>.
                The following expression evaluates to the string <code>concatenate</code>:</p>
             <eg><![CDATA[() || "con" || ("cat", "enate")]]></eg>
@@ -15220,7 +15220,7 @@ return `The months with 31 days are: { $long-months }.`]]></eg>
             <p>The syntax of a string constructor is convenient for generating
                JSON, JavaScript, CSS, SPARQL, XQuery, XPath, or other languages that
                use curly brackets, quotation marks, or other strings that are
-               delimiters in &language;.</p>
+               delimiters in <?inject language?>.</p>
             
             <scrap>
                <prodrecap ref="StringConstructor"/>
@@ -15364,7 +15364,7 @@ declare function local:prize-message($a) as xs:string {
       
       <div2 id="id-comparisons">
          <head>Comparison Expressions</head>
-         <p>Comparison expressions allow two values to be compared. &language; provides
+         <p>Comparison expressions allow two values to be compared. <?inject language?> provides
 three kinds of comparison expressions, called value comparisons, general
 comparisons, and GNode comparisons.</p>
          <scrap>
@@ -15380,7 +15380,7 @@ must be followed; thus <code>&lt;</code> must be written as
          </note>
          
          <p>For a summary of the differences between different ways of comparing atomic items
-         in &language;, see <specref ref="id-atomic-comparisons"/>.</p>
+         in <?inject language?>, see <specref ref="id-atomic-comparisons"/>.</p>
 
 
          <div3 id="id-value-comparisons">
@@ -16304,7 +16304,7 @@ following expression must raise a <termref def="dt-dynamic-error"
             </item>
          </ulist>
 
-         <p>In addition to and- and or-expressions, &language; provides a
+         <p>In addition to and- and or-expressions, <?inject language?> provides a
 function named <function>fn:not</function> that takes a general sequence as
 parameter and returns a boolean value.  The <function>fn:not</function> function
 is defined in <bibref
@@ -16329,7 +16329,7 @@ encountered in finding the effective boolean value of its operand,
             </change>
          </changes>
          
-         <p>&language; provides node constructors that can create XML nodes within a query.</p>
+         <p><?inject language?> provides node constructors that can create XML nodes within a query.</p>
 
          <scrap>
             <prodrecap ref="NodeConstructor"/>
@@ -17411,7 +17411,7 @@ end of the content, or by a <nt
    boundary-space policy is <code>preserve</code>, this example is
    equivalent to <code
                            role="parse-test"
-                        >&lt;a&gt;&nbsp;&nbsp;abc&nbsp;&nbsp;&lt;/a&gt;</code>.</p>
+                        >&lt;a&gt;&#xa0;&#xa0;abc&#xa0;&#xa0;&lt;/a&gt;</code>.</p>
                   </item>
 
                   <item>
@@ -17421,7 +17421,7 @@ end of the content, or by a <nt
    whitespace surrounding the <code>z</code> is not boundary
    whitespace, it is always preserved. This example is equivalent to
    <code
-                           role="parse-test">&lt;a&gt;&nbsp;z&nbsp;abc&lt;/a&gt;</code>.</p>
+                           role="parse-test">&lt;a&gt;&#xa0;z&#xa0;abc&lt;/a&gt;</code>.</p>
                   </item>
 
                   <item>
@@ -17429,7 +17429,7 @@ end of the content, or by a <nt
                      <eg role="parse-test">&lt;a&gt;&amp;#x20;{ "abc" }&lt;/a&gt;</eg>
                      <p>This
    example is equivalent to <code role="parse-test"
-                           >&lt;a&gt;&nbsp;abc&lt;/a&gt;</code>, regardless
+                           >&lt;a&gt;&#xa0;abc&lt;/a&gt;</code>, regardless
    of the boundary-space policy, because the space generated by the <termref
                            def="dt-character-reference"
                         >character reference</termref> is not treated as a whitespace character.</p>
@@ -17634,7 +17634,7 @@ same result as the first example in <specref
                         <sitem><code>element Q{http://http://www.w3.org/1999/xhtml}table {}</code></sitem>
                         <sitem><code>element Q{http://http://www.w3.org/1999/xhtml}html:table {}</code></sitem>
                      </slist>
-                     <p>In &language; the first form (using an unprefixed <termref def="dt-qname">lexical QName</termref>)
+                     <p>In <?inject language?> the first form (using an unprefixed <termref def="dt-qname">lexical QName</termref>)
                      is allowed only if the element name is not a reserved keyword (such as <code>div</code> or <code>case</code>): see
                   <loc href="#parse-note-unreserved-name">unreserved-name</loc>. In all other cases,
                      the effect is exactly the same as when a leading <code>#</code>
@@ -17974,7 +17974,7 @@ element {
                         <sitem><code>attribute Q{http://www.w3.org/2001/XMLSchema-instance}xsi:type {}</code></sitem>
                         <sitem><code>attribute Q{http://www.w3.org/2001/XMLSchema-instance}type {}</code></sitem>
                      </slist>
-                     <p>In &language; the first form (using an unprefixed <termref def="dt-qname">lexical QName</termref>)
+                     <p>In <?inject language?> the first form (using an unprefixed <termref def="dt-qname">lexical QName</termref>)
                      is allowed only if the attribute name is not a reserved keyword (such as <code>div</code> or <code>value</code>): see
                   <loc href="#parse-note-unreserved-name">unreserved-name</loc>. In all other cases,
                      the effect is exactly the same as when a leading <code>#</code>
@@ -18331,7 +18331,7 @@ attribute {
                <p>No validation is performed on the constructed document node. The <bibref ref="XML"
                   /> rules that govern the structure of an XML document (for example, the 
                   document node must have exactly one child that is an element node)  
-                  are not enforced by the &language; document node constructor.</p>
+                  are not enforced by the <?inject language?> document node constructor.</p>
             </div4>
             <div4 id="id-textConstructors">
                <head>Text Node Constructors</head>
@@ -20545,7 +20545,7 @@ group by $g1, $g2, $g3 collation "Spanish"]]></eg>
   collation.</termdef></p>
                      
                      <note diff="add" at="2023-12-05"><p>The <function>fn:deep-equal</function> function has been changed
-                     in &language; so that it is now transitive; the problem that existed
+                     in <?inject language?> so that it is now transitive; the problem that existed
                      in earlier versions when comparing numeric values of different
                      types has thereby been resolved.</p></note>
 
@@ -20624,7 +20624,7 @@ evaluates to:</p>
 </department>]]></eg>
 
                <p>In XQuery, each group is a sequence of items that match the group
-by criteria&mdash;in a tree-structured language like XQuery, this is
+by criteria—in a tree-structured language like XQuery, this is
 convenient, because further structures can be built based on the items
 in this sequence. Because there are three items in the group,
 <code>$x</code> evaluates to a sequence of three items. To reduce this
@@ -21697,10 +21697,10 @@ return upper-case($x)
          <p>Most modern programming languages have support for collections of
 key/value pairs, which may be called maps, dictionaries, associative
 arrays, hash tables, keyed lists, or objects (these are not the same
-thing as objects in object-oriented systems). In &language; these are called
+thing as objects in object-oriented systems). In <?inject language?> these are called
 maps. Most modern programming languages also support ordered
 lists of values, which may be called arrays, vectors, or sequences.
-In &language;, there are two kinds of ordered lists, called
+In <?inject language?>, there are two kinds of ordered lists, called
 sequences and arrays. Unlike sequences, an array is an
 item, and can appear as an item in a sequence.</p>
 
@@ -21708,7 +21708,7 @@ item, and can appear as an item in a sequence.</p>
 
 
          <note>
-            <p>This specification focuses on &language; syntax provided for maps
+            <p>This specification focuses on <?inject language?> syntax provided for maps
   and arrays, especially constructors and lookup expressions.</p>
 
             <p>Some of the functionality typically needed for maps and
@@ -21751,7 +21751,7 @@ item, and can appear as an item in a sequence.</p>
             see <xspecref spec="FO40" ref="maps"/>.</p>
             
             <note>
-               <p>Maps in &language; are ordered.
+               <p>Maps in <?inject language?> are ordered.
                   The effect of this property is explained 
                   in <xspecref spec="DM40" ref="map-items"/>. 
                   In an ordered map, the order of entries is predictable
@@ -21796,7 +21796,7 @@ item, and can appear as an item in a sequence.</p>
                
                <note>
                   <p>The keyword <code>map</code> was required in earlier versions
-                  of the language; in &language; it becomes optional. There may be cases
+                  of the language; in <?inject language?> it becomes optional. There may be cases
                   where using the keyword improves readability.</p>
                   
                   <p>In order to allow the <code>map</code> keyword to be omitted,
@@ -21984,10 +21984,10 @@ return { $persons/*/* }
     ]]></eg>
                
                <note><p>The syntax deliberately mimics JSON, but there are a few differences.
-               JSON constructs that are not accepted in &language; map
+               JSON constructs that are not accepted in <?inject language?> map
                constructors include the keywords <code>true</code>, <code>false</code>,
                and <code>null</code>, and backslash-escaped characters such as <code>"\n"</code>
-               in string literals. In an &language; map constructor, of course, any literal 
+               in string literals. In an <?inject language?> map constructor, of course, any literal 
                value can be replaced with an expression.</p></note>
       </example>
                
@@ -22094,7 +22094,7 @@ return { $persons/*/* }
                </ulist>
 
                <note>
-                  <p>&language; also provides an alternate syntax for map and
+                  <p><?inject language?> also provides an alternate syntax for map and
       array lookup that is more terse, supports wildcards, and allows lookup to
       iterate over a sequence of maps or arrays. See <specref
                         ref="id-lookup"/> for details.</p>
@@ -22274,7 +22274,7 @@ return { $persons/*/* }
                </ulist>
 
                <note>
-                  <p>&language; does not provide explicit support for sparse arrays. Use integer-valued maps to represent sparse arrays, 
+                  <p><?inject language?> does not provide explicit support for sparse arrays. Use integer-valued maps to represent sparse arrays, 
                      for example: <code>{ 27 : -1, 153 : 17 }</code>.</p>
                </note>
 
@@ -22333,7 +22333,7 @@ return { $persons/*/* }
                </ulist>
 
                <note>
-                  <p>&language; also provides an alternate syntax for map and
+                  <p><?inject language?> also provides an alternate syntax for map and
       array lookup that is more terse, supports wildcards, and allows
       lookup to iterate over a sequence of maps or arrays. See
       <specref
@@ -22657,7 +22657,7 @@ return $r?z</eg>
                   minor changes from the previous version 3.1. They remain a convenient
                   solution for simple lookups of entries in maps and arrays.</p>
                   
-                  <p>For more complex queries into trees of maps and arrays, &language;
+                  <p>For more complex queries into trees of maps and arrays, <?inject language?>
                   introduces a generalization of path expressions (see <specref ref="id-path-expressions"/>)
                   which can now handle <termref def="dt-JTree">JTrees</termref> 
                      as well as <termref def="dt-XTree">XTrees</termref>.</p>
@@ -23006,7 +23006,7 @@ return $lib =?> product((1.2, 1.3, 1.4))
                by the expression <code>$rectangle =?> contents()</code>.</p>
                
                <p role="xquery">A record type representing a rectangle containing nested rectangles might be defined
-               in &language;  like this:</p>
+               in <?inject language?>  like this:</p>
                
                
                <eg role="xquery">
@@ -23074,7 +23074,7 @@ declare record my:rectangle (
             </change>
          </changes>
          
-         <p diff="chg" at="2022-12-07">&language; allows conditional expressions to be written in several different ways.</p>
+         <p diff="chg" at="2022-12-07"><?inject language?> allows conditional expressions to be written in several different ways.</p>
          <scrap>
             <prodrecap ref="IfExpr"/>
          </scrap>
@@ -23435,7 +23435,7 @@ one <code>employee</code> element satisfies the given comparison expression:</p>
                <note diff="add" at="A"><p>Like many quantified expressions, this can be simplified. This example can be written
                   <code>every $emp in /emps/employee satisfies $emp/salary[@current = 'true']</code>, or even
                   more concisely as <code>empty(/emps/employee[not(salary/@current = 'true')]</code>.</p>
-               <p>Another alternative in &language; is to use the higher-order functions <function>fn:some</function> and <function>fn:every</function>.
+               <p>Another alternative in <?inject language?> is to use the higher-order functions <function>fn:some</function> and <function>fn:every</function>.
                This example can be written <code diff="chg" at="2023-04-25">every(/emps/employee, fn { salary/@current = 'true' })</code></p>
                </note>
             </item>
@@ -24052,7 +24052,7 @@ be used to process an expression in a way that depends on its <termref
             </scrap>
             <p>Sometimes
 it is necessary to convert a value to a specific datatype. For this
-purpose, &language; provides a <code>cast</code> expression that
+purpose, <?inject language?> provides a <code>cast</code> expression that
 creates a new value of a specific type based on an existing value. A
 <code>cast</code> expression takes two operands: an <term>input
 expression</term> and a <term>target type</term>. The type of the
@@ -24206,7 +24206,7 @@ mechanism such as a data dictionary.-->
                <prodrecap ref="CastableExpr"/>
             </scrap>
             
-            <p>&language;
+            <p><?inject language?>
 provides an expression that tests whether a given value
 is castable into a given target type. 
 
@@ -24420,7 +24420,7 @@ raised <errorref class="DY" code="0050"/>.</p>
                rarely necessary, though it can be useful for documentation, and might in
                some cases (depending on the processor) have performance benefits.
              </p>
-             <p>&language; redefines the error raised by a <code>treat as</code> expression
+             <p><?inject language?> redefines the error raised by a <code>treat as</code> expression
              as a type error rather than a dynamic error, which allows a processor to raise
              the error statically in the case of an expression (such as <code>3 treat as xs:string</code>)
              which can never succeed. However, the error code remains unchanged, for compatibility.</p>
@@ -25204,3 +25204,4 @@ raise a <termref
       </div2>
    </div1>
 
+</fascicle>

--- a/specifications/xquery-40/src/introduction.xml
+++ b/specifications/xquery-40/src/introduction.xml
@@ -38,7 +38,7 @@
 	</termdef></p>
 
 	<p>
-		<termdef id="dt-datamodel" term="data model">&language; operates on the abstract, logical
+		<termdef id="dt-datamodel" term="data model"><?inject language?> operates on the abstract, logical
 			structure of an XML document or JSON object rather than its surface syntax. This logical structure,
 			known as the <term>data model</term>, is defined in <bibref ref="xpath-datamodel-40"
 			/>.</termdef>
@@ -73,22 +73,22 @@
 	<p>Because these languages are so closely related, their grammars and language descriptions are
 		generated from a common source to ensure consistency.</p>
 
-	<p>&language; also depends on and is closely related to the following specifications:</p>
+	<p><?inject language?> also depends on and is closely related to the following specifications:</p>
 
 	<ulist>
 		<item>
 			<p><bibref ref="xpath-datamodel-40"/> defines the data model that underlies all
-				&language; expressions.</p>
+				<?inject language?> expressions.</p>
 		</item>
 
 		<item>
-			<p>The type system of &language; is based on XML Schema. Specifically, it follows
+			<p>The type system of <?inject language?> is based on XML Schema. Specifically, it follows
 				the rules of XSD 1.1 <bibref ref="XMLSchema11"/>, though it also allows implementations
 				to use a schema processor based on XSD 1.0 <bibref ref="XMLSchema10"/>.</p>
 		</item>
 
 		<item>
-			<p>The system function library and the operators supported by &language; are defined
+			<p>The system function library and the operators supported by <?inject language?> are defined
 				in <bibref ref="xpath-functions-40"/>.</p>
 		</item>
 
@@ -113,13 +113,13 @@
 	
 
 
-	<p>This document specifies a grammar for &language;, using EBNF notation described
+	<p>This document specifies a grammar for <?inject language?>, using EBNF notation described
 		in <specref ref="id-ebnf-introduction"/>. Grammar productions are introduced together with the features
 		that they describe, and a complete grammar is also presented in the appendix [<specref
 			ref="nt-bnf"/>]. The appendix is the normative version.</p>
 	
 
-	<p>This document normatively defines the static and dynamic semantics of &language;. In this
+	<p>This document normatively defines the static and dynamic semantics of <?inject language?>. In this
 		document, examples and material labeled as “Note” are provided for explanatory purposes and
 		are not normative.</p>
 

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -70,7 +70,7 @@
         <term>major version number</term> and the  <term>minor version number</term>.</termdef></p>
     
       <p>The version number is written as a <code>StringLiteral</code> following the <code>version</code>
-      keyword, and in a conformant &language; query it <rfc2119>must</rfc2119> match the regular expression 
+      keyword, and in a conformant <?inject language?> query it <rfc2119>must</rfc2119> match the regular expression 
       <code>[1-9][0-9]*\.[0-9]</code>: for example <code>"4.0"</code>. The major version is the integer 
         preceding the dot (which must be written without any leading zero); the minor version is the
       integer after the dot (which must be a single digit).</p>
@@ -91,28 +91,28 @@
       be processed by an <termref def="dt-xquery-40-processor">XQuery
         4.0 processor</termref>.</p>
     
-      <p>An &language; processor must accept a module in which the version number is given as
+      <p>An <?inject language?> processor must accept a module in which the version number is given as
       "1.0", "3.0", or "3.1". It is then <termref def="dt-implementation-defined"/> whether
-      the module is processed using the syntax and semantics of the &language; specification, or the rules
+      the module is processed using the syntax and semantics of the <?inject language?> specification, or the rules
       of the relevant earlier version. For example, if a query module specifies version <code>"3.0"</code>
       but contains a call to the <code>parse-html</code> function, the processor at its option can
-      either raise an error, or process the function call according to the &language; specification.</p>
+      either raise an error, or process the function call according to the <?inject language?> specification.</p>
     
-      <p>The &language; specification does not attempt to define the semantics of a query in which
+      <p>The <?inject language?> specification does not attempt to define the semantics of a query in which
       different modules use different version numbers. One approach is to process all modules as if
       they specified version "4.0". Another approach (which may be appropriate if modules
       are separately compiled) is to process each module using its own version number; but it is then
       <termref def="dt-implementation-defined"/> what happens if (say) a 3.1 module imports a 
       4.0 library module that declares a function with a signature that 3.1 does not recognize.</p>
     
-      <p>A conformant &language; processor <rfc2119>may</rfc2119> raise an error if the version number is anything
+      <p>A conformant <?inject language?> processor <rfc2119>may</rfc2119> raise an error if the version number is anything
       other than "1.0", "3.0", "3.1", or "4.0". If the processor does not raise an error, the effect of such
       a query is <termref def="dt-implementation-defined"/>.</p>
     
       <note>
         <p>The effect of this rule is to permit the use of non-standard version numbers to
         label non-standard extensions of the XQuery language. It also leaves flexibility as
-        to how an &language; processor should handle future version numbers such as "4.1",
+        to how an <?inject language?> processor should handle future version numbers such as "4.1",
         or version numbers such as "1" or "3.00" that were permitted by earlier XQuery
         specifications.</p>
       </note>
@@ -1669,7 +1669,7 @@ declare context value as document-node()* := collection($uri); </eg>
       is <termref def="dt-udf">user-defined</termref> or <termref def="dt-external-function">external</termref>.</p>
     
     <p>In addition to <termref def="dt-udf">user-defined functions</termref>
-      and <termref def="dt-external-function">external functions</termref>, &language; allows anonymous
+      and <termref def="dt-external-function">external functions</termref>, <?inject language?> allows anonymous
       functions to be declared in the body of a query using <termref def="dt-inline-func">inline function expressions</termref>.</p>
     
     
@@ -2012,7 +2012,7 @@ function smath:copySign($magnitude, $sign) external;</eg>
 
 
 
-    <p>A function declaration may be recursive&mdash;that is, it may reference itself. Mutually
+    <p>A function declaration may be recursive—that is, it may reference itself. Mutually
       recursive functions, whose bodies reference each other, are also allowed.</p>
       
       <example>
@@ -2549,7 +2549,7 @@ module namespace set = "http://qt4cg.org/atomic-set";
       suppress the detection of <termref def="dt-static-error">static errors</termref>. However, it
       may be used without restriction to modify the semantics of the query. The scope of the option
       declaration is <termref def="dt-implementation-defined"
-      >implementation-defined</termref>&mdash;for example, an option declaration might apply to the
+      >implementation-defined</termref>—for example, an option declaration might apply to the
       whole query, to the current module, or to the immediately following function declaration.</p>
     <p>The following examples illustrate several possible uses for option declarations:</p>
     <ulist>

--- a/style/assemble-spec.xsl
+++ b/style/assemble-spec.xsl
@@ -23,6 +23,24 @@
   <xsl:param name="not-spec" select="''"/>
   <xsl:param name="grammar-file" select="'xpath-grammar.xml'"/>
   <xsl:param name="grammar-map-file-name">grammar-map.xml</xsl:param>
+  
+  <xsl:variable name="injections" as="map(*)">
+    <xsl:choose>
+      <xsl:when test="$spec eq 'xpath40'">
+        <xsl:sequence select="map{ 'language': 'XPath 4.0' }"/>
+      </xsl:when>
+      <xsl:when test="$spec eq 'xquery40'">
+        <xsl:sequence select="map{ 'language': 'XQuery 4.0' }"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:sequence select="map{ 'language': $spec }"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:variable>
+  
+  <xsl:template match="processing-instruction('inject')">
+    <xsl:value-of select="$injections(string(.))"/>
+  </xsl:template>
 
   <!-- xsl:variable name="grammar" select="document($grammar-file)"/ -->
   <xsl:variable name="sourceTree" select="/"/>
@@ -54,6 +72,10 @@
   </xsl:template>
 
   <xsl:include href="grammar2spec.xsl"/>
+  
+  <xsl:template match="fascicle">
+    <xsl:apply-templates/>
+  </xsl:template>
 
   <xsl:template name="get-gfn">
     <!-- Assumes predrecap context -->


### PR DESCRIPTION
Fix #2709

(at least in part...)

In most of the parts making up the XPath and XQuery spec (with the exceptions of front and back matter), I have made the document well-formed by (a) adding a wrapper `fascicle` element where necessary (and declaring this in the DTD), and (b) eliminating external entity and character references that depend on the internal DTD subset.

The `&language;` entity reference is replaced by the processing instruction `<?inject language?>`

I have modified the assemble-specs stylesheet to:

- shallow-skip the `fascicle` element
- expand the `<?inject?>` processing instruction