### PR TITLE
2521 URIs: unify handling of fragment identifiers

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19880,8 +19880,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
          <p diff="add" at="2026-07-04">The URI may include a fragment identifier. The effect of a
             fragment identifier is <termref def="implementation-defined"
             >implementation-defined</termref>; one possible interpretation for text resources
-            is described in <bibref ref="rfc5147"/>. Implementations that associate no semantics
-            with the fragment identifier <rfc2119>should</rfc2119> ignore it.</p>
+            is described in <bibref ref="rfc5147"/>.</p>
          <p>If <code>$source</code> is a relative URI reference, it is resolved relative to the value
             of the <xtermref spec="XP40" ref="dt-executable-base-uri">executable base URI</xtermref> property 
             from the dynamic context of the caller. The resulting absolute URI is
@@ -20279,8 +20278,7 @@ return $lines[not(position() = last() and . = '')]
             available.</p>
          <p diff="add" at="2026-07-04">The URI may include a fragment identifier. The effect of a
             fragment identifier is <termref def="implementation-defined"
-            >implementation-defined</termref>. Implementations that associate no semantics
-            with the fragment identifier <rfc2119>should</rfc2119> ignore it.</p>
+            >implementation-defined</termref>.</p>
          
          <p>If <code>$source</code> is a relative URI reference, it is resolved relative to the value
             of the <xtermref spec="XP40" ref="dt-executable-base-uri">executable base URI</xtermref> property 

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19874,10 +19874,14 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             file) and returns a string representation of the resource.</p>
       </fos:summary>
       <fos:rules>
-         <p>The <code>$source</code> argument <rfc2119>must</rfc2119> be a string in the form of a URI
-            reference, which <rfc2119>must</rfc2119> contain no fragment identifier, and
-               <rfc2119>must</rfc2119> identify a resource for which a string representation is
+         <p diff="chg" at="2026-07-04">The <code>$source</code> argument <rfc2119>must</rfc2119> be a string in the form of a URI
+            reference, which <rfc2119>must</rfc2119> identify a resource for which a string representation is
             available.</p>
+         <p diff="add" at="2026-07-04">The URI may include a fragment identifier. The effect of a
+            fragment identifier is <termref def="implementation-defined"
+            >implementation-defined</termref>; one possible interpretation for text resources
+            is described in <bibref ref="rfc5147"/>. Implementations that associate no semantics
+            with the fragment identifier <rfc2119>should</rfc2119> ignore it.</p>
          <p>If <code>$source</code> is a relative URI reference, it is resolved relative to the value
             of the <xtermref spec="XP40" ref="dt-executable-base-uri">executable base URI</xtermref> property 
             from the dynamic context of the caller. The resulting absolute URI is
@@ -19971,11 +19975,10 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
          
       </fos:rules>
       <fos:errors>
-         <p>A dynamic error is raised <errorref class="UT" code="1170"
-               /> if the <code>$source</code> argument
-            contains a fragment identifier, <phrase>or if it cannot be resolved
-            to an absolute URI (for example, because the base-URI property in the static context is absent), 
-            </phrase>or if it cannot be used to retrieve the string
+         <p diff="chg" at="2026-07-04">A dynamic error is raised <errorref class="UT" code="1170"
+               /> if the <code>$source</code> argument cannot be resolved
+            to an absolute URI (for example, because the base-URI property in the static context is absent),
+            or if it cannot be used to retrieve the string
             representation of a resource. </p>
          <p diff="chg" at="2023-06-12">A dynamic error is raised <errorref class="UT" code="1190"
             /> if the value of the
@@ -20068,6 +20071,10 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
          </fos:example>
       </fos:examples>
       <fos:changes>
+         <fos:change issue="2521" date="2026-07-04">
+            <p>The supplied URI may now include a fragment identifier; its effect
+               is implementation-defined.</p>
+         </fos:change>
          <fos:change issue="1116" PR="1117" date="2024-05-21">
             <p>The <code>$options</code> parameter has been added.</p>
          </fos:change>
@@ -20267,10 +20274,13 @@ return $lines[not(position() = last() and . = '')]
             file) and returns its contents in binary.</p>
       </fos:summary>
       <fos:rules>
