### PR TITLE
2738 XSLT - tree terminology

### DIFF
--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -116,39 +116,33 @@ Michael Sperberg-McQueen (1954–2024).</p>
          <head>Introduction</head>   
          <div2 id="what-is-xslt">
             <head>What is XSLT?</head>
-            <p>XSLT is a programming language designed principally to transform data.</p>
+            <p>XSLT is a programming language designed to transform data.</p>
             <p>A transformation in the XSLT language is expressed in the
                form of a <term>stylesheet</term>. A stylesheet is made up of one or more well-formed
                XML <bibref ref="REC-xml"/> documents conforming to the Namespaces in XML
                Recommendation <bibref ref="xml-names"/>. </p>
-            <p>A stylesheet generally includes elements that are defined by XSLT as well as elements
-               that are not defined by XSLT. XSLT-defined elements are distinguished by use of the
+            <p>A stylesheet generally includes elements whose meaning is defined by the XSLT language, as well as elements
+               whose meaning is application-defined. XSLT-defined elements are distinguished by use of the
                namespace <code>http://www.w3.org/1999/XSL/Transform</code> (see <specref ref="xslt-namespace"/>), which is referred to in this specification as the
                   <termref def="dt-xslt-namespace">XSLT namespace</termref>. Thus this specification
-               is a definition of the syntax and semantics of the XSLT namespace.</p>
+               is a definition of the syntax and semantics of elements in the XSLT namespace.</p>
             <p>The term <termref def="dt-stylesheet">stylesheet</termref> reflects the fact that one
-               of the important roles of XSLT is to add styling information to an XML source
+               of the original roles of XSLT was to add styling information to an XML source
                document, by transforming it into a document consisting of XSL formatting objects
                (see <bibref ref="xsl11"/>), or into another presentation-oriented format such as
                HTML, XHTML, or SVG. However, XSLT is used for a wide range of transformation tasks,
                not exclusively for formatting and presentation applications.</p>
             <p>A transformation expressed in XSLT describes rules for transforming input data into output data. The inputs and outputs
-                  will all be instances of the XDM data model, described in <bibref ref="xpath-datamodel-40"/>. In the simplest and most common case, the input is
-                  an XML document referred to as the source document or <termref def="dt-source-tree">source tree</termref>, and the output is an XML document
-                  referred to as the <termref def="dt-result-tree">result tree</termref>. It is also possible to process multiple source
-                  documents, to generate multiple result documents, and to handle formats other than
-                  XML.</p>
+                  will all be instances of the XDM data model, described in <bibref ref="xpath-datamodel-40"/>. In the simplest case, the input is
+                  a single XML document called the source document, and the output is another XML document
+                  referred to as the result document. In the general case, however, the input consists of a set of XDM 
+               <xtermref spec="DM40" ref="dt-value">values</xtermref>, and the result is another set of XDM values.</p>
             <p>The transformation is achieved by a set of
-                  <termref def="dt-template-rule">template rules</termref>. A template rule
-               associates a <termref def="dt-pattern">pattern</termref>, which typically matches nodes in the source document, with a
+                  <termref def="dt-template-rule">template rules</termref> and <termref def="dt-stylesheet-function">functions</termref>. A template rule
+               associates a <termref def="dt-pattern">pattern</termref>, which typically matches nodes in a source document, with a
                   <termref def="dt-sequence-constructor">sequence constructor</termref>. In many
                cases, evaluating the sequence constructor will cause new nodes to be constructed,
-               which can be used to produce part of a result tree. The structure of the result trees
-               can be completely different from the structure of the source trees. In constructing a
-               result tree, nodes from the source trees can be filtered and reordered, and arbitrary
-               structure can be added. Because <termref def="dt-pattern">pattern</termref>s can
-               point to nodes according to typological features, a <termref def="dt-stylesheet">stylesheet</termref> 
-               can be applicable to a wide class of source documents that have similar tree structures.</p>
+               which can be used to produce part of a result document. </p>
 
 
 
@@ -175,6 +169,9 @@ Michael Sperberg-McQueen (1954–2024).</p>
                   principal stylesheet module using <elcode>xsl:include</elcode> and
                      <elcode>xsl:import</elcode> elements: see <specref ref="include"/> and <specref ref="import"/>.</termdef></p>
 
