### PR TITLE
2644 Extend casts to sequences, arrays, maps, and records

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1712,7 +1712,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
       <g:string>as</g:string>
       <g:ref name="CastTarget"/>
       <g:optional>
-        <g:string>?</g:string>
+        <g:ref name="OccurrenceIndicator"/>
       </g:optional>
     </g:optional>
   </g:production>
@@ -1724,7 +1724,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
       <g:string>as</g:string>
       <g:ref name="CastTarget"/>
       <g:optional>
-        <g:string>?</g:string>
+        <g:ref name="OccurrenceIndicator"/>
       </g:optional>
     </g:optional>
   </g:production>
@@ -2889,9 +2889,13 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   <g:production name="CastTarget" if="xpath40 xquery40  xslt40-patterns">
     <g:ref name="TypeName" not-if="xpath40 xquery40"/>
     <g:choice if="xpath40 xquery40">
+      <g:ref name="AnyItemType"/>
       <g:ref name="TypeName"/>
       <g:ref name="ChoiceItemType"/>
       <g:ref name="EnumerationType"/>
+      <g:ref name="TypedArrayType"/>
+      <g:ref name="TypedMapType"/>
+      <g:ref name="TypedRecordType"/>
     </g:choice>
   </g:production>
 

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -2889,7 +2889,6 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   <g:production name="CastTarget" if="xpath40 xquery40  xslt40-patterns">
     <g:ref name="TypeName" not-if="xpath40 xquery40"/>
     <g:choice if="xpath40 xquery40">
-      <g:ref name="AnyItemType"/>
       <g:ref name="TypeName"/>
       <g:ref name="ChoiceItemType"/>
       <g:ref name="EnumerationType"/>

--- a/specifications/xquery-40/src/errors.xml
+++ b/specifications/xquery-40/src/errors.xml
@@ -613,7 +613,8 @@
 
       <error spec="XP" code="0080" class="ST" type="static">
          <p>It is a <termref def="dt-static-error">static error</termref> if the target type of a
-               <code>cast</code> or <code>castable</code> expression is
+               <code>cast</code> or <code>castable</code> expression is not eligible as a casting target,
+            for example if it is
                <code>xs:NOTATION</code>, <phrase diff="add"><code>xs:anySimpleType</code>,</phrase> or
                <code>xs:anyAtomicType</code>.</p>
       </error>

--- a/specifications/xquery-40/src/errors.xml
+++ b/specifications/xquery-40/src/errors.xml
@@ -1139,6 +1139,13 @@ It is a static error if the name of a feature in
             if a <nt def="URIQualifiedName">URIQualifiedName</nt> includes a prefix but no URI.</p>
       </error>
       
+      <error spec="XP" code="0155" class="TY" type="static">
+         <p>It is a <termref def="dt-type-error">type error</termref> 
+            if, when casting to an array type, map type, or record type, a value <var>V</var> within the input
+            needs to be cast to a type <var>T</var>, unless (a) <var>V</var> already matches <var>T</var>, 
+            or (b) <var>T</var> is a valid <nt def="CastTarget">CastTarget</nt>.</p>
+      </error>
+      
       
       
       

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -24164,133 +24164,124 @@ be used to process an expression in a way that depends on its <termref
                   The specification now insists that the result of a cast to type <var>T</var> must be an
                   instance of <var>T</var>, and not of any subtype of <var>T</var>.
                </change>
+               <change issue="2644" date="2026-07-08">
+                  The target of a <code>cast</code> or <code>castable</code> expression can now
+                  be a sequence, an array, a map, or a record type.
+               </change>
             </changes>
             <scrap>
                <prodrecap ref="CastExpr"/>
             </scrap>
-            <p>Sometimes
-it is necessary to convert a value to a specific datatype. For this
-purpose, <?inject language?> provides a <code>cast</code> expression that
-creates a new value of a specific type based on an existing value. A
+            <p>A <code>cast</code> expression 
+creates a new value of a specific type by converting an existing value. A
 <code>cast</code> expression takes two operands: an <term>input
 expression</term> and a <term>target type</term>. The type of the
-atomized value of the input expression is called the <term>input type</term>. 
-The target type must be a <termref def="dt-generalized-atomic-type"/>. In practice
-               this means it may be any of:</p>
-            <ulist>
-               <item diff="add" at="issue688"><p>The name of an <termref def="dt-named-item-type">named item type</termref>
-               defined in the <termref def="dt-static-context"/>, which in turn must refer to an item
-               type in one of the following categories.</p></item>
-               <item><p>The name of a type defined in the  <termref def="dt-is-types">in-scope schema types</termref>, 
-                  which must be a simple type (of variety atomic, list or union) <errorref class="ST" code="0052"/> .
-                  In addition, the target type cannot be <code>xs:NOTATION</code>, <code>xs:anySimpleType</code>,
-                  or <code>xs:anyAtomicType</code></p></item>
-               <item diff="add" at="A"><p>A <code>ChoiceItemType</code> representing a 
-                  <termref def="dt-generalized-atomic-type"/> (such as <code>(xs:date | xs:dateTime)</code>).</p></item>
-               <item diff="add" at="issue688"><p>An <code>EnumerationType</code> such as <code>enum("red", "green", "blue")</code>.</p></item>
-            </ulist>
-               <p>Otherwise, a static error is raised <errorref class="ST" code="0080"/>.</p> 
-            <p>The optional occurrence indicator <code>?</code> denotes that the empty
-sequence is permitted.</p> 
+input expression is called the <term>input type</term>. The item type of the <term>target type</term>
+            is called the <term>target item type</term>.</p>
             
