### PR TITLE
2787 XQuery changes to merge declare record and declare type

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -493,7 +493,6 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
         <g:ref name="VarDecl"/>
         <g:ref name="FunctionDecl"/>
         <g:ref name="ItemTypeDecl"/>
-        <g:ref name="NamedRecordTypeDecl"/>
         <g:ref name="OptionDecl" lookahead="2"/>
       </g:choice>
       <g:ref name="Separator"/>
@@ -721,28 +720,6 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:ref name="URILiteral"/>
   </g:production>
 
-  <!--<g:production name="FTOptionDecl" if="fulltext" not-if="xpath40 xslt40-patterns">
-    <g:string>declare</g:string>
-    <g:string>ft-option</g:string>
-    <g:ref name="FTMatchOptions"/>
-  </g:production>-->
-
-  <!--<g:production name="AnnotatedDecl" if="xquery40">
-    <g:string>declare</g:string>
-    <g:zeroOrMore>
-      <g:choice>
-        <g:ref name="CompatibilityAnnotation" if="update10 update30"/>
-        <g:ref name="Annotation"/>
-      </g:choice>
-    </g:zeroOrMore>
-    <g:choice>
-      <g:ref name="VarDecl"/>
-      <g:ref name="FunctionDecl"/>
-      <g:ref name="ItemTypeDecl"/>
-      <g:ref name="NamedRecordTypeDecl"/>
-    </g:choice>
-  </g:production>-->
-
   <g:production name="CompatibilityAnnotation" if="update10 update30">
     <g:string>updating</g:string>
   </g:production>
@@ -762,24 +739,32 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   <g:production name="Constant" if="xpath40 xquery40 xslt40-patterns">
     <g:choice>
       <g:ref name="StringLiteral"/>
-      <g:sequence>
-        <g:optional>
-          <g:string>-</g:string>
-        </g:optional>
-        <g:ref name="NumericLiteral"/>
-      </g:sequence>
+      <g:ref name="SignedNumericLiteral"/>
       <g:ref name="QNameLiteral"/>
-      <g:sequence>
-        <g:string>true</g:string>
-        <g:string>(</g:string>
-        <g:string>)</g:string>
-      </g:sequence>
-      <g:sequence>
-        <g:string>false</g:string>
-        <g:string>(</g:string>
-        <g:string>)</g:string>
-      </g:sequence>
+      <g:ref name="BooleanLiteral"/>
+      <g:ref name="EmptySequence"/>
     </g:choice>
+  </g:production>
+  
+  <g:production name="SignedNumericLiteral" if="xpath40 xquery40 xslt40-patterns">
+    <g:optional>
+      <g:string>-</g:string>
+    </g:optional>
+    <g:ref name="NumericLiteral"/>   
+  </g:production>   
+  
+  <g:production name="BooleanLiteral" if="xpath40 xquery40 xslt40-patterns">
+    <g:choice>
+      <g:string>true</g:string>
+      <g:string>false</g:string>
+    </g:choice>
+    <g:string>(</g:string>
+    <g:string>)</g:string>
+  </g:production>
+  
+  <g:production name="EmptySequence" if="xpath40 xquery40 xslt40-patterns">
+    <g:string>(</g:string>
+    <g:string>)</g:string>
   </g:production>
 
   <g:production name="VarDecl" if="xquery40">
@@ -924,9 +909,13 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:ref name="EQName"/>
     <g:string>as</g:string>
     <g:ref name="ItemType"/>
+    <g:optional>
+      <g:string>with</g:string>
+      <g:string>constructor</g:string>
+    </g:optional>
   </g:production>
   
-  <g:production name="NamedRecordTypeDecl" if="xquery40">
+  <!--<g:production name="NamedRecordTypeDecl" if="xquery40">
     <g:string>declare</g:string>
     <g:zeroOrMore>
       <g:ref name="Annotation"/>
@@ -937,19 +926,19 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:zeroOrMore separator=",">
       <g:ref name="ExtendedFieldDeclaration"/>
     </g:zeroOrMore>
-    <!--<g:optional>
+    <!-\-<g:optional>
       <g:ref name="ExtensibleFlag"/>
-    </g:optional>-->
+    </g:optional>-\->
     <g:string>)</g:string>
-  </g:production>
+  </g:production>-->
   
-  <g:production name="ExtendedFieldDeclaration" if="xquery40">
+  <!--<g:production name="ExtendedFieldDeclaration" if="xquery40">
     <g:ref name="FieldDeclaration"/>
     <g:optional>
       <g:string>:=</g:string>
       <g:ref name="ExprSingle"/>
     </g:optional>
-  </g:production>
+  </g:production>-->
 
   <g:production name="OptionDecl" if=" xquery40">
     <g:string>declare</g:string>
@@ -2983,16 +2972,20 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:string>record</g:string>
     <g:string>(</g:string>
     <g:zeroOrMore separator=",">
-      <g:ref name="FieldDeclaration"/>
+      <g:ref name="FieldDecl"/>
     </g:zeroOrMore>
     <g:string>)</g:string>
   </g:production>
   
-  <g:production name="FieldDeclaration" if="xpath40 xquery40 xslt40-patterns">
+  <g:production name="FieldDecl" if="xpath40 xquery40 xslt40-patterns">
     <g:ref name="FieldName"/>
     <g:optional>
       <g:string>as</g:string>
       <g:ref name="SequenceType"/>
+    </g:optional>
+    <g:optional>
+      <g:string>:=</g:string>
+      <g:ref name="Constant"/>
     </g:optional>
   </g:production>
   

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -2985,7 +2985,10 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     </g:optional>
     <g:optional>
       <g:string>:=</g:string>
-      <g:ref name="Constant"/>
+      <g:choice>
+        <g:ref name="Constant"/>
+        <g:ref name="InlineFunctionExpr"/>
+      </g:choice>
     </g:optional>
   </g:production>
   

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -2991,7 +2991,10 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     </g:optional>
     <g:optional>
       <g:string>:=</g:string>
-      <g:ref name="Constant"/>
+      <g:choice>
+        <g:ref name="Constant"/>
+        <g:ref name="InlineFunctionExpr"/>
+      </g:choice>
     </g:optional>
   </g:production>
   

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -2992,8 +2992,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:optional>
       <g:string>:=</g:string>
       <g:choice>
-        <g:ref name="Constant"/>
-        <g:ref name="InlineFunctionExpr"/>
+        <g:ref name="ConstantExpr"/>
       </g:choice>
     </g:optional>
   </g:production>
@@ -3005,10 +3004,9 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     </g:choice>
   </g:production>
   
-  <!--<g:production name="ExtensibleFlag" if="xpath40 xquery40 xslt40-patterns">
-    <g:string>,</g:string>
-    <g:string>*</g:string>
-  </g:production>-->
+  <g:production name="ConstantExpr" if="xpath40 xquery40 xslt40-patterns">
+    <g:ref name="ExprSingle"/>
+  </g:production>
   
   <g:production name="EnumerationType" if="xpath40 xquery40 xslt40-patterns">
     <g:string>enum</g:string>

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -493,7 +493,6 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
         <g:ref name="VarDecl"/>
         <g:ref name="FunctionDecl"/>
         <g:ref name="ItemTypeDecl"/>
-        <g:ref name="NamedRecordTypeDecl"/>
         <g:ref name="OptionDecl" lookahead="2"/>
       </g:choice>
       <g:ref name="Separator"/>
@@ -721,28 +720,6 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:ref name="URILiteral"/>
   </g:production>
 
-  <!--<g:production name="FTOptionDecl" if="fulltext" not-if="xpath40 xslt40-patterns">
-    <g:string>declare</g:string>
-    <g:string>ft-option</g:string>
-    <g:ref name="FTMatchOptions"/>
-  </g:production>-->
-
-  <!--<g:production name="AnnotatedDecl" if="xquery40">
-    <g:string>declare</g:string>
-    <g:zeroOrMore>
-      <g:choice>
-        <g:ref name="CompatibilityAnnotation" if="update10 update30"/>
-        <g:ref name="Annotation"/>
-      </g:choice>
-    </g:zeroOrMore>
-    <g:choice>
-      <g:ref name="VarDecl"/>
-      <g:ref name="FunctionDecl"/>
-      <g:ref name="ItemTypeDecl"/>
-      <g:ref name="NamedRecordTypeDecl"/>
-    </g:choice>
-  </g:production>-->
-
   <g:production name="CompatibilityAnnotation" if="update10 update30">
     <g:string>updating</g:string>
   </g:production>
@@ -762,24 +739,32 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   <g:production name="Constant" if="xpath40 xquery40 xslt40-patterns">
     <g:choice>
       <g:ref name="StringLiteral"/>
-      <g:sequence>
-        <g:optional>
-          <g:string>-</g:string>
-        </g:optional>
-        <g:ref name="NumericLiteral"/>
-      </g:sequence>
+      <g:ref name="SignedNumericLiteral"/>
       <g:ref name="QNameLiteral"/>
-      <g:sequence>
-        <g:string>true</g:string>
-        <g:string>(</g:string>
-        <g:string>)</g:string>
-      </g:sequence>
-      <g:sequence>
-        <g:string>false</g:string>
-        <g:string>(</g:string>
-        <g:string>)</g:string>
-      </g:sequence>
+      <g:ref name="BooleanLiteral"/>
+      <g:ref name="EmptySequence"/>
     </g:choice>
+  </g:production>
+  
+  <g:production name="SignedNumericLiteral" if="xpath40 xquery40 xslt40-patterns">
+    <g:optional>
+      <g:string>-</g:string>
+    </g:optional>
+    <g:ref name="NumericLiteral"/>   
+  </g:production>   
+  
+  <g:production name="BooleanLiteral" if="xpath40 xquery40 xslt40-patterns">
+    <g:choice>
+      <g:string>true</g:string>
+      <g:string>false</g:string>
+    </g:choice>
+    <g:string>(</g:string>
+    <g:string>)</g:string>
+  </g:production>
+  
+  <g:production name="EmptySequence" if="xpath40 xquery40 xslt40-patterns">
+    <g:string>(</g:string>
+    <g:string>)</g:string>
   </g:production>
 
   <g:production name="VarDecl" if="xquery40">
@@ -930,9 +915,13 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:ref name="EQName"/>
     <g:string>as</g:string>
     <g:ref name="ItemType"/>
+    <g:optional>
+      <g:string>with</g:string>
+      <g:string>constructor</g:string>
+    </g:optional>
   </g:production>
   
-  <g:production name="NamedRecordTypeDecl" if="xquery40">
+  <!--<g:production name="NamedRecordTypeDecl" if="xquery40">
     <g:string>declare</g:string>
     <g:zeroOrMore>
       <g:ref name="Annotation"/>
@@ -943,19 +932,19 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:zeroOrMore separator=",">
       <g:ref name="ExtendedFieldDeclaration"/>
     </g:zeroOrMore>
-    <!--<g:optional>
+    <!-\-<g:optional>
       <g:ref name="ExtensibleFlag"/>
-    </g:optional>-->
+    </g:optional>-\->
     <g:string>)</g:string>
-  </g:production>
+  </g:production>-->
   
-  <g:production name="ExtendedFieldDeclaration" if="xquery40">
+  <!--<g:production name="ExtendedFieldDeclaration" if="xquery40">
     <g:ref name="FieldDeclaration"/>
     <g:optional>
       <g:string>:=</g:string>
       <g:ref name="ExprSingle"/>
     </g:optional>
-  </g:production>
+  </g:production>-->
 
   <g:production name="OptionDecl" if=" xquery40">
     <g:string>declare</g:string>
@@ -2989,16 +2978,20 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:string>record</g:string>
     <g:string>(</g:string>
     <g:zeroOrMore separator=",">
-      <g:ref name="FieldDeclaration"/>
+      <g:ref name="FieldDecl"/>
     </g:zeroOrMore>
     <g:string>)</g:string>
   </g:production>
   
-  <g:production name="FieldDeclaration" if="xpath40 xquery40 xslt40-patterns">
+  <g:production name="FieldDecl" if="xpath40 xquery40 xslt40-patterns">
     <g:ref name="FieldName"/>
     <g:optional>
       <g:string>as</g:string>
       <g:ref name="SequenceType"/>