+            <p>XSLT also includes optional facilities to serialize the results of a transformation,
+               by means of an interface to the serialization component described in 
+               <bibref ref="xslt-xquery-serialization-40"/>.</p>
 
          </div2>
          <div2 id="whats-new-in-xslt4">
@@ -189,30 +186,88 @@ Michael Sperberg-McQueen (1954–2024).</p>
             
             <p>XSLT 4.0 is a revised version of the XSLT 3.0 Recommendation <bibref ref="xslt-30"/>
                published on 8 June 2017.</p>
-            <p>The changes in this version of the language are relatively minor usability enhancements. There
-               are no changes to the data model or processing model. Instead, the specification attempts to fill
-               a number of gaps in functionality resulting from feedback from XSLT 3.0 users. The main areas
+            <p>The changes in this version of the language are many and varied, but there is a particular
+            focus on making it easier to transform trees of maps and arrays produced by parsing JSON.</p>
+            
+            <p>The most significant change to the data model is the introduction of <xtermref spec="DM40" ref="dt-JNode">JNodes</xtermref>, which
+               provide a mechanism for navigating over a tree of maps and arrays in a very similar way
+               to the navigation over the nodes representing an XML document.</p>
+            
+               <p>The basic processing model is largely unchanged. However, there are many new features designed
+               to improve usability or to fill gaps in functionality resulting from feedback from XSLT 3.0 users. The main areas
                covered are:</p>
             <ulist>
                <item><p>Enhancements to the type system to allow more expressive constraints, especially
                   for maps and atomic items.</p></item>
-               <item><p>Additional functionality for processing arrays.</p></item>
+               <item><p>Additional functionality for processing maps and arrays.</p></item>
                <item><p>Exploitation of the power afforded by first-class function items.</p></item>
             </ulist>
-            <p>XSLT 4.0 also includes optional facilities to serialize the results of a transformation,
-               by means of an interface to the serialization component described in 
-               <bibref ref="xslt-xquery-serialization-40"/>.
-            </p>
-            <p>XSLT 4.0 requires support for XPath 4.0.</p>
+            
+            <p>XSLT 4.0 requires support for XPath 4.0, which has many enhancements relative to XPath 3.1.</p>
             
                        
-            <p>A full list of changes is at <specref ref="changes-since-3.0"/>.</p>
+            <p>A full list of substantive changes is at <specref ref="changes-since-3.0"/>, and details of changes also appear at the start
+            of each affected section.</p>
          </div2>
       </div1>
       <div1 id="concepts">
          <head>Concepts</head>
