### PR TITLE
2781a Fix parsing errors in F&O and XQuery specs

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -28754,7 +28754,7 @@ element-to-map-plan((<a><b/><b/></a>, <a><b/><c/></a>))
    <fos:function name="element-to-map" prefix="fn">
       <fos:signatures>
          <fos:proto name="element-to-map" return-type="map(xs:string, item()?)?">
-            <fos:arg name="element" type="document-node(*)|element()?" usage="absorption"/>
+            <fos:arg name="element" type="(document-node(*) | element())?" usage="absorption"/>
             <fos:arg name="options" type="map(*)?" usage="inspection" default="{}" note="default-on-empty"/>
          </fos:proto>
       </fos:signatures>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -30368,8 +30368,8 @@ return document {
             </fos:test>
             <fos:test>
                <fos:expression><eg>parse-json(
-  ["2.0", 1e6]
-  { 'number-format': 'adaptive' } }
+  '[2.0, 1e6]',
+  { 'number-format': 'adaptive' }
 )</eg></fos:expression>
                <fos:result>[ xs:integer('2'), xs:double('1.0e6') ]</fos:result>
             </fos:test>
@@ -36676,7 +36676,7 @@ return $array/jnode(*, xs:integer) =!> jkey()
             <fos:test>
                <fos:expression><eg>
 let $map := { 'Mo': 'Monday', 'Tu': 'Tuesday', 'We': 'Wednesday' }
-return $map/child::get(("Mo", "We", "Fr", "Su")) =!> jkey()
+return $map/child::{"Mo", "We", "Fr", "Su"} =!> jkey()
                </eg></fos:expression>
                <fos:result>"Mo", "We"</fos:result>
             </fos:test>
@@ -36887,7 +36887,7 @@ return $array/jnode(*, xs:integer) =!> jvalue()
             <fos:test>
                <fos:expression><eg>
 let $map := { 'Mo': 'Monday', 'Tu': 'Tuesday', 'We': 'Wednesday' }
-return $map/child::get(("Mo", "We", "Fr", "Su")) =!> jvalue()
+return $map/child::{"Mo", "We", "Fr", "Su"} =!> jvalue()
                </eg></fos:expression>
                <fos:result>"Monday", "Wednesday"</fos:result>
             </fos:test>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -22704,7 +22704,7 @@ return $r?z</eg>
                   Path expressions, however, have more power, and with it, more complexity.
                   The expression <code>$m/code = 3</code> (unless simplified by an optimizer)
                   effectively expands the expression to
-                  <code>(jtree($m)/child::get("code") => jvalue()) = 3</code>:
+                  <code>(jtree($m)/child::{"code"} => jvalue()) = 3</code>:
                   that is, the supplied map is wrapped in a JNode, the child axis returns a sequence of JNodes,
                   and the <term>·jvalue·</term> properties of these JNodes are compared with the
                   supplied value <code>3</code>.</p>
@@ -22734,7 +22734,7 @@ return $r?z</eg>
                   <p>Lookup expressions on arrays result in a dynamic error if the subscript is out
                   of bounds, whereas the equivalent path expression succeeds, returning the empty
                   sequence. For example, <code>array{1 to 5}?10</code> raises 
-                     <xerrorref spec="FO40" class="AY" code="0001"/>, whereas <code>array{1 to 5}/get(10)</code>
+                     <xerrorref spec="FO40" class="AY" code="0001"/>, whereas <code>array{1 to 5}/child::{10}</code>
                      returns a empty sequence.
                  </p>
                   
@@ -22743,7 +22743,7 @@ return $r?z</eg>
                   expression succeeds, returning the empty sequence. For example,
                   <code>fn:dateTime-record(2026, 4, 1)?quarter</code> raises 
                   <errorref spec="XP" class="TY" code="0004"/>, whereas
-                  <code>fn:dateTime-record(2026, 4, 1)/get("quarter")</code>
+                  <code>fn:dateTime-record(2026, 4, 1)/child::{"quarter"}</code>
                      returns an empty sequence.
                   </p>
 


### PR DESCRIPTION
The changes here correct spec examples and function signatures that fail to parse against the XQuery 4.0 grammar, detected by the [RExification test](https://github.com/GuntherRademacher/rex-parser-generator/tree/main/docs/sample-grammars/XQuery-40) when parsing the QT4 test suite.

**xpath-functions-40 (function-catalog.xml)**

- `fn:parse-json`: the number-format: 'adaptive' example had an XQuery array where a JSON string was intended, a missing argument comma, and a stray `}`. Replaced with the string literal `'[2.0, 1e6]'` and a well-formed options map.
- `fn:jkey`/`fn:jvalue`: the map-selection examples used the obsolete `child::get(("Mo", "We", …))`. Replaced with the enclosed-expression selector `child::{"Mo", "We", …}`.
- `fn:element-to-map`: the element argument type `document-node(*)|element()?` was an unparenthesized union. Corrected to `(document-node(*) | element())?`.

**xquery-40 (expressions.xml)**

- updated three prose examples that used the same obsolete `get(...)` step (`child::get("code")`, `/get(10)`, `/get("quarter")`) to the enclosed-expression selector form (`child::{"code"}`, `child::{10}`, `child::{"quarter"}`).