### PR TITLE
2750 Make fn:unparsed-text, ... nondeterministic

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19987,7 +19987,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
-         <fos:property>deterministic</fos:property>
+         <fos:property>nondeterministic</fos:property>
          <fos:property dependency="executable-base-uri">context-dependent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
@@ -20145,8 +20145,9 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                <p>The handling of media types is implementation-defined.</p>
             </item>
             <item>
-               <p>Implementations may provide user options that relax the requirement for the function
-               to return deterministic results.</p>
+               <p>Although the function is <termref def="dt-nondeterministic"/>, implementations may
+               provide user options that request deterministic (stable) results, so that repeated
+               calls with the same arguments during a single execution return the same result.</p>
             </item>
 
             <item>
@@ -20215,6 +20216,9 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                invoking <function>bin:infer-encoding</function>; redundant rules have
                been dropped.</p>
          </fos:change>
+         <fos:change issue="2750" date="2026-07-05">
+            <p>The function is now classified as <termref def="dt-nondeterministic"/>.</p>
+         </fos:change>
       </fos:changes>
    </fos:function>
    <fos:function name="unparsed-text-lines" prefix="fn">
@@ -20225,7 +20229,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
-         <fos:property>deterministic</fos:property>
+         <fos:property>nondeterministic</fos:property>
          <fos:property dependency="executable-base-uri">context-dependent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
@@ -20300,9 +20304,12 @@ return $lines[not(position() = last() and . = '')]
             <p>A fallback option is now provided to address characters that cannot be
             decoded or are not permitted.</p>
          </fos:change>
+         <fos:change issue="2750" date="2026-07-05">
+            <p>The function is now classified as <termref def="dt-nondeterministic"/>.</p>
+         </fos:change>
       </fos:changes>
    </fos:function>
-   
+
    <fos:function name="unparsed-text-available" prefix="fn">
       <fos:signatures>
          <fos:proto name="unparsed-text-available" return-type="xs:boolean">
@@ -20311,7 +20318,7 @@ return $lines[not(position() = last() and . = '')]
          </fos:proto>
       </fos:signatures>
       <fos:properties>
-         <fos:property>deterministic</fos:property>
+         <fos:property>nondeterministic</fos:property>
          <fos:property dependency="executable-base-uri">context-dependent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
@@ -20333,17 +20340,13 @@ return $lines[not(position() = last() and . = '')]
             fail with a non-recoverable dynamic error.</p>
          
          <p>The functions <function>fn:unparsed-text</function> and
-               <function>fn:unparsed-text-available</function> have the same requirement for
-               <termref
-               def="dt-deterministic"
-               >determinism</termref> as the functions
-               <function>fn:doc</function> and <function>fn:doc-available</function>. This means that unless the
-            user has explicitly stated a requirement for a reduced level of determinism, either of
-            these functions if called twice with the same arguments during the course of a
-            transformation <rfc2119>must</rfc2119> return the same results each time; moreover, the
-            results of a call on <function>fn:unparsed-text-available</function>
-            <rfc2119>must</rfc2119> be consistent with the results of a subsequent call on
-               <code>unparsed-text</code> with the same arguments.</p>
+               <function>fn:unparsed-text-available</function> are
+               <termref def="dt-nondeterministic"/>. This means that a call on
+               <function>fn:unparsed-text-available</function> is not guaranteed to be consistent
+            with the result of a subsequent call on <function>fn:unparsed-text</function> with the
+            same arguments, because the availability or content of the external resource may change
+            between the two calls. Implementations may provide user options that request
+            deterministic (stable) results.</p>
          
          <note><p>The ability to access external resources depends on whether the
          calling code is <xtermref spec="XP40" ref="dt-trusted"/>.</p></note>
@@ -20374,6 +20377,9 @@ return $lines[not(position() = last() and . = '')]
          <fos:change issue="1116" PR="1117" date="2024-05-21">
             <p>The <code>$options</code> parameter has been added.</p>
          </fos:change>
+         <fos:change issue="2750" date="2026-07-05">
+            <p>The function is now classified as <termref def="dt-nondeterministic"/>.</p>
+         </fos:change>
       </fos:changes>
 
    </fos:function>
@@ -20386,7 +20392,7 @@ return $lines[not(position() = last() and . = '')]
          </fos:proto>
       </fos:signatures>
       <fos:properties>