+    </g:optional>
+    <g:optional>
+      <g:string>:=</g:string>
+      <g:ref name="Constant"/>
     </g:optional>
   </g:production>
   

--- a/specifications/xquery-40/src/errors.xml
+++ b/specifications/xquery-40/src/errors.xml
@@ -1138,7 +1138,21 @@ It is a static error if the name of a feature in
          <p>It is a <termref def="dt-static-error">static error</termref> 
             if a <nt def="URIQualifiedName">URIQualifiedName</nt> includes a prefix but no URI.</p>
       </error>
+
+      <error spec="XP" code="0155" class="TY" type="static">
+         <p>It is a <termref def="dt-type-error">type error</termref> 
+            if, when casting to an array type, map type, or record type, a value <var>V</var> within the input
+            needs to be cast to a type <var>T</var>, unless (a) <var>V</var> already matches <var>T</var>, 
+            or (b) <var>T</var> is a valid <nt def="CastTarget">CastTarget</nt>.</p>
+      </error>
       
+      <error spec="XP" code="0156" class="DY" type="dynamic">
+         <p>It is a <termref def="dt-dynamic-error">dynamic error</termref> 
+            if the default value expression for a field in a record type does not satisfy the
+            constraints defined for such expressions.</p>
+      </error>
+      
+
       
       
       

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -5833,7 +5833,7 @@ name.</p>
 
     <p>The keywords <code>function</code> and <code>fn</code> are synonyms.</p>
                
-               <p role="xquery">If the <nt def="FunctionType">FunctionTyoe</nt> contains an 
+               <p role="xquery">If the <nt def="FunctionType">FunctionType</nt> contains an 
                <nt def="Annotation">Annotation</nt>, then this is interpreted as a
                <termref def="dt-function-assertion"/>, as described below.</p>
                
@@ -6298,7 +6298,7 @@ name.</p>
                
                <ulist>
                   <item><p>Any constructor function generated for the record type will use the same default value.</p></item>
-                  <item><p>When a map are coerced to the record, any field that is absent in the map will be populated with its default
+                  <item><p>When a map is coerced to the record type, any field that is absent in the map will be populated with its default
                   value in the resulting record.</p></item>
                </ulist>
                
@@ -6400,13 +6400,13 @@ name.</p>
                
                <p>For example, the following XQuery declaration defines a linked list:</p>
                
-               <p><eg>declare type my:list as record (value as item()*, next? as my:list);</eg></p>
+               <p><eg>declare type my:list as record (value as item()*, next as my:list?);</eg></p>
                
                <p>The equivalent in XSLT is:</p>
                
                <eg><![CDATA[<xsl:record-type name="my:list">
    <xsl:field name="value" as="item()*"/>
-   <xsl:field name="next" as="my:list" required="no"/>
+   <xsl:field name="next" as="my:list?"/>
 </xsl:record-type>]]></eg>
                
                
@@ -6464,13 +6464,13 @@ name.</p>
                   <p>A recursive function to walk this tree and return all the leaf values in depth-first order might be written 
                      (again using XQuery syntax) as:</p>
                   <eg><![CDATA[declare function t:walk-tree($tree as t:binary-tree?) as item()* {
-  $tree ! (t:walk-tree(?left), ?value, t:walk-tree(?right))   
+  $tree -> (t:walk-tree(?left), ?value, t:walk-tree(?right))   
 }]]></eg>
                </example>
                
                <example id="e-arbitrary-tree">
                   <head>An Arbitrary Tree</head>
-                  <p>A record used to represent a node in a tree where each node has an arbitrary number
+                  <p>A record type used to represent a node in a tree where each node has an arbitrary number
                      of children might be represented (using XQuery syntax) as:</p>
                   <eg>declare type t:tree as record (value, children as t:tree*);</eg>
                   <p>A function to walk this tree and enumerate all the values in order might be written 
