### PR TITLE
2569 Rules for unprefixed function calls with explicit default function ns

### DIFF
--- a/specifications/xquery-40/src/back-matter.xml
+++ b/specifications/xquery-40/src/back-matter.xml
@@ -104,7 +104,7 @@ per lexical scope.</td>
 
 <tr>
   <td>Default function namespace</td>
-  <td><code>fn</code></td>
+  <td><phrase diff="chg" at="issue2569">absent</phrase></td>
   <td>overwriteable (not recommended)</td>
   <td>overwriteable by <specref ref="id-default-namespace"/></td>
   <td>no</td>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -518,19 +518,37 @@ The term URI has been retained in preference to IRI to avoid introducing new nam
                is expanded using the <term>no-namespace rule</term>, it is interpreted as having an absent namespace URI.</termdef>
                </p></item>
                <item>
-                  <p><termdef id="dt-default-function-namespace-rule" term="default function namespace rule">When 
+                  <p diff="chg" at="issue2569"><termdef id="dt-default-function-namespace-rule" term="default function namespace rule">When
                      an unprefixed lexical QName
-                     is expanded using the <term>default function namespace rule</term>, 
-                     the processor searches for a matching function definition as follows: 
-                     first, if the static context includes a no-namespace function definition 
-                     with the required local name and arity, then that function definition is used; 
-                     otherwise, the name is expanded using the <termref def="dt-default-function-namespace"/> from 
-                     the <termref def="dt-static-context"/>.</termdef>
+                     is expanded using the <term>default function namespace rule</term>,
+                     the outcome depends on the <termref def="dt-default-function-namespace"/> in
+                     the <termref def="dt-static-context"/>, as follows.</termdef>
                   </p>
-                  <note><p>The implication of this rule is that if there is a user-defined function in no namespace
+                  <olist>
+                     <item><p diff="add" at="issue2569">If the <termref def="dt-default-function-namespace"/> is
+                        <xtermref spec="DM40" ref="dt-absent"/>, the processor searches for a matching function
+                        definition as follows: first, if the static context includes a no-namespace function definition
+                        with the required local name and arity, then that function definition is used;
+                        otherwise, the name is interpreted as having the namespace URI
+                        <code>http://www.w3.org/2005/xpath-functions</code>.</p></item>
+                     <item><p diff="add" at="issue2569">If the <termref def="dt-default-function-namespace"/> is the
+                        zero-length string, the name is interpreted as having an absent namespace URI.</p></item>
+                     <item><p diff="add" at="issue2569">Otherwise, the name is interpreted as having the
+                        <termref def="dt-default-function-namespace"/> as its namespace URI.</p></item>
+                  </olist>
+                  <note><p diff="chg" at="issue2569">The implication of the first rule is that if the default function
+                     namespace is absent, and there is a user-defined function in no namespace
                   with the same local name as a system-defined function in the <code>fn</code>
                      namespace, then a function call using the unprefixed function name invokes the user-defined
                      function in preference to the system-defined function.</p>
+                     <p diff="add" at="issue2569">If, by contrast, the default function namespace is present<phrase
+                        role="xquery"> (that is, if the query prolog contains an explicit default function
+                        namespace declaration)</phrase>,
+                        an unprefixed function name always refers to a function in that namespace (or, if the
+                        namespace is the zero-length string, to a function in no namespace); no search
+                        takes place. In particular, if the default function namespace is a non-zero-length
+                        string, functions in no namespace can only be called by using a no-namespace
+                        EQName such as <code>Q{}f()</code>.</p>
                      <p>It is generally advisable to avoid any danger of user confusion by keeping the names
                         of user-defined functions noticably distinct from the names of system-defined functions,
                         for example by using different naming conventions (for example, leading upper-case letters
@@ -817,11 +835,14 @@ and by <termref def="dt-namespace-decl-attr"
                   <p>Host languages may use a more complex algorithm for resolving function names. For
                      example XSLT resolves ambiguities using the concept of import precedence.
                   </p>
-                  <p role="xquery">
+                  <p role="xquery" diff="chg" at="issue2569">
                      In XQuery, a default function namespace can be
                      declared in the prolog in a <term>default function namespace declaration</term>
-                     (see <specref ref="id-default-namespace"/>); in the absence of such a declaration, the namespace
-                     <code>http://www.w3.org/2005/xpath-functions</code> is used.</p>
+                     (see <specref ref="id-default-namespace"/>); in the absence of such a declaration, the
+                     default function namespace is <xtermref spec="DM40" ref="dt-absent"/>, so unprefixed
+                     function names fall back to the namespace
+                     <code>http://www.w3.org/2005/xpath-functions</code> if no matching no-namespace
+                     function definition exists.</p>
                </item>
 
 

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -976,6 +976,11 @@ return $node/xx:bing]]>
         now be in no namespace, and a search for an unprefixed function name will be resolved first
         against functions in no namespace, and only then against functions in the standard function namespace.
       </change>
