### PR TITLE
2774 Reversion of PR 2747 which allowed `A/B?C`

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1950,10 +1950,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
       <g:ref name="FullStep"/>
     </g:choice>
     <g:zeroOrMore>
-      <g:choice>
-        <g:ref name="Predicate"/>
-        <g:ref name="Lookup" if="xpath40 xquery40 xslt40-patterns"/>
-      </g:choice>
+        <g:ref name="Predicate"/>     
     </g:zeroOrMore>
   </g:production>
 

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -12558,9 +12558,9 @@ return if (every $r in $R satisfies $r instance of gnode())
 	               as well as XNodes (found in trees representing parsed XML).
 	            </change>           
                 <change issue="2624" PR="2627" date="2026-05-11">Error code XPTY0020 is replaced by XPTY0004.</change>
-                <change issue="2591" PR="2747" date="2026-07-01">An axis step may now be followed
+                <!--<change issue="2591" PR="2747" date="2026-07-01">An axis step may now be followed
                    directly by a <nt def="Lookup">lookup</nt> (as well as by predicates), so that
-                   <code>a/b?c</code> is permitted without parentheses.</change>
+                   <code>a/b?c</code> is permitted without parentheses.</change>-->
             </changes>
 
             <scrap>
@@ -12579,18 +12579,18 @@ return if (every $r in $R satisfies $r instance of gnode())
                      def="dt-node-test"
                      >node test</termref>,
 		which selects GNodes based on their properties, and zero or more
-               <termref def="dt-predicate">predicates</termref> and
-               <nt def="Lookup">lookups</nt>, applied in order, which filter or
-               dereference the results.</termdef></p>
+               <termref def="dt-predicate">predicates</termref><!-- and
+               <nt def="Lookup">lookups</nt>-->, applied in order, which filter<!-- or
+               dereference--> the results.</termdef></p>
 
-            <p>A <nt def="Lookup">Lookup</nt> that follows an axis step has the same meaning as when
+            <!--<p>A <nt def="Lookup">Lookup</nt> that follows an axis step has the same meaning as when
                it follows a <nt def="PostfixExpr">postfix expression</nt>: it applies the
                <specref ref="id-lookup"/> to the sequence produced by the preceding step. The lookup
                binds to that step alone: <code>a/b?c</code> is parsed as <code>a/(b?c)</code>, so
                the <code>?c</code> lookup is applied to the <code>b</code> nodes selected from each
                <code>a</code>. As with any lookup, the items to which it is applied must be maps,
                arrays, or JNodes; otherwise a <termref def="dt-type-error">type error</termref> is
-               raised.</p>
+               raised.</p>-->
             
             <note><p>An <termref def="dt-axis-step"/> is an expression in its own right.
                While axis steps are often used as the operands of 


### PR DESCRIPTION
Fix #2774

This PR reverts the effect of PR 2747, which introduced the ability to write the expression `A/B?C`, with the lookup `?C` being part of the step `(B?C)`.

As discussed in the issue, the problem is the interaction with the rules on sorting nodes into document order and deduplication. The expression "feels like" it should evaluate `(A/B) ? C` - typically searching a JTree to obtain a JNode that wraps a map, and then extracting the entry C from that map; but that's not the actual semantics, because assuming that `?C` doesn't select JNodes) it disrupts the deduplication and sorting that `(A/B)` would otherwise undertake.