### PR TITLE
1697 Add documentary names to callback function signatures

### DIFF
--- a/specifications/css/xpath-functions-40.css
+++ b/specifications/css/xpath-functions-40.css
@@ -125,6 +125,12 @@ table.proto tr td:nth-child(3) code {
     white-space: nowrap;
 }
 
+/* Callback parameter names are documentary only (the caller supplies the function
+   and chooses its own names); mute them to set them apart from assignable arguments */
+.doc-param {
+    color: #8f7f8f;
+}
+
 /*
 table.record tr.arg td code.req {
   font-weight: bold;

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -207,14 +207,14 @@
                In all other cases, absent.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="matches" type="fn(xs:anyAtomicType) as xs:boolean" required="false">
+      <fos:field name="matches" type="fn($v as xs:anyAtomicType) as xs:boolean" required="false">
          <fos:meaning>
             <p>For a <xtermref spec="XP40" ref="dt-generalized-atomic-type"/>, 
                a function item that can be called to establish whether the supplied atomic item
                is an instance of this type. In all other cases, absent.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="constructor" type="fn(xs:anyAtomicType?) as xs:anyAtomicType*" required="false">
+      <fos:field name="constructor" type="fn($v as xs:anyAtomicType?) as xs:anyAtomicType*" required="false">
          <fos:meaning>
             <p>For a simple type, a function item that can be used to construct instances of this type. In the case of a named
              type that is present in the dynamic context, the result is the same function as returned by 
@@ -284,13 +284,13 @@
                to be the same as the result of <code>fn:tokenize($s, <var>R</var>?pattern, <var>R</var>?flags)</code>.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="replace" type="fn($s as xs:string, $replacement as (xs:string | fn(xs:untypedAtomic, xs:untypedAtomic*) as item()?)?) as xs:string" required="true">
+      <fos:field name="replace" type="fn($s as xs:string, $r as (xs:string | fn($m as xs:untypedAtomic, $g as xs:untypedAtomic*) as item()?)?) as xs:string" required="true">
          <fos:meaning>
             <p>An arity-two function that can be used to replace parts of the supplied string <var>$s</var> that match
             the regular expression. If <var>R</var> is a <code>compiled-regex-record</code> 
                produced by the function <function>fn:regex</function>, then the effect
-               of the expression <code><var>R</var>?replace($s, $rep)</code> is defined
-               to be the same as the result of <code>fn:replace($s, <var>R</var>?pattern, $rep, <var>R</var>?flags)</code>.</p>
+               of the expression <code><var>R</var>?replace($s, $r)</code> is defined
+               to be the same as the result of <code>fn:replace($s, <var>R</var>?pattern, $r, <var>R</var>?flags)</code>.</p>
          </fos:meaning>
       </fos:field>
       <fos:field name="analyze-string" type="fn($s as xs:string) as element(fn:analyze-string-result)" required="true">
@@ -357,7 +357,7 @@
                   value; the associated value is the value of the variable.</p>
          </fos:meaning>        
       </fos:field>
-      <fos:field name="functions" type="map(xs:QName, map(xs:integer, function(*)))" required="true">
+      <fos:field name="functions" type="map(xs:QName, map(xs:integer, fn(*)))" required="true">
          <fos:meaning>
             <p>This map (<var>F</var> ) contains one entry for each distinct QName
             <var>Q</var> that represents the name of a public and non-external
@@ -506,20 +506,20 @@
                   option is <code>true</code>. If there are no data rows in the CSV, the
                   value will be the empty sequence.</p></fos:meaning>
       </fos:field>
-      <fos:field name="get" type="function(xs:positiveInteger, (xs:positiveInteger | xs:string)) as xs:string" required="true">
+      <fos:field name="get" type="fn($r as xs:positiveInteger, $c as (xs:positiveInteger | xs:string)) as xs:string" required="true">
          <fos:meaning><p>A function providing ready access to a given field in a given
       row. The <code>get</code> function has signature:</p>
-                     <eg>function($row as xs:positiveInteger, $column as (xs:positiveInteger | xs:string)) as xs:string</eg>
-                     <p>The function takes two arguments: the first is an
-                     integer giving the row number (1-based), the second
+                     <eg>fn($r as xs:positiveInteger, $c as (xs:positiveInteger | xs:string)) as xs:string</eg>
+                     <p>The function takes two arguments: <code>$r</code>, an
+                     integer giving the row number (1-based), and <code>$c</code>, which
                      identifies a column either by its name or by its 1-based
                      position.</p>
          
          <p>Except in error cases (described below), 
-                  the function call <code>$csv?get($R, $C)</code>, where <code>$C</code>
-                  is an integer, returns the value of <code>$csv?rows[$R] => array:get($C, "")</code>,
-                  and the function call <code>$csv?get($R, $K)</code>, where <code>$K</code>
-                  is a string, returns the value of <code>$csv?get($R, $csv?column-index($K))</code>.</p>
+                  the function call <code>$csv?get($r, $c)</code>, where <code>$c</code>
+                  is an integer, returns the value of <code>$csv?rows[$r] => array:get($c, "")</code>,
+                  and the function call <code>$csv?get($r, $c)</code>, where <code>$c</code>
+                  is a string, returns the value of <code>$csv?get($r, $csv?column-index($c))</code>.</p>
 
                <p>The properties of the function are as follows:</p>
                   <glist>
@@ -542,26 +542,26 @@
                      <gitem>
                         <label>Errors</label>
                         <def><p>A dynamic error <errorref class="CV" code="0004"/> occurs if the
-                           supplied <var>$key</var> is a string and does not occur in the map of column
+                           supplied <code>$c</code> is a string and does not occur in the map of column
                            names.</p></def>
                      </gitem>
                      <gitem>
                         <label>Rules</label>
                         <def>
                            <p>The function returns a field in the result.</p>
-                           <p>The first argument <code>$row</code> selects a row within the sequence of rows
+                           <p>The first argument <code>$r</code> selects a row within the sequence of rows
                               returned as <var>rows</var> by position (one-based). If the value is out of range for the number
                               of rows returned, the <code>get</code> function returns a zero-length
                               string.</p>
-                           <p>The second argument <code>$col</code> may be either an integer or a string.</p>
-                           <p>If <code>$col</code> is an integer then it selects a field within the
+                           <p>The second argument <code>$c</code> may be either an integer or a string.</p>
+                           <p>If <code>$c</code> is an integer then it selects a field within the
                               selected row by position (one-based). If the value is out of range for the number
                               of fields in the selected row, the <code>get</code> function returns a zero-length
                               string.</p>
-                           <p>If <code>$col</code> is a string, the string is mapped to an integer using the
+                           <p>If <code>$c</code> is a string, the string is mapped to an integer using the
                               map in the returned <var>column-index</var>. If the string is not present
                               in this map, then an error is raised <errorref class="CV" code="0004"/>. The resulting
-                              integer is then used as if it were supplied as <code>$col</code> directly.</p>
+                              integer is then used as if it were supplied as <code>$c</code> directly.</p>
 
                         </def>
                      </gitem>
@@ -580,7 +580,7 @@
                   value; the associated value is the value of the variable.</p>
          </fos:meaning>        
       </fos:field>
-      <fos:field name="functions" type="map(xs:QName, map(xs:integer, function(*)))" required="true">
+      <fos:field name="functions" type="map(xs:QName, map(xs:integer, fn(*)))" required="true">
          <fos:meaning>
             <p>This map (<var>F</var> ) contains one entry for each distinct QName
             <var>Q</var> that represents the name of a public and non-external
@@ -633,7 +633,7 @@
                </ulist>
          </fos:meaning>
       </fos:field>
-      <fos:field name="permute" type="function(item()*) as item()*" required="true">
+      <fos:field name="permute" type="fn($s as item()*) as item()*" required="true">
          <fos:meaning>
                <p>A function with arity 1 (one), which takes an arbitrary sequence
             as its argument, and returns a random permutation of that sequence.</p>
@@ -7745,7 +7745,7 @@ Tak, tak, tak! - da kommen sie.
          <fos:proto name="replace" return-type="xs:string">
             <fos:arg name="value" type="xs:string?"/>
             <fos:arg name="pattern" type="xs:string"/>
-            <fos:arg name="replacement" type="(xs:string | fn(xs:untypedAtomic, xs:untypedAtomic*) as item()?)?" default='""' note="default-on-empty"/>
+            <fos:arg name="replacement" type="(xs:string | fn($match as xs:untypedAtomic, $groups as xs:untypedAtomic*) as item()?)?" default='""' note="default-on-empty"/>
             <fos:arg name="flags" type="xs:string?" default='""' note="default-on-empty"/>
          </fos:proto>
       </fos:signatures>
@@ -7773,9 +7773,9 @@ Tak, tak, tak! - da kommen sie.
             <item><p>If <code>$replacement</code> is a function item <var>F</var>, then
                <var>R</var> is obtained by calling <var>F</var>, and then applying the
                function <function>fn:string</function> to the result.</p>
-               <p>The first argument to <var>F</var> is the string to be replaced,
+               <p>The first argument, <code>$match</code>, is the string to be replaced,
                   provided as <code>xs:untypedAtomic</code>.</p>
-               <p>The second argument to <var>F</var> provides the captured
+               <p>The second argument, <code>$groups</code>, provides the captured
                   groups as an <code>xs:untypedAtomic</code> sequence.
                   The <code>Nth</code> item in this sequence is the string value of the segment captured by 
                   the <code>Nth</code> capturing subexpression. If the
@@ -7783,7 +7783,7 @@ Tak, tak, tak! - da kommen sie.
                   will be the zero-length string.</p>
                <p>Note that the rules for function coercion mean that the function actually
                   supplied for <var>F</var> may be an arity-1 function: the
-                  second argument does not need to be declared if it is not used.</p>
+                  <code>$groups</code> argument does not need to be declared if it is not used.</p>
             </item>
             
             <item><p>If <code>$replacement</code> is a string and the 
@@ -16317,8 +16317,8 @@ filter(
       <fos:signatures>
          <fos:proto name="subsequence-where" return-type="item()*">
             <fos:arg name="input" type="item()*" usage="transmission"/>
-            <fos:arg name="from" type="(fn(item(), xs:integer) as xs:boolean?)?" default="true#0" note="default-on-empty"/>
-            <fos:arg name="to" type="(fn(item(), xs:integer) as xs:boolean?)?" default="false#0" note="default-on-empty"/>
+            <fos:arg name="from" type="(fn($item as item(), $pos as xs:integer) as xs:boolean?)?" default="true#0" note="default-on-empty"/>
+            <fos:arg name="to" type="(fn($item as item(), $pos as xs:integer) as xs:boolean?)?" default="false#0" note="default-on-empty"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -16705,7 +16705,7 @@ for-each($at, fn($index) { subsequence($input, $index, 1) })
          <fos:proto name="starts-with-subsequence" return-type="xs:boolean">
             <fos:arg name="input" type="item()*" usage="transmission"/>
             <fos:arg name="subsequence" type="item()*" usage="transmission"/>
-            <fos:arg name="compare" type="(fn(item(), item()) as xs:boolean?)?" default="fn:deep-equal#2" note="default-on-empty"/>
+            <fos:arg name="compare" type="(fn($item1 as item(), $item2 as item()) as xs:boolean?)?" default="fn:deep-equal#2" note="default-on-empty"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -16822,7 +16822,7 @@ return starts-with-subsequence(
          <fos:proto name="ends-with-subsequence" return-type="xs:boolean">
             <fos:arg name="input" type="item()*" usage="transmission"/>
             <fos:arg name="subsequence" type="item()*" usage="transmission"/>
-            <fos:arg name="compare" type="(fn(item(), item()) as xs:boolean?)?" default="fn:deep-equal#2" note="default-on-empty"/>
+            <fos:arg name="compare" type="(fn($item1 as item(), $item2 as item()) as xs:boolean?)?" default="fn:deep-equal#2" note="default-on-empty"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -16939,7 +16939,7 @@ return ends-with-subsequence(
          <fos:proto name="contains-subsequence" return-type="xs:boolean">
             <fos:arg name="input" type="item()*" usage="transmission"/>
             <fos:arg name="subsequence" type="item()*" usage="transmission"/>
-            <fos:arg name="compare" type="(fn(item(), item()) as xs:boolean?)?" default="fn:deep-equal#2" note="default-on-empty"/>
+            <fos:arg name="compare" type="(fn($item1 as item(), $item2 as item()) as xs:boolean?)?" default="fn:deep-equal#2" note="default-on-empty"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -17367,7 +17367,7 @@ else error(#Q{http://www.w3.org/2005/xqt-errors}FORG0005))
                      rules should be followed. Note that returning <code>()</code>
                      is <emph>not</emph> equivalent to returning <code>false</code>.
                   </fos:meaning>
-                  <fos:type>fn(item(), item()) as xs:boolean?</fos:type>
+                  <fos:type>fn($item1 as item(), $item2 as item()) as xs:boolean?</fos:type>
                   <fos:default>fn:void#0</fos:default>
                </fos:option>
                <fos:option key="map-order">
@@ -21167,7 +21167,7 @@ return { "width": $int16-at($loc + 5),
    
     <fos:function name="xsd-validator" prefix="fn">
       <fos:signatures>
-         <fos:proto name="xsd-validator" return-type="function((document-node(*) | element() | attribute())?) as record(is-valid as xs:boolean, typed-node? as node(), error-details? as map(*)*)">
+         <fos:proto name="xsd-validator" return-type="fn((document-node(*) | element() | attribute())?) as record(is-valid as xs:boolean, typed-node? as node(), error-details? as map(*)*)">
             <fos:arg name="options" type="map(*)?" default="{}" note="default-on-empty"/>
          </fos:proto>
       </fos:signatures>
@@ -22939,7 +22939,7 @@ return map:merge($ann)
       <fos:signatures>
          <fos:proto name="for-each" return-type="item()*">
             <fos:arg name="input" type="item()*" usage="navigation"/>
-            <fos:arg name="action" type="fn(item(), xs:integer) as item()*" usage="inspection"/>
+            <fos:arg name="action" type="fn($item as item(), $pos as xs:integer) as item()*" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -22953,10 +22953,9 @@ return map:merge($ann)
             in turn, returning the concatenation of the resulting sequences in order.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function calls <code>$action($item, $pos)</code> for each item in <code>$input</code>,
-            where <code>$item</code> is the item in question and <code>$pos</code> is its 1-based
-            ordinal position in <code>$input</code>. The final result is the sequence concatenation
-            of the result of these calls, preserving order.
+         <p>The function calls <code>$action($item, $pos)</code> for each item in <code>$input</code>.
+            The final result is the sequence concatenation
+            of the results of these calls, preserving order.
          </p>
       </fos:rules>
       <fos:equivalent style="dm-primitive">
@@ -23004,7 +23003,7 @@ dm:iterate-sequence($input, $action)
       <fos:signatures>
          <fos:proto name="filter" return-type="item()*">
             <fos:arg name="input" type="item()*" usage="navigation"/>
-            <fos:arg name="predicate" type="fn(item(), xs:integer) as xs:boolean?" usage="inspection"/>
+            <fos:arg name="predicate" type="fn($item as item(), $pos as xs:integer) as xs:boolean?" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -23019,8 +23018,7 @@ dm:iterate-sequence($input, $action)
       </fos:summary>
       <fos:rules>
          <p>The function returns a sequence containing those items from <code>$input</code>
-            for which <code>$predicate($item, $pos)</code> returns <code>true</code>, where <code>$item</code>
-            is the item in question, and <code>$pos</code> is its 1-based ordinal position within <code>$input</code>.</p>
+            for which <code>$predicate($item, $pos)</code> returns <code>true</code>.</p>
 
       </fos:rules>
       <fos:equivalent style="xpath-expression">
@@ -23090,7 +23088,7 @@ return filter(
          <fos:proto name="fold-left" return-type="item()*">
             <fos:arg name="input" type="item()*" usage="navigation"/>
             <fos:arg name="init" type="item()*"/>
-            <fos:arg name="action" type="fn(item()*, item()) as item()*" usage="inspection"/>
+            <fos:arg name="action" type="fn($acc as item()*, $item as item()) as item()*" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -23118,7 +23116,7 @@ return filter(
 declare function fold-left(
   $input  as item()*,
   $init   as item()*,
-  $action as function(item()*, item()) as item()*
+  $action as fn(item()*, item()) as item()*
 ) as item()* {
   if (empty($input)) 
   then $init
@@ -23127,16 +23125,16 @@ declare function fold-left(
       </fos:equivalent>
       <fos:errors>
          <p>As a consequence of the function signature and the function calling rules, a type error
-            occurs if the supplied function <code>$action</code> cannot be applied to two arguments, where
-            the first argument is either the value of <code>$init</code> or the result of a previous
-            application of <code>$action</code>, and the second 
+            occurs if <code>$action</code> cannot be applied to arguments <code>$acc</code> and <code>$item</code>, where
+            <code>$acc</code> is either the value of <code>$init</code> or the result of a previous
+            application of <code>$action</code>, and <code>$item</code>
             is any single item from the sequence <code>$input</code>.</p>
       </fos:errors>
       <fos:notes>
          <p>This operation is often referred to in the functional programming literature as
             “folding” or “reducing” a sequence. It typically takes a function that operates on a pair of
-            values, and applies it repeatedly, with an accumulated result as the first argument, and
-            the next item in the sequence as the second argument. The accumulated result is
+            values, and applies it repeatedly, with the accumulated result (<code>$acc</code>) as the first argument, and
+            the next item in the sequence (<code>$item</code>) as the second argument. The accumulated result is
             initially set to the value of the <code>$init</code> argument, which is conventionally a
             value (such as zero in the case of addition, one in the case of multiplication, or a
             zero-length string in the case of string concatenation) that causes the function to
@@ -23257,7 +23255,7 @@ return fold-left($input, (),
          <fos:proto name="fold-right" return-type="item()*">
             <fos:arg name="input" type="item()*" usage="navigation"/>
             <fos:arg name="init" type="item()*"/>
-            <fos:arg name="action" type="fn(item(), item()*) as item()*" usage="inspection"/>
+            <fos:arg name="action" type="fn($item as item(), $acc as item()*) as item()*" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -23287,7 +23285,7 @@ return fold-left($input, (),
 declare function fold-right(
   $input  as item()*,
   $init   as item()*,
-  $action as function(item(), item()*) as item()*
+  $action as fn(item(), item()*) as item()*
 ) as item()* {
   if (empty($input))
   then $init
@@ -23296,8 +23294,8 @@ declare function fold-right(
       </fos:equivalent>
       <fos:errors>
          <p>As a consequence of the function signature and the function calling rules, a type error
-            occurs if the supplied function <code>$action</code> cannot be applied to two arguments, where
-            the first argument is any item in the sequence <code>$input</code>, and the second is either
+            occurs if <code>$action</code> cannot be applied to arguments <code>$item</code> and <code>$acc</code>, where
+            <code>$item</code> is any item in the sequence <code>$input</code>, and <code>$acc</code> is either
             the value of <code>$init</code> or the result of a previous application of
             <code>$action</code>.</p>
 
@@ -23691,8 +23689,8 @@ chain((1, 2, 3, 4), $product3)
       <fos:signatures>
          <fos:proto name="while-do" return-type="item()*">
             <fos:arg name="input" type="item()*" usage="navigation"/>
-            <fos:arg name="predicate" type="fn(item()*, xs:integer) as xs:boolean?" example="false#0" usage="inspection"/>
-            <fos:arg name="action" type="fn(item()*, xs:integer) as item()*" usage="inspection"/>
+            <fos:arg name="predicate" type="fn($input as item()*, $pos as xs:integer) as xs:boolean?" example="false#0" usage="inspection"/>
+            <fos:arg name="action" type="fn($input as item()*, $pos as xs:integer) as item()*" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -23841,8 +23839,8 @@ return $result?numbers
       <fos:signatures>
          <fos:proto name="do-until" return-type="item()*">
             <fos:arg name="input" type="item()*" usage="navigation"/>
-            <fos:arg name="action" type="fn(item()*, xs:integer) as item()*" usage="inspection"/>
-            <fos:arg name="predicate" type="fn(item()*, xs:integer) as xs:boolean?" usage="inspection"/>
+            <fos:arg name="action" type="fn($input as item()*, $pos as xs:integer) as item()*" usage="inspection"/>
+            <fos:arg name="predicate" type="fn($input as item()*, $pos as xs:integer) as xs:boolean?" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -23951,7 +23949,7 @@ do-until(
          <fos:proto name="for-each-pair" return-type="item()*">
             <fos:arg name="input1" type="item()*" usage="navigation"/>
             <fos:arg name="input2" type="item()*" usage="navigation"/>
-            <fos:arg name="action" type="fn(item(), item(), xs:integer) as item()*" usage="inspection"/>
+            <fos:arg name="action" type="fn($item1 as item(), $item2 as item(), $pos as xs:integer) as item()*" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -24037,7 +24035,7 @@ for-each-pair(
          <fos:proto name="sort" return-type="item()*">
             <fos:arg name="input" type="item()*" usage="navigation"/>
             <fos:arg name="collation" type="xs:string?" usage="absorption" default="fn:default-collation()" note="default-on-empty"/>
-            <fos:arg name="key" type="fn(item()) as xs:anyAtomicType*" usage="inspection" default="fn:data#1" note="default-on-empty"/>
+            <fos:arg name="key" type="fn($item as item()) as xs:anyAtomicType*" usage="inspection" default="fn:data#1" note="default-on-empty"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -24117,7 +24115,7 @@ return sort(//name!string(), $SWEDISH)</eg></fos:expression>
       <fos:signatures>
          <fos:proto name="sort-by" return-type="item()*">
             <fos:arg name="input" type="item()*" usage="navigation"/>
-            <fos:arg name="keys" type="record(key as (fn(item()) as xs:anyAtomicType*)?, collation as xs:string?, order as enum('ascending', 'descending')?)*"/>
+            <fos:arg name="keys" type="record(key as (fn($item as item()) as xs:anyAtomicType*)?, collation as xs:string?, order as enum('ascending', 'descending')?)*"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -24317,7 +24315,7 @@ return sort-by(//name, { 'collation': $SWEDISH })</eg></fos:expression>
       <fos:signatures>
          <fos:proto name="sort-with" return-type="item()*">
             <fos:arg name="input" type="item()*"/>
-            <fos:arg name="comparators" type="(fn(item(), item()) as xs:integer)+"/>
+            <fos:arg name="comparators" type="(fn($item1 as item(), $item2 as item()) as xs:integer)+"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -24443,7 +24441,7 @@ return sort-with($persons/person, (
       <fos:signatures>
          <fos:proto name="transitive-closure" return-type="gnode()*">
             <fos:arg name="node" type="gnode()?" usage="navigation"/>
-            <fos:arg name="step" type="fn(gnode()) as gnode()*" usage="inspection"/>
+            <fos:arg name="step" type="fn($node as gnode()) as gnode()*" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -24473,7 +24471,7 @@ return sort-with($persons/person, (
       <fos:equivalent style="xquery-function">
 declare %private function tc-inclusive(
   $nodes as gnode()*,
-  $step  as fn(gnode()) as gnode()*
+  $step  as fn($node as gnode()) as gnode()*
 ) as gnode()* {
   let $nextStep := $nodes/$step(.)
   let $newNodes := $nextStep except $nodes
@@ -24484,7 +24482,7 @@ declare %private function tc-inclusive(
 
 declare function transitive-closure (
   $node as gnode(),
-  $step as fn(gnode()) as gnode()*
+  $step as fn($node as gnode()) as gnode()*
 ) as gnode()* {
   tc-inclusive($node/$step(.), $step)
 };
@@ -25581,7 +25579,7 @@ map:of-pairs(
                      The effect is that the result contains the <xtermref spec="XP40" ref="dt-sequence-concatenation"/>
                      of the values having the same key, retaining order.
                   </fos:value>
-                  <fos:value value="function(*)">
+                  <fos:value value="fn(*)">
                      A function with signature <code>fn(item()*, item()*) as item()*</code>.
                      The function is called for any entry in the input sequence that has the 
                      <termref def="dt-same-key"/> as a previous entry. The first argument
@@ -26714,7 +26712,7 @@ map:filter(
       <fos:signatures>
          <fos:proto name="for-each" return-type="item()*">
             <fos:arg name="map" type="map(*)" usage="inspection"/>
-            <fos:arg name="action" type="fn($key as xs:anyAtomicType, $value as item()*, $position as xs:integer) as item()*"
+            <fos:arg name="action" type="fn($key as xs:anyAtomicType, $value as item()*, $pos as xs:integer) as item()*"
                usage="inspection"/>
          </fos:proto>
       </fos:signatures>
@@ -26735,9 +26733,8 @@ map:filter(
             the result is the <xtermref spec="XP40" ref="dt-sequence-concatenation"/> 
             of the results of these function calls.</p>
          
-         <p>The function supplied as <code>$action</code> takes three arguments. It is called
-            supplying the key of the map entry as the first argument, the associated value as
-            the second argument, and the 1-based integer position as the third argument.</p>
+         <p>For each entry of the map, the function calls <code>$action($key, $value, $pos)</code>,
+            where <code>$key</code> and <code>$value</code> are the key and associated value of the entry.</p>
       </fos:rules>
       
       <fos:equivalent style="dm-primitive">
@@ -26812,7 +26809,7 @@ return map:for-each($en-ja, fn($en, $ja, $pos) {
       <fos:signatures>
          <fos:proto name="filter" return-type="map(*)">
             <fos:arg name="map" type="map(*)" usage="inspection"/>
-            <fos:arg name="predicate" type="fn($key as xs:anyAtomicType, $value as item()*, $position as xs:integer) as xs:boolean?"
+            <fos:arg name="predicate" type="fn($key as xs:anyAtomicType, $value as item()*, $pos as xs:integer) as xs:boolean?"
                usage="inspection"/>
          </fos:proto>
       </fos:signatures>
@@ -26830,16 +26827,15 @@ return map:for-each($en-ja, fn($en, $ja, $pos) {
             the function returns <code>true</code>. A return value of <code>()</code> from the
          predicate is treated as <code>false</code>.</p>
 
-         <p>The function supplied as <code>$predicate</code> takes three arguments. It is called
-            supplying the key of the map entry as the first argument, the associated value as
-            the second argument, and the 1-based integer position as the third argument.</p>
+         <p>For each entry of the map, the function calls <code>$predicate($key, $value, $pos)</code>,
+            where <code>$key</code> and <code>$value</code> are the key and associated value of the entry.</p>
          
          <p>The relative <xtermref spec="DM40" ref="dt-entry-order">order of entries</xtermref> 
             in the returned map is the same as their relative order in <code>$map</code>.</p>
       </fos:rules>
       <fos:equivalent style="xpath-expression">
-map:for-each($map, fn($key, $value, $position) {
-  if ($predicate($key, $value, $position)) {
+map:for-each($map, fn($key, $value, $pos) {
+  if ($predicate($key, $value, $pos)) {
     map:entry($key, $value)
   }
 })
@@ -26892,8 +26888,8 @@ return map:filter($en-ja, fn($en, $ja, $pos) {
       <fos:signatures>
          <fos:proto name="build" return-type="map(*)">
             <fos:arg name="input" type="item()*" usage="navigation"/>
-            <fos:arg name="key" type="(fn($item as item(), $position as xs:integer) as xs:anyAtomicType*)?" default="fn:identity#1" usage="inspection" note="default-on-empty"/>
-            <fos:arg name="value" type="(fn($item as item(), $position as xs:integer) as item()*)?" default="fn:identity#1" usage="inspection" note="default-on-empty"/>
+            <fos:arg name="key" type="(fn($item as item(), $pos as xs:integer) as xs:anyAtomicType*)?" default="fn:identity#1" usage="inspection" note="default-on-empty"/>
+            <fos:arg name="value" type="(fn($item as item(), $pos as xs:integer) as item()*)?" default="fn:identity#1" usage="inspection" note="default-on-empty"/>
             <fos:arg name="options" type="map(*)?" default="{}" note="default-on-empty"/>
          </fos:proto>
       </fos:signatures>
@@ -26975,7 +26971,7 @@ return map:filter($en-ja, fn($en, $ja, $pos) {
                      The effect is that the result contains the <xtermref spec="XP40" ref="dt-sequence-concatenation"/>
                      of the values having the same key, retaining order.
                   </fos:value>
-                  <fos:value value="function(*)">
+                  <fos:value value="fn(*)">
                      A function with signature <code>fn(item()*, item()*) as item()*</code>.
                      The function is called for any entry in the input sequence that has the 
                      <termref def="dt-same-key"/> as a previous entry. The first argument
@@ -27934,7 +27930,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                   It is an error to supply the <code>fallback</code> option if the <code>escape</code>
                   option is present with the value <code>true</code>.
                </fos:meaning>
-               <fos:type>(fn(xs:string) as xs:anyAtomicType)?</fos:type>
+               <fos:type>(fn($escape as xs:string) as xs:anyAtomicType)?</fos:type>
                <fos:default>fn { char(0xFFFD) }</fos:default>
                <fos:values>
                   <fos:value value="User-supplied function">
@@ -27959,7 +27955,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
 
             <!--<fos:option key="number-parser" diff="add" at="A">
                <fos:meaning>Determines how numeric values should be processed.</fos:meaning>
-               <fos:type>(fn(xs:untypedAtomic) as item()?)?</fos:type>
+               <fos:type>(fn($number as xs:untypedAtomic) as item()?)?</fos:type>
                <fos:default>xs:identity#1</fos:default>
                <fos:values>
                   <fos:value value="User-supplied function">
@@ -30027,7 +30023,7 @@ return document {
                   It is an error to supply the <code>fallback</code> option if the <code>escape</code>
                   option is present with the value <code>true</code>.
                </fos:meaning>
-               <fos:type>(fn(xs:string) as xs:anyAtomicType)?</fos:type>
+               <fos:type>(fn($escape as xs:string) as xs:anyAtomicType)?</fos:type>
                <fos:default>fn { char(0xFFFD) }</fos:default>
                <fos:values>
                   <fos:value value="User-supplied function">
@@ -30894,7 +30890,7 @@ array:index-of(
       <fos:signatures>
          <fos:proto name="index-where" return-type="xs:integer*">
             <fos:arg name="array" type="array(*)" usage="inspection"/>
-            <fos:arg name="predicate" type="fn(item()*, xs:integer) as xs:boolean?" usage="inspection"/>
+            <fos:arg name="predicate" type="fn($member as item()*, $pos as xs:integer) as xs:boolean?" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -31451,7 +31447,7 @@ $array
       <fos:signatures>
          <fos:proto name="for-each" return-type="array(*)">
             <fos:arg name="array" type="array(*)" usage="inspection"/>
-            <fos:arg name="action" type="fn(item()*, xs:integer) as item()*" usage="inspection"/>
+            <fos:arg name="action" type="fn($member as item()*, $pos as xs:integer) as item()*" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -31468,9 +31464,8 @@ $array
       <fos:rules>
          <p>Informally, the function returns an array whose members are obtained by applying 
          the supplied <code>$action</code> function to each member of the input array in turn.</p>
-         <p>The <code>$action</code> function is called with two arguments: the first is the
-         array member (which in general is an arbitrary sequence), and the second is the 1-based
-         integer position.</p>
+         <p>For each member of the array, the function calls <code>$action($member, $pos)</code>;
+         a member is in general an arbitrary sequence.</p>
       </fos:rules>
       <fos:equivalent style="xpath-expression">
 array:of-members(
@@ -31523,7 +31518,7 @@ array:of-members(
       <fos:signatures>
          <fos:proto name="filter" return-type="array(*)">
             <fos:arg name="array" type="array(*)" usage="inspection"/>
-            <fos:arg name="predicate" type="fn(item()*, xs:integer) as xs:boolean?" usage="inspection"/>
+            <fos:arg name="predicate" type="fn($member as item()*, $pos as xs:integer) as xs:boolean?" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -31600,7 +31595,7 @@ return array:filter(
          <fos:proto name="fold-left" return-type="item()*">
             <fos:arg name="array" type="array(*)" usage="inspection"/>
             <fos:arg name="init" type="item()*" usage="navigation"/>
-            <fos:arg name="action" type="fn(item()*, item()*) as item()*" usage="inspection"/>
+            <fos:arg name="action" type="fn($acc as item()*, $member as item()*) as item()*" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -31668,7 +31663,7 @@ fold-left(
          <fos:proto name="fold-right" return-type="item()*">
             <fos:arg name="array" type="array(*)" usage="inspection"/>
             <fos:arg name="init" type="item()*" usage="navigation"/>
-            <fos:arg name="action" type="fn(item()*, item()*) as item()*" usage="inspection"/>
+            <fos:arg name="action" type="fn($member as item()*, $acc as item()*) as item()*" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -31735,7 +31730,7 @@ fold-right(
          <fos:proto name="for-each-pair" return-type="array(*)">
             <fos:arg name="array1" type="array(*)" usage="inspection"/>
             <fos:arg name="array2" type="array(*)" usage="inspection"/>
-            <fos:arg name="action" type="fn(item()*, item()*, xs:integer) as item()*" usage="inspection"/>
+            <fos:arg name="action" type="fn($member1 as item()*, $member2 as item()*, $pos as xs:integer) as item()*" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -31813,7 +31808,7 @@ array:for-each-pair(
       <fos:signatures>
          <fos:proto name="build" return-type="array(*)">
             <fos:arg name="input" type="item()*" usage="navigation"/>
-            <fos:arg name="action" type="(fn(item(), xs:integer) as item()*)?" usage="inspection" default="fn:identity#1" note="default-on-empty"/>
+            <fos:arg name="action" type="(fn($item as item(), $pos as xs:integer) as item()*)?" usage="inspection" default="fn:identity#1" note="default-on-empty"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -32086,7 +32081,7 @@ fold-left($input, [], fn($array, $record) {
          <fos:proto name="sort" return-type="array(*)">
             <fos:arg name="array" type="array(*)" usage="navigation"/>
             <fos:arg name="collation" type="xs:string?" usage="absorption" default="fn:default-collation()" note="default-on-empty"/>
-            <fos:arg name="key" type="fn(item()*) as xs:anyAtomicType*" usage="inspection" default="fn:data#1" note="default-on-empty"/>
+            <fos:arg name="key" type="fn($member as item()*) as xs:anyAtomicType*" usage="inspection" default="fn:data#1" note="default-on-empty"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -32146,7 +32141,7 @@ fold-left($input, [], fn($array, $record) {
       <fos:signatures>
          <fos:proto name="sort-by" return-type="array(*)">
             <fos:arg name="array" type="array(*)" usage="navigation"/>
-            <fos:arg name="keys" type="record(key as (fn(item()*) as xs:anyAtomicType*)?, collation as xs:string?, order as enum('ascending', 'descending')?)*"/>
+            <fos:arg name="keys" type="record(key as (fn($member as item()*) as xs:anyAtomicType*)?, collation as xs:string?, order as enum('ascending', 'descending')?)*"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -32322,7 +32317,7 @@ $array
       <fos:signatures>
          <fos:proto name="sort-with" return-type="array(*)">
             <fos:arg name="array" type="array(*)"/>
-            <fos:arg name="comparators" type="(fn(item()*, item()*) as xs:integer)+"/>
+            <fos:arg name="comparators" type="(fn($member1 as item()*, $member2 as item()*) as xs:integer)+"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -33779,7 +33774,7 @@ tail(fold-left(
       <fos:signatures>
          <fos:proto name="every" return-type="xs:boolean">
             <fos:arg name="input" type="item()*" usage="navigation"/>
-            <fos:arg name="predicate" type="(fn(item(), xs:integer) as xs:boolean?)?"
+            <fos:arg name="predicate" type="(fn($item as item(), $pos as xs:integer) as xs:boolean?)?"
                default="fn:boolean#1" example="fn:boolean#1" usage="inspection" note="default-on-empty"/>
          </fos:proto>
       </fos:signatures>
@@ -33793,7 +33788,7 @@ tail(fold-left(
       </fos:summary>
       <fos:rules>
          <p>The function returns true if <code>$input</code> is empty, or if <code>$predicate($item, $pos)</code>
-            returns true for every item <code>$item</code> at position <code>$pos</code> (1-based) in <code>$input</code>.</p>
+            returns true for every item of <code>$input</code>.</p>
       
       </fos:rules>
       
@@ -34140,7 +34135,7 @@ return every($dl/*, fn($elem, $pos) {
          <fos:proto name="highest" return-type="item()*">
             <fos:arg name="input" type="item()*" usage="navigation"/>
             <fos:arg name="collation" type="xs:string?" usage="absorption" default="fn:default-collation()" note="default-on-empty"/>
-            <fos:arg name="key" type="(fn(item()) as xs:anyAtomicType*)?" usage="inspection" default="fn:data#1" note="default-on-empty"/>
+            <fos:arg name="key" type="(fn($item as item()) as xs:anyAtomicType*)?" usage="inspection" default="fn:data#1" note="default-on-empty"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -34277,7 +34272,7 @@ return every($dl/*, fn($elem, $pos) {
       <fos:signatures>
          <fos:proto name="index-where" return-type="xs:integer*">
             <fos:arg name="input" type="item()*" usage="navigation"/>
-            <fos:arg name="predicate" type="fn(item(), xs:integer) as xs:boolean?" usage="inspection"/>
+            <fos:arg name="predicate" type="fn($item as item(), $pos as xs:integer) as xs:boolean?" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -34398,7 +34393,7 @@ for-each(
       <fos:signatures>
          <fos:proto name="take-while" return-type="item()*">
             <fos:arg name="input" type="item()*" usage="navigation"/>
-            <fos:arg name="predicate" type="fn(item(), xs:integer) as xs:boolean?" usage="inspection"/>
+            <fos:arg name="predicate" type="fn($item as item(), $pos as xs:integer) as xs:boolean?" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -34410,9 +34405,8 @@ for-each(
          <p>Returns items from the input sequence prior to the first one that fails to match a supplied predicate.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function returns all items in the sequence prior to the first one where the result of
-         calling the supplied <code>$predicate</code> function, with the current item and its position
-         as arguments, returns the value <code>false</code> or <code>()</code>.</p>
+         <p>The function returns all items in <code>$input</code> prior to the first one for which
+         <code>$predicate($item, $pos)</code> returns the value <code>false</code> or <code>()</code>.</p>
          <p>If every item in the sequence satisfies the predicate, then <code>$input</code> is returned
          in its entirety.</p>
          
@@ -34507,7 +34501,7 @@ return $item
          <fos:proto name="lowest" return-type="item()*">
             <fos:arg name="input" type="item()*" usage="navigation"/>
             <fos:arg name="collation" type="xs:string?" usage="absorption" default="fn:default-collation()" note="default-on-empty"/>
-            <fos:arg name="key" type="(fn(item()) as xs:anyAtomicType*)?" usage="inspection" default="fn:data#1" note="default-on-empty"/>
+            <fos:arg name="key" type="(fn($item as item()) as xs:anyAtomicType*)?" usage="inspection" default="fn:data#1" note="default-on-empty"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -34638,7 +34632,7 @@ return $item
       <fos:signatures>
          <fos:proto name="some" return-type="xs:boolean">
             <fos:arg name="input" type="item()*" usage="navigation"/>
-            <fos:arg name="predicate" type="(fn(item(), xs:integer) as xs:boolean?)?"
+            <fos:arg name="predicate" type="(fn($item as item(), $pos as xs:integer) as xs:boolean?)?"
                default="fn:boolean#1" example="fn:boolean#1" usage="inspection" note="default-on-empty"/>
          </fos:proto>
       </fos:signatures>
@@ -34651,8 +34645,8 @@ return $item
          <p>Returns <code>true</code> if at least one item in the input sequence matches a supplied predicate.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function returns true if (and only if) there is an item <code>$item</code> at position <code>$pos</code>
-            in the input sequence such that <code>$predicate($item, $pos)</code> returns true.</p>
+         <p>The function returns true if (and only if) <code>$predicate($item, $pos)</code>
+            returns true for at least one item of <code>$input</code>.</p>
       </fos:rules>
       <fos:equivalent style="xpath-expression">
 exists(filter($input, $predicate))         
@@ -35980,7 +35974,7 @@ path with an explicit <code>file:</code> scheme.</p>
       <fos:signatures>
          <fos:proto name="partition" return-type="array(item()*)*">
             <fos:arg name="input" type="item()*" usage="navigation"/>
-            <fos:arg name="split-when" type="fn(item()*, item(), xs:integer) as xs:boolean?" usage="inspection"/>
+            <fos:arg name="split-when" type="fn($partition as item()*, $item as item(), $pos as xs:integer) as xs:boolean?" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -35994,15 +35988,15 @@ path with an explicit <code>file:</code> scheme.</p>
       </fos:summary>
       <fos:rules>
          <p>Informally, the function starts by creating a partition containing the first item in the input sequence,
-            if any. For each remaining item <var>J</var> in the input sequence,
-            other than the first, it calls the supplied <code>$split-when</code> function with three 
-            arguments: the contents of the current partition, the item <var>J</var>, and the current
-            position in the input sequence.</p>
+            if any. For each remaining item <code>$item</code> in the input sequence,
+            other than the first, it calls <code>$split-when($partition, $item, $pos)</code>, where
+            <code>$partition</code> is the contents of the current partition and <code>$pos</code> is the
+            position of <code>$item</code> in the input sequence.</p>
          <p>Each partition is a sequence of items; the function result wraps each partition as an array, and returns
             the sequence of arrays.</p>
-         <p>If the <code>$split-when</code> function returns <code>true</code>, the current partition is wrapped as an array and added to the result,
-            and a new current partition is created, initially containing the item <var>J</var> only. If the <code>$split-when</code> 
-            function returns <code>false</code> or <code>()</code>, the item <var>J</var> is added to the current partition.</p>
+         <p>If <code>$split-when</code> returns <code>true</code>, the current partition is wrapped as an array and added to the result,
+            and a new current partition is created, initially containing <code>$item</code> only. If <code>$split-when</code>
+            returns <code>false</code> or <code>()</code>, <code>$item</code> is added to the current partition.</p>
   
       </fos:rules>
       <fos:equivalent style="xpath-expression">
@@ -36027,8 +36021,8 @@ for-each(
                starts a new group whenever an item is encountered whose value is less than
                the value of the previous item.</p></item>
          </ulist>
-         <p>The callback function is not called to process the first item in the input sequence, because this will
-            always start a new partition. The first argument to the callback function (the current partition) is always
+         <p><code>$split-when</code> is not called to process the first item in the input sequence, because this will
+            always start a new partition. Its first argument, <code>$partition</code> (the current partition), is always
             a non-empty sequence.</p>
       </fos:notes>
       <fos:examples>
@@ -36091,7 +36085,7 @@ for-each(
          <fos:proto name="scan-left" return-type="array(*)*">
             <fos:arg name="input" type="item()*" usage ="navigation"/>           
             <fos:arg name="init" type="item()*" usage="navigation"/>           
-            <fos:arg name="action" type="fn(item()*, item()) as item()*" usage="inspection"/>   
+            <fos:arg name="action" type="fn($acc as item()*, $item as item()) as item()*" usage="inspection"/>   
          </fos:proto>
        </fos:signatures>
       <fos:properties>
@@ -36157,7 +36151,7 @@ for-each(
          <fos:proto name="scan-right" return-type="array(*)*">
             <fos:arg name="input" type="item()*" usage ="navigation"/>           
             <fos:arg name="init" type="item()*" usage="navigation"/>           
-            <fos:arg name="action" type="fn(item(), item()*) as item()*" usage="inspection"/>   
+            <fos:arg name="action" type="fn($item as item(), $acc as item()*) as item()*" usage="inspection"/>   
          </fos:proto>
        </fos:signatures>
       <fos:properties>
@@ -36216,7 +36210,7 @@ for-each(
     
    <fos:function name="invisible-xml" prefix="fn">
       <fos:signatures>
-         <fos:proto name="invisible-xml" return-type="fn(xs:string) as item()">
+         <fos:proto name="invisible-xml" return-type="fn($input as xs:string) as item()">
             <fos:arg name="grammar" type="(xs:string | element(Q{}ixml))?" default="()" usage="navigation"/>
             <fos:arg name="options" type="map(*)?" default="{}" note="default-on-empty"/>
          </fos:proto>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -873,9 +873,9 @@ Item types form a directed graph, rather than a
 hierarchy or lattice: in the relationship defined by the
 <code>derived-from(A, B)</code> function, some types are derived from
 more than one other type. Examples include functions
-(<code>function(xs:string) as xs:int</code> is substitutable for
-<code>function(xs:NCName) as xs:int</code> and also for
-<code>function(xs:string) as xs:decimal</code>), and choice types
+(<code>fn(xs:string) as xs:int</code> is substitutable for
+<code>fn(xs:NCName) as xs:int</code> and also for
+<code>fn(xs:string) as xs:decimal</code>), and choice types
 (<code>A</code> is substitutable for the choice type <code>(A | B)</code> and also
 for <code>(A | C)</code>. Record types provide an alternative way of categorizing
    maps: the instances of <code>record(longitude, latitude)</code> overlap with
@@ -1487,6 +1487,13 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
             
             <p>With all these functions, if the caller-supplied function fails with a dynamic error,
             this error is propagated as an error from the higher-order function itself.</p>
+
+            <p>Several higher-order functions in this specification pass the 1-based position of an
+            item to the caller-supplied function as an additional <code>xs:integer</code> argument,
+            shown in the function signatures as <code>$pos</code>. The descriptions of individual
+            functions rely on this convention rather than restating it. A caller that does not need
+            the position may, by function coercion, supply a function of lower arity that omits the
+            parameter.</p>
             
             <div3 id="func-apply">
                <head><?function fn:apply?></head>
@@ -6440,7 +6447,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
          
          <p>A map can also be viewed as a function from keys to associated values. To achieve this, a map is also a 
             function item. The function corresponding to the map has the signature 
-            <code>function($key as xs:anyAtomicValue) as item()*</code>. Calling the function has the same effect as calling
+            <code>fn($key as xs:anyAtomicValue) as item()*</code>. Calling the function has the same effect as calling
             the <function>map:get</function> function: the expression
             <code>$map($key)</code> returns the same result as <code>get($map, $key)</code>. For example, if <code>$books-by-isbn</code>
             is a map whose keys are ISBNs and whose assocated values are <code>book</code> elements, then the expression
@@ -8461,7 +8468,7 @@ map( xs:string,
          <p>An array acts as a function from integer positions to associated values, so the
             function call <code>$array($index)</code> can be used to retrieve the array member at a given position.
             The function corresponding to the array has the signature 
-            <code>function($index as xs:integer) as item()*</code>. 
+            <code>fn($index as xs:integer) as item()*</code>. 
             The fact that an array is a function item allows it to be passed as an argument to higher-order functions 
             that expect a function item as one of their arguments.</p>
          

--- a/specifications/xpath-functions-40/style/xpath-functions.xsl
+++ b/specifications/xpath-functions-40/style/xpath-functions.xsl
@@ -378,7 +378,14 @@
   
 <xsl:template match="@*" mode="render-type" priority="11">
   <code>
-    <xsl:sequence select="replace(string(.), ' as ', ' as ')"/>
+    <xsl:analyze-string select="string(.)" regex="\$[\w-]+">
+      <xsl:matching-substring>
+        <span class="doc-param"><xsl:value-of select="."/></span>
+      </xsl:matching-substring>
+      <xsl:non-matching-substring>
+        <xsl:value-of select="."/>
+      </xsl:non-matching-substring>
+    </xsl:analyze-string>
   </code>
 </xsl:template>
 


### PR DESCRIPTION
Summary:
* All function parameters are now decorated with documentary variables.
* The variables are rendered in a grey/gray/grau color, to indicate that they are not assignable.
* In various places (certainly not everywhere) I have changed the function prose to reference the variables.
* For callback functions I have (finally) added a section to explain what the `$pos` parameters are about, and that they can be omitted.
* The variables in function parameters in record definitions now consistently use a single character (for example: `$s as xs:string, $replacement as ...` → `$s as xs:string, $r as ...`).
* Minor consistency tweaks (use `function() → fn()` everywhere) and fixes.

It seems that no changes were needed for the EXPath functions.
Feedback is welcome!
Closes #1697