+            <p>The target type may be any of the following:</p>
+            
+            <ulist>
+               <item><p>The type <code>item()</code>. Casting to <code>item()</code> has no effect (the result is identical
+               to the input), other than raising a type error <errorref class="TY" code="0004"/> if the cardinality of the input
+               does not match the requirements of the explicit or implicit occurrence indicator.</p>
+               <note><p>Casting directly to <code>item()</code> at the top level is not useful, but is allowed in order to enable
+               casting to types such as <code>map(xs:integer, item()*)</code>.</p></note>
+               </item>
+               <item><p>A <termref def="dt-generalized-atomic-type"/>, specifically one of the following:</p>
 
-            <p>Casting a node to <code>xs:QName</code> can cause surprises because it uses the <termref def="dt-static-context"/>
-               of the cast expression to provide the <termref def="dt-namespace-binding">namespace bindings</termref> for this operation. 
-               Instead of casting to <code>xs:QName</code>, it is generally preferable to use the <function>fn:QName</function> 
-               function, which allows the namespace context to be taken from the document containing the QName.</p>
+                 <ulist>
+                    
+                    <item><p>The name of a type defined in the  <termref def="dt-is-types">in-scope schema types</termref>, 
+                       which must be a simple type (of variety atomic, list or union) <errorref class="ST" code="0052"/> .
+                       In addition, the target type cannot be <code>xs:NOTATION</code>, <code>xs:anySimpleType</code>,
+                       or <code>xs:anyAtomicType</code></p></item>
+                    <item diff="add" at="A"><p>A <code>ChoiceItemType</code> representing a 
+                       <termref def="dt-generalized-atomic-type"/> (such as <code>(xs:date | xs:dateTime)</code>).</p></item>
+                    <item diff="add" at="issue688"><p>An <code>EnumerationType</code> such as <code>enum("red", "green", "blue")</code>.</p></item>
+                 </ulist>
+                  <p>Casting to a generalized atomic type is described in <specref ref="casting-to-atomic"/>.</p>
+                  <p>Casting to a schema-defined list type is described in <specref ref="casting-to-list"/>.</p>
+                  <p>Casting to a schema-defined union type is described in <specref ref="casting-to-union"/>.</p>
+               </item>
+               <item>
+                  <p>A <nt def="TypedArrayType">TypedArrayType</nt> (for example <code>array(xs:integer)</code>). Casting to an array
+                  type is described in <specref ref="casting-to-array"/>.</p>
+               </item>
+               <item>
+                  <p>A <nt def="TypedMapType">TypedMapType</nt> (for example <code>map(xs:string, element(foo)*)</code>). Casting to a map
+                     type is described in <specref ref="casting-to-map"/>.</p>
+               </item>
+               <item>
+                  <p>A <nt def="TypedRecordType">TypedRecordType</nt> (for example <code>record(x as xs:double, y as xs:double)</code>). Casting to a record
+                     type is described in <specref ref="casting-to-record"/>.</p>
+               </item>
+               <item><p>The name of a <termref def="dt-named-item-type">named item type</termref>
+                  defined in the <termref def="dt-static-context"/>, which <rfc2119>must</rfc2119> refer to an item
+                  type in one of the categories described above. The semantics are the same as if the target type
+                  were included directly.</p></item>
+               <item>
+                  <p>Any of the above item types followed by an occurrence indicator (<code>*</code>, <code>+</code>, or <code>?</code>). </p>
+               </item>
+               
+            </ulist>
+               <p>If the target type is not in one of the categories listed, then a static error is raised <errorref class="ST" code="0080"/>.</p> 
+            <!--<p>The optional occurrence indicator <code>?</code> denotes that the empty
+sequence is permitted.</p> -->
+            
+            <div4 id="casting-to-atomic">
+               <head>Casting to a Generalized Atomic Type</head>
+            
+            <p>The semantics of the <code>cast</code> expression when the target type is a <termref def="dt-generalized-atomic-type"/>
+               are as follows:</p>
 
-
-            <p>The semantics of the <code>cast</code> expression
-are as follows:</p>
 
             <olist>
 
                <item>
-                  <p>The input expression is evaluated.</p>
+                  <p>The input expression is evaluated to provide a value <var>V0</var>.</p>
                </item>
 
                <item>
-                  <p>The result of the first step is <termref def="dt-atomization"
-                        >atomized</termref>.</p>
-               </item>
-
-
-               <item>
-                  <p> If the result of atomization is a
-sequence of more than one atomic item, a <termref
-                        def="dt-type-error">type error</termref> is raised <errorref class="TY"
-                        code="0004"/>.</p>
+                  <p><var>V0</var> is <termref def="dt-atomization"
+                        >atomized</termref>, producing a value <var>V1</var>.</p>
                </item>
 
 
 
                <item>
