### PR TITLE
2769 Clarify repeatability of random-number-generator() results

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -33796,6 +33796,17 @@ return $result?output//body
                />: calling the function twice with the same arguments, within a single
          <termref
                def="execution-scope">execution scope</termref>, produces the same results.</p>
+         
+         <p>The <code>next</code> and <code>permute</code> functions returned by a given
+            random number generator are also <termref def="dt-deterministic"/>. If
+         <code>$rng</code> is the result of a call to <code>random-number-generator</code>, then:</p>
+         
+         <ulist>
+            <item><p>The value of <code>$rng?next()?number = $rng?next()?number</code>
+               will always be true.</p></item>
+            <item><p>For any sequence <code>$seq</code>, <code>deep-equal($rng?permute($seq), $rng?permute($seq)</code>
+            will always be true.</p></item>
+         </ulist>
 
 
          <p>The value of the <code>number</code> entry <rfc2119>should</rfc2119> be such that <phrase diff="del" at="B">all eligible <code>xs:double</code>


### PR DESCRIPTION
Clarifies and strengthens the statement about the determinism of random-number-generator (and adds tests)

Fix #2769