### PR TITLE
2284 fn:csv-doc, fn:json-doc: Equivalent code, unifications

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -22264,7 +22264,8 @@ serialize(
          <p>Reads an external resource containing HTML, and returns the result of parsing the resource as HTML.</p>
       </fos:summary>
       <fos:rules>
-         <p>The effect of the two-argument function call <code>fn:html-doc($H, $M)</code>is equivalent to the function composition
+         <p>The effect of the two-argument function call <code>fn:html-doc($H, $M)</code> is
+            equivalent to the function composition
             <code>fn:unparsed-binary($H) => fn:parse-html($M)</code>.</p>
          <p>If <code>$source</code> is the empty sequence, the function returns the empty sequence.</p>
          <note><p>The ability to access external resources depends on whether the
@@ -29248,7 +29249,10 @@ return (
       <fos:rules>
          <p>The effect of the two-argument function call <code>fn:csv-doc($H, $M)</code> is
             equivalent to the function composition
-            <code>fn:unparsed-binary($H) => fn:parse-csv($M)</code>.</p>
+            <code>fn:unparsed-text($H) => fn:parse-csv($M)</code>, except that the
+            special handling of media types such as <code>text/xml</code> and
+            <code>application/xml</code> in the selection of the effective encoding
+            may be skipped.</p>
          <p>If <code>$source</code> is the empty sequence, the function returns the empty sequence.</p>
          <note><p>The ability to access external resources depends on whether the
          calling code is <xtermref spec="XP40" ref="dt-trusted"/>.</p></note>
@@ -30328,14 +30332,14 @@ return document {
          <p>Reads an external resource containing JSON, and returns the result of parsing the resource as JSON.</p>
       </fos:summary>
       <fos:rules>
-         <p>The effect of the two-argument function call <code>fn:json-doc($H, $M)</code>is equivalent to the function composition
+         <p>The effect of the two-argument function call <code>fn:json-doc($H, $M)</code> is
+            equivalent to the function composition
             <code>fn:unparsed-text($H) => fn:parse-json($M)</code>, except that:</p>
-         
+
          <ulist>
-            <item><p>The function may accept a resource in any encoding. <bibref ref="rfc8259"/> requires 
-               UTF-8 to be accepted, but does not disallow other encodings. 
-               Unless other information is available (either externally, or from a byte order mark), 
-               the function must assume that the encoding is UTF-8.</p></item>
+            <item><p>The special handling of media types such as <code>text/xml</code> and
+               <code>application/xml</code> in the selection of the effective encoding
+               may be skipped.</p></item>
             <item><p>Having established the encoding, the function must accept any codepoint that
                can validly occur in a JSON text, with the exception of unpaired surrogates.</p></item>
          </ulist>
@@ -30360,11 +30364,10 @@ return document {
             and the JSON escape sequence is then passed to the fallback function specified in the <code>$options</code> argument, which in turn
             defaults to a function that returns <char>U+FFFD</char>.</p>
          
-         <p>The function <rfc2119>may</rfc2119> accept a resource in any encoding. <bibref ref="rfc8259"/> requires
-               UTF-8 to be used when data is exchanged between systems that are not part of a closed ecosystem.
-               The function detects the encoding using the same rules as the <function>unparsed-text</function>
-               function, except that the special handling of media types such as <code>text/xml</code>
-            and <code>application/xml</code> may be skipped.</p>
+         <p><bibref ref="rfc8259"/> requires UTF-8 to be used when JSON data is exchanged between
+            systems that are not part of a closed ecosystem. Nevertheless, the function
+            <rfc2119>may</rfc2119> accept a resource in any encoding recognized by the
+            <function>fn:unparsed-text</function> function.</p>
          
          
          


### PR DESCRIPTION
Editorial, and overdue: Ensures that the `-doc` functions use the same rules.

Closes #2284