### PR TITLE
2620 fn:unparsed-text: editorial issues

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19935,7 +19935,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             The values for this option follow the same rules as for the <code>encoding</code> attribute
             in an XML declaration. The values which an implementation is <rfc2119>required</rfc2119>
             to recognize are <code>UTF-8</code>, <code>UTF-16</code>, <code>UTF-16LE</code>,
-            and <code>UTF-16BE</code>.</p>
+            and <code>UTF-16BE</code> (in any upper/lower case combination).</p>
 
          <p>The encoding candidate is chosen as follows:</p>
          <olist>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19935,9 +19935,9 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             The values for this option follow the same rules as for the <code>encoding</code> attribute
             in an XML declaration. The values which an implementation is <rfc2119>required</rfc2119>
             to recognize are <code>UTF-8</code>, <code>UTF-16</code>, <code>UTF-16LE</code>,
-            and <code>UTF-16BE</code> (in any upper/lower case combination).</p>
+            and <code>UTF-16BE</code>.</p>
 
-         <p>The effective encoding is chosen as follows:</p>
+         <p>The encoding candidate is chosen as follows:</p>
          <olist>
             <item>
                <p>external encoding information if available; otherwise</p>
@@ -19953,20 +19953,20 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                <p>the value of the <code>encoding</code> option if present; otherwise</p>
             </item>
             <item>
-               <p>the encoding inferred from the initial octets of the resource,
-               or from <termref def="implementation-defined"/> heuristics
-               as defined by the rules of the <function>bin:infer-encoding</function>
-               function.</p>
+               <p>the empty sequence.</p>
             </item>
          </olist>
 
-         
-         <note><p>Encoding names are compared without regard to case.</p></note>
-         <p>If the input (as decoded using the effective encoding) starts with a byte order mark,
-            then the byte order mark is not included in the result.</p>
+         <p>The effective encoding and the effective start position are determined by invoking
+            <function>bin:infer-encoding</function> with the octets of the retrieved resource
+            and the encoding candidate.</p>
+
+         <note><p>As a consequence of these rules, a byte order mark at the start of the
+            resource is not included in the result.</p></note>
 
          <p>The result of the function is a string containing the string representation of the
-            resource retrieved using the URI, decoded according to the effective encoding.</p>
+            resource retrieved using the URI, starting at the effective start position, and
+            decoded according to the effective encoding.</p>
          
          
       </fos:rules>
@@ -19986,9 +19986,10 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             encoding, or if any resulting character is not a
             <termref def="dt-permitted-character">permitted character</termref>.</p>
          <p>A dynamic error is raised <errorref class="UT" code="1200"
-            /> if the <code>encoding</code> option
-            is absent and the processor cannot infer the
-            encoding using external information and the actual encoding is not UTF-8.</p>
+            /> if the encoding candidate is absent and the string representation of the
+            retrieved resource contains octets that cannot be decoded into Unicode
+            <termref def="character">characters</termref> using the encoding determined
+            by <function>bin:infer-encoding</function>.</p>
       </fos:errors>
 
       <fos:notes>
@@ -20086,6 +20087,11 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
          <fos:change issue="2460" PR="2510" date="2026-03-11">
             <p>A fallback option is now provided to address characters that cannot be
             decoded or are not permitted.</p>
+         </fos:change>
+         <fos:change issue="2620" date="2026-07-03">
+            <p>The encoding and the start position of the content are now determined by
+               invoking <function>bin:infer-encoding</function>; redundant rules have
+               been dropped.</p>
          </fos:change>
       </fos:changes>
    </fos:function>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -14753,9 +14753,9 @@ ISBN 0 521 77752 6.</bibl>
             <error class="UT" code="1200" label="Cannot infer encoding of external resource."
                type="dynamic">
                <p>Raised by <function>fn:unparsed-text</function> or <function>fn:unparsed-text-lines</function>
-                  if the <code>$encoding</code> argument is absent and the processor
-                  cannot infer the encoding using external information and the
-                  encoding is not UTF-8.</p>
+                  if no encoding has been supplied or can be inferred using external
+                  information, and the resource cannot be decoded using the encoding
+                  determined by <function>bin:infer-encoding</function>.</p>
             </error>
             <error class="UR" code="0001" label="Invalid IPv6/IPvFuture authority"
                type="dynamic">


### PR DESCRIPTION
Cleanups (`fn:unparsed-text` was streamlined).
Mostly editorial, but we’ll need some more tests here (with or without this PR).

Closes #2620