-         <fos:property>deterministic</fos:property>
+         <fos:property>nondeterministic</fos:property>
          <fos:property dependency="executable-base-uri">context-dependent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
@@ -20466,8 +20472,9 @@ return $lines[not(position() = last() and . = '')]
                <p>The handling of media types is implementation-defined.</p>
             </item>
             <item>
-               <p>Implementations may provide user options that relax the requirement for the function
-               to return deterministic results.</p>
+               <p>Although the function is <termref def="dt-nondeterministic"/>, implementations may
+               provide user options that request deterministic (stable) results, so that repeated
+               calls with the same arguments during a single execution return the same result.</p>
             </item>
 
             <item>
@@ -20489,8 +20496,8 @@ return $lines[not(position() = last() and . = '')]
          <p>A comprehensive set of functions for manipulating binary data is available in the
             EXPath binary module: see <bibref ref="expath"/>. In addition, the EXPath file module
             provides a function <code>file:read-binary</code> with similar functionality to
-            <code>fn:unparsed-binary</code>, the notable differences being (a) that it takes
-            a file name rather than a URI, and (b) that it is defined to be nondeterministic.
+            <code>fn:unparsed-binary</code>, the notable difference being that it takes
+            a file name rather than a URI.
           </p>
       </fos:notes>
 
@@ -20516,6 +20523,9 @@ return { "width": $int16-at($loc + 5),
       <fos:changes>
          <fos:change issue="557" PR="1587" date="2024-11-18">
             <p>New in 4.0</p>
+         </fos:change>
+         <fos:change issue="2750" date="2026-07-05">
+            <p>The function is now classified as <termref def="dt-nondeterministic"/>.</p>
          </fos:change>
       </fos:changes>
    </fos:function>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -20159,6 +20159,12 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             
          </ulist>
 
+         <note><p diff="add" at="2026-07-07">In earlier versions this function was
+            <termref def="dt-deterministic"/>: repeated reads of the same resource within a single
+            execution returned the same result. From 4.0 it is <termref def="dt-nondeterministic"/>,
+            so a program that requires consistency across reads should read the resource once and
+            reuse the value.</p></note>
+
          <p>The rules for determining the encoding are chosen for consistency with <bibref
                ref="xinclude"
             />. Files with an XML media type are treated specially because there
@@ -20216,7 +20222,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                invoking <function>bin:infer-encoding</function>; redundant rules have
                been dropped.</p>
          </fos:change>
-         <fos:change issue="2750" date="2026-07-05">
+         <fos:change issue="2750" PR="2767" date="2026-07-05">
             <p>The function is now classified as <termref def="dt-nondeterministic"/>.</p>
          </fos:change>
       </fos:changes>
@@ -20304,7 +20310,7 @@ return $lines[not(position() = last() and . = '')]
             <p>A fallback option is now provided to address characters that cannot be
             decoded or are not permitted.</p>
          </fos:change>
-         <fos:change issue="2750" date="2026-07-05">
+         <fos:change issue="2750" PR="2767" date="2026-07-05">
             <p>The function is now classified as <termref def="dt-nondeterministic"/>.</p>
          </fos:change>
       </fos:changes>
@@ -20377,7 +20383,7 @@ return $lines[not(position() = last() and . = '')]
          <fos:change issue="1116" PR="1117" date="2024-05-21">
             <p>The <code>$options</code> parameter has been added.</p>
          </fos:change>
-         <fos:change issue="2750" date="2026-07-05">
+         <fos:change issue="2750" PR="2767" date="2026-07-05">
             <p>The function is now classified as <termref def="dt-nondeterministic"/>.</p>
          </fos:change>
       </fos:changes>
@@ -20524,7 +20530,7 @@ return { "width": $int16-at($loc + 5),
          <fos:change issue="557" PR="1587" date="2024-11-18">
             <p>New in 4.0</p>
          </fos:change>
-         <fos:change issue="2750" date="2026-07-05">
+         <fos:change issue="2750" PR="2767" date="2026-07-05">
             <p>The function is now classified as <termref def="dt-nondeterministic"/>.</p>
          </fos:change>
       </fos:changes>


### PR DESCRIPTION
The changes are trivial, but we need to decide whether we want to make a function nondeterministic that has been deterministic so far (at least officially… I don’t know how many processors complied to this rule without exceptions).

Closes #2750