### PR TITLE
1506 Type declarations: Constructor functions

### DIFF
--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -2047,7 +2047,14 @@ local:depth(doc("partlist.xml"))
   
   <div2 id="id-item-type-declaration" diff="add" at="A">
     <head>Item Type Declarations</head>
-    
+
+    <changes>
+      <change issue="1506" PR="TODO" date="2026-07-04">
+        Clarified that an item type declaration whose type expands to a generalized atomic type
+        or to a record type implicitly declares a constructor function.
+      </change>
+    </changes>
+
     <p>An item type declaration defines a name for an <termref def="dt-item-type"/>. Defining a name for an item type
     allows it to be referenced by name rather than repeating
     the <termref def="dt-item-type-designator"/> in full.</p>
@@ -2120,11 +2127,33 @@ local:depth(doc("partlist.xml"))
     <p diff="add" at="issue275">The name of an item type must be unique among the names of all
       declared item types and <termref def="dt-generalized-atomic-type">generalized atomic types</termref>
       in the <termref def="dt-static-context"/> of the query module. <errorref class="ST" code="0146"/></p>
-    
-    
-    <note><p>Named item types have been designed so that a reference to an item type name can be expanded
+
+    <p diff="add" at="issue1506">If the declared item type expands to a <termref def="dt-generalized-atomic-type"/>
+      or to a <nt def="RecordType">RecordType</nt>, then the declaration also implicitly defines a
+      <termref def="dt-constructor-function"/> whose name is the name of the item type;
+      the rules are given in <specref ref="id-constructor-functions"/>.</p>
+
+    <p diff="add" at="issue1506">Any <code>%public</code> or <code>%private</code> annotations apply
+      both to the item type declaration and to the constructor function. As with named record declarations,
+      the constructor function must not have an arity range that overlaps the arity range of another
+      function declaration having the same name in the same static context.</p>
+
+    <example diff="add" at="issue1506">
+      <p>Given the declaration:</p>
+
+      <eg>declare type world:continent as enum('Africa', 'America', 'Asia', 'Australia', 'Europe');</eg>
+
+      <p>the function call <code>world:continent('Africa')</code> returns the string <code>Africa</code>,
+        which is an instance of <code>world:continent</code>, while the call
+        <code>world:continent('Atlantis')</code> raises a dynamic error
+        <xerrorref spec="FO" class="RG" code="0001"/>.</p>
+    </example>
+
+    <note><p diff="chg" at="issue1506">Named item types have been designed so that a reference to an item type name can be expanded
       (that is, replaced by its definition) as soon as the declaration is encountered during query parsing.
-      There is never any need to retain item type names at execution time except optionally for diagnostics.</p></note>
+      There is never any need to retain item type names at execution time except optionally for diagnostics;
+      however, if the declaration gives rise to a constructor function, then the name remains visible at
+      execution time as the name of that function (for example, to <code>fn:function-lookup</code>).</p></note>
       
     <note><p>The specification allows forwards references to named item type declarations. 
       While disallowing this would appear to make life easier for implementers, it is not practical because it


### PR DESCRIPTION
[NEW] This PR originally introduced constructor functions for type declarations, restricted to enums and atomic types (see below). As it turned out, the feature already existed in the spec (which also explains the existing test case).

My confusion was caused by the fact that we closed #1506 without further notice, and that this was not mentioned in the *Item Type Declarations* section. Next, its note claims that item type names never need to be retained at execution time, which contradicts the constructor functions. The PR tries to complete the picture, without changing the scope of the feature:

* The section on item type declarations points to the existing constructor function rules.
* Annotations rules/arity overlap have been added, they seemed to be missing.
* A note has been corrected.

→ And we definitely need more test cases (indicated, for now, with the »Tests Needed« label). I will do my best soon.

-------------

[OLD] This PR introduces constructor functions for type declarations – a feature for which, surprisingly, we already have a test case, [itemTypeDecl-026](https://github.com/qt4cg/qt4tests/blob/c0183a06487621e5f218b2e44f69acd02b39a8a4/prod/ItemTypeDecl.xml#L381-L394)… (we certainly need more)

I decided to restrict the creation of constructor functions to declarations of enums and atomic types, for the following reasons mainly:

* We avoid different semantics for `record` and `type ... as record` declarations.
* Functions (incl. maps & arrays) can’t be built from a value; it would basically be a simulation of `instance of`/`treat as`.
* Unions and choices are non-trivial: for `declare type n as (xs:double | xs:decimal)`, `n(1.5)` the result depends on the order in which the type was written, which is easy to get wrong.