+         <div2 id="conformance-terms">
+            <head>Conformance Terms</head>
+            <p>
+               <termdef id="dt-processor" term="processor">The software responsible for transforming
+                  source values into result values using an XSLT stylesheet is referred to as the
+                  <term>processor</term>. This is sometimes expanded to <emph>XSLT
+                     processor</emph> to avoid any confusion with other processors, for example an
+                  XML processor.</termdef>
+            </p>
+            <p>
+               <termdef id="dt-implementation" term="implementation">A specific product that
+                  performs the functions of an <termref def="dt-processor">XSLT processor</termref>
+                  is referred to as an <term>implementation</term>.</termdef></p>
+            
+            <p>In this specification the phrases <rfc2119>must</rfc2119>, <rfc2119>must
+               not</rfc2119>, <rfc2119>should</rfc2119>, <rfc2119>should not</rfc2119>,
+               <rfc2119>may</rfc2119>, <rfc2119>required</rfc2119>, and
+               <rfc2119>recommended</rfc2119>, when used in normative
+               text and rendered in small capitals, are to be interpreted as described in
+               <bibref ref="rfc2119"/>.</p>
+            
+            <p>Where the phrase <rfc2119>must</rfc2119>, <rfc2119>must not</rfc2119>, or
+               <rfc2119>required</rfc2119> relates to the behavior of the XSLT processor, then an
+               implementation is not conformant unless it behaves as specified, subject to the more
+               detailed rules in <specref ref="conformance"/>. </p>
+            <p>Where the phrase <rfc2119>must</rfc2119>, <rfc2119>must not</rfc2119>, or
+               <rfc2119>required</rfc2119> relates to a stylesheet then the processor
+               <rfc2119>must</rfc2119> enforce this constraint on stylesheets by raising an
+               error if the constraint is not satisfied.</p>
+            <p>Where the phrase <rfc2119>should</rfc2119>, <rfc2119>should not</rfc2119>, or
+               <rfc2119>recommended</rfc2119> relates to a stylesheet then a processor
+               <rfc2119>may</rfc2119> produce warning messages if the constraint is not
+               satisfied, but <rfc2119>must not</rfc2119> treat this as an error.</p>
+            <p>
+               <termdef id="dt-implementation-defined" term="implementation-defined">In this
+                  specification, the term <term>implementation-defined</term> refers to a feature
+                  where the implementation is allowed some flexibility, and where the choices made
+                  by the implementation <rfc2119>must</rfc2119> be described in documentation that
+                  accompanies any conformance claim.</termdef>
+            </p>
+            <p>
+               <termdef id="dt-implementation-dependent" term="implementation-dependent">The term
+                  <term>implementation-dependent</term> refers to a feature where the behavior
+                  <rfc2119>may</rfc2119> vary from one implementation to another, and where the
+                  vendor is not expected to provide a full specification of the behavior.</termdef>
+               (This might apply, for example, to limits on the size of source documents that can be
+               transformed.)</p>
+            <p>In all cases where this specification leaves the behavior implementation-defined or
+               implementation-dependent, the implementation has the option of providing mechanisms
+               that allow the user to influence the behavior.</p>
+            <p>A paragraph labeled as a <term>Note</term> or described as an <term>example</term> is
+               non-normative.</p>
+            
+         </div2>
          <div2 id="terminology">
-            <head>Terminology</head>
+            <head>General Terminology</head>
             
             <changes>
                <change issue="1337" PR="1361" date="2024-08-02">
@@ -221,21 +276,13 @@ Michael Sperberg-McQueen (1954–2024).</p>
             </changes>
             
             <p>For a full glossary of terms, see <specref ref="glossary"/>.</p>
+            
             <p>
-               <termdef id="dt-processor" term="processor">The software responsible for transforming
-                  source trees into result trees using an XSLT stylesheet is referred to as the
-                     <term>processor</term>. This is sometimes expanded to <emph>XSLT
-                     processor</emph> to avoid any confusion with other processors, for example an
-                  XML processor.</termdef>
-            </p>
-            <p>
-               <termdef id="dt-implementation" term="implementation">A specific product that
-                  performs the functions of an <termref def="dt-processor">XSLT processor</termref>
-                  is referred to as an <term>implementation</term>.</termdef></p>
-            <p>
-               <termdef id="dt-tree" term="tree">The term <term>tree</term> is used (as in <bibref ref="xpath-datamodel-40"/>) to refer to the aggregate consisting of a
+               <termdef id="dt-tree" term="tree">The term <term>tree</term> is used (as in <bibref ref="xpath-datamodel-40"/>) 
+                  to refer to the aggregate consisting of a
                   parentless node together with all its descendant nodes, plus all their attributes
-                  and namespaces.</termdef>
+                  and namespaces. A tree may be either an <xtermref spec="DM40" ref="dt-XTree"/> (containing <xtermref spec="DM40" ref="dt-XNode">XNodes</xtermref>)
+                  or a <xtermref spec="DM40" ref="dt-JTree"/> (containing <xtermref spec="DM40" ref="dt-JNode">JNodes</xtermref>).</termdef>
             </p>
                <note>
                   <p>The use of the term <term>tree</term> in this document in phrases such as <term>source
@@ -245,6 +292,9 @@ Michael Sperberg-McQueen (1954–2024).</p>
                      elements have a hierarchic relationship to each other. When a source document
                      is being processed in a streaming manner, access to the nodes in this tree is
                      constrained, but it is still viewed and described as a tree.</p>