-                  <p>If the result
-of atomization is the empty sequence:</p>
-
-                  <olist>
-
-
-
-                     <item>
-                        <p>If
-<code>?</code> is specified after the target type, the result of the
-<code>cast</code> expression is the empty sequence.</p>
-                     </item>
-
-
-
-                     <item>
-                        <p>
-If <code>?</code> is not specified after the target type, a <termref
-                              def="dt-type-error">type error</termref> is raised <errorref
-                              class="TY" code="0004"/>.</p>
-                     </item>
-                  </olist>
+                  <p>Each atomic item in <var>V1</var> is cast to the target item type as described in <xspecref
+                        spec="FO40" ref="casting"/>, producing a sequence of atomic items <var>V2</var>.</p>
+                  
+                  
+                     <p> 
+                        This process may result in a type error, if casting from the source type to the
+                        target type is not supported (for example attempting to convert an
+                        integer to a date).
+                     </p>
+                  
+                     <p>The process may also result in a dynamic error, if the particular input value cannot be
+                        converted to the target type (for example, attempting to convert
+                        the string <code>"three"</code> to an integer).</p>
+                  
                </item>
-
-
-
+               
                <item>
-                  <p>If the result of atomization is a single
-atomic item, the result of the cast expression is determined by
-casting to the target type as described in <xspecref
-                        spec="FO40" ref="casting"
-                        />.</p> <!--When casting, an
-implementation may need to determine whether one type is derived by
-restriction from another. An implementation can determine this either
-by examining the <termref
-                        def="dt-issd"
-                        >in-scope schema
-definitions</termref> or by using an alternative, <termref
-                        def="dt-implementation-dependent">implementation-dependent</termref>
-mechanism such as a data dictionary.-->
+                  <p>If the number of items in <var>V2</var> does not match the requirements of the
+                     (explicit or implicit) occurrence indicator, then a type error <errorref class="TY" code="0004"/>
+                  is raised.</p>
+                  <p>For example, a type error is raised if the input is an empty sequence and the target type
+                  does not include the occurrence indicator <code>?</code> or <code>*</code>.</p>
+               </item>
+            </olist>
+               
 
-<p>The result of a cast expression is one of the following:</p> 
-
-<olist>
-                        <item>
-                           <p> 
-    A value of the target type (or, in the case of list types,
-    a sequence of values that are instances of the item type of the
-    list type).
-  </p>
-                        </item>
-                        <item>
-                           <p> 
-    A type error, if casting from the source type to the
-    target type is not supported (for example attempting to convert an
-    integer to a date).
-  </p>
-                        </item>
-                        <item>
-                           <p> 
-    A dynamic error, if the particular input value cannot be
-    converted to the target type (for example, attempting to convert
-    the string <code>"three"</code> to an integer).
-  </p>
-                        </item>
-                     </olist>
+                  
+                  <note><p>Casting a node to <code>xs:QName</code> can cause surprises because it uses the <termref def="dt-static-context"/>
+                     of the cast expression to provide the <termref def="dt-namespace-binding">namespace bindings</termref> for this operation. 
+                     Instead of casting to <code>xs:QName</code>, it is generally preferable to use the <function>fn:QName</function> 
+                     function, which allows the namespace context to be taken from the document containing the QName.</p>
+                  </note>
                   
 
                   <note diff="add" at="issue688"><p>Casting to an enumeration type relies on the fact that an enumeration type
@@ -24309,16 +24300,180 @@ mechanism such as a data dictionary.-->
                   
                   
 
-               </item>
-            </olist>
             
             <p>In general, expressions are free to return a value belonging to a subtype of the type
                required by the specification. Cast expressions are an exception to this rule: when casting
                to an atomic type <var>T</var>, the result (if the cast succeeds) will always be an atomic
                item whose type annotation is <var>T</var>, rather than some subtype of <var>T</var>.</p>
