### PR TITLE
2790 fn:pad-string, truncation

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -34328,9 +34328,10 @@ return every($dl/*, fn($elem, $pos) {
             <termref def="character">characters</termref>, it is returned unchanged: the function
             never truncates. Otherwise, padding characters are added to bring its length up to
             <code>$length</code> characters. They are formed by repeating the <code>padding</code>
-            option as often as necessary and truncating the result to the number of characters
-            required: for example, seven padding characters formed from <code>"ab"</code> are
-            <code>"abababa"</code>.</p>
+            option as often as necessary and truncating the result on the right to the number of
+            characters required: each run of padding characters is thus a prefix of the repeated
+            <code>padding</code> string. For example, seven padding characters formed from
+            <code>"ab"</code> are <code>"abababa"</code>.</p>
          <p>The <code>side</code> option determines where the padding characters are added: at the
             end of the input string, at its start, or divided between both sides. In the last case
             each of the two runs is formed independently, and if an odd number of padding characters
@@ -34369,6 +34370,18 @@ return every($dl/*, fn($elem, $pos) {
             <fos:test>
                <fos:expression><eg>pad-string("abc", 8, { "side": "both", "padding": "*" })</eg></fos:expression>
                <fos:result>"**abc***"</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>pad-string("x", 5, { "padding": "0123456789", "side": "start" })</eg></fos:expression>
+               <fos:result>"0123x"</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>pad-string("x", 8, { "padding": "0123456789", "side": "both" })</eg></fos:expression>
+               <fos:result>"012x0123"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>


### PR DESCRIPTION
I hope it’s less ambiguous now. Closes #2790
No extra QT4 tests needed (the PR contains two new examples).