+                  <p>In informal prose where the meaning is clear from the context, the term <term>tree</term> 
+                  is sometimes used to mean an XTree or a JTree respectively. It is also sometimes used to refer
+                  to a subtree, that is, a part of a larger tree.</p>
                </note>
             
             <p>The output of a transformation consists of the
@@ -252,14 +302,15 @@ Michael Sperberg-McQueen (1954–2024).</p>
             <olist>
                <item>
                   <p><termdef id="dt-principal-result" term="principal result">A <term>principal
-                           result</term>: this can be any sequence of items (as defined in <bibref ref="xpath-datamodel-40"/>).</termdef> The principal result is the value
+                           result</term>: this can be any <termref def="dt-value"/>: that is, any sequence
+                     ot items, as defined in <bibref ref="xpath-datamodel-40"/>).</termdef> The principal result is the value
                      returned by the function or template in the stylesheet that is nominated as the
                      entry point, as described in <specref ref="initiating"/>.</p>
                </item>
                <item>
                   <p><termdef id="dt-secondary-result" term="secondary result">Zero or more
-                           <term>secondary results</term>: each secondary result can be any sequence
-                        of items (as defined in <bibref ref="xpath-datamodel-40"/>).</termdef> A
+                     <term>secondary results</term>: each secondary result can be <termref def="dt-value"/>: that is, any sequence
+                        of items, as defined in <bibref ref="xpath-datamodel-40"/>.</termdef> A
                      secondary result is the value returned by evaluating the body of an
                         <elcode>xsl:result-document</elcode> instruction.</p>
                </item>
@@ -275,20 +326,23 @@ Michael Sperberg-McQueen (1954–2024).</p>
                described in <specref ref="post-processing"/>.</p>
             <p>
                <termdef id="dt-result-tree" term="result tree">The term <term>result tree</term> is
-                  used to refer to any <termref def="dt-tree">tree</termref> constructed by <termref def="dt-instruction">instructions</termref> in the stylesheet. A result tree is
+                  used to refer to any <xtermref spec="DM40" ref="dt-XTree"/> constructed by 
+                  <termref def="dt-instruction">instructions</termref> in the stylesheet. A result tree is
                   either a <termref def="dt-final-result-tree">final result tree</termref> or a
                      <termref def="dt-temporary-tree">temporary tree</termref>.</termdef>
             </p>
             <p>
                <termdef id="dt-final-result-tree" term="final result tree">A <term>final result
                      tree</term> is a <termref def="dt-result-tree">result tree</termref> that forms
-                  part of the output of a transformation: specifically, a tree built by post-processing the items in the <termref def="dt-principal-result"/> or in a <termref def="dt-secondary-result"/>. Once created, the contents of a final result tree are not
+                  part of the output of a transformation: specifically, an <xtermref spec="DM40" ref="dt-XTree"/> 
+                  built by post-processing the items in the <termref def="dt-principal-result"/> or in 
+                  a <termref def="dt-secondary-result"/>. Once created, the contents of a final result tree are not
                   accessible within the stylesheet itself.</termdef>
                 Any final result tree
                   <rfc2119>may</rfc2119> be serialized as described in <specref ref="serialization"/>.</p>
             <p>
                <termdef id="dt-source-tree" term="source tree">The term <term>source tree</term>
-                  means any tree provided as input to the transformation. This includes the document
+                  means any <xtermref spec="DM40" ref="dt-XTree"/> provided as input to the transformation. This includes the document
                   containing the <termref def="dt-global-context-item"/> if any, documents containing
                      nodes present in the <termref def="dt-initial-match-selection"/>,
                   documents containing nodes supplied as the values of <termref def="dt-stylesheet-parameter">stylesheet parameters</termref>, documents
@@ -303,57 +357,20 @@ Michael Sperberg-McQueen (1954–2024).</p>
             </p>
             <p>
                <termdef id="dt-temporary-tree" term="temporary tree">The term <term>temporary
-                     tree</term> means any tree that is neither a <termref def="dt-source-tree">source tree</termref> nor a <termref def="dt-final-result-tree">final result
+                  tree</term> means any <xtermref spec="DM40" ref="dt-XTree"/> that is neither a <termref def="dt-source-tree">source tree</termref> nor a <termref def="dt-final-result-tree">final result
                      tree</termref>.</termdef> Temporary trees are used to hold intermediate results
                during the execution of the transformation.</p>
             <!-- Duplicates the note just above. -->
