### PR TITLE
2169 Reformulate `StringInterpolation` to remove the `` `{ `` and `` }` `` literal terminals

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -2666,12 +2666,10 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     </g:zeroOrMore>
   </g:production>
 
-  <g:production name="StringInterpolation" if="xquery40">
-    <g:string>`{</g:string>
-    <g:optional>
-      <g:ref name="Expr"/>
-    </g:optional>
-    <g:string>}`</g:string>
+  <g:production name="StringInterpolation" if="xquery40" whitespace-spec="explicit">
+    <g:string>`</g:string>
+    <g:ref name="EnclosedExpr"/>
+    <g:string>`</g:string>
   </g:production>
 
   <g:production name="UnaryLookup" if="xpath40 xquery40 xslt40-patterns">


### PR DESCRIPTION
Reformulates `StringInterpolation` as proposed and discussed in #2169.

Closes #2169