+            
+            </div4>
+            <div4 id="casting-to-union">
+               <head>Casting to a Union Type</head>
+               
+               <p>The target type of a cast expression may be a schema-defined union type, even if the union
+               type does not satisfy the conditions making it a <termref def="dt-generalized-atomic-type"/>. (For example,
+               it may be a union type that includes a list type in its transitive membership.)</p>
+               
+               <p>The rules for casting a single item to a union type are given in <xspecref spec="FO40" ref="casting-to-union"/>.</p>
+               
+               <p>In the general case:</p>
+               <olist>
+               <item>
+                    <p>The input expression is evaluated to provide a value <var>V0</var>.</p>
+                 </item>
+                
+                 <item>
+                    <p><var>V0</var> is <termref def="dt-atomization"
+                       >atomized</termref>, producing a value <var>V1</var>.</p>
+                 </item>
+  
+                 <item>
+                    <p>Each atomic item in <var>V1</var> is cast to the target union type as described 
+                       in <xspecref spec="FO40" ref="casting-to-union"/>, producing a sequence of atomic items <var>V2</var>.</p>
+                                       
+                    <p> 
+                       This process may result in a type error, if casting from the source type to the
+                       target type is not supported (for example attempting to convert an
+                       integer to a date).
+                    </p>
+                    
+                    <p>The process may also result in a dynamic error, if the particular input value cannot be
+                       converted to the target type (for example, attempting to convert
+                       the string <code>"three"</code> to an integer).</p>
+                    
+                 </item>
+                 
+                 <item>
+                    <p>If the number of items in <var>V2</var> does not match the requirements of the
+                       (explicit or implicit) occurrence indicator, then a type error <errorref class="TY" code="0004"/>
+                       is raised.</p>
+                    <p>For example, a type error is raised if the input is an empty sequence and the target type
+                       does not include the occurrence indicator <code>?</code> or <code>*</code>.</p>
+                 </item>
+               </olist>
+            </div4>
+            <div4 id="casting-to-list">
+               <head>Casting to a List Type</head>
+               
+               <p>The target type of a cast expression may be a schema-defined list type.</p>
+               
+               <p>The rules for casting a single item to a list type are given in <xspecref spec="FO40" ref="casting-to-list"/>.
+               The result is, in general, a sequence of atomic items, each being an instance of the list type's item type.
+               The result of the cast expression is the <termref def="dt-sequence-concatenation"/> of the results of casting
+               the individual items in the input sequence.</p>
+               
+               <p>For backwards compatibility, when the target type is a list type, the cardinality of the result is not
+               constrained by the occurrence indicator in the cast expression.</p>
+               
+               <note>
+                  <p>In earlier versions of the specification, the occurrence indicator <code>?</code> constrained the
+                  number of items in the input of the cast expression, not the number of items in the output.</p>
+               </note>
+               
+               
+            </div4>
+            
+            <div4 id="casting-to-array">
+               <head>Casting to an Array Type</head>
+               
+               <p>The target type of a cast expression may be a <nt def="TypedArrayType">TypedArrayType</nt>, for example
+                  <code>array(xs:integer)</code>. The member type of the array type (here <code>xs:integer</code>) must
+                  be eligible in its own right as the target of a cast expression, otherwise a static error <errorref class="ST" code="0080"/>
+                  is raised.</p>
+               
+               <p>The input to the cast expression must be a sequence of arrays, otherwise a type error <errorref class="TY" code="0004"/>
+               is raised.</p>
+               
+               <p>The effect of the cast expression is to process each input array <var>A</var> by constructing a new array, 
+                  whose members correspond one-to-one with the members
+               of <var>A</var>, each member of the result array being obtained by casting the corresponding member of <var>A</var>
+               to the member type of the target array type.</p>
+               
+               <p>For example, <code>[[1], [2], [3]] cast as array(xs:integer)</code> returns <code>[1, 2, 3]</code>, because casting
+                  the array <code>[1]</code> to <code>xs:integer</code> produces the integer <code>1</code>.</p>
+               
+               <p>The number of arrays in the result (and therefore in the input) must conform with the explicit or implicit occurrence indicator, otherwise
+                  a type error <errorref class="TY" code="0004"/> is raised.</p>
+               
+              
+               
+            </div4>
+            
+            <div4 id="casting-to-map">
+               <head>Casting to a Map Type</head>
+               
+               <p>The target type of a cast expression may be a <nt def="TypedMapType">TypedMapType</nt>, for example
+                  <code>map(xs:integer, item()*)</code>. Both the key type and the value type (here <code>xs:integer</code> and
+                  <code>item()*</code> respectively) must
+                  be eligible in their own right as the target of a cast expression, otherwise a static error <errorref class="ST" code="0080"/>
+                  is raised.</p>
+               
+               <p>The input to the cast expression must be a sequence of maps, otherwise a type error <errorref class="TY" code="0004"/>
+                  is raised.</p>
+               
+               <p>The effect of the cast expression is to process each input map <var>M</var> by constructing a new map, whose entries correspond one-to-one with the entries
+                  of <var>M</var>, each entry in the result map being obtained by casting the key and value of the corresponding entry in <var>M</var>
+                  to the key and value types respectively of the target map type.</p>
+               
+               <p>For example, <code>{"1":"a", "2":"b", "3":"c"} cast as map(xs:integer, xs:string)</code> returns 
+                  <code>{1:"a", 2:"b", 2:"c"}</code>.</p>
+               
+               <p>If the effect of casting is to generate duplicate keys, then a dynamic
+                  error is raised <errorref class="DY" code="0137"/>.</p>
+               
+               <p>The number of maps in the result (and therefore in the input) must conform with the explicit or implicit occurrence indicator, otherwise
+                  a type error <errorref class="TY" code="0004"/> is raised.</p>
+               
+               
+               
+            </div4>
+            
+            <div4 id="casting-to-record">
+               <head>Casting to a Record Type</head>
+               
+               <p>The target type of a cast expression may be a <nt def="TypedRecordType">TypedRecordType</nt>, for example
+                  <code>record(x as xs:integer, y as item()*)</code>. The value types for each field  (here <code>xs:integer</code> and
+                  <code>item()*</code> respectively) must
+                  be eligible in their own right as the target of a cast expression, otherwise a static error <errorref class="ST" code="0080"/>
+                  is raised.</p>
+               
+               <p>The input to the cast expression must be a sequence of maps, otherwise a type error <errorref class="TY" code="0004"/>
+                  is raised. Records are maps, so the input can also include records.</p>
+               
+               <p>The effect of the cast expression is to process each input map <var>M</var> by constructing a new record of the target record type.
+                  For each field in the definition of the target record type, if <var>K</var> is the name of the field (as a string),
+                  and <var>T</var> is the required type of the field, then the value of field <var>K</var> in the constructed
+               record will be the result of the expression <code>map:get(<var>M</var>, <var>K</var>) cast as <var>T</var></code>.</p>
+               
+               <p>Note that if the map does not contain an entry with key <var>K</var>, the value of the corresponding field will be
+                  an empty sequence; a type error occurs if the empty sequence is not a valid value for the field.</p>
+               
+               <p>Note also that unreferenced entries in the map are simply ignored (that is, they are effectively discarded).</p>
+               
+                          
+               <p>For example, <code>{"first": "John", "middle": "Ignatius", "last": "Smith"} cast as record(title, first, last)</code> returns 
+                  <code>{"title": (), "first": "John", "last": "Smith}</code> as an instance of the target record type.</p>
+               
+              
+               
+               <p>The number of records in the result (and therefore, the number of maps in the input) must conform with the explicit 
+                  or implicit occurrence indicator, otherwise
+                  a type error <errorref class="TY" code="0004"/> is raised.</p>
+               
+               
+               
+            </div4>
+         
          </div3>
          <div3 id="id-castable">
             <head>Castable</head>
+            
+            <changes>
+               <change issue="2644" date="2026-07-08">
+                  The target of a <code>cast</code> or <code>castable</code> expression can now
+                  be a sequence, an array, a map, or a record type.
+               </change>
+            </changes>
             
             <scrap>
                <prodrecap ref="CastableExpr"/>
@@ -24336,7 +24491,7 @@ The <phrase diff="chg" at="A">target type</phrase> is subject to the same
 if the result of evaluating <code>E</code>  
 can be successfully cast into the target type <code>T</code> by using a <code>cast</code> expression; 
 otherwise it returns <code>false</code>. 
-If evaluation of <code>E</code> fails with a dynamic error or if the value of <code>E</code> cannot be atomized, 
+If evaluation of <code>E</code> fails with a dynamic error or if an error occurs when atomizing <code>E</code>, 
 the <code>castable</code> expression as a whole fails.</p> 
 
 <p>The <code>castable</code> expression can be used as a <termref

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -24182,12 +24182,7 @@ input expression is called the <term>input type</term>. The item type of the <te
             <p>The target type may be any of the following:</p>
             
             <ulist>
-               <item><p>The type <code>item()</code>. Casting to <code>item()</code> has no effect (the result is identical
-               to the input), other than raising a type error <errorref class="TY" code="0004"/> if the cardinality of the input
-               does not match the requirements of the explicit or implicit occurrence indicator.</p>
-               <note><p>Casting directly to <code>item()</code> at the top level is not useful, but is allowed in order to enable
-               casting to types such as <code>map(xs:integer, item()*)</code>.</p></note>
-               </item>
+               
                <item><p>A <termref def="dt-generalized-atomic-type"/>, specifically one of the following:</p>
 
                  <ulist>
@@ -24226,8 +24221,7 @@ input expression is called the <term>input type</term>. The item type of the <te
                
             </ulist>
                <p>If the target type is not in one of the categories listed, then a static error is raised <errorref class="ST" code="0080"/>.</p> 
-            <!--<p>The optional occurrence indicator <code>?</code> denotes that the empty
-sequence is permitted.</p> -->
+           
             
             <div4 id="casting-to-atomic">
                <head>Casting to a Generalized Atomic Type</head>
@@ -24374,23 +24368,33 @@ sequence is permitted.</p> -->
                <head>Casting to an Array Type</head>
                
                <p>The target type of a cast expression may be a <nt def="TypedArrayType">TypedArrayType</nt>, for example
-                  <code>array(xs:integer)</code>. The member type of the array type (here <code>xs:integer</code>) must
-                  be eligible in its own right as the target of a cast expression, otherwise a static error <errorref class="ST" code="0080"/>
-                  is raised.</p>
+                  <code>array(xs:integer)</code>. Let <var>T</var> be the member type of the array type (<code>xs:integer</code>
+               in this example).</p>
                
-               <p>The input to the cast expression is <termref def="dt-coercion-rules">coerced</termref> to the required type <code>array(*)*</code>; 
+               <p>The input to the cast expression is first <termref def="dt-coercion-rules">coerced</termref> to the required type <code>array(*)*</code>; 
                   if this fails then a type error <errorref class="TY" code="0004"/> is raised.</p>
                
-               <p>The effect of the cast expression is to process each input array <var>A</var> by constructing a new array, 
+               <p>The effect of the cast expression is to process each input array <var>A0</var> by constructing a new array <var>A1</var>, 
                   whose members correspond one-to-one with the members
-               of <var>A</var>, each member of the result array being obtained by casting the corresponding member of <var>A</var>
-               to the member type of the target array type.</p>
+               of <var>A0</var>, each member <var>M0</var> of <var>A0</var> being processed to produce a member <var>M1</var> of <var>A1</var> as follows:</p>
+               
+               <ulist>
+                  <item><p>If <var>M0</var> matches <var>T</var>, then <var>M1</var> is <var>M0</var>.</p></item>
+                  <item><p>Otherwise, if <var>T</var> is a valid <nt def="CastTarget">CastTarget</nt>, then <var>M1</var> is <code><var>M0</var> cast as <var>T</var></code>.</p></item>
+                  <item><p>Otherwise a type error <errorref class="TY" code="0155"/> is raised.</p></item>
+               </ulist>
+             
                
                <p>For example, <code>[[1], [2], [3]] cast as array(xs:integer)</code> returns <code>[1, 2, 3]</code>, because casting
                   the array <code>[1]</code> to <code>xs:integer</code> produces the integer <code>1</code>.</p>
                
                <p>The number of arrays in the result (and therefore in the input) must conform with the explicit or implicit occurrence indicator, otherwise
                   a type error <errorref class="TY" code="0004"/> is raised.</p>
+               
+               <note><p>If the member type of the array is not a valid <code>CastTarget</code>, for example if the array type
+                  is <code>array(function(*))</code> or <code>array(element(*))</code>, then the existing array members must already
+                  be instances of the target type: the cast will then leave the input array unchanged.
+               </p></note>
                
               
                
@@ -24400,21 +24404,37 @@ sequence is permitted.</p> -->
                <head>Casting to a Map Type</head>
                
                <p>The target type of a cast expression may be a <nt def="TypedMapType">TypedMapType</nt>, for example
-                  <code>map(xs:integer, item()*)</code>. Both the key type and the value type (here <code>xs:integer</code> and
+                  <code>map(xs:integer, item()*)</code>. Let <var>T/K</var> and <var>T/V</var> be respectively the key type
+                  and the value type of the <nt def="TypedMapType">TypedMapType</nt>, that is, in this example, <code>xs:integer</code>
+                  and <code>item()*</code> respectively.</p>
+                  
+                  <!--Both the key type and the value type (here <code>xs:integer</code> and
                   <code>item()*</code> respectively) must
                   be eligible in their own right as the target of a cast expression, otherwise a static error <errorref class="ST" code="0080"/>
-                  is raised.</p>
+                  is raised.</p>-->
                
                
-               <p>The input to the cast expression is <termref def="dt-coercion-rules">coerced</termref> to the required type <code>map(*)*</code>; 
+               <p>The input to the cast expression is first <termref def="dt-coercion-rules">coerced</termref> to the required type <code>map(*)*</code>; 
                   if this fails then a type error <errorref class="TY" code="0004"/> is raised.</p>
                
-               <p>The effect of the cast expression is to process each input map <var>M</var> by constructing a new map, whose entries correspond one-to-one with the entries
-                  of <var>M</var>, each entry in the result map being obtained by casting the key and value of the corresponding entry in <var>M</var>
-                  to the key and value types respectively of the target map type.</p>
+               <p>The effect of the cast expression is to process each input map <var>M0</var> by constructing a new map <var>M1</var>, whose entries correspond one-to-one with the entries
+                  of <var>M</var>, each entry in the result map being obtained as follows. Let (<var>K0</var>, <var>V0</var>) be an entry
+                  in <var>M0</var>, and let (<var>K1</var>, <var>V1</var>) be the corresponding entry in <var>M1</var>. Then:</p>
+               
+               <ulist>
+                  <item><p>If <var>K0</var> matches <var>T/K</var>, then <var>K1</var> is <var>K0</var>.</p></item>
+                  <item><p>Otehrwise, if <var>T/K</var> is a valid <nt def="CastTarget">CastTarget</nt>, then <var>K1</var> is <code><var>K0</var> cast as <var>T/K</var></code>.</p></item>
+                  <item><p>Otherwise a type error <errorref class="TY" code="0155"/> is raised.</p></item>
+                  <item><p>If <var>V0</var> matches <var>T/V</var>, then <var>V1</var> is <var>V0</var>.</p></item>
+                  <item><p>Otherwise, if <var>T/V</var> is a valid <nt def="CastTarget">CastTarget</nt>, then <var>V1</var> is <code><var>V0</var> cast as <var>T/V</var></code>.</p></item>
+                  <item><p>Otherwise a type error <errorref class="TY" code="0155"/> is raised.</p></item>
+               </ulist>
+               
+               
+              
                
                <p>For example, <code>{"1":"a", "2":"b", "3":"c"} cast as map(xs:integer, xs:string)</code> returns 
-                  <code>{1:"a", 2:"b", 2:"c"}</code>.</p>
+                  <code>{1:"a", 2:"b", 3:"c"}</code>.</p>
                
                <p>If the effect of casting is to generate duplicate keys, then a dynamic
                   error is raised <errorref class="DY" code="0137"/>.</p>
@@ -24430,24 +24450,39 @@ sequence is permitted.</p> -->
                <head>Casting to a Record Type</head>
                
                <p>The target type of a cast expression may be a <nt def="TypedRecordType">TypedRecordType</nt>, for example
-                  <code>record(x as xs:integer, y as item()*)</code>. The value types for each field  (here <code>xs:integer</code> and
+                  <code>record(x as xs:integer, y as item()*)</code>. <!--The value types for each field  (here <code>xs:integer</code> and
                   <code>item()*</code> respectively) must
                   be eligible in their own right as the target of a cast expression, otherwise a static error <errorref class="ST" code="0080"/>
-                  is raised.</p>
+                  is raised.--></p>
                
                <p>The input to the cast expression is <termref def="dt-coercion-rules">coerced</termref> to the required type <code>map(*)*</code>; 
-                  if this fails then a type error <errorref class="TY" code="0004"/> is raised. 
+                  if this fails then a type error <errorref class="TY" code="0155"/> is raised. 
                   Records are maps, so the input can also include records.</p>
                
-               <p>The effect of the cast expression is to process each input map <var>M</var> by constructing a new record of the target record type.
-                  For each field in the definition of the target record type, if <var>K</var> is the name of the field (as a string),
-                  and <var>T</var> is the required type of the field, then the value of field <var>K</var> in the constructed
-               record will be the result of the expression <code>map:get(<var>M</var>, <var>K</var>) cast as <var>T</var></code>.</p>
+               <p>The effect of the cast expression is to process each input map <var>M0</var> by constructing a new record <var>R1</var>of the target record type.
+                  For each field in the definition of the target record type, if <var>K0</var> is the name of the field (as a string)
+                  and <var>T</var> is the required type of the field, then the value of field <var>K0</var> in record <var>R1</var>
+               will be as follows:</p>
                
-               <p>Note that if the map does not contain an entry with key <var>K</var>, the value of the corresponding field will be
-                  an empty sequence; a type error occurs if the empty sequence is not a valid value for the field.</p>
+               <ulist>
+                  <item>
+                     <p>If <code>map:contains(<var>M0</var>, <var>K0</var>)</code> is true, let <var>V0</var> be 
+                        <code>map:get(<var>M0</var>, <var>K0</var>)</code>:</p>
+                     <ulist>
+                        <item><p>If <var>V0</var> matches <var>T</var>, then <var>V0</var>;</p></item>
+                        <item><p>Otherwise, if <var>T</var> is a valid <code>CastTarget</code>, then <code><var>V0</var> cast as <var>T</var></code>;</p></item>
+                        <item><p>Otherwise a type error <errorref class="TY" code="0155"/> is raised.</p></item>
+                     </ulist>
+                  </item>
+                  <item><p>Otherwise:</p>
+                     <ulist>
+                        <item><p>If the empty sequence matches <var>T</var>, then the empty sequence;</p></item>
+                        <item><p>Otherwise a type error <errorref class="TY" code="0155"/> is raised.</p></item>
+                     </ulist>
+                  </item>
+               </ulist>
                
-               <p>Note also that unreferenced entries in the map are simply ignored (that is, they are effectively discarded).</p>
+               <p>Note that unreferenced entries in the map are simply ignored (that is, they are effectively discarded).</p>
                
                           
                <p>For example, <code>{"first": "John", "middle": "Ignatius", "last": "Smith"} cast as record(title, first, last)</code> returns 

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -24472,6 +24472,10 @@ sequence is permitted.</p> -->
                   The target of a <code>cast</code> or <code>castable</code> expression can now
                   be a sequence, an array, a map, or a record type.
                </change>
+               <change issue="2644" PR="2777" date="2026-07-08">
+                  An error that occurs while atomizing the operand of a <code>castable</code> expression now results
+                  in the expression returning false, not in an error.
+               </change>
             </changes>
             
             <scrap>
@@ -24490,8 +24494,13 @@ The <phrase diff="chg" at="A">target type</phrase> is subject to the same
 if the result of evaluating <code>E</code>  
 can be successfully cast into the target type <code>T</code> by using a <code>cast</code> expression; 
 otherwise it returns <code>false</code>. 
-If evaluation of <code>E</code> fails with a dynamic error or if an error occurs when atomizing <code>E</code>, 
+If evaluation of <code>E</code> fails with a dynamic error, 
 the <code>castable</code> expression as a whole fails.</p> 
+            
+            <note><p>In earlier versions of this specification, an error in atomizing the operand resulted
+            in the expression failing with an error; it now causes the expression to return false. This is because
+            atomization is now one of many coercions that might be applied, and it can occur implicitly
+            when casting to a target type such as <code>map(xs:integer, xs:string)</code>.</p></note>
 
 <p>The <code>castable</code> expression can be used as a <termref
                   def="dt-predicate"

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -24164,7 +24164,7 @@ be used to process an expression in a way that depends on its <termref
                   The specification now insists that the result of a cast to type <var>T</var> must be an
                   instance of <var>T</var>, and not of any subtype of <var>T</var>.
                </change>
-               <change issue="2644" date="2026-07-08">
+               <change issue="2644" PR="2777" date="2026-07-08">
                   The target of a <code>cast</code> or <code>castable</code> expression can now
                   be a sequence, an array, a map, or a record type.
                </change>
@@ -24209,7 +24209,7 @@ input expression is called the <term>input type</term>. The item type of the <te
                   type is described in <specref ref="casting-to-array"/>.</p>
                </item>
                <item>
-                  <p>A <nt def="TypedMapType">TypedMapType</nt> (for example <code>map(xs:string, element(foo)*)</code>). Casting to a map
+                  <p>A <nt def="TypedMapType">TypedMapType</nt> (for example <code>map(xs:string, array(xs:integer)*)</code>). Casting to a map
                      type is described in <specref ref="casting-to-map"/>.</p>
                </item>
                <item>
@@ -24273,6 +24273,8 @@ sequence is permitted.</p> -->
                   <p>For example, a type error is raised if the input is an empty sequence and the target type
                   does not include the occurrence indicator <code>?</code> or <code>*</code>.</p>
                </item>
+               
+               <item><p>The result of the cast expression is <var>V2</var>.</p></item>
             </olist>
                
 
@@ -24331,15 +24333,8 @@ sequence is permitted.</p> -->
                     <p>Each atomic item in <var>V1</var> is cast to the target union type as described 
                        in <xspecref spec="FO40" ref="casting-to-union"/>, producing a sequence of atomic items <var>V2</var>.</p>
                                        
-                    <p> 
-                       This process may result in a type error, if casting from the source type to the
-                       target type is not supported (for example attempting to convert an
-                       integer to a date).
-                    </p>
-                    
-                    <p>The process may also result in a dynamic error, if the particular input value cannot be
-                       converted to the target type (for example, attempting to convert
-                       the string <code>"three"</code> to an integer).</p>
+                    <p>The process may result in a dynamic error, if the particular input value cannot be
+                       converted to any of the member types of the union type.</p>
                     
                  </item>
                  
@@ -24350,6 +24345,8 @@ sequence is permitted.</p> -->
                     <p>For example, a type error is raised if the input is an empty sequence and the target type
                        does not include the occurrence indicator <code>?</code> or <code>*</code>.</p>
                  </item>
+                  
+                 <item><p>The result of the cast expression is <var>V2</var>.</p></item>
                </olist>
             </div4>
             <div4 id="casting-to-list">
@@ -24381,8 +24378,8 @@ sequence is permitted.</p> -->
                   be eligible in its own right as the target of a cast expression, otherwise a static error <errorref class="ST" code="0080"/>
                   is raised.</p>
                
-               <p>The input to the cast expression must be a sequence of arrays, otherwise a type error <errorref class="TY" code="0004"/>
-               is raised.</p>
+               <p>The input to the cast expression is <termref def="dt-coercion-rules">coerced</termref> to the required type <code>array(*)*</code>; 
+                  if this fails then a type error <errorref class="TY" code="0004"/> is raised.</p>
                
                <p>The effect of the cast expression is to process each input array <var>A</var> by constructing a new array, 
                   whose members correspond one-to-one with the members
@@ -24408,8 +24405,9 @@ sequence is permitted.</p> -->
                   be eligible in their own right as the target of a cast expression, otherwise a static error <errorref class="ST" code="0080"/>
                   is raised.</p>
                
-               <p>The input to the cast expression must be a sequence of maps, otherwise a type error <errorref class="TY" code="0004"/>
-                  is raised.</p>
+               
+               <p>The input to the cast expression is <termref def="dt-coercion-rules">coerced</termref> to the required type <code>map(*)*</code>; 
+                  if this fails then a type error <errorref class="TY" code="0004"/> is raised.</p>
                
                <p>The effect of the cast expression is to process each input map <var>M</var> by constructing a new map, whose entries correspond one-to-one with the entries
                   of <var>M</var>, each entry in the result map being obtained by casting the key and value of the corresponding entry in <var>M</var>
@@ -24437,8 +24435,9 @@ sequence is permitted.</p> -->
                   be eligible in their own right as the target of a cast expression, otherwise a static error <errorref class="ST" code="0080"/>
                   is raised.</p>
                
-               <p>The input to the cast expression must be a sequence of maps, otherwise a type error <errorref class="TY" code="0004"/>
-                  is raised. Records are maps, so the input can also include records.</p>
+               <p>The input to the cast expression is <termref def="dt-coercion-rules">coerced</termref> to the required type <code>map(*)*</code>; 
+                  if this fails then a type error <errorref class="TY" code="0004"/> is raised. 
+                  Records are maps, so the input can also include records.</p>
                
                <p>The effect of the cast expression is to process each input map <var>M</var> by constructing a new record of the target record type.
                   For each field in the definition of the target record type, if <var>K</var> is the name of the field (as a string),
@@ -24469,7 +24468,7 @@ sequence is permitted.</p> -->
             <head>Castable</head>
             
             <changes>
-               <change issue="2644" date="2026-07-08">
+               <change issue="2644" PR="2777" date="2026-07-08">
                   The target of a <code>cast</code> or <code>castable</code> expression can now
                   be a sequence, an array, a map, or a record type.
                </change>


### PR DESCRIPTION
Fix #2644

The main purpose of this proposal is to make it easier to construct instances of a record type, but the spin-offs for casting sequences, maps and arrays also seem quite useful in their own right.