-         <p>The <code>$source</code> argument <rfc2119>must</rfc2119> be a string in the form of a URI
-            reference, which <rfc2119>must</rfc2119> contain no fragment identifier, and
-               <rfc2119>must</rfc2119> identify a resource for which a binary representation is
+         <p diff="chg" at="2026-07-04">The <code>$source</code> argument <rfc2119>must</rfc2119> be a string in the form of a URI
+            reference, which <rfc2119>must</rfc2119> identify a resource for which a binary representation is
             available.</p>
+         <p diff="add" at="2026-07-04">The URI may include a fragment identifier. The effect of a
+            fragment identifier is <termref def="implementation-defined"
+            >implementation-defined</termref>. Implementations that associate no semantics
+            with the fragment identifier <rfc2119>should</rfc2119> ignore it.</p>
          
          <p>If <code>$source</code> is a relative URI reference, it is resolved relative to the value
             of the <xtermref spec="XP40" ref="dt-executable-base-uri">executable base URI</xtermref> property 
@@ -20296,11 +20306,10 @@ return $lines[not(position() = last() and . = '')]
          
       </fos:rules>
       <fos:errors>
-         <p>A dynamic error is raised <errorref class="UT" code="1170"
-               /> if the <code>$source</code> argument
-            contains a fragment identifier, <phrase>or if it cannot be resolved
-            to an absolute URI (for example, because the base-URI property in the static context is absent), 
-            </phrase>or if it cannot be used to retrieve the binary
+         <p diff="chg" at="2026-07-04">A dynamic error is raised <errorref class="UT" code="1170"
+               /> if the <code>$source</code> argument cannot be resolved
+            to an absolute URI (for example, because the base-URI property in the static context is absent),
+            or if it cannot be used to retrieve the binary
             representation of a resource. </p>
          
       </fos:errors>
@@ -20386,6 +20395,10 @@ return { "width": $int16-at($loc + 5),
          </fos:example>
       </fos:examples>
       <fos:changes>
+         <fos:change issue="2521" date="2026-07-04">
+            <p>The supplied URI may now include a fragment identifier; its effect
+               is implementation-defined.</p>
+         </fos:change>
          <fos:change issue="557" PR="1587" date="2024-11-18">
             <p>New in 4.0</p>
          </fos:change>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -14070,6 +14070,9 @@ Organization for Standardization, 2012. Available from: <loc href="http://www.is
                </bibl>
                <bibl id="rfc7303" key="RFC 7303">H. Thompson and C. Lilley. <emph>XML Media Types</emph>.
                   IETF RFC 7303. See <loc href="http://www.ietf.org/rfc/rfc7303.txt">http://www.ietf.org/rfc/rfc7303.txt</loc>.</bibl>
+               <bibl id="rfc5147" key="RFC 5147" diff="add" at="2026-07-04">E. Wilde and M. Duerst. <emph>URI Fragment Identifiers
+                  for the text/plain Media Type</emph>.
+                  IETF RFC 5147. See <loc href="http://www.ietf.org/rfc/rfc5147.txt">http://www.ietf.org/rfc/rfc5147.txt</loc>.</bibl>
                
                <bibl id="fips180-4" key="FIPS 180-4">National Institute of Standards and Technology.
                  <emph>Secure Hash Standard (SHS)</emph>. FIPS PUB 180-4. August 2015. 
@@ -14734,11 +14737,11 @@ ISBN 0 521 77752 6.</bibl>
             </error>
             <error class="UT" code="1170" label="Invalid URI reference."
                type="dynamic">
-               <p>Raised by <function>fn:unparsed-text</function> or <function>fn:unparsed-text-lines</function>
-                  if the <code>$source</code> argument contains a fragment identifier,
-                  or if it cannot be resolved to an absolute URI (for example, because the
+               <p diff="chg" at="2026-07-04">Raised by <function>fn:unparsed-text</function>, <function>fn:unparsed-text-lines</function>,
+                  or <function>fn:unparsed-binary</function>
+                  if the <code>$source</code> argument cannot be resolved to an absolute URI (for example, because the
                   base-URI property in the static context is absent), or if it cannot be used to
-                  retrieve the string representation of a resource.</p>
+                  retrieve the string or binary representation of a resource.</p>
             </error>
             <error class="UT" code="1190" label="Cannot decode external resource."
                type="dynamic">


### PR DESCRIPTION
This PR proposes to treat fragment identifiers identically for `fn:doc`, `fn:unparsed-text`, and `fn:unparsed-binary`. I have added a reference to RFC5147.

Closes #2521