@@ -8545,8 +8545,12 @@ declare record Particle (
                         </item>
                         <item><p>A type error is raised if <var>J</var> contains an entry whose
                            key is not the <termref def="dt-same-key"/> as any field declaration in 
-                           <var>R</var>, or whose name is the <termref def="dt-same-key"/> as a
-                           field declaration whose default value is given by an <termref def="dt-inline-func"/> (that is, a method).</p></item>
+                           <var>R</var>.</p>
+                           <note><p>No error is raised if <var>J</var> contains an entry whose key is 
+                              the <termref def="dt-same-key"/> as a method in <var>R</var>: the entry is
+                              simply ignored. This ensures that a record that is already an instance
+                              of the required record type can be coerced to that type without error.</p></note>
+                        </item>
                         <!--<item><p>Entries in <var>J</var> whose key does not match the name of
                         any field in <var>R</var> are discarded.</p></item>-->
                         <item><p>The order of entries in <var>N</var> corresponds to the order

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -6308,6 +6308,10 @@ name.</p>
                <p>If a default value is defined for a field, and the field has a declared type, then the default value
                must be coercible to the declared type (<errorref class="TY" code="0004"/>).</p>
                
+               <p>If the default value for a field is an <termref def="dt-inline-func"/> then its <nt def="FunctionBody">FunctionBody</nt>
+               must contain no references to variables declared outside the function body. Fields whose default value is an inline
+               function expression are known as methods: see <specref ref="id-methods"/>.</p>
+               
                <p>Record types may be named, or they may be anonymous. Naming a record type has
                a number of benefits:</p>
                
@@ -8516,7 +8520,12 @@ declare record Particle (
                         <item><p>For every field declaration <var>F</var> in <var>R</var>,
                         <var>N</var> contains an entry (key/value pair) as follows:</p>
                            <olist>
-                              <item><p>If <var>J</var> contains an entry <var>E</var> with the <termref def="dt-same-key"/>
+                              <item><p>If the default value of <var>F</var> is given by an <termref def="dt-inline-func"/>
+                                 (that is, if the field is a method), then an entry whose key is the
+                                 name of <var>F</var> and whose associated value is the result of evaluating
+                              the inline function expression.</p></item>
+                              
+                              <item><p>Otherwise, if <var>J</var> contains an entry <var>E</var> with the <termref def="dt-same-key"/>
                               value as the name of <var>F</var>, then an entry whose key is the
                               name of <var>F</var> and whose associated value is the value part
                               of <var>E</var>, coerced to the declared type of <var>F</var>
@@ -8536,7 +8545,8 @@ declare record Particle (
                         </item>
                         <item><p>A type error is raised if <var>J</var> contains an entry whose
                            key is not the <termref def="dt-same-key"/> as any field declaration in 
-                           <var>R</var>.</p></item>
+                           <var>R</var>, or whose name is the <termref def="dt-same-key"/> as a
+                           field declaration whose default value is given by an <termref def="dt-inline-func"/> (that is, a method).</p></item>
                         <!--<item><p>Entries in <var>J</var> whose key does not match the name of
                         any field in <var>R</var> are discarded.</p></item>-->
                         <item><p>The order of entries in <var>N</var> corresponds to the order

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -4118,8 +4118,8 @@ of applying the <function>fn:boolean</function> function to the value.</termdef>
             <head>Constants</head>
             
             <p>Some grammatical contexts allow a <nt def="Constant">Constant</nt> to appear.
-            A constant may be a string or numeric literal, but it also allows negative numbers
-            and booleans.</p>
+            A constant may be a literal (see <specref ref="id-literals"/>), but it also allows a negative number,
+            a boolean, or the empty sequence.</p>
             
             <scrap>
                <prodrecap ref="Constant"/>
@@ -4134,7 +4134,10 @@ of applying the <function>fn:boolean</function> function to the value.</termdef>
                    or <code>1e-6</code>,
                    denoting a value of type <code>xs:decimal</code>, <code>xs:integer</code>, 
                    or <code>xs:double</code>. The literal may be preceded by a minus sign to represent a negative
-                   number.</p></item>
+                   number.</p>
+                   <note><p>A hexadecimal literal, in the absence of a sign, always represents a positive number. 
+                      For example, <code>0xFF</code> is 255.</p></note>
+                 </item>
                  <item><p>One of the constructs <code>true()</code> or <code>false()</code>, denoting
                  the <code>xs:boolean</code> values <code>true</code> and <code>false</code> respectively.</p>
                  <note diff="add" at="issue637"><p>The constructs <code>true()</code> and <code>false()</code> must be written as
@@ -4144,6 +4147,7 @@ of applying the <function>fn:boolean</function> function to the value.</termdef>
                  </item>
                  <item><p>A QName literal, for example <code>#div</code> or <code>#xml:space</code>, denoting
                  a value of type <code>xs:QName</code>.</p></item>
+                  <item><p>The empty sequence, written as <code>()</code>.</p></item>
                </ulist>
                        
                        
@@ -4564,7 +4568,7 @@ types</term> (such as <code>xs:integer</code>) and function types
          
          <p>In most cases, the set of items matched by an item type consists either
          exclusively of <termref def="dt-atomic-item">atomic items</termref>,
-         exclusively of <termref def="dt-node">nodes</termref>, 
+         exclusively of <termref def="dt-GNode">GNodes</termref>, 
          or exclusively of <xtermref spec="DM40" ref="dt-function-item">function items</xtermref>.
          Exceptions include the generic types <code>item()</code>, which matches all items, <code>xs:error</code>,
          which matches no items, and <termref def="dt-choice-item-type">choice item types</termref>,
@@ -5829,8 +5833,8 @@ name.</p>
 
     <p>The keywords <code>function</code> and <code>fn</code> are synonyms.</p>
                
-               <p role="xquery">If the <nt def="FunctionType"/> contains an 
-               <nt def="Annotation"/>, then this is interpreted as a
+               <p role="xquery">If the <nt def="FunctionType">FunctionTyoe</nt> contains an 
+               <nt def="Annotation">Annotation</nt>, then this is interpreted as a
                <termref def="dt-function-assertion"/>, as described below.</p>
                
     <p>An <nt def="AnyFunctionType">AnyFunctionType</nt>
@@ -6158,7 +6162,7 @@ name.</p>
                
                <changes>
                   <change>
-                     Record types are added as a new kind of <code>ItemType</code>, constraining
+                     Record types are introduced in <?inject language?> as a new kind of <code>ItemType</code>, constraining
                      the value space of maps.
                   </change>
                   <!--<change issue="52" PR="728" date="2023-10-10">
@@ -6186,7 +6190,8 @@ name.</p>
                
                <p><termdef id="dt-record-type" term="record type">A <term>record type</term>
                is a sequence of field declarations, where each field declaration defines a name (an arbitrary
-               <xtermref spec="DM40" ref="dt-string"/>) and a type (an arbitrary <termref def="dt-sequence-type"/>).</termdef></p>
+               <xtermref spec="DM40" ref="dt-string"/>), a type (an arbitrary <termref def="dt-sequence-type"/>),
+                  and optionally, a default value.</termdef></p>
                
                <p>The syntax for defining a <termref def="dt-record-type"/> is the production
                <nt def="TypedRecordType">TypedRecordType</nt>.</p>
@@ -6288,6 +6293,21 @@ name.</p>
                
                <p>The names of the fields in a record type must be distinct <errorref class="ST" code="0021"/>.</p>
                
+               <p>If a default value is defined for a field (for example, <code>record(height, width, depth := 0)</code>,
+               this is used in two circumstances:</p>
+               
+               <ulist>
+                  <item><p>Any constructor function generated for the record type will use the same default value.</p></item>
+                  <item><p>When a map are coerced to the record, any field that is absent in the map will be populated with its default
+                  value in the resulting record.</p></item>
+               </ulist>
+               
+               <p>Default values for fields play no part in determining whether a particular item matches the record type,
+               or whether one record type is a subtype of another.</p>
+               
+               <p>If a default value is defined for a field, and the field has a declared type, then the default value
+               must be coercible to the declared type (<errorref class="TY" code="0004"/>).</p>
+               
                <p>Record types may be named, or they may be anonymous. Naming a record type has
                a number of benefits:</p>
                
@@ -6295,7 +6315,7 @@ name.</p>
                   <item><p>It avoids repeated use of a type definition that may be lengthy.</p></item>
                   <item><p>It means that when the details of the type definition change, the change
                   need only be made in one place, and there is less risk of multiple definitions diverging.</p></item>
-                  <item><p>A named record type definition automatically has an associated constructor
+                  <item><p>A named record type definition may have an associated constructor
                   function that can be used to construct instances of the record type.</p></item>
                   <item><p>Named record type definitions can be recursive, allowing more complex data structures
                   such as lists and trees to be defined: see <specref ref="id-recursive-record-tests"/>.</p></item>
@@ -6308,9 +6328,9 @@ name.</p>
                and the argument to <function>fn:build-dateTime</function>, is defined using the named record type
                <code>fn:dateTime-record</code>.</p>
                
-               <p>User-defined named record types may be declared in XQuery using the <code>declare record</code>
-               construct<phrase role="xquery"> (see <specref ref="id-named-record-types"/>)</phrase>, and 
-               in XSLT using an <code>xsl:record-type</code> declaration.</p>
+               <p>User-defined named record types may be declared in XQuery using the <code>declare type</code>
+                  construct<phrase role="xquery"> (see <specref ref="id-item-type-declaration"/>)</phrase>, and 
+               in XSLT using an <code>xsl:item-type</code> declaration.</p>
                
                <p>Some built-in functions also use unnamed record types in their signatures.</p>
                
@@ -6376,7 +6396,7 @@ name.</p>
                
                <p>For example, the following XQuery declaration defines a linked list:</p>
                
-               <p><eg>declare record my:list (value as item()*, next? as my:list);</eg></p>
+               <p><eg>declare type my:list as record (value as item()*, next? as my:list);</eg></p>
                
                <p>The equivalent in XSLT is:</p>
                
@@ -6397,10 +6417,10 @@ name.</p>
                <p>and the third value in the map can be retrieved as <code>$list?next?next?value</code>.
                In practice, recursive data structures are usually manipulated using recursive functions.</p>
                
-               <p>It is possible to define a recursive record type that cannot be instantiated, because it
+               <!--<p>It is possible to define a recursive record type that cannot be instantiated, because it
                has no finite instances: for example (in XQuery) <code>declare record X (next as X);</code>.
                Such a record declaration is <termref def="dt-implausible"/>, so the processor may
-               treat it as an error <errorref class="ST" code="0023"/>, but it is not obliged to do so.</p>
+               treat it as an error <errorref class="ST" code="0023"/>, but it is not obliged to do so.</p>-->
                
                <note><p>For an example of a practical use of recursive record types, see the
                specification of the function <function>fn:random-number-generator</function>.</p></note>
@@ -6432,7 +6452,7 @@ name.</p>
                <example id="e-binary-tree">
                   <head>A Binary Tree</head>
                   <p>A record used to represent a node in a binary tree might be represented (using XQuery syntax) as:</p>
-                  <eg>declare record t:binary-tree 
+                  <eg>declare type t:binary-tree as record
    ( left as t:binary-tree?, 
      value as item()*, 
      right as t:binary-tree?
@@ -6448,7 +6468,7 @@ name.</p>
                   <head>An Arbitrary Tree</head>
                   <p>A record used to represent a node in a tree where each node has an arbitrary number
                      of children might be represented (using XQuery syntax) as:</p>
-                  <eg>declare record t:tree as (value, children as t:tree*);</eg>
+                  <eg>declare type t:tree as record (value, children as t:tree*);</eg>
                   <p>A function to walk this tree and enumerate all the values in order might be written 
                      as:</p>
                   <eg>declare function t:flatten($tree as t:tree) as item()* {
@@ -7996,12 +8016,10 @@ declare record Particle (
                   <ulist>
                      <item><p>If <var>B</var> is a reference to a recursive record type, then
                         <var>A</var> ⊆ <var>B</var> is true if and only if 
-                        <var>A</var> and <var>B</var>
-                        are references to the same named record type.</p></item>
-                     <item><p>If <var>A</var> is a reference to a recursive named item type, then
+                         <var>A</var> is a reference to the same recursive record type.</p></item>
+                     <item><p>If <var>A</var> is a reference to a recursive record type, then
                         <var>A</var> ⊆ <var>B</var> is true if and only if 
-                        <var>A</var> and <var>B</var>
-                        are references to the same named record type.</p>
+                        <var>B</var> is a reference to the same recursive record type.</p>
                      </item>
                         
                   </ulist>
@@ -8503,12 +8521,22 @@ declare record Particle (
                               name of <var>F</var> and whose associated value is the value part
                               of <var>E</var>, coerced to the declared type of <var>F</var>
                               by applying these coercion rules recursively.</p></item>
+                              
                               <item><p>Otherwise (if <var>J</var> contains no such entry),
                               an entry whose key is the name of <var>F</var> and whose
-                              associated value is the empty sequence; a type error occurs
-                              if the empty sequence does not match the declared type of <var>F</var>.</p></item>
+                              associated value is determined as follows:</p>
+                                 <olist>
+                                    <item><p>If the record type defines a default value for <var>F</var>,
+                                    then that default value.</p></item>
+                                    <item><p>Otherwise, the empty sequence.</p></item>
+                                 </olist>
+                              <p>A type error is raised
+                              if the chosen value does not match the declared type of <var>F</var>.</p></item>
                            </olist>
                         </item>
+                        <item><p>A type error is raised if <var>J</var> contains an entry whose
+                           key is not the <termref def="dt-same-key"/> as any field declaration in 
+                           <var>R</var>.</p></item>
                         <!--<item><p>Entries in <var>J</var> whose key does not match the name of
                         any field in <var>R</var> are discarded.</p></item>-->
                         <item><p>The order of entries in <var>N</var> corresponds to the order
@@ -8522,7 +8550,7 @@ declare record Particle (
                         <code>{ "latitude": 53.2, "longitude": 0}</code>,
                         then the map is converted to the record <code>{ "longitude": 0.0e0, "latitude": 53.2e0 }</code>.
                      But if the supplied value is <code>{ "latitude": 53.2, "longitude": 0, "altitude": 3_500 }</code>,
-                     then a type error occurs because the field <code>"altitude"</code> is not defined
+                     then a type error is raised because the field <code>"altitude"</code> is not defined
                      in the record type.</p></note>
 
                   </item>
@@ -23128,7 +23156,7 @@ return $lib =?> product((1.2, 1.3, 1.4))
                
                
                <eg role="xquery">
-declare record my:rectangle (
+declare type my:rectangle as record (
    height as xs:double,
    width as xs:double,
    children as my:rectangle* 

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -5833,7 +5833,7 @@ name.</p>
 
     <p>The keywords <code>function</code> and <code>fn</code> are synonyms.</p>
                
-               <p role="xquery">If the <nt def="FunctionType">FunctionTyoe</nt> contains an 
+               <p role="xquery">If the <nt def="FunctionType">FunctionType</nt> contains an 
                <nt def="Annotation">Annotation</nt>, then this is interpreted as a
                <termref def="dt-function-assertion"/>, as described below.</p>
                
@@ -6298,7 +6298,7 @@ name.</p>
                
                <ulist>
                   <item><p>Any constructor function generated for the record type will use the same default value.</p></item>
-                  <item><p>When a map are coerced to the record, any field that is absent in the map will be populated with its default
+                  <item><p>When a map is coerced to the record type, any field that is absent in the map will be populated with its default
                   value in the resulting record.</p></item>
                </ulist>
                
@@ -6400,9 +6400,9 @@ name.</p>
                
                <p>For example, the following XQuery declaration defines a linked list:</p>
 
-               <p><eg>declare record my:list (value as item()*, next as my:list?);</eg></p>
-
                
+               <p><eg>declare type my:list as record (value as item()*, next as my:list?);</eg></p>
+             
                <p>The equivalent in XSLT is:</p>
                
                <eg><![CDATA[<xsl:record-type name="my:list">
@@ -6465,13 +6465,13 @@ name.</p>
                   <p>A recursive function to walk this tree and return all the leaf values in depth-first order might be written 
                      (again using XQuery syntax) as:</p>
                   <eg><![CDATA[declare function t:walk-tree($tree as t:binary-tree?) as item()* {
-  $tree ! (t:walk-tree(?left), ?value, t:walk-tree(?right))   
+  $tree -> (t:walk-tree(?left), ?value, t:walk-tree(?right))   
 }]]></eg>
                </example>
                
                <example id="e-arbitrary-tree">
                   <head>An Arbitrary Tree</head>
-                  <p>A record used to represent a node in a tree where each node has an arbitrary number
+                  <p>A record type used to represent a node in a tree where each node has an arbitrary number
                      of children might be represented (using XQuery syntax) as:</p>
                   <eg>declare type t:tree as record (value, children as t:tree*);</eg>
                   <p>A function to walk this tree and enumerate all the values in order might be written 
@@ -8546,8 +8546,12 @@ declare record Particle (
                         </item>
                         <item><p>A type error is raised if <var>J</var> contains an entry whose
                            key is not the <termref def="dt-same-key"/> as any field declaration in 
-                           <var>R</var>, or whose name is the <termref def="dt-same-key"/> as a
-                           field declaration whose default value is given by an <termref def="dt-inline-func"/> (that is, a method).</p></item>
+                           <var>R</var>.</p>
+                           <note><p>No error is raised if <var>J</var> contains an entry whose key is 
+                              the <termref def="dt-same-key"/> as a method in <var>R</var>: the entry is
+                              simply ignored. This ensures that a record that is already an instance
+                              of the required record type can be coerced to that type without error.</p></note>
+                        </item>
                         <!--<item><p>Entries in <var>J</var> whose key does not match the name of
                         any field in <var>R</var> are discarded.</p></item>-->
                         <item><p>The order of entries in <var>N</var> corresponds to the order

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -4118,8 +4118,8 @@ of applying the <function>fn:boolean</function> function to the value.</termdef>
             <head>Constants</head>
             
             <p>Some grammatical contexts allow a <nt def="Constant">Constant</nt> to appear.
-            A constant may be a string or numeric literal, but it also allows negative numbers
-            and booleans.</p>
+            A constant may be a literal (see <specref ref="id-literals"/>), but it also allows a negative number,
+            a boolean, or the empty sequence.</p>
             
             <scrap>
                <prodrecap ref="Constant"/>
@@ -4134,7 +4134,10 @@ of applying the <function>fn:boolean</function> function to the value.</termdef>
                    or <code>1e-6</code>,
                    denoting a value of type <code>xs:decimal</code>, <code>xs:integer</code>, 
                    or <code>xs:double</code>. The literal may be preceded by a minus sign to represent a negative
-                   number.</p></item>
+                   number.</p>
+                   <note><p>A hexadecimal literal, in the absence of a sign, always represents a positive number. 
+                      For example, <code>0xFF</code> is 255.</p></note>
+                 </item>
                  <item><p>One of the constructs <code>true()</code> or <code>false()</code>, denoting
                  the <code>xs:boolean</code> values <code>true</code> and <code>false</code> respectively.</p>
                  <note diff="add" at="issue637"><p>The constructs <code>true()</code> and <code>false()</code> must be written as
@@ -4144,6 +4147,7 @@ of applying the <function>fn:boolean</function> function to the value.</termdef>
                  </item>
                  <item><p>A QName literal, for example <code>#div</code> or <code>#xml:space</code>, denoting
                  a value of type <code>xs:QName</code>.</p></item>
+                  <item><p>The empty sequence, written as <code>()</code>.</p></item>
                </ulist>
                        
                        
@@ -4564,7 +4568,7 @@ types</term> (such as <code>xs:integer</code>) and function types
          
          <p>In most cases, the set of items matched by an item type consists either
          exclusively of <termref def="dt-atomic-item">atomic items</termref>,
-         exclusively of <termref def="dt-node">nodes</termref>, 
+         exclusively of <termref def="dt-GNode">GNodes</termref>, 
          or exclusively of <xtermref spec="DM40" ref="dt-function-item">function items</xtermref>.
          Exceptions include the generic types <code>item()</code>, which matches all items, <code>xs:error</code>,
          which matches no items, and <termref def="dt-choice-item-type">choice item types</termref>,
@@ -5829,8 +5833,8 @@ name.</p>
 
     <p>The keywords <code>function</code> and <code>fn</code> are synonyms.</p>
                
-               <p role="xquery">If the <nt def="FunctionType"/> contains an 
-               <nt def="Annotation"/>, then this is interpreted as a
+               <p role="xquery">If the <nt def="FunctionType">FunctionTyoe</nt> contains an 
+               <nt def="Annotation">Annotation</nt>, then this is interpreted as a
                <termref def="dt-function-assertion"/>, as described below.</p>
                
     <p>An <nt def="AnyFunctionType">AnyFunctionType</nt>
@@ -6158,7 +6162,7 @@ name.</p>
                
                <changes>
                   <change>
-                     Record types are added as a new kind of <code>ItemType</code>, constraining
+                     Record types are introduced in <?inject language?> as a new kind of <code>ItemType</code>, constraining
                      the value space of maps.
                   </change>
                   <!--<change issue="52" PR="728" date="2023-10-10">
@@ -6186,7 +6190,8 @@ name.</p>
                
                <p><termdef id="dt-record-type" term="record type">A <term>record type</term>
                is a sequence of field declarations, where each field declaration defines a name (an arbitrary
-               <xtermref spec="DM40" ref="dt-string"/>) and a type (an arbitrary <termref def="dt-sequence-type"/>).</termdef></p>
+               <xtermref spec="DM40" ref="dt-string"/>), a type (an arbitrary <termref def="dt-sequence-type"/>),
+                  and optionally, a default value.</termdef></p>
                
                <p>The syntax for defining a <termref def="dt-record-type"/> is the production
                <nt def="TypedRecordType">TypedRecordType</nt>.</p>
@@ -6288,6 +6293,21 @@ name.</p>
                
                <p>The names of the fields in a record type must be distinct <errorref class="ST" code="0021"/>.</p>
                
+               <p>If a default value is defined for a field (for example, <code>record(height, width, depth := 0)</code>,
+               this is used in two circumstances:</p>
+               
+               <ulist>
+                  <item><p>Any constructor function generated for the record type will use the same default value.</p></item>
+                  <item><p>When a map are coerced to the record, any field that is absent in the map will be populated with its default
+                  value in the resulting record.</p></item>
+               </ulist>
+               
+               <p>Default values for fields play no part in determining whether a particular item matches the record type,
+               or whether one record type is a subtype of another.</p>
+               
+               <p>If a default value is defined for a field, and the field has a declared type, then the default value
+               must be coercible to the declared type (<errorref class="TY" code="0004"/>).</p>
+               
                <p>Record types may be named, or they may be anonymous. Naming a record type has
                a number of benefits:</p>
                
@@ -6295,7 +6315,7 @@ name.</p>
                   <item><p>It avoids repeated use of a type definition that may be lengthy.</p></item>
                   <item><p>It means that when the details of the type definition change, the change
                   need only be made in one place, and there is less risk of multiple definitions diverging.</p></item>
-                  <item><p>A named record type definition automatically has an associated constructor
+                  <item><p>A named record type definition may have an associated constructor
                   function that can be used to construct instances of the record type.</p></item>
                   <item><p>Named record type definitions can be recursive, allowing more complex data structures
                   such as lists and trees to be defined: see <specref ref="id-recursive-record-tests"/>.</p></item>
@@ -6308,9 +6328,9 @@ name.</p>
                and the argument to <function>fn:build-dateTime</function>, is defined using the named record type
                <code>fn:dateTime-record</code>.</p>
                
-               <p>User-defined named record types may be declared in XQuery using the <code>declare record</code>
-               construct<phrase role="xquery"> (see <specref ref="id-named-record-types"/>)</phrase>, and 
-               in XSLT using an <code>xsl:record-type</code> declaration.</p>
+               <p>User-defined named record types may be declared in XQuery using the <code>declare type</code>
+                  construct<phrase role="xquery"> (see <specref ref="id-item-type-declaration"/>)</phrase>, and 
+               in XSLT using an <code>xsl:item-type</code> declaration.</p>
                
                <p>Some built-in functions also use unnamed record types in their signatures.</p>
                
@@ -6375,8 +6395,9 @@ name.</p>
                </p>
                
                <p>For example, the following XQuery declaration defines a linked list:</p>
-               
+
                <p><eg>declare record my:list (value as item()*, next as my:list?);</eg></p>
+
                
                <p>The equivalent in XSLT is:</p>
                
@@ -6397,10 +6418,10 @@ name.</p>
                <p>and the third value in the map can be retrieved as <code>$list?next?next?value</code>.
                In practice, recursive data structures are usually manipulated using recursive functions.</p>
                
-               <p>It is possible to define a recursive record type that cannot be instantiated, because it
+               <!--<p>It is possible to define a recursive record type that cannot be instantiated, because it
                has no finite instances: for example (in XQuery) <code>declare record X (next as X);</code>.
                Such a record declaration is <termref def="dt-implausible"/>, so the processor may
-               treat it as an error <errorref class="ST" code="0023"/>, but it is not obliged to do so.</p>
+               treat it as an error <errorref class="ST" code="0023"/>, but it is not obliged to do so.</p>-->
                
                <note><p>For an example of a practical use of recursive record types, see the
                specification of the function <function>fn:random-number-generator</function>.</p></note>
@@ -6432,7 +6453,7 @@ name.</p>
                <example id="e-binary-tree">
                   <head>A Binary Tree</head>
                   <p>A record used to represent a node in a binary tree might be represented (using XQuery syntax) as:</p>
-                  <eg>declare record t:binary-tree 
+                  <eg>declare type t:binary-tree as record
    ( left as t:binary-tree?, 
      value as item()*, 
      right as t:binary-tree?
@@ -6448,7 +6469,7 @@ name.</p>
                   <head>An Arbitrary Tree</head>
                   <p>A record used to represent a node in a tree where each node has an arbitrary number
                      of children might be represented (using XQuery syntax) as:</p>
-                  <eg>declare record t:tree as (value, children as t:tree*);</eg>
+                  <eg>declare type t:tree as record (value, children as t:tree*);</eg>
                   <p>A function to walk this tree and enumerate all the values in order might be written 
                      as:</p>
                   <eg>declare function t:flatten($tree as t:tree) as item()* {
@@ -7996,12 +8017,10 @@ declare record Particle (
                   <ulist>
                      <item><p>If <var>B</var> is a reference to a recursive record type, then
                         <var>A</var> ⊆ <var>B</var> is true if and only if 
-                        <var>A</var> and <var>B</var>
-                        are references to the same named record type.</p></item>
-                     <item><p>If <var>A</var> is a reference to a recursive named item type, then
+                         <var>A</var> is a reference to the same recursive record type.</p></item>
+                     <item><p>If <var>A</var> is a reference to a recursive record type, then
                         <var>A</var> ⊆ <var>B</var> is true if and only if 
-                        <var>A</var> and <var>B</var>
-                        are references to the same named record type.</p>
+                        <var>B</var> is a reference to the same recursive record type.</p>
                      </item>
                         
                   </ulist>
@@ -8503,12 +8522,22 @@ declare record Particle (
                               name of <var>F</var> and whose associated value is the value part
                               of <var>E</var>, coerced to the declared type of <var>F</var>
                               by applying these coercion rules recursively.</p></item>
+                              
                               <item><p>Otherwise (if <var>J</var> contains no such entry),
                               an entry whose key is the name of <var>F</var> and whose
-                              associated value is the empty sequence; a type error occurs
-                              if the empty sequence does not match the declared type of <var>F</var>.</p></item>
+                              associated value is determined as follows:</p>
+                                 <olist>
+                                    <item><p>If the record type defines a default value for <var>F</var>,
+                                    then that default value.</p></item>
+                                    <item><p>Otherwise, the empty sequence.</p></item>
+                                 </olist>
+                              <p>A type error is raised
+                              if the chosen value does not match the declared type of <var>F</var>.</p></item>
                            </olist>
                         </item>
+                        <item><p>A type error is raised if <var>J</var> contains an entry whose
+                           key is not the <termref def="dt-same-key"/> as any field declaration in 
+                           <var>R</var>.</p></item>
                         <!--<item><p>Entries in <var>J</var> whose key does not match the name of
                         any field in <var>R</var> are discarded.</p></item>-->
                         <item><p>The order of entries in <var>N</var> corresponds to the order
@@ -8522,7 +8551,7 @@ declare record Particle (
                         <code>{ "latitude": 53.2, "longitude": 0}</code>,
                         then the map is converted to the record <code>{ "longitude": 0.0e0, "latitude": 53.2e0 }</code>.
                      But if the supplied value is <code>{ "latitude": 53.2, "longitude": 0, "altitude": 3_500 }</code>,
-                     then a type error occurs because the field <code>"altitude"</code> is not defined
+                     then a type error is raised because the field <code>"altitude"</code> is not defined
                      in the record type.</p></note>
 
                   </item>
@@ -23197,7 +23226,7 @@ return $lib =?> product((1.2, 1.3, 1.4))
                
                
                <eg role="xquery">
-declare record my:rectangle (
+declare type my:rectangle as record (
    height as xs:double,
    width as xs:double,
    children as my:rectangle* 

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -6293,25 +6293,10 @@ name.</p>
                
                <p>The names of the fields in a record type must be distinct <errorref class="ST" code="0021"/>.</p>
                
-               <p>If a default value is defined for a field (for example, <code>record(height, width, depth := 0)</code>,
-               this is used in two circumstances:</p>
+               <p>The optional construct <code>:= ConstantExpr</code> defines a default value for a field.
+               The rules governing default values appear at <specref ref="id-default-values-for-fields"/>.</p>
                
-               <ulist>
-                  <item><p>Any constructor function generated for the record type will use the same default value.</p></item>
-                  <item><p>When a map is coerced to the record type, any field that is absent in the map will be populated with its default
-                  value in the resulting record.</p></item>
-               </ulist>
-               
-               <p>Default values for fields play no part in determining whether a particular item matches the record type,
-               or whether one record type is a subtype of another.</p>
-               
-               <p>If a default value is defined for a field, and the field has a declared type, then the default value
-               must be coercible to the declared type (<errorref class="TY" code="0004"/>).</p>
-               
-               <p>If the default value for a field is an <termref def="dt-inline-func"/> then its <nt def="FunctionBody">FunctionBody</nt>
-               must contain no references to variables declared outside the function body. Fields whose default value is an inline
-               function expression are known as methods: see <specref ref="id-methods"/>.</p>
-               
+              
                <p>Record types may be named, or they may be anonymous. Naming a record type has
                a number of benefits:</p>
                
@@ -6389,7 +6374,62 @@ name.</p>
                <p>Rules defining whether one record type is a <termref def="dt-subtype"/> of another
                   are given in <specref ref="id-item-subtype-records"/>.</p>
 
-            
+            <div5 id="id-default-values-for-fields">
+               <head>Default Values for Fields</head>
+               
+               <p>If a default value is defined for a field (for example, <code>record(height, width, depth := 0)</code>,
+               this is used in two circumstances:</p>
+               
+               <ulist>
+                  <item><p>Any constructor function generated for the record type will use the same default value.</p></item>
+                  <item><p>When a map is coerced to the record type, any field that is absent in the map will be populated with its default
+                  value in the resulting record.</p></item>
+               </ulist>
+               
+               <p>Default values for fields play no part in determining whether a particular item matches the record type,
+               or whether one record type is a subtype of another.</p>
+               
+               <p>If a default value is defined for a field, and the field has a declared type, then the default value
+               must be coercible to the declared type (<errorref class="TY" code="0004"/>).</p>
+               
+               <p>Syntactically, the default value is given as an <nt def="ExprSingle">ExprSingle</nt>. Semantically, however, it is
+               severely constrained by rules defining the information available in its evaluation context. Specifically:</p>
+
+               <ulist>
+                  <item><p>The set of in-scope variables is empty. Any variable reference, other than a reference to a variable
+                  declared within the expression itself, is therefore a static error.</p></item>
+                  <item><p>The context value, position, and size are all absent.</p></item>
+                  <item><p>The set of statically known function definitions excludes all user-defined
+                        functions and external functions; and the set of dynamically known function definitions
+                  is the same as the set of statically known function definitions.</p></item>
+                  <item><p>No access to external resources is allowed. Any function call that attempts to
+                        access external resources (such as 
+                  <function>doc</function>, <function>unparsed-text</function>, <code>collection</code>,
+                  <function>uri-collection</function>, <function>unparsed-binary</function>, <function>html-doc</function>,
+                  <function>csv-doc</function>) fails with a dynamic error indicating that the resource is not
+                  available.</p></item>
+                  <item><p>The result of the expression must not be a GNode. This rule is to avoid complications
+                  involving node identity.</p></item>
+               </ulist>
+               
+               <p>A violation of the above rules is defined as a dynamic error, but it may be reported statically
+               if it can be detected statically: <errorref spec="XP" class="DY" code="0156"/>.</p>
+               
+               <p>Below are some examples of acceptable default value expressions:</p>
+               
+               <slist>
+                  <sitem><code>0</code></sitem>
+                  <sitem><code>""</code></sitem>
+                  <sitem><code>false()</code></sitem>
+                  <sitem><code>xs:date('1900-01-01')</code></sitem>
+                  <sitem><code>()</code></sitem>
+                  <sitem><code>[]</code></sitem>
+                  <sitem><code>{}</code></sitem>
+                  <sitem><code>fn:identity#1</code></sitem>
+                  <sitem><code>fn($x){ $x+1 }</code></sitem>
+                  <sitem><code>fn($this){ $this?height * $this?width }</code></sitem>
+               </slist>
+            </div5>
             
             <div5 id="id-recursive-record-tests" diff="add" at="issue295">
                <head>Recursive Record Types</head>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -6308,6 +6308,10 @@ name.</p>
                <p>If a default value is defined for a field, and the field has a declared type, then the default value
                must be coercible to the declared type (<errorref class="TY" code="0004"/>).</p>
                
+               <p>If the default value for a field is an <termref def="dt-inline-func"/> then its <nt def="FunctionBody">FunctionBody</nt>
+               must contain no references to variables declared outside the function body. Fields whose default value is an inline
+               function expression are known as methods: see <specref ref="id-methods"/>.</p>
+               
                <p>Record types may be named, or they may be anonymous. Naming a record type has
                a number of benefits:</p>
                
@@ -8517,7 +8521,12 @@ declare record Particle (
                         <item><p>For every field declaration <var>F</var> in <var>R</var>,
                         <var>N</var> contains an entry (key/value pair) as follows:</p>
                            <olist>
-                              <item><p>If <var>J</var> contains an entry <var>E</var> with the <termref def="dt-same-key"/>
+                              <item><p>If the default value of <var>F</var> is given by an <termref def="dt-inline-func"/>
+                                 (that is, if the field is a method), then an entry whose key is the
+                                 name of <var>F</var> and whose associated value is the result of evaluating
+                              the inline function expression.</p></item>
+                              
+                              <item><p>Otherwise, if <var>J</var> contains an entry <var>E</var> with the <termref def="dt-same-key"/>
                               value as the name of <var>F</var>, then an entry whose key is the
                               name of <var>F</var> and whose associated value is the value part
                               of <var>E</var>, coerced to the declared type of <var>F</var>
@@ -8537,7 +8546,8 @@ declare record Particle (
                         </item>
                         <item><p>A type error is raised if <var>J</var> contains an entry whose
                            key is not the <termref def="dt-same-key"/> as any field declaration in 
-                           <var>R</var>.</p></item>
+                           <var>R</var>, or whose name is the <termref def="dt-same-key"/> as a
+                           field declaration whose default value is given by an <termref def="dt-inline-func"/> (that is, a method).</p></item>
                         <!--<item><p>Entries in <var>J</var> whose key does not match the name of
                         any field in <var>R</var> are discarded.</p></item>-->
                         <item><p>The order of entries in <var>N</var> corresponds to the order

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -2080,7 +2080,10 @@ local:depth(doc("partlist.xml"))
 
     <p>An item type declaration defines a name for an <termref def="dt-item-type"/>. Defining a name for an item type
     allows it to be referenced by name rather than repeating
-    the <termref def="dt-item-type-designator"/> in full.</p>
+    the <termref def="dt-item-type-designator"/> in full every time it is used. Subject to certain constraints, it also allows the
+    type to be recursive: that is, to refer to itself, directly or indirectly. The item type name may also,
+    in appropriate circumstances, be used as the name of a constructor function used to create instances
+    of the item type.</p>
     
     <scrap>
       <prodrecap ref="ItemTypeDecl"/>
@@ -2157,14 +2160,21 @@ local:depth(doc("partlist.xml"))
       declared item types and <termref def="dt-generalized-atomic-type">generalized atomic types</termref>
       in the <termref def="dt-static-context"/> of the query module. <errorref class="ST" code="0146"/></p>
 
-    <p diff="add" at="issue1506">If the declared item type expands to a <termref def="dt-generalized-atomic-type"/>
-      or to a <nt def="RecordType">RecordType</nt>, then the declaration also implicitly defines a
-      <termref def="dt-constructor-function"/> whose name is the name of the item type;
-      the rules are given in <specref ref="id-constructor-functions"/>.</p>
+    <p>If the item type declaration includes the phrase <code>with constructor</code>, then the declaration also implicitly defines a
+      <termref def="dt-constructor-function"/> whose name is the name of the item type. Constructor
+      functions are available only for generalized atomic types and record types:</p>
+    
+    <ulist>
+      <item><p>The rules for generalized atomic types are given in <specref ref="id-constructor-functions"/>.</p></item>
+      <item><p>The rules for record types are given in <specref ref="named-records-as-functions"/>.</p></item>
+      <item><p>If the type is neither a generalized atomic type nor a record type, then a static error is
+      raised ([TODO: define error code]).</p></item>
+    </ulist>
+   
 
     <p diff="add" at="issue1506">Any <code>%public</code> or <code>%private</code> annotations apply
-      both to the item type declaration and to the constructor function. As with named record declarations,
-      the constructor function must not have an arity range that overlaps the arity range of another
+      both to the item type declaration and to the constructor function. The constructor function must not
+      have an arity range that overlaps the arity range of another
       function declaration having the same name in the same static context.</p>
 
     <example diff="add" at="issue1506">
@@ -2194,10 +2204,46 @@ local:depth(doc("partlist.xml"))
     its definition. However, it is generally more convenient if any named item types used
     in public function and variable declarations are themselves public.</p></note>
     
+    <div3 id="id-recursive-record-types">
+      <head>Recursive Record Types</head>
+      <p>In limited circumstances, a named item type may refer to itself, directly or indirectly. Such
+      an item type is said to be <term>recursive</term>.</p>
+      <p>Specifically, if there is a cycle of references such that <var>T0</var> refers to <var>T1</var>,
+        <var>T1</var> refers to <var>T2</var>, ..., and <var>T/n</var> refers to <var>T0</var>, then
+        at least one of these references must appear within a <term>discretionary field</term> of a record
+      type definition. A field of a record type is discretionary if the empty sequence is a valid value
+      for the field.</p>
+      <note><p>The reason for this rule is to ensure that it is possible to construct
+      instances of the record type.</p></note>
+      <p>The following example shows a simple recursive record type:</p>
+      
+      <eg>declare type linked-list as record(data as item()*, next as linked-list?);</eg>
+      
+      <p>The next example illustrates mutual recursion:</p>
+      
+      <eg>declare type binary-tree as record(left as node?, data as item()*, right as node?);
+declare type node as (binary-tree | leaf);
+declare type leaf as item()*;</eg>
+      
+      <p><termdef id="recursive-record-type" term="recursive record type">A named record type is
+      <term>recursive</term> if it contains a reference to itself, or if it participates
+      in a cycle of named item types where each item type contains a reference to the next.</termdef></p>
+      
+      <p>A static error is raised (<errorref class="ST" code="0023"/>) if there is a cycle 
+        of named item types that does not satisfy the constraints defined in this section.
+      </p>
+      
+      <note><p>Although items other than record types may participate in a cycle, only the
+      record types in the cycle are considered to be recursive.</p></note>
+      
+      <p>There a special rules defining subtyping of recursive record types: see
+        <specref ref="id-itemtype-subtype-aliases"/>.</p>
+    </div3>
     
-  </div2>
+    
   
-  <div2 id="id-named-record-types">
+  
+  <!--<div2 id="id-named-record-types">
     <head>Named Record Types</head>
     <p>Although item type declarations, as described in <specref ref="id-item-type-declaration"/>, can be
     used to give names to record types as well as any other item type, named record types as described
@@ -2279,7 +2325,7 @@ local:depth(doc("partlist.xml"))
         A recursive record type that is not instantiable is considered to be <termref def="dt-implausible"/>, 
         which means that a processor may treat it as an error but is not obliged to do so <errorref class="ST" code="0023"/>.</p>
         
-    </div3>
+    </div3>-->
     <div3 id="named-records-as-functions">
       <head>Constructor Functions for Named Record Types</head>
       
@@ -2297,7 +2343,7 @@ local:depth(doc("partlist.xml"))
    
        <p>The construct:</p>
         
-        <eg>declare record cx:complex(r as xs:double, i as xs:double := 0);</eg>
+        <eg>declare type cx:complex as record(r as xs:double, i as xs:double := 0) with constructor;</eg>
       
       <p>implicitly defines the function:</p>
        
@@ -2312,34 +2358,17 @@ local:depth(doc("partlist.xml"))
       <p>The result of the function is a <termref def="dt-record"/> whose type annotation is the
       declared <termref def="dt-record-type"/>.</p>
       
-      <!--<p>The order of entries in the map corresponds
+      <p>The order of entries in the map corresponds
       to the order of field declarations in the record type. This means, for example, that when
       the map is serialized using the JSON output method, the order of entries in the output will
-      correspond to the order of field declarations.</p>-->
+      correspond to the order of field declarations.</p>
       
-      <!--<p>If a field is declared as optional, by including a question mark after the name, and if it has no initializer,
-      then the initializer <code>:= ()</code> is added implicitly. If the declared type of an optional field does
-        not permit an empty sequence, then the declared type of the function parameter is adjusted by changing the
-        occurrence indicator (from absent to <code>?</code> or from <code>+</code> to <code>*</code>) in order
-      to make the empty sequence an acceptable value.</p>-->
-      
-      <!--<p>Given the declaration:</p>
-      
-      <eg>declare record cx:complex(r as xs:double, i as xs:double? := ());</eg>
-      
-      <p>the equivalent function declaration is:</p>
-       
-       <eg>declare function cx:complex($r as xs:double, $i as xs:double? := ()) as cx:complex {
-  map:merge((
-    { "r": $r },
-    if (exists($i)) { { "i": $i } }
-  ), { "retain-order" : true() })
-};
-       </eg>
-      -->
+    
       
       <p>If any field has an explicit initializer, 
-        then all subsequent fields must also have an explicit initializer
+        then all subsequent fields must either (a) have an explicit initializer, or
+        (b) permit the empty sequence as a value, in which case the initializer <code>:= ()</code>
+        is assumed.
         <errorref class="ST" code="0148"/>.</p>
       
       
@@ -2348,7 +2377,7 @@ local:depth(doc("partlist.xml"))
        <p>More formally, the equivalent function declaration is derived as follows:</p>
      
      <ulist>
-       <item><p>The function annotations are the annotations on the named record declaration.</p></item>
+       <item><p>The function annotations are the annotations on the item type declaration.</p></item>
        <item><p>The function name is the QName of the named record declaration, expanded using
          the <termref def="dt-default-type-namespace-rule"/>. <phrase diff="chg" at="issue2257">If the
        declaration appears in a library module, the resulting QName must be in the
@@ -2362,11 +2391,19 @@ local:depth(doc("partlist.xml"))
        <item><p>The parameters of the function declaration are derived from the fields of the named record
        declaration, in order.</p>
        <ulist>
-         <item><p>The name of the parameter is the name of the field (always an NCName).</p></item>
+         <item><p>The name of the parameter is the name of the field, if this is an NCName. If the field
+         name is not an NCName, then the name of the parameter is an implementation-dependent QName
+         in an implementation-dependent (but non-null) namespace.</p>
+           <note><p>Effectively this means that such a field name cannot be used as a keyword in a function call; the corresponding
+           argument must either be supplied positionally, or must take its default value.</p></note>
+         </item>
          <item><p>The declared type of the parameter is the declared type of the field, defaulting to 
              <code>item()*</code>.</p></item>
          <item><p>The default value for the parameter is given by the initializing expression in
-         the <nt def="ExtendedFieldDeclaration">ExtendedFieldDeclaration</nt>, if present.</p></item>
+         the <nt def="FieldDecl">FieldDecl</nt>, if present. If there is no explicit initializer but
+         the type of the field permits the empty sequence, then the initializer <code>:= ()</code> is
+         assumed. In other cases, the parameter becomes mandatory, which means that all previous
+         parameters are also treated as being mandatory.</p></item>
        </ulist>
        </item>
        
@@ -2374,7 +2411,9 @@ local:depth(doc("partlist.xml"))
        indicator.</p></item>
        <item><p>The body of the function is a <nt def="MapConstructor">MapConstructor</nt>
            containing one <nt def="MapConstructorEntry">MapConstructorEntry</nt> for each field of the record type,
-           in the form <code>"<var>N</var>": $<var>N</var></code>, where <var>N</var> is the field name.</p>
+           in the form <code>"<var>N</var>" : $<var>N</var></code>, where <var>N</var> is the field name in the case where this is an NCName,
+         or in the form <code>"<var>N</var>" : $<var>QN</var></code> where <var>QN</var> is the implementation-dependent
+       QName used to identify a field whose name is not an NCName.</p>
        </item>  
  
  
@@ -2382,26 +2421,7 @@ local:depth(doc("partlist.xml"))
       
        
       
-       <!--<p>Note that a question mark <code>?</code> after the field name indicates that the field is optional from the point of
-       view of conformance of an item to the record type. The presence of an initializer indicates that it is optional
-       from the point of view of a call on the constructor function. The two things are independent of each other. For example:</p>
-     
-       <ulist>
-         <item>
-           <p><code>record(longitude, latitude, altitude?)</code></p>
-           <p>Defines a record type in which <code>altitude</code> entry may be absent, and a constructor
-           function with three arguments, of which the last is optional; if the function is called
-           with two arguments (or with the third argument set to an empty sequence), then there will be no
-           <code>altitude</code> entry in the resulting map.</p>
-           <p><code>record(longitude, latitude, altitude := 0)</code></p>
-           <p>Defines a record type in which all three fields will always be present, and a constructor
-           function in which the third argument can be omitted, defaulting to zero.</p>
-           <p><code>record(longitude, latitude, altitude? := ())</code></p>
-           <p>Defines a record type in which the <code>altitude</code> entry may be absent both from the
-             record and in the function call: but because a default value has been supplied explicitly,
-             the constructed map will always have an entry for <code>altitude</code>.</p>
-         </item>
-       </ulist>-->
+       
       
       <note>
         <p>Although the constructor function for a named record type produces a map in which the
@@ -2418,7 +2438,7 @@ local:depth(doc("partlist.xml"))
          described in <specref ref="id-methods"/>. For example, given the declaration:</p>
        
 <eg role="xquery">
-declare record my:rectangle (
+declare type my:rectangle as record (
    height as xs:double,
    width as xs:double,
    area as fn(my:rectangle) as xs:double 
@@ -2428,7 +2448,7 @@ declare record my:rectangle (
            $rect => map:put('height', $rect?height × $factor)
                  => map:put('width', $rect?width × $factor)
         }
-);
+) with constructor;
                </eg>
       
       
@@ -2443,7 +2463,7 @@ return $box =?> area()</eg>
       <eg>let $box := my:rectangle(3, 2)
 return $box =?> expand(2) =?> perimeter()</eg>
      <note><p>There is nothing to stop a user constructing an instance of <code>my:rectangle</code>
-     in which the <code>area</code> entry holds some different function: while the syntax imitates
+     in which the <code>area</code> or <code>resize</code> entries hold some different function: while the syntax imitates
      that of object-oriented languages, there is no encapsulation.</p></note>
     </div3>
     
@@ -2497,19 +2517,19 @@ module namespace set = "http://qt4cg.org/atomic-set";
       If $A and $B are instances of set:atomic-set, then they
       can be manipulated using methods including:
       
-      $A=?>size() - returns the number of items in the set
-      $A=?>empty() - returns true if the set is empty
-      $A=?>contains($k) - determines whether $k is a member of the set
-      $A=?>contains-all($B) - returns true if $B is a subset of $A
-      $A=?>values() - returns the items in $A, as a sequence
-      $A=?>add($k) - returns a new atomic set containing an additional item
-      $A=?>remove($k) - returns a new atomic set in which the given item is absent
-      $A=?>union($B) - returns a new atomic set holding the union of $A and $B
-      $A=?>intersect($B) - returns a new atomic set holding the intersection of $A and $B
-      $A=?>except($B) - returns a new atomic set holding the difference of $A and $B
+      $A =?> size() - returns the number of items in the set
+      $A =?> empty() - returns true if the set is empty
+      $A =?> contains($k) - determines whether $k is a member of the set
+      $A =?> contains-all($B) - returns true if $B is a subset of $A
+      $A =?> values() - returns the items in $A, as a sequence
+      $A =?> add($k) - returns a new atomic set containing an additional item
+      $A =?> remove($k) - returns a new atomic set in which the given item is absent
+      $A =?> union($B) - returns a new atomic set holding the union of $A and $B
+      $A =?> intersect($B) - returns a new atomic set holding the intersection of $A and $B
+      $A =?> except($B) - returns a new atomic set holding the difference of $A and $B
    :)
    
-   declare %public record set:atomic-set (
+   declare %public type set:atomic-set as record (
        _data        as map(xs:anyAtomicType, xs:boolean),
        size         as fn($set as set:atomic-set) as xs:integer,
        empty        as fn($set as set:atomic-set) as xs:boolean,
@@ -2573,7 +2593,7 @@ module namespace set = "http://qt4cg.org/atomic-set";
     
     
   </div2>
-  
+ 
   
   <div2 id="id-option-declaration">
     <head>Option Declarations</head>

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -2208,7 +2208,7 @@ local:depth(doc("partlist.xml"))
       <head>Recursive Record Types</head>
       <p>In limited circumstances, a named item type may refer to itself, directly or indirectly. Such
       an item type is said to be <term>recursive</term>.</p>
-      <p>Specifically, if there is a cycle of references such that <var>T0</var> refers to <var>T1</var>,
+      <p>If there is a cycle of references such that <var>T0</var> refers to <var>T1</var>,
         <var>T1</var> refers to <var>T2</var>, ..., and <var>T/n</var> refers to <var>T0</var>, then
         at least one of these references must appear within a <term>discretionary field</term> of a record
       type definition. A field of a record type is discretionary if the empty sequence is a valid value
@@ -2352,10 +2352,11 @@ declare type leaf as item()*;</eg>
 };
        </eg>
       
-      <p>So the call <code>cx:complex(3, 2)</code> produces the value <code>{ "r": 3e0, "i": 2e0 }</code>,
-      while the call <code>cx:complex(3)</code> produces the value <code>{ "r": 3e0, "i": 0e0 }</code></p>
+      <p>So the call <code>cx:complex(3, 2)</code> produces the record <code>{ "r": 3e0, "i": 2e0 }</code>,
+      while the call <code>cx:complex(3)</code> produces the record <code>{ "r": 3e0, "i": 0e0 }</code>
+        (in both cases, as instances of the record type <code>cx:complex</code>).</p>
       
-      <p>The result of the function is a <termref def="dt-record"/> whose type annotation is the
+      <p>The result of the constructor function is a <termref def="dt-record"/> whose type annotation is the
       declared <termref def="dt-record-type"/>.</p>
       
       <p>If the record declaration defines a field whose default value is given by an <termref def="dt-inline-func"/>
@@ -2398,7 +2399,7 @@ declare type leaf as item()*;</eg>
          <item><p>No parameter is generated in respect of a field whose default value is an <termref def="dt-inline-func"/>.</p></item>
          <item><p>The name of the parameter is the name of the field, if this is an NCName. If the field
          name is not an NCName, then the name of the parameter is an implementation-dependent QName
-         in an implementation-dependent (but non-null) namespace.</p>
+         in a non-null namespace.</p>
            <note><p>Effectively this means that such a field name cannot be used as a keyword in a function call; the corresponding
            argument must either be supplied positionally, or must take its default value.</p></note>
          </item>
@@ -2415,7 +2416,7 @@ declare type leaf as item()*;</eg>
        <item><p>The return type of the function is the <termref def="dt-record-type"/> being declared, with no occurrence
        indicator.</p></item>
        <item><p>The body of the function is a <nt def="MapConstructor">MapConstructor</nt>
-           containing one <nt def="MapConstructorEntry">MapConstructorEntry</nt> for each field of the record type.
+           containing one <nt def="MapConstructorEntry">MapConstructorEntry</nt> for each field of the record type, in order.
          The <nt def="MapConstructorEntry">MapConstructorEntry</nt> takes one of the following forms, where <var>N</var> is the field name:</p>
          <ulist>
            <item><p>If the default value of the field is the inline function expression <var>M</var>,
@@ -2456,8 +2457,8 @@ declare type my:rectangle as record (
      := fn{?height × ?width},
    resize as fn(my:rectangle, xs:double) as my:rectangle 
      := fn($rect, $factor) {
-           $rect => map:put('height', $rect?height × $factor)
-                 => map:put('width', $rect?width × $factor)
+           $rect +:= {'height': $rect?height × $factor}
+                 +:= {'width': $rect?width × $factor}
         }
 ) with constructor;
                </eg>
@@ -2476,6 +2477,7 @@ return $box =?> expand(2) =?> perimeter()</eg>
      <note><p>The two standard ways of constructing an instance of a record, namely coercion from a map, or the use of a constructor
        function, both disallow setting the value of a method to any value other than its default. This provides a degree
      of encapsulation.</p></note>
+      <ednote><edtext>Should we ban the use of <code>+:=</code> to modify method-values fields?</edtext></ednote>
     </div3>
     
     <div3 id="id-atomic-set-example">

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -2358,6 +2358,10 @@ declare type leaf as item()*;</eg>
       <p>The result of the function is a <termref def="dt-record"/> whose type annotation is the
       declared <termref def="dt-record-type"/>.</p>
       
+      <p>If the record declaration defines a field whose default value is given by an <termref def="dt-inline-func"/>
+      (that is, a method), then the generated constructor function does not include a parameter corresponding
+      to that field; the corresponding field in the constructed record will always take its default value.</p>
+      
       <p>The order of entries in the map corresponds
       to the order of field declarations in the record type. This means, for example, that when
       the map is serialized using the JSON output method, the order of entries in the output will
@@ -2391,6 +2395,7 @@ declare type leaf as item()*;</eg>
        <item><p>The parameters of the function declaration are derived from the fields of the named record
        declaration, in order.</p>
        <ulist>
+         <item><p>No parameter is generated in respect of a field whose default value is an <termref def="dt-inline-func"/>.</p></item>
          <item><p>The name of the parameter is the name of the field, if this is an NCName. If the field
          name is not an NCName, then the name of the parameter is an implementation-dependent QName
          in an implementation-dependent (but non-null) namespace.</p>
@@ -2410,10 +2415,16 @@ declare type leaf as item()*;</eg>
        <item><p>The return type of the function is the <termref def="dt-record-type"/> being declared, with no occurrence
        indicator.</p></item>
        <item><p>The body of the function is a <nt def="MapConstructor">MapConstructor</nt>
-           containing one <nt def="MapConstructorEntry">MapConstructorEntry</nt> for each field of the record type,
-           in the form <code>"<var>N</var>" : $<var>N</var></code>, where <var>N</var> is the field name in the case where this is an NCName,
-         or in the form <code>"<var>N</var>" : $<var>QN</var></code> where <var>QN</var> is the implementation-dependent
-       QName used to identify a field whose name is not an NCName.</p>
+           containing one <nt def="MapConstructorEntry">MapConstructorEntry</nt> for each field of the record type.
+         The <nt def="MapConstructorEntry">MapConstructorEntry</nt> takes one of the following forms, where <var>N</var> is the field name:</p>
+         <ulist>
+           <item><p>If the default value of the field is the inline function expression <var>M</var>,
+             then <code>"<var>N</var>" : <var>M</var></code>.</p></item>
+           <item><p>Otherwise, if <var>N</var> is an NCName, 
+             then <code>"<var>N</var>" : $<var>N</var></code>.</p></item>
+           <item><p>Otherwise, <code>"<var>N</var>" : $<var>QN</var></code> where <var>QN</var> is the implementation-dependent
+             QName used to identify a field whose name is not an NCName.</p></item>
+         </ulist>
        </item>  
  
  
@@ -2462,9 +2473,9 @@ return $box =?> area()</eg>
         calculates the perimeter of the result:</p>
       <eg>let $box := my:rectangle(3, 2)
 return $box =?> expand(2) =?> perimeter()</eg>
-     <note><p>There is nothing to stop a user constructing an instance of <code>my:rectangle</code>
-     in which the <code>area</code> or <code>resize</code> entries hold some different function: while the syntax imitates
-     that of object-oriented languages, there is no encapsulation.</p></note>
+     <note><p>The two standard ways of constructing an instance of a record, namely coercion from a map, or the use of a constructor
+       function, both disallow setting the value of a method to any value other than its default. This provides a degree
+     of encapsulation.</p></note>
     </div3>
     
     <div3 id="id-atomic-set-example">

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -2093,7 +2093,10 @@ local:depth(doc("partlist.xml"))
 
     <p>An item type declaration defines a name for an <termref def="dt-item-type"/>. Defining a name for an item type
     allows it to be referenced by name rather than repeating
-    the <termref def="dt-item-type-designator"/> in full.</p>
+    the <termref def="dt-item-type-designator"/> in full every time it is used. Subject to certain constraints, it also allows the
+    type to be recursive: that is, to refer to itself, directly or indirectly. The item type name may also,
+    in appropriate circumstances, be used as the name of a constructor function used to create instances
+    of the item type.</p>
     
     <scrap>
       <prodrecap ref="ItemTypeDecl"/>
@@ -2170,14 +2173,21 @@ local:depth(doc("partlist.xml"))
       declared item types and <termref def="dt-generalized-atomic-type">generalized atomic types</termref>
       in the <termref def="dt-static-context"/> of the query module. <errorref class="ST" code="0146"/></p>
 
-    <p diff="add" at="issue1506">If the declared item type expands to a <termref def="dt-generalized-atomic-type"/>
-      or to a <nt def="RecordType">RecordType</nt>, then the declaration also implicitly defines a
-      <termref def="dt-constructor-function"/> whose name is the name of the item type;
-      the rules are given in <specref ref="id-constructor-functions"/>.</p>
+    <p>If the item type declaration includes the phrase <code>with constructor</code>, then the declaration also implicitly defines a
+      <termref def="dt-constructor-function"/> whose name is the name of the item type. Constructor
+      functions are available only for generalized atomic types and record types:</p>
+    
+    <ulist>
+      <item><p>The rules for generalized atomic types are given in <specref ref="id-constructor-functions"/>.</p></item>
+      <item><p>The rules for record types are given in <specref ref="named-records-as-functions"/>.</p></item>
+      <item><p>If the type is neither a generalized atomic type nor a record type, then a static error is
+      raised ([TODO: define error code]).</p></item>
+    </ulist>
+   
 
     <p diff="add" at="issue1506">Any <code>%public</code> or <code>%private</code> annotations apply
-      both to the item type declaration and to the constructor function. As with named record declarations,
-      the constructor function must not have an arity range that overlaps the arity range of another
+      both to the item type declaration and to the constructor function. The constructor function must not
+      have an arity range that overlaps the arity range of another
       function declaration having the same name in the same static context.</p>
 
     <example diff="add" at="issue1506">
@@ -2207,10 +2217,46 @@ local:depth(doc("partlist.xml"))
     its definition. However, it is generally more convenient if any named item types used
     in public function and variable declarations are themselves public.</p></note>
     
+    <div3 id="id-recursive-record-types">
+      <head>Recursive Record Types</head>
+      <p>In limited circumstances, a named item type may refer to itself, directly or indirectly. Such
+      an item type is said to be <term>recursive</term>.</p>
+      <p>Specifically, if there is a cycle of references such that <var>T0</var> refers to <var>T1</var>,
+        <var>T1</var> refers to <var>T2</var>, ..., and <var>T/n</var> refers to <var>T0</var>, then
+        at least one of these references must appear within a <term>discretionary field</term> of a record
+      type definition. A field of a record type is discretionary if the empty sequence is a valid value
+      for the field.</p>
+      <note><p>The reason for this rule is to ensure that it is possible to construct
+      instances of the record type.</p></note>
+      <p>The following example shows a simple recursive record type:</p>
+      
+      <eg>declare type linked-list as record(data as item()*, next as linked-list?);</eg>
+      
+      <p>The next example illustrates mutual recursion:</p>
+      
+      <eg>declare type binary-tree as record(left as node?, data as item()*, right as node?);
+declare type node as (binary-tree | leaf);
+declare type leaf as item()*;</eg>
+      
+      <p><termdef id="recursive-record-type" term="recursive record type">A named record type is
+      <term>recursive</term> if it contains a reference to itself, or if it participates
+      in a cycle of named item types where each item type contains a reference to the next.</termdef></p>
+      
+      <p>A static error is raised (<errorref class="ST" code="0023"/>) if there is a cycle 
+        of named item types that does not satisfy the constraints defined in this section.
+      </p>
+      
+      <note><p>Although items other than record types may participate in a cycle, only the
+      record types in the cycle are considered to be recursive.</p></note>
+      
+      <p>There a special rules defining subtyping of recursive record types: see
+        <specref ref="id-itemtype-subtype-aliases"/>.</p>
+    </div3>
     
-  </div2>
+    
   
-  <div2 id="id-named-record-types">
+  
+  <!--<div2 id="id-named-record-types">
     <head>Named Record Types</head>
     <p>Although item type declarations, as described in <specref ref="id-item-type-declaration"/>, can be
     used to give names to record types as well as any other item type, named record types as described
@@ -2292,7 +2338,7 @@ local:depth(doc("partlist.xml"))
         A recursive record type that is not instantiable is considered to be <termref def="dt-implausible"/>, 
         which means that a processor may treat it as an error but is not obliged to do so <errorref class="ST" code="0023"/>.</p>
         
-    </div3>
+    </div3>-->
     <div3 id="named-records-as-functions">
       <head>Constructor Functions for Named Record Types</head>
       
@@ -2310,7 +2356,7 @@ local:depth(doc("partlist.xml"))
    
        <p>The construct:</p>
         
-        <eg>declare record cx:complex(r as xs:double, i as xs:double := 0);</eg>
+        <eg>declare type cx:complex as record(r as xs:double, i as xs:double := 0) with constructor;</eg>
       
       <p>implicitly defines the function:</p>
        
@@ -2325,34 +2371,17 @@ local:depth(doc("partlist.xml"))
       <p>The result of the function is a <termref def="dt-record"/> whose type annotation is the
       declared <termref def="dt-record-type"/>.</p>
       
-      <!--<p>The order of entries in the map corresponds
+      <p>The order of entries in the map corresponds
       to the order of field declarations in the record type. This means, for example, that when
       the map is serialized using the JSON output method, the order of entries in the output will
-      correspond to the order of field declarations.</p>-->
+      correspond to the order of field declarations.</p>
       
-      <!--<p>If a field is declared as optional, by including a question mark after the name, and if it has no initializer,
-      then the initializer <code>:= ()</code> is added implicitly. If the declared type of an optional field does
-        not permit an empty sequence, then the declared type of the function parameter is adjusted by changing the
-        occurrence indicator (from absent to <code>?</code> or from <code>+</code> to <code>*</code>) in order
-      to make the empty sequence an acceptable value.</p>-->
-      
-      <!--<p>Given the declaration:</p>
-      
-      <eg>declare record cx:complex(r as xs:double, i as xs:double? := ());</eg>
-      
-      <p>the equivalent function declaration is:</p>
-       
-       <eg>declare function cx:complex($r as xs:double, $i as xs:double? := ()) as cx:complex {
-  map:merge((
-    { "r": $r },
-    if (exists($i)) { { "i": $i } }
-  ), { "retain-order" : true() })
-};
-       </eg>
-      -->
+    
       
       <p>If any field has an explicit initializer, 
-        then all subsequent fields must also have an explicit initializer
+        then all subsequent fields must either (a) have an explicit initializer, or
+        (b) permit the empty sequence as a value, in which case the initializer <code>:= ()</code>
+        is assumed.
         <errorref class="ST" code="0148"/>.</p>
       
       
@@ -2361,7 +2390,7 @@ local:depth(doc("partlist.xml"))
        <p>More formally, the equivalent function declaration is derived as follows:</p>
      
      <ulist>
-       <item><p>The function annotations are the annotations on the named record declaration.</p></item>
+       <item><p>The function annotations are the annotations on the item type declaration.</p></item>
        <item><p>The function name is the QName of the named record declaration, expanded using
          the <termref def="dt-default-type-namespace-rule"/>. <phrase diff="chg" at="issue2257">If the
        declaration appears in a library module, the resulting QName must be in the
@@ -2375,11 +2404,19 @@ local:depth(doc("partlist.xml"))
        <item><p>The parameters of the function declaration are derived from the fields of the named record
        declaration, in order.</p>
        <ulist>
-         <item><p>The name of the parameter is the name of the field (always an NCName).</p></item>
+         <item><p>The name of the parameter is the name of the field, if this is an NCName. If the field
+         name is not an NCName, then the name of the parameter is an implementation-dependent QName
+         in an implementation-dependent (but non-null) namespace.</p>
+           <note><p>Effectively this means that such a field name cannot be used as a keyword in a function call; the corresponding
+           argument must either be supplied positionally, or must take its default value.</p></note>
+         </item>
          <item><p>The declared type of the parameter is the declared type of the field, defaulting to 
              <code>item()*</code>.</p></item>
          <item><p>The default value for the parameter is given by the initializing expression in
-         the <nt def="ExtendedFieldDeclaration">ExtendedFieldDeclaration</nt>, if present.</p></item>
+         the <nt def="FieldDecl">FieldDecl</nt>, if present. If there is no explicit initializer but
+         the type of the field permits the empty sequence, then the initializer <code>:= ()</code> is
+         assumed. In other cases, the parameter becomes mandatory, which means that all previous
+         parameters are also treated as being mandatory.</p></item>
        </ulist>
        </item>
        
@@ -2387,7 +2424,9 @@ local:depth(doc("partlist.xml"))
        indicator.</p></item>
        <item><p>The body of the function is a <nt def="MapConstructor">MapConstructor</nt>
            containing one <nt def="MapConstructorEntry">MapConstructorEntry</nt> for each field of the record type,
-           in the form <code>"<var>N</var>": $<var>N</var></code>, where <var>N</var> is the field name.</p>
+           in the form <code>"<var>N</var>" : $<var>N</var></code>, where <var>N</var> is the field name in the case where this is an NCName,
+         or in the form <code>"<var>N</var>" : $<var>QN</var></code> where <var>QN</var> is the implementation-dependent
+       QName used to identify a field whose name is not an NCName.</p>
        </item>  
  
  
@@ -2395,26 +2434,7 @@ local:depth(doc("partlist.xml"))
       
        
       
-       <!--<p>Note that a question mark <code>?</code> after the field name indicates that the field is optional from the point of
-       view of conformance of an item to the record type. The presence of an initializer indicates that it is optional
-       from the point of view of a call on the constructor function. The two things are independent of each other. For example:</p>
-     
-       <ulist>
-         <item>
-           <p><code>record(longitude, latitude, altitude?)</code></p>
-           <p>Defines a record type in which <code>altitude</code> entry may be absent, and a constructor
-           function with three arguments, of which the last is optional; if the function is called
-           with two arguments (or with the third argument set to an empty sequence), then there will be no
-           <code>altitude</code> entry in the resulting map.</p>
-           <p><code>record(longitude, latitude, altitude := 0)</code></p>
-           <p>Defines a record type in which all three fields will always be present, and a constructor
-           function in which the third argument can be omitted, defaulting to zero.</p>
-           <p><code>record(longitude, latitude, altitude? := ())</code></p>
-           <p>Defines a record type in which the <code>altitude</code> entry may be absent both from the
-             record and in the function call: but because a default value has been supplied explicitly,
-             the constructed map will always have an entry for <code>altitude</code>.</p>
-         </item>
-       </ulist>-->
+       
       
       <note>
         <p>Although the constructor function for a named record type produces a map in which the
@@ -2431,7 +2451,7 @@ local:depth(doc("partlist.xml"))
          described in <specref ref="id-methods"/>. For example, given the declaration:</p>
        
 <eg role="xquery">
-declare record my:rectangle (
+declare type my:rectangle as record (
    height as xs:double,
    width as xs:double,
    area as fn(my:rectangle) as xs:double 
@@ -2441,7 +2461,7 @@ declare record my:rectangle (
            $rect => map:put('height', $rect?height × $factor)
                  => map:put('width', $rect?width × $factor)
         }
-);
+) with constructor;
                </eg>
       
       
@@ -2456,7 +2476,7 @@ return $box =?> area()</eg>
       <eg>let $box := my:rectangle(3, 2)
 return $box =?> expand(2) =?> perimeter()</eg>
      <note><p>There is nothing to stop a user constructing an instance of <code>my:rectangle</code>
-     in which the <code>area</code> entry holds some different function: while the syntax imitates
+     in which the <code>area</code> or <code>resize</code> entries hold some different function: while the syntax imitates
      that of object-oriented languages, there is no encapsulation.</p></note>
     </div3>
     
@@ -2510,19 +2530,19 @@ module namespace set = "http://qt4cg.org/atomic-set";
       If $A and $B are instances of set:atomic-set, then they
       can be manipulated using methods including:
       
-      $A=?>size() - returns the number of items in the set
-      $A=?>empty() - returns true if the set is empty
-      $A=?>contains($k) - determines whether $k is a member of the set
-      $A=?>contains-all($B) - returns true if $B is a subset of $A
-      $A=?>values() - returns the items in $A, as a sequence
-      $A=?>add($k) - returns a new atomic set containing an additional item
-      $A=?>remove($k) - returns a new atomic set in which the given item is absent
-      $A=?>union($B) - returns a new atomic set holding the union of $A and $B
-      $A=?>intersect($B) - returns a new atomic set holding the intersection of $A and $B
-      $A=?>except($B) - returns a new atomic set holding the difference of $A and $B
+      $A =?> size() - returns the number of items in the set
+      $A =?> empty() - returns true if the set is empty
+      $A =?> contains($k) - determines whether $k is a member of the set
+      $A =?> contains-all($B) - returns true if $B is a subset of $A
+      $A =?> values() - returns the items in $A, as a sequence
+      $A =?> add($k) - returns a new atomic set containing an additional item
+      $A =?> remove($k) - returns a new atomic set in which the given item is absent
+      $A =?> union($B) - returns a new atomic set holding the union of $A and $B
+      $A =?> intersect($B) - returns a new atomic set holding the intersection of $A and $B
+      $A =?> except($B) - returns a new atomic set holding the difference of $A and $B
    :)
    
-   declare %public record set:atomic-set (
+   declare %public type set:atomic-set as record (
        _data        as map(xs:anyAtomicType, xs:boolean),
        size         as fn($set as set:atomic-set) as xs:integer,
        empty        as fn($set as set:atomic-set) as xs:boolean,
@@ -2586,7 +2606,7 @@ module namespace set = "http://qt4cg.org/atomic-set";
     
     
   </div2>
-  
+ 
   
   <div2 id="id-option-declaration">
     <head>Option Declarations</head>

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -2221,7 +2221,7 @@ local:depth(doc("partlist.xml"))
       <head>Recursive Record Types</head>
       <p>In limited circumstances, a named item type may refer to itself, directly or indirectly. Such
       an item type is said to be <term>recursive</term>.</p>
-      <p>Specifically, if there is a cycle of references such that <var>T0</var> refers to <var>T1</var>,
+      <p>If there is a cycle of references such that <var>T0</var> refers to <var>T1</var>,
         <var>T1</var> refers to <var>T2</var>, ..., and <var>T/n</var> refers to <var>T0</var>, then
         at least one of these references must appear within a <term>discretionary field</term> of a record
       type definition. A field of a record type is discretionary if the empty sequence is a valid value
@@ -2365,10 +2365,11 @@ declare type leaf as item()*;</eg>
 };
        </eg>
       
-      <p>So the call <code>cx:complex(3, 2)</code> produces the value <code>{ "r": 3e0, "i": 2e0 }</code>,
-      while the call <code>cx:complex(3)</code> produces the value <code>{ "r": 3e0, "i": 0e0 }</code></p>
+      <p>So the call <code>cx:complex(3, 2)</code> produces the record <code>{ "r": 3e0, "i": 2e0 }</code>,
+      while the call <code>cx:complex(3)</code> produces the record <code>{ "r": 3e0, "i": 0e0 }</code>
+        (in both cases, as instances of the record type <code>cx:complex</code>).</p>
       
-      <p>The result of the function is a <termref def="dt-record"/> whose type annotation is the
+      <p>The result of the constructor function is a <termref def="dt-record"/> whose type annotation is the
       declared <termref def="dt-record-type"/>.</p>
       
       <p>If the record declaration defines a field whose default value is given by an <termref def="dt-inline-func"/>
@@ -2411,7 +2412,7 @@ declare type leaf as item()*;</eg>
          <item><p>No parameter is generated in respect of a field whose default value is an <termref def="dt-inline-func"/>.</p></item>
          <item><p>The name of the parameter is the name of the field, if this is an NCName. If the field
          name is not an NCName, then the name of the parameter is an implementation-dependent QName
-         in an implementation-dependent (but non-null) namespace.</p>
+         in a non-null namespace.</p>
            <note><p>Effectively this means that such a field name cannot be used as a keyword in a function call; the corresponding
            argument must either be supplied positionally, or must take its default value.</p></note>
          </item>
@@ -2428,7 +2429,7 @@ declare type leaf as item()*;</eg>
        <item><p>The return type of the function is the <termref def="dt-record-type"/> being declared, with no occurrence
        indicator.</p></item>
        <item><p>The body of the function is a <nt def="MapConstructor">MapConstructor</nt>
-           containing one <nt def="MapConstructorEntry">MapConstructorEntry</nt> for each field of the record type.
+           containing one <nt def="MapConstructorEntry">MapConstructorEntry</nt> for each field of the record type, in order.
          The <nt def="MapConstructorEntry">MapConstructorEntry</nt> takes one of the following forms, where <var>N</var> is the field name:</p>
          <ulist>
            <item><p>If the default value of the field is the inline function expression <var>M</var>,
@@ -2469,8 +2470,8 @@ declare type my:rectangle as record (
      := fn{?height × ?width},
    resize as fn(my:rectangle, xs:double) as my:rectangle 
      := fn($rect, $factor) {
-           $rect => map:put('height', $rect?height × $factor)
-                 => map:put('width', $rect?width × $factor)
+           $rect +:= {'height': $rect?height × $factor}
+                 +:= {'width': $rect?width × $factor}
         }
 ) with constructor;
                </eg>
@@ -2489,6 +2490,7 @@ return $box =?> expand(2) =?> perimeter()</eg>
      <note><p>The two standard ways of constructing an instance of a record, namely coercion from a map, or the use of a constructor
        function, both disallow setting the value of a method to any value other than its default. This provides a degree
      of encapsulation.</p></note>
+      <ednote><edtext>Should we ban the use of <code>+:=</code> to modify method-values fields?</edtext></ednote>
     </div3>
     
     <div3 id="id-atomic-set-example">

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -2371,6 +2371,10 @@ declare type leaf as item()*;</eg>
       <p>The result of the function is a <termref def="dt-record"/> whose type annotation is the
       declared <termref def="dt-record-type"/>.</p>
       
+      <p>If the record declaration defines a field whose default value is given by an <termref def="dt-inline-func"/>
+      (that is, a method), then the generated constructor function does not include a parameter corresponding
+      to that field; the corresponding field in the constructed record will always take its default value.</p>
+      
       <p>The order of entries in the map corresponds
       to the order of field declarations in the record type. This means, for example, that when
       the map is serialized using the JSON output method, the order of entries in the output will
@@ -2404,6 +2408,7 @@ declare type leaf as item()*;</eg>
        <item><p>The parameters of the function declaration are derived from the fields of the named record
        declaration, in order.</p>
        <ulist>
+         <item><p>No parameter is generated in respect of a field whose default value is an <termref def="dt-inline-func"/>.</p></item>
          <item><p>The name of the parameter is the name of the field, if this is an NCName. If the field
          name is not an NCName, then the name of the parameter is an implementation-dependent QName
          in an implementation-dependent (but non-null) namespace.</p>
@@ -2423,10 +2428,16 @@ declare type leaf as item()*;</eg>
        <item><p>The return type of the function is the <termref def="dt-record-type"/> being declared, with no occurrence
        indicator.</p></item>
        <item><p>The body of the function is a <nt def="MapConstructor">MapConstructor</nt>
-           containing one <nt def="MapConstructorEntry">MapConstructorEntry</nt> for each field of the record type,
-           in the form <code>"<var>N</var>" : $<var>N</var></code>, where <var>N</var> is the field name in the case where this is an NCName,
-         or in the form <code>"<var>N</var>" : $<var>QN</var></code> where <var>QN</var> is the implementation-dependent
-       QName used to identify a field whose name is not an NCName.</p>
+           containing one <nt def="MapConstructorEntry">MapConstructorEntry</nt> for each field of the record type.
+         The <nt def="MapConstructorEntry">MapConstructorEntry</nt> takes one of the following forms, where <var>N</var> is the field name:</p>
+         <ulist>
+           <item><p>If the default value of the field is the inline function expression <var>M</var>,
+             then <code>"<var>N</var>" : <var>M</var></code>.</p></item>
+           <item><p>Otherwise, if <var>N</var> is an NCName, 
+             then <code>"<var>N</var>" : $<var>N</var></code>.</p></item>
+           <item><p>Otherwise, <code>"<var>N</var>" : $<var>QN</var></code> where <var>QN</var> is the implementation-dependent
+             QName used to identify a field whose name is not an NCName.</p></item>
+         </ulist>
        </item>  
  
  
@@ -2475,9 +2486,9 @@ return $box =?> area()</eg>
         calculates the perimeter of the result:</p>
       <eg>let $box := my:rectangle(3, 2)
 return $box =?> expand(2) =?> perimeter()</eg>
-     <note><p>There is nothing to stop a user constructing an instance of <code>my:rectangle</code>
-     in which the <code>area</code> or <code>resize</code> entries hold some different function: while the syntax imitates
-     that of object-oriented languages, there is no encapsulation.</p></note>
+     <note><p>The two standard ways of constructing an instance of a record, namely coercion from a map, or the use of a constructor
+       function, both disallow setting the value of a method to any value other than its default. This provides a degree
+     of encapsulation.</p></note>
     </div3>
     
     <div3 id="id-atomic-set-example">


### PR DESCRIPTION
Now that "declare type" produces constructor functions, there is no longer any good reason to preserve the overlapping functionality of "declare type" and "declare record".

This PR currently makes the XQuery changes to merge these constructs; I intend to make similar changes for XSLT.

Along the way, there are some other minor changes:

* The definition of Constant now allows the empty sequence, ()
* The initialiser defining the default value of a field in a record type must be a Constant
* The default value for a field is used in coercion from maps to record types as well as in constructor functions
* Creating a constructor function for a named type is optional, by explicit request
* Constructor functions can be created for a record type even if its field names are not all NCNames
* The rule that coercion from maps to record types doesn't allow extraneous fields in the map is now explicit. We seem to have somehow referred to this rule without actually defining it. 