+      <change issue="2569" date="2026-07-03">
+        It has been clarified that the search for no-namespace functions only applies in the absence of
+        an explicit default function namespace declaration: if a default function namespace has been
+        declared, unprefixed function names always refer to functions in that namespace.
+      </change>
     </changes>
     <scrap>
       <prodrecap ref="DefaultNamespaceDecl"/>
@@ -1062,7 +1067,7 @@ return $node/xx:bing]]>
         <olist>
           <item><p>If there is an explicit default function namespace declaration and the
           <code>StringLiteral</code> is a zero-length string, the
-          default function namespace is <xtermref spec="DM40" ref="dt-absent"/>.</p>
+          default function namespace is <phrase diff="chg" at="issue2569">set to the zero-length string</phrase>.</p>
             
             <p>In this case:</p>
             
@@ -1106,7 +1111,9 @@ return $node/xx:bing]]>
             
             </item>
           
-          <item><p>If there is no explicit default function namespace declaration, then:</p>
+          <item><p diff="chg" at="issue2569">If there is no explicit default function namespace declaration, the
+          default function namespace is <xtermref spec="DM40" ref="dt-absent"/>.</p>
+            <p diff="add" at="issue2569">In this case:</p>
             
             
             <olist>
@@ -1140,7 +1147,21 @@ return $node/xx:bing]]>
             </item>
         </olist>
  
-       
+
+        <example diff="add" at="issue2569">
+          <head>An Explicit Default Function Namespace Takes Precedence</head>
+          <p>Consider the following query:</p>
+          <eg role="parse-test">declare default function namespace "urn:example";
+declare function f() { "namespace" };
+declare function Q{}f() { "no-namespace" };
+f()</eg>
+          <p>Since a default function namespace has been explicitly declared, the unprefixed
+            names in the first function declaration and in the function call are both
+            expanded to names in the namespace <code>urn:example</code>: no search for a
+            no-namespace function takes place, and the query returns <code>"namespace"</code>.
+            The function in no namespace can be called only as <code>Q{}f()</code>.</p>
+        </example>
+
         <p diff="add" at="2023-10-16">The keyword <code>"fixed"</code> has no effect when declaring
           a default function namespace, since there is no mechanism to change the default function
           namespace within a query module.</p>
@@ -1719,7 +1740,8 @@ local:summary(doc("acme_corp.xml")//employee[location = "Denver"])</eg>
           <ulist>
             <item><p>If the query module includes an explicit declaration of a <termref def="dt-default-function-namespace"/>,
             then the name is expanded using the <termref def="dt-default-function-namespace-rule"/>.
-            That is, an unprefixed name represents a name in the default function namespace.</p></item>
+            That is, an unprefixed name represents a name in the default function namespace<phrase diff="add" at="issue2569">
+            (or, if the declaration specifies a zero-length string, a name in no namespace)</phrase>.</p></item>
             <item><p>Otherwise (if the query module does not include an explicit declaration of a 
               <termref def="dt-default-function-namespace"/>), the name is expanded 
             using the <termref def="dt-no-namespace-rule"/>.
@@ -1727,9 +1749,10 @@ local:summary(doc("acme_corp.xml")//employee[location = "Denver"])</eg>
             <note><p>In previous XQuery versions this would generally be an error, because in the
             absence of an explicit default function namespace declaration, the default function
             namespace would generally be a <termref def="dt-reserved-namespaces">reserved namespace</termref>.</p>
-              <p>In 4.0, an unprefixed function name used in a static function call is resolved first
+              <p diff="chg" at="issue2569">In 4.0, in the absence of an explicit default function namespace declaration,
+              an unprefixed function name used in a static function call is resolved first
               by looking for a function in no namespace, and only if that fails to find a match, by looking
-              for a function in the default function namespace.</p>
+              for a function in the standard function namespace <code>http://www.w3.org/2005/xpath-functions</code>.</p>
             </note></item>
           </ulist>
           


### PR DESCRIPTION
After further reflection, I have chosen to have three states:

* The no-namespace-first search exists for one simple reason: without any declaration, the default function namespace is the reserved `fn:` namespace, where users cannot declare functions.
* This means that the search is the only way to make unprefixed calls to user-defined functions work.
* Once a default function namespace is explicitly declared, that reason disappears: users can declare functions there.
* I believe the declaration should simply mean what it says: unprefixed calls go to the declared namespace and are not silently redirected by some no-namespace function that happens to exist.

The implementation is straightforward, and the proposed solution goes hand in hand with #2257.

Closes #2569