-            <p><!--The use of the term “tree” in phrases such as <term>source
-                  tree</term>, <term>result tree</term>, and <term>temporary tree</term> is not
-               confined to documents that the processor materializes in memory in their entirety.
-               The processor <rfc2119>may</rfc2119>, and in some cases <rfc2119>must</rfc2119>, use
-               streaming techniques to limit the amount of memory used to hold source and result
-               documents. When streaming is used, the nodes of the tree may never all be in memory
-               at the same time, but at an abstract level the information is still modeled as a tree
-               of nodes, and the document is therefore still described as a tree. -->Unless otherwise stated, the term “tree” refers to a tree rooted
+            <p>Unless otherwise stated, the term “tree” refers to a tree rooted
                   at a parentless node: that is, the term does not include subtrees of larger trees.
                   Every node therefore belongs to exactly one tree.</p>
-            <p>In this specification the phrases <rfc2119>must</rfc2119>, <rfc2119>must
-                  not</rfc2119>, <rfc2119>should</rfc2119>, <rfc2119>should not</rfc2119>,
-                  <rfc2119>may</rfc2119>, <rfc2119>required</rfc2119>, and
-                  <rfc2119>recommended</rfc2119>, when used in normative
-                  text and rendered in small capitals, are to be interpreted as described in
-                  <bibref ref="rfc2119"/>.</p>
-            <p>Where the phrase <rfc2119>must</rfc2119>, <rfc2119>must not</rfc2119>, or
-                  <rfc2119>required</rfc2119> relates to the behavior of the XSLT processor, then an
-               implementation is not conformant unless it behaves as specified, subject to the more
-               detailed rules in <specref ref="conformance"/>. </p>
-            <p>Where the phrase <rfc2119>must</rfc2119>, <rfc2119>must not</rfc2119>, or
-                  <rfc2119>required</rfc2119> relates to a stylesheet then the processor
-                  <rfc2119>must</rfc2119> enforce this constraint on stylesheets by raising an
-               error if the constraint is not satisfied.</p>
-            <p>Where the phrase <rfc2119>should</rfc2119>, <rfc2119>should not</rfc2119>, or
-                  <rfc2119>recommended</rfc2119> relates to a stylesheet then a processor
-                  <rfc2119>may</rfc2119> produce warning messages if the constraint is not
-               satisfied, but <rfc2119>must not</rfc2119> treat this as an error.</p>
+            
             <p>
-               <termdef id="dt-implementation-defined" term="implementation-defined">In this
-                  specification, the term <term>implementation-defined</term> refers to a feature
-                  where the implementation is allowed some flexibility, and where the choices made
-                  by the implementation <rfc2119>must</rfc2119> be described in documentation that
-                  accompanies any conformance claim.</termdef>
-            </p>
-            <p>
-               <termdef id="dt-implementation-dependent" term="implementation-dependent">The term
-                     <term>implementation-dependent</term> refers to a feature where the behavior
-                     <rfc2119>may</rfc2119> vary from one implementation to another, and where the
-                  vendor is not expected to provide a full specification of the behavior.</termdef>
-               (This might apply, for example, to limits on the size of source documents that can be
-               transformed.)</p>
-            <p>In all cases where this specification leaves the behavior implementation-defined or
-               implementation-dependent, the implementation has the option of providing mechanisms
-               that allow the user to influence the behavior.</p>
-            <p>A paragraph labeled as a <term>Note</term> or described as an <term>example</term> is
-               non-normative.</p>
+               <termdef id="dt-document" term="document">The term <term>document</term>, unless
+                  indicated to the contrary, means any <xtermref spec="DM40" ref="dt-XTree"/> rooted at
+                   a document node.</termdef></p>
+            
+            
             <p>Many terms used in this document are defined in the XPath specification <bibref ref="xpath-40"/> or the XDM specification <bibref ref="xpath-datamodel-40"/>.
                Particular attention is drawn to the following:</p>
             <ulist>
@@ -429,6 +446,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
             </ulist>
             
          </div2>
+         
          <div2 id="notation">
             <head>Notation</head>
             <p>
@@ -1322,11 +1340,12 @@ Michael Sperberg-McQueen (1954–2024).</p>
                   </item>
 
                   <item>
-                     <p>A list of values to act as parameters to the <termref def="dt-initial-function"/>. The number of values in the list must be the
-                        same as the arity of the function.</p>
+                     <p>Values to act as arguments to the <termref def="dt-initial-function"/>. A concrete invocation API
+                     may allow function parameters to be bound either by name or by position, and may allow optional
+                     parameters to be defaulted.</p>
 
                      <p>A supplied value is converted if necessary to the declared
-                        type of the function parameter using the <termref def="dt-coercion-rules"/>.</p>
+                        type of the corresponding function parameter using the <termref def="dt-coercion-rules"/>.</p>
                   </item>
 
                   <item>
@@ -1364,10 +1383,11 @@ Michael Sperberg-McQueen (1954–2024).</p>
                
 
 
-               <p>When a transformation is invoked by calling an <termref def="dt-initial-function"/>, the entire transformation executes in <termref def="dt-temporary-output-state"/>, which means that calls on
+               <p>When a transformation is invoked by calling an <termref def="dt-initial-function"/>, 
+                  the entire transformation executes in <termref def="dt-temporary-output-state"/>, which means that calls on
                      <elcode>xsl:result-document</elcode> are not permitted.</p>
                
-               <p>[TODO: Generalize the above description to allow for the possibility of keyword-based and optional arguments.]</p>
+              
 
             </div3>
             <div3 id="post-processing">
@@ -1378,9 +1398,9 @@ Michael Sperberg-McQueen (1954–2024).</p>
                also to secondary results, generated using <elcode>xsl:result-document</elcode>.)</p>
                
                <olist>
-                  <item><p>The <termref def="dt-raw-result"/> (a sequence of values) may be returned
+                  <item><p>The <termref def="dt-raw-result"/> (a sequence of items) may be returned
                   directly to the calling application.</p></item>
-                  <item><p>A result tree may be constructed from the <termref def="dt-raw-result"/>.
+                  <item><p>A <termref def="dt-result-tree"/> may be constructed from the <termref def="dt-raw-result"/>.
                      By default, a result tree is constructed if the <code>build-tree</code>
                      attribute of the unnamed <termref def="dt-output-definition"/>
                      has the <termref def="dt-effective-value"/> <code>yes</code>. An API for invoking transformations <rfc2119>may</rfc2119>
@@ -1401,7 +1421,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
                      however, result tree construction and serialization may be inappropriate as
                      defaults. These considerations may affect the design of APIs.</p>
                   <p>In previous versions of XSLT, results were delivered either
-                  in serialized form (as a character or byte stream), or as a tree. In the latter case processors
+                     in serialized form (as a character or byte stream), or as an <xtermref spec="DM40" ref="dt-XTree"/>. In the latter case processors
                   typically would use either their own tree representation, or a standardized tree
                   representation such as the W3C Document Object Model (DOM) (see <bibref ref="DOM-Level-2-Core"/>),
                      adapted to the data structures offered by the programming language in which the API is defined.
@@ -1422,13 +1442,13 @@ Michael Sperberg-McQueen (1954–2024).</p>
  <div4 id="result-tree-construction">
     <head>Result Tree Construction</head>
     
-    <p>If a result tree is to be constructed from the <termref def="dt-raw-result"/>, then this is done
+    <note><p>In this section, the term <term>tree</term> always means <xtermref spec="DM40" ref="dt-XTree"/>.</p></note>
+    
+    <p>If a <termref def="dt-final-result-tree"/> is to be constructed from the <termref def="dt-raw-result"/>, then this is done
     by applying the rules for the process of <xtermref spec="SE40" ref="sequence-normalization"/> as defined in 
        <bibref ref="xslt-xquery-serialization-40"/>. This process takes as input the serialization parameters defined in the
     unnamed <termref def="dt-output-definition"/> of the <termref def="dt-top-level-package"/>; though the only parameter
-    that is actually used by this process is <code>item-separator</code>. <phrase diff="del" at="2022-01-01">In particular, sequence normalization is carried
-       out regardless of any <code>method</code> attribute in the unnamed <termref def="dt-output-definition"/>.</phrase>
-    <!--<phrase diff="add" at="2022-01-01">[XSLT 3.0 Erratum E14, bug 30208].</phrase>--></p>
+    that is actually used by this process is <code>item-separator</code>.</p>
     
     <p>The sequence normalization process either returns a document node, or raises
     a serialization error. The content of the document node is not necessarily well-formed (the document node may have any number
@@ -1459,49 +1479,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
        a text node whose string value is a single comma, and a copy of <code>B</code>.</p>
     </note>
  
-              <!--       <p>If the raw result is non-empty, then it is used to construct an implicit
-                           <termref def="dt-final-result-tree">final result tree</termref>,
-                        following the rules described in <specref ref="constructing-complex-content"
-                        />: the effect is as if the raw result <var>R</var> were processed by the
-                        following function:</p>
-                     <eg xml:space="preserve" role="xslt-declaration xmlns:f='f'"><![CDATA[
-<xsl:function name="f:construct-result-tree" as="document-node()">
-  <xsl:param name="R" as="item()*"/>
-  <xsl:document validation="preserve">
-    <xsl:sequence select="$R"/>
-  </xsl:document>  
-</xsl:function>]]></eg>
-                     <p>An implicit result tree is also created when the raw result is empty,
-                        provided that no <elcode>xsl:result-document</elcode> instruction has been
-                        evaluated during the course of the transformation <phrase diff="add"
-                           at="R-bug24690">(which will always be the case if the stylesheet is
-                           invoked by calling an initial function)</phrase>. In this situation the
-                        implicit result tree will consist of a document node with no children.</p>
-                     <note>
-                        <p diff="chg" at="Q">This means that there is always at least one result
-                           tree. It also means that <phrase diff="add" at="R-bug24690">when
-                              stylesheet invocation is by supplying an <termref
-                                 def="dt-initial-mode"/> (see <specref ref="invoking-initial-mode"
-                              />) or a named template (see <specref ref="invoking-initial-template"
-                              />), and</phrase> the content of the <termref
-                              def="dt-initial-named-template"/> is a single
-                              <elcode>xsl:result-document</elcode> instruction, as in the example
-                              <phrase diff="chg" at="R-bug24690">template with
-                                 <code>name="IMPLICIT"</code> shown in <specref
-                                 ref="executing-a-transformation"/></phrase>, then only one result
-                           tree is produced, not two. It is useful to make the result document
-                           explicit as this is a convenient way of invoking document-level
-                           validation. (Validation of the implicit result document can also be
-                           achieved by adding an <elcode>xsl:document</elcode> instruction to the
-                           initial template.) </p>
-                        <p>If the result of the <termref def="dt-initial-named-template"/> is
-                           non-empty, and an explicit <elcode>xsl:result-document</elcode>
-                           instruction has been evaluated with the empty attribute
-                              <code>href=""</code>, then an error will occur <errorref spec="XT"
-                              class="DE" code="1490"/>, since it is not possible to create two final
-                           result trees with the same URI.</p>
-                     </note>
-                     -->
+              
  </div4>
                <div4 id="result-serialization">
                      <head>Serializing the Result</head>
@@ -17523,9 +17501,9 @@ return $tree =?> depth()]]></eg>
                   <termref def="dt-variable">variable</termref> with the additional property that
                its value can be set by the caller.</termdef>
          </p>
-         <p>
-            <termdef id="dt-value" term="value">A variable is a binding between a name and a value.
-               The <term>value</term> of a variable is any sequence (of nodes, atomic items,
+         <p>A variable is a binding between a name and a value.
+            <termdef id="dt-value" term="value">
+               A <term>value</term> is any sequence (of nodes, atomic items,
                   and/or function items), as defined in <bibref ref="xpath-datamodel-40"/>.</termdef>
          </p>
 


### PR DESCRIPTION
Fix #2738

Gently improves the introductory sections of the XSLT spec to better reflect the introduction of JTrees and JNodes.

It could do with a more radical overhaul but this is a step in the right direction.