### PR TITLE
2748 CSV Serialization

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -21847,6 +21847,42 @@ return $typed-result instance of element(distance, xs:decimal)
                      <code>()</code>
                   </td>
                </tr>
+               <tr diff="add" at="2026-07-02">
+                  <td>
+                     <code>csv-header</code>
+                  </td>
+                  <td>
+                     <code>xs:boolean?</code>
+                  </td>
+                  <td><code>true()</code> means <code>"yes"</code>, <code>false()</code> means <code>"no"</code></td>
+                  <td>
+                     <code>no</code>
+                  </td>
+               </tr>
+               <tr diff="add" at="2026-07-02">
+                  <td>
+                     <code>csv-quote-character</code>
+                  </td>
+                  <td>
+                     <code>xs:string?</code>
+                  </td>
+                  <td/>
+                  <td>
+                     <code>"</code>
+                  </td>
+               </tr>
+               <tr diff="add" at="2026-07-02">
+                  <td>
+                     <code>csv-separator</code>
+                  </td>
+                  <td>
+                     <code>xs:string?</code>
+                  </td>
+                  <td/>
+                  <td>
+                     <code>,</code>
+                  </td>
+               </tr>
                <tr>
                   <td>
                      <code>doctype-public</code>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -21933,6 +21933,42 @@ return $typed-result instance of element(distance, xs:decimal)
                      <code>()</code>
                   </td>
                </tr>
+               <tr diff="add" at="2026-07-02">
+                  <td>
+                     <code>csv-header</code>
+                  </td>
+                  <td>
+                     <code>xs:boolean?</code>
+                  </td>
+                  <td><code>true()</code> means <code>"yes"</code>, <code>false()</code> means <code>"no"</code></td>
+                  <td>
+                     <code>no</code>
+                  </td>
+               </tr>
+               <tr diff="add" at="2026-07-02">
+                  <td>
+                     <code>csv-quote-character</code>
+                  </td>
+                  <td>
+                     <code>xs:string?</code>
+                  </td>
+                  <td/>
+                  <td>
+                     <code>"</code>
+                  </td>
+               </tr>
+               <tr diff="add" at="2026-07-02">
+                  <td>
+                     <code>csv-separator</code>
+                  </td>
+                  <td>
+                     <code>xs:string?</code>
+                  </td>
+                  <td/>
+                  <td>
+                     <code>,</code>
+                  </td>
+               </tr>
                <tr>
                   <td>
                      <code>doctype-public</code>

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -2806,6 +2806,18 @@ parent. </p>
   <td>cdata-section-elements</td>
   <td>empty</td>
 </tr>
+<tr diff="add" at="2026-07-02">
+  <td>csv-header</td>
+  <td>no</td>
+</tr>
+<tr diff="add" at="2026-07-02">
+  <td>csv-quote-character</td>
+  <td><code>"</code></td>
+</tr>
+<tr diff="add" at="2026-07-02">
+  <td>csv-separator</td>
+  <td><code>,</code></td>
+</tr>
 <tr>
   <td>doctype-public</td>
   <td>none</td>

--- a/specifications/xslt-40/src/element-catalog.xml
+++ b/specifications/xslt-40/src/element-catalog.xml
@@ -1958,6 +1958,7 @@
             <e:constant value="xhtml"/>
             <e:constant value="text"/>
             <e:constant value="json"/>
+            <e:constant value="csv"/>
             <e:constant value="adaptive"/>
             <e:data-type name="eqname"/>
          </e:attribute-value-template>
@@ -1985,6 +1986,21 @@
       <e:attribute name="cdata-section-elements">
          <e:attribute-value-template>
             <e:data-type name="eqnames"/>
+         </e:attribute-value-template>
+      </e:attribute>
+      <e:attribute name="csv-header">
+         <e:attribute-value-template>
+            <e:data-type name="boolean"/>
+         </e:attribute-value-template>
+      </e:attribute>
+      <e:attribute name="csv-quote-character">
+         <e:attribute-value-template>
+            <e:data-type name="string"/>
+         </e:attribute-value-template>
+      </e:attribute>
+      <e:attribute name="csv-separator">
+         <e:attribute-value-template>
+            <e:data-type name="string"/>
          </e:attribute-value-template>
       </e:attribute>
       <e:attribute name="doctype-public">
@@ -2115,6 +2131,7 @@
          <e:constant value="xhtml"/>
          <e:constant value="text"/>
          <e:constant value="json"/>
+         <e:constant value="csv"/>
          <e:constant value="adaptive"/>
          <e:data-type name="eqname"/>
       </e:attribute>
@@ -2132,6 +2149,15 @@
       </e:attribute>
       <e:attribute name="cdata-section-elements">
          <e:data-type name="eqnames"/>
+      </e:attribute>
+      <e:attribute name="csv-header">
+         <e:data-type name="boolean"/>
+      </e:attribute>
+      <e:attribute name="csv-quote-character">
+         <e:data-type name="string"/>
+      </e:attribute>
+      <e:attribute name="csv-separator">
+         <e:data-type name="string"/>
       </e:attribute>
       <e:attribute name="doctype-public">
          <e:data-type name="string"/>

--- a/specifications/xslt-40/src/element-catalog.xml
+++ b/specifications/xslt-40/src/element-catalog.xml
@@ -1958,6 +1958,7 @@
             <e:constant value="xhtml"/>
             <e:constant value="text"/>
             <e:constant value="json"/>
+            <e:constant value="csv"/>
             <e:constant value="adaptive"/>
             <e:data-type name="eqname"/>
          </e:attribute-value-template>
@@ -1985,6 +1986,21 @@
       <e:attribute name="cdata-section-elements">
          <e:attribute-value-template>
             <e:data-type name="eqnames"/>
+         </e:attribute-value-template>
+      </e:attribute>
+      <e:attribute name="csv-header">
+         <e:attribute-value-template>
+            <e:data-type name="boolean"/>
+         </e:attribute-value-template>
+      </e:attribute>
+      <e:attribute name="csv-quote-character">
+         <e:attribute-value-template>
+            <e:data-type name="string"/>
+         </e:attribute-value-template>
+      </e:attribute>
+      <e:attribute name="csv-separator">
+         <e:attribute-value-template>
+            <e:data-type name="string"/>
          </e:attribute-value-template>
       </e:attribute>
       <e:attribute name="doctype-public">
@@ -2130,6 +2146,7 @@
          <e:constant value="xhtml"/>
          <e:constant value="text"/>
          <e:constant value="json"/>
+         <e:constant value="csv"/>
          <e:constant value="adaptive"/>
          <e:data-type name="eqname"/>
       </e:attribute>
@@ -2147,6 +2164,15 @@
       </e:attribute>
       <e:attribute name="cdata-section-elements">
          <e:data-type name="eqnames"/>
+      </e:attribute>
+      <e:attribute name="csv-header">
+         <e:data-type name="boolean"/>
+      </e:attribute>
+      <e:attribute name="csv-quote-character">
+         <e:data-type name="string"/>
+      </e:attribute>
+      <e:attribute name="csv-separator">
+         <e:data-type name="string"/>
       </e:attribute>
       <e:attribute name="doctype-public">
          <e:data-type name="string"/>

--- a/specifications/xslt-40/src/schema-for-xslt40.rnc
+++ b/specifications/xslt-40/src/schema-for-xslt40.rnc
@@ -197,7 +197,7 @@ mode.datatype = eqname.datatype | "#unnamed" | "#default" | "#current"
 on-no-match.datatype = "deep-copy" | "shallow-copy" | "shallow-copy-all" | "deep-skip" | "shallow-skip" | "text-only-copy" | "fail"
 streamability.datatype = eqname.datatype | "unclassified" | "absorbing" | "inspection" | "filter" | "shallow-descent" | "deep-descent" | "ascent"
 validation.datatype = "strict" | "lax" | "preserve" | "strip"
-method.datatype = eqname.datatype | "xml" | "xhtml" | "html" | "text" | "json" | "adaptive"
+method.datatype = eqname.datatype | "xml" | "xhtml" | "html" | "text" | "json" | "csv" | "adaptive"
 
 avt.datatype =
   xsd:string
@@ -1293,6 +1293,12 @@ result-document.element =
       attribute _canonical { avt.datatype }?,
       attribute cdata-section-elements { eqnames.datatype | avt.datatype }?,
       attribute _cdata-section-elements { avt.datatype }?,
+      attribute csv-header { boolean.datatype | avt.datatype }?,
+      attribute _csv-header { avt.datatype }?,
+      attribute csv-quote-character { string.datatype | avt.datatype }?,
+      attribute _csv-quote-character { avt.datatype }?,
+      attribute csv-separator { string.datatype | avt.datatype }?,
+      attribute _csv-separator { avt.datatype }?,
       attribute doctype-public { string.datatype | avt.datatype }?,
       attribute _doctype-public { avt.datatype }?,
       attribute doctype-system { string.datatype | avt.datatype }?,
@@ -1349,6 +1355,12 @@ output.element =
       attribute _canonical { avt.datatype }?,
       attribute cdata-section-elements { eqnames.datatype }?,
       attribute _cdata-section-elements { avt.datatype }?,
+      attribute csv-header { boolean.datatype }?,
+      attribute _csv-header { avt.datatype }?,
+      attribute csv-quote-character { string.datatype }?,
+      attribute _csv-quote-character { avt.datatype }?,
+      attribute csv-separator { string.datatype }?,
+      attribute _csv-separator { avt.datatype }?,
       attribute doctype-public { string.datatype }?,
       attribute _doctype-public { avt.datatype }?,
       attribute doctype-system { string.datatype }?,

--- a/specifications/xslt-40/src/schema-for-xslt40.rnc
+++ b/specifications/xslt-40/src/schema-for-xslt40.rnc
@@ -197,7 +197,7 @@ mode.datatype = eqname.datatype | "#unnamed" | "#default" | "#current"
 on-no-match.datatype = "deep-copy" | "shallow-copy" | "shallow-copy-all" | "deep-skip" | "shallow-skip" | "text-only-copy" | "fail"
 streamability.datatype = eqname.datatype | "unclassified" | "absorbing" | "inspection" | "filter" | "shallow-descent" | "deep-descent" | "ascent"
 validation.datatype = "strict" | "lax" | "preserve" | "strip"
-method.datatype = eqname.datatype | "xml" | "xhtml" | "html" | "text" | "json" | "adaptive"
+method.datatype = eqname.datatype | "xml" | "xhtml" | "html" | "text" | "json" | "csv" | "adaptive"
 
 avt.datatype =
   xsd:string
@@ -1293,6 +1293,12 @@ result-document.element =
       attribute _canonical { avt.datatype }?,
       attribute cdata-section-elements { eqnames.datatype | avt.datatype }?,
       attribute _cdata-section-elements { avt.datatype }?,
+      attribute csv-header { boolean.datatype | avt.datatype }?,
+      attribute _csv-header { avt.datatype }?,
+      attribute csv-quote-character { string.datatype | avt.datatype }?,
+      attribute _csv-quote-character { avt.datatype }?,
+      attribute csv-separator { string.datatype | avt.datatype }?,
+      attribute _csv-separator { avt.datatype }?,
       attribute doctype-public { string.datatype | avt.datatype }?,
       attribute _doctype-public { avt.datatype }?,
       attribute doctype-system { string.datatype | avt.datatype }?,
@@ -1355,6 +1361,12 @@ output.element =
       attribute _canonical { avt.datatype }?,
       attribute cdata-section-elements { eqnames.datatype }?,
       attribute _cdata-section-elements { avt.datatype }?,
+      attribute csv-header { boolean.datatype }?,
+      attribute _csv-header { avt.datatype }?,
+      attribute csv-quote-character { string.datatype }?,
+      attribute _csv-quote-character { avt.datatype }?,
+      attribute csv-separator { string.datatype }?,
+      attribute _csv-separator { avt.datatype }?,
       attribute doctype-public { string.datatype }?,
       attribute _doctype-public { avt.datatype }?,
       attribute doctype-system { string.datatype }?,

--- a/specifications/xslt-40/src/schema-for-xslt40.xsd
+++ b/specifications/xslt-40/src/schema-for-xslt40.xsd
@@ -1467,6 +1467,9 @@ of problems processing the schema using various tools
           <xs:attribute name="byte-order-mark" type="xsl:yes-or-no"/>
           <xs:attribute name="canonical" type="xsl:yes-or-no"/>
           <xs:attribute name="cdata-section-elements" type="xsl:EQNames"/>
+          <xs:attribute name="csv-header" type="xsl:yes-or-no"/>
+          <xs:attribute name="csv-quote-character" type="xs:string"/>
+          <xs:attribute name="csv-separator" type="xs:string"/>
           <xs:attribute name="doctype-public" type="xs:string"/>
           <xs:attribute name="doctype-system" type="xs:string"/>
           <xs:attribute name="encoding" type="xs:string"/>
@@ -1494,6 +1497,9 @@ of problems processing the schema using various tools
           <xs:attribute name="_byte-order-mark" type="xs:string"/>
           <xs:attribute name="_canonical" type="xs:string"/>
           <xs:attribute name="_cdata-section-elements" type="xs:string"/>
+          <xs:attribute name="_csv-header" type="xs:string"/>
+          <xs:attribute name="_csv-quote-character" type="xs:string"/>
+          <xs:attribute name="_csv-separator" type="xs:string"/>
           <xs:attribute name="_doctype-public" type="xs:string"/>
           <xs:attribute name="_doctype-system" type="xs:string"/>
           <xs:attribute name="_encoding" type="xs:string"/>
@@ -1748,6 +1754,9 @@ of problems processing the schema using various tools
           <xs:attribute name="byte-order-mark" type="xsl:avt"/>
           <xs:attribute name="canonical" type="xsl:avt"/>
           <xs:attribute name="cdata-section-elements" type="xsl:avt"/>
+          <xs:attribute name="csv-header" type="xsl:avt"/>
+          <xs:attribute name="csv-quote-character" type="xsl:avt"/>
+          <xs:attribute name="csv-separator" type="xsl:avt"/>
           <xs:attribute name="doctype-public" type="xsl:avt"/>
           <xs:attribute name="doctype-system" type="xsl:avt"/>
           <xs:attribute name="encoding" type="xsl:avt"/>
@@ -1779,6 +1788,9 @@ of problems processing the schema using various tools
           <xs:attribute name="_byte-order-mark" type="xs:string"/>
           <xs:attribute name="_canonical" type="xs:string"/>
           <xs:attribute name="_cdata-section-elements" type="xs:string"/>
+          <xs:attribute name="_csv-header" type="xs:string"/>
+          <xs:attribute name="_csv-quote-character" type="xs:string"/>
+          <xs:attribute name="_csv-separator" type="xs:string"/>
           <xs:attribute name="_doctype-public" type="xs:string"/>
           <xs:attribute name="_doctype-system" type="xs:string"/>
           <xs:attribute name="_encoding" type="xs:string"/>
@@ -2727,7 +2739,7 @@ of problems processing the schema using various tools
       <xs:documentation>
         <p>
            The <code>method</code> attribute of <code>xsl:output</code>: Either one of the recognized names
-           "xml", "xhtml", "html", "text", "json", or "adaptive",
+           "xml", "xhtml", "html", "text", "json", "csv", or "adaptive",
             or an EQName that must include a prefix or namespace URI.
         </p>
       </xs:documentation>
@@ -2740,6 +2752,7 @@ of problems processing the schema using various tools
           <xs:enumeration value="html"/>
           <xs:enumeration value="text"/>
           <xs:enumeration value="json"/>
+          <xs:enumeration value="csv"/>
           <xs:enumeration value="adaptive"/>
         </xs:restriction>
       </xs:simpleType>

--- a/specifications/xslt-40/src/schema-for-xslt40.xsd
+++ b/specifications/xslt-40/src/schema-for-xslt40.xsd
@@ -1467,6 +1467,9 @@ of problems processing the schema using various tools
           <xs:attribute name="byte-order-mark" type="xsl:yes-or-no"/>
           <xs:attribute name="canonical" type="xsl:yes-or-no"/>
           <xs:attribute name="cdata-section-elements" type="xsl:EQNames"/>
+          <xs:attribute name="csv-header" type="xsl:yes-or-no"/>
+          <xs:attribute name="csv-quote-character" type="xs:string"/>
+          <xs:attribute name="csv-separator" type="xs:string"/>
           <xs:attribute name="doctype-public" type="xs:string"/>
           <xs:attribute name="doctype-system" type="xs:string"/>
           <xs:attribute name="encoding" type="xs:string"/>
@@ -1497,6 +1500,9 @@ of problems processing the schema using various tools
           <xs:attribute name="_byte-order-mark" type="xs:string"/>
           <xs:attribute name="_canonical" type="xs:string"/>
           <xs:attribute name="_cdata-section-elements" type="xs:string"/>
+          <xs:attribute name="_csv-header" type="xs:string"/>
+          <xs:attribute name="_csv-quote-character" type="xs:string"/>
+          <xs:attribute name="_csv-separator" type="xs:string"/>
           <xs:attribute name="_doctype-public" type="xs:string"/>
           <xs:attribute name="_doctype-system" type="xs:string"/>
           <xs:attribute name="_encoding" type="xs:string"/>
@@ -1754,6 +1760,9 @@ of problems processing the schema using various tools
           <xs:attribute name="byte-order-mark" type="xsl:avt"/>
           <xs:attribute name="canonical" type="xsl:avt"/>
           <xs:attribute name="cdata-section-elements" type="xsl:avt"/>
+          <xs:attribute name="csv-header" type="xsl:avt"/>
+          <xs:attribute name="csv-quote-character" type="xsl:avt"/>
+          <xs:attribute name="csv-separator" type="xsl:avt"/>
           <xs:attribute name="doctype-public" type="xsl:avt"/>
           <xs:attribute name="doctype-system" type="xsl:avt"/>
           <xs:attribute name="encoding" type="xsl:avt"/>
@@ -1788,6 +1797,9 @@ of problems processing the schema using various tools
           <xs:attribute name="_byte-order-mark" type="xs:string"/>
           <xs:attribute name="_canonical" type="xs:string"/>
           <xs:attribute name="_cdata-section-elements" type="xs:string"/>
+          <xs:attribute name="_csv-header" type="xs:string"/>
+          <xs:attribute name="_csv-quote-character" type="xs:string"/>
+          <xs:attribute name="_csv-separator" type="xs:string"/>
           <xs:attribute name="_doctype-public" type="xs:string"/>
           <xs:attribute name="_doctype-system" type="xs:string"/>
           <xs:attribute name="_encoding" type="xs:string"/>
@@ -2739,7 +2751,7 @@ of problems processing the schema using various tools
       <xs:documentation>
         <p>
            The <code>method</code> attribute of <code>xsl:output</code>: Either one of the recognized names
-           "xml", "xhtml", "html", "text", "json", or "adaptive",
+           "xml", "xhtml", "html", "text", "json", "csv", or "adaptive",
             or an EQName that must include a prefix or namespace URI.
         </p>
       </xs:documentation>
@@ -2752,6 +2764,7 @@ of problems processing the schema using various tools
           <xs:enumeration value="html"/>
           <xs:enumeration value="text"/>
           <xs:enumeration value="json"/>
+          <xs:enumeration value="csv"/>
           <xs:enumeration value="adaptive"/>
         </xs:restriction>
       </xs:simpleType>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -29870,7 +29870,8 @@ the same group, and the-->
                <p>
                   <termref def="dt-extension-attribute">Extension attributes</termref> may also be
                   used to influence the behavior of the standard serialization methods <code>xml</code>,
-                     <code>xhtml</code>, <code>html</code>, <code>text</code>, <code>json</code>, 
+                     <code>xhtml</code>, <code>html</code>, <code>text</code>, <code>json</code>,
+                  <code diff="add" at="2026-07-02">csv</code>,
                   and <code>adaptive</code>. For example, an extension attribute might
                   be used to define the amount of indentation to be used when
                      <code>indent="yes"</code> is specified.</p>
@@ -30268,7 +30269,9 @@ the same group, and the-->
                attributes are merged in the same way as when multiple <elcode>xsl:output</elcode>
                declarations are merged.</p>
             <p>The attributes <code>method</code>, <code>allow-duplicate-names</code>, <code>build-tree</code>, <code>byte-order-mark</code>
-               <code>canonical</code>, <code>cdata-section-elements</code>, <code>doctype-public</code>,
+               <code>canonical</code>, <code>cdata-section-elements</code>,
+               <code diff="add" at="2026-07-02">csv-header</code>, <code diff="add" at="2026-07-02">csv-quote-character</code>,
+               <code diff="add" at="2026-07-02">csv-separator</code>, <code>doctype-public</code>,
                   <code>doctype-system</code>, <code>encoding</code>,
                <code diff="add" at="2023-03-31">escape-solidus</code>
                   <code>escape-uri-attributes</code>, <code>html-version</code>, <code>indent</code>, <code>item-separator</code>,
@@ -31403,8 +31406,9 @@ the same group, and the-->
                   If it is a <termref def="dt-lexical-qname">lexical
                      QName</termref> in no namespace, then it identifies a method specified in
                      <bibref ref="xslt-xquery-serialization-40"/> and <rfc2119>must</rfc2119> be one
-                  of <code>xml</code>, <code>html</code>, <code>xhtml</code>, 
-                  <code>text</code>, <code>json</code>, or <code>adaptive</code>.</p>
+                  of <code>xml</code>, <code>html</code>, <code>xhtml</code>,
+                  <code>text</code>, <code>json</code>, <code diff="add" at="2026-07-02">csv</code>,
+                  or <code>adaptive</code>.</p>
             </error> If it is a <termref def="dt-lexical-qname">lexical QName</termref> with a
             prefix, then the <termref def="dt-lexical-qname">lexical QName</termref> is expanded
             into an <termref def="dt-expanded-qname">expanded QName</termref> as described in
@@ -31485,6 +31489,21 @@ the same group, and the-->
                      therefore follow the same convention as the name of a literal result element or
                      the <code>name</code> attribute of <elcode>xsl:element</elcode>.</p>
                </note>
+            </item>
+            <item diff="add" at="2026-07-02">
+               <p> The value of the <code>csv-header</code> attribute provides the value of the
+                     <code>csv-header</code> parameter to the serialization method. The default
+                  value is <code>no</code>. </p>
+            </item>
+            <item diff="add" at="2026-07-02">
+               <p> The value of the <code>csv-quote-character</code> attribute provides the value
+                  of the <code>csv-quote-character</code> parameter to the serialization method.
+                  The default value is <code>"</code>. </p>
+            </item>
+            <item diff="add" at="2026-07-02">
+               <p> The value of the <code>csv-separator</code> attribute provides the value of the
+                     <code>csv-separator</code> parameter to the serialization method. The default
+                  value is <code>,</code>. </p>
             </item>
             <item>
                <p> The value of the <code>doctype-system</code> attribute provides the value of the

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -29869,7 +29869,8 @@ the same group, and the-->
                <p>
                   <termref def="dt-extension-attribute">Extension attributes</termref> may also be
                   used to influence the behavior of the standard serialization methods <code>xml</code>,
-                     <code>xhtml</code>, <code>html</code>, <code>text</code>, <code>json</code>, 
+                     <code>xhtml</code>, <code>html</code>, <code>text</code>, <code>json</code>,
+                  <code diff="add" at="2026-07-02">csv</code>,
                   and <code>adaptive</code>. For example, an extension attribute might
                   be used to define the amount of indentation to be used when
                      <code>indent="yes"</code> is specified.</p>
@@ -30270,7 +30271,9 @@ the same group, and the-->
                attributes are merged in the same way as when multiple <elcode>xsl:output</elcode>
                declarations are merged.</p>
             <p>The attributes <code>method</code>, <code>allow-duplicate-names</code>, <code>build-tree</code>, <code>byte-order-mark</code>
-               <code>canonical</code>, <code>cdata-section-elements</code>, <code>doctype-public</code>,
+               <code>canonical</code>, <code>cdata-section-elements</code>,
+               <code diff="add" at="2026-07-02">csv-header</code>, <code diff="add" at="2026-07-02">csv-quote-character</code>,
+               <code diff="add" at="2026-07-02">csv-separator</code>, <code>doctype-public</code>,
                   <code>doctype-system</code>, <code>encoding</code>,
                <code diff="add" at="2023-03-31">escape-solidus</code>
                   <code>escape-uri-attributes</code>, <code>html-version</code>, <code>indent</code>, <code diff="add" at="2026-06-25">indent-attributes</code>, <code diff="add" at="2026-06-25">indent-unit</code>, <code>item-separator</code>,
@@ -31411,8 +31414,9 @@ the same group, and the-->
                   If it is a <termref def="dt-lexical-qname">lexical
                      QName</termref> in no namespace, then it identifies a method specified in
                      <bibref ref="xslt-xquery-serialization-40"/> and <rfc2119>must</rfc2119> be one
-                  of <code>xml</code>, <code>html</code>, <code>xhtml</code>, 
-                  <code>text</code>, <code>json</code>, or <code>adaptive</code>.</p>
+                  of <code>xml</code>, <code>html</code>, <code>xhtml</code>,
+                  <code>text</code>, <code>json</code>, <code diff="add" at="2026-07-02">csv</code>,
+                  or <code>adaptive</code>.</p>
             </error> If it is a <termref def="dt-lexical-qname">lexical QName</termref> with a
             prefix, then the <termref def="dt-lexical-qname">lexical QName</termref> is expanded
             into an <termref def="dt-expanded-qname">expanded QName</termref> as described in
@@ -31493,6 +31497,21 @@ the same group, and the-->
                      therefore follow the same convention as the name of a literal result element or
                      the <code>name</code> attribute of <elcode>xsl:element</elcode>.</p>
                </note>
+            </item>
+            <item diff="add" at="2026-07-02">
+               <p> The value of the <code>csv-header</code> attribute provides the value of the
+                     <code>csv-header</code> parameter to the serialization method. The default
+                  value is <code>no</code>. </p>
+            </item>
+            <item diff="add" at="2026-07-02">
+               <p> The value of the <code>csv-quote-character</code> attribute provides the value
+                  of the <code>csv-quote-character</code> parameter to the serialization method.
+                  The default value is <code>"</code>. </p>
+            </item>
+            <item diff="add" at="2026-07-02">
+               <p> The value of the <code>csv-separator</code> attribute provides the value of the
+                     <code>csv-separator</code> parameter to the serialization method. The default
+                  value is <code>,</code>. </p>
             </item>
             <item>
                <p> The value of the <code>doctype-system</code> attribute provides the value of the

--- a/specifications/xslt-xquery-serialization-40/src/bibl.xml
+++ b/specifications/xslt-xquery-serialization-40/src/bibl.xml
@@ -93,6 +93,14 @@ Available at:
 <loc href="http://www.rfc-editor.org/rfc/rfc8259.txt">http://www.rfc-editor.org/rfc/rfc8259.txt</loc>
 </bibl>
 
+<bibl id="rfc4180" key="RFC 4180">IETF.
+<emph>RFC 4180: Common Format and MIME Type for Comma-Separated Values (CSV) Files</emph>,
+Y. Shafranovich, Editor.
+Internet Engineering Task Force, October 2005.
+Available at:
+<loc href="http://www.rfc-editor.org/rfc/rfc4180.txt">http://www.rfc-editor.org/rfc/rfc4180.txt</loc>
+</bibl>
+
 
 </blist>
 </div2>

--- a/specifications/xslt-xquery-serialization-40/src/errors.xml
+++ b/specifications/xslt-xquery-serialization-40/src/errors.xml
@@ -147,10 +147,17 @@ diff="add" at="2014-11-06">
 <p>It is an error if a sequence being serialized using the JSON output
 method is of length greater than one.</p></error>
 
-<error spec="SE" code="0024" class="RE" type="serialization" 
+<error spec="SE" code="0024" class="RE" type="serialization"
 diff="add" at="2025-11-14">
-<p>It is an error if the processing the rules for canonicalization result in a 
+<p>It is an error if the processing the rules for canonicalization result in a
     serialization failure.</p></error>
+
+<error spec="SE" code="0025" class="RE" type="serialization"
+diff="add" at="2026-07-02">
+<p>It is an error if the value being serialized using the CSV output
+method is not a supported CSV structure; in particular, if it is neither a map
+containing a <code>rows</code> entry nor a sequence of arrays, or if a member of a
+row array is not a single atomic value.</p></error>
 
 </error-list>
 </div1>

--- a/specifications/xslt-xquery-serialization-40/src/schema-for-serialization-parameters.xsd
+++ b/specifications/xslt-xquery-serialization-40/src/schema-for-serialization-parameters.xsd
@@ -150,12 +150,13 @@
           <xs:enumeration value="xml"/>
           <xs:enumeration value="xhtml"/>
           <xs:enumeration value="json"/>
+          <xs:enumeration value="csv"/>
           <xs:enumeration value="adaptive"/>
         </xs:restriction>
       </xs:simpleType>
       <xs:simpleType>
         <xs:restriction base="output:EQName">
-          <xs:pattern value="Q\{\s*\}(html|text|xml|xhtml|json|adaptive)"/>
+          <xs:pattern value="Q\{\s*\}(html|text|xml|xhtml|json|csv|adaptive)"/>
         </xs:restriction>
       </xs:simpleType>
       <!--* other values must have non-null namespace URI *-->
@@ -332,6 +333,52 @@
   <xs:element id="cdata-section-elements" 
               name="cdata-section-elements" 
               type="output:QNames-param-type"
+              substitutionGroup
+              = "output:serialization-parameter-element"/>
+
+  <!--
+     - Serialization parameter element for csv-header parameter
+    -->
+  <xs:element id="csv-header"
+              name="csv-header"
+              type="output:yes-no-param-type"
+              substitutionGroup
+              = "output:serialization-parameter-element"/>
+
+  <!--
+     - Serialization parameter type for csv-quote-character and csv-separator parameters
+    -->
+  <xs:simpleType name="csv-char-type">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[^\n]"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:complexType name="csv-char-param-type">
+    <xs:complexContent>
+      <xs:extension base="output:base-param-type">
+        <xs:attribute name="value"
+                      type="output:csv-char-type"
+                      use="required"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!--
+     - Serialization parameter element for csv-quote-character parameter
+    -->
+  <xs:element id="csv-quote-character"
+              name="csv-quote-character"
+              type="output:csv-char-param-type"
+              substitutionGroup
+              = "output:serialization-parameter-element"/>
+
+  <!--
+     - Serialization parameter element for csv-separator parameter
+    -->
+  <xs:element id="csv-separator"
+              name="csv-separator"
+              type="output:csv-char-param-type"
               substitutionGroup
               = "output:serialization-parameter-element"/>
 

--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -4198,11 +4198,10 @@ according to the <bibref ref="JSON-LINES"/> format, as described in <specref ref
 
     <div3 id="CSV_LINE-ENDING">
       <head>CSV Output Method: <code>line-ending</code></head>
-      <p>The <code>line-ending</code> parameter is applicable to the CSV output method; see
-        <specref ref="XML_LINE-ENDING"/> for more information. Its value is used to separate
-        records, and it replaces line endings occurring in the content of fields, as described in
-        <specref ref="serializing-csv"/>. If the parameter is absent, <char>U+000A</char> is
-        used.</p>
+      <p>The <code>line-ending</code> parameter is applicable to the CSV output method. Its value
+        is used to separate records, and it replaces line endings occurring in the content of
+        fields, as described in <specref ref="serializing-csv"/>. If the parameter is absent,
+        <char>U+000A</char> is used.</p>
     </div3>
 
     <div3 id="CSV_ENCODING">

--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -697,6 +697,10 @@ nodes.</p></note></div1>
     <change issue="938" PR="2259" date="2025-10-20">
       Added the <code>canonical</code> parameter for XML, XHTML, and JSON serialization.
     </change>
+    <change issue="2748" date="2026-07-02">
+      Added the <code>csv-separator</code>, <code>csv-quote-character</code>, and
+      <code>csv-header</code> parameters for CSV serialization.
+    </change>
   </changes>
 <p>There are a number of parameters that influence how serialization
 is performed. <termref def="host-language">Host languages</termref> <rfc2119>MAY</rfc2119> allow users to specify any or all of these parameters, but
@@ -738,6 +742,16 @@ is specified, a serialization error <errorref code="0022" class="RE"/> may be ra
           this parameter is ignored.</td></tr>
 <tr><td rowspan="1" colspan="1" valign="top"><code>canonical</code></td><td rowspan="1" colspan="1">A boolean value, <code>true</code> or <code>false</code>.</td></tr>
 <tr><td rowspan="1" colspan="1" valign="top"><code>cdata-section-elements</code></td><td rowspan="1" colspan="1">A list of expanded QNames, possibly empty.</td></tr>
+<tr diff="add" at="2026-07-02"><td rowspan="1" colspan="1" valign="top"><code>csv-header</code></td>
+<td rowspan="1" colspan="1">A boolean value, <code>true</code> or <code>false</code>. This parameter indicates
+whether the CSV output method writes a header record derived from the <code>columns</code> entry
+of a supplied parsed CSV structure.</td></tr>
+<tr diff="add" at="2026-07-02"><td rowspan="1" colspan="1" valign="top"><code>csv-quote-character</code></td>
+<td rowspan="1" colspan="1">A string consisting of exactly one character. This parameter is used by the
+CSV output method to quote fields whose content requires quoting.</td></tr>
+<tr diff="add" at="2026-07-02"><td rowspan="1" colspan="1" valign="top"><code>csv-separator</code></td>
+<td rowspan="1" colspan="1">A string consisting of exactly one character. This parameter is used by the
+CSV output method to separate the fields within a record.</td></tr>
 <tr><td rowspan="1" colspan="1" valign="top"><code>doctype-public</code></td><!--Text replaced by erratum E10 change 1"-->
 <td>A string of
 <xnt spec="XML" ref="NT-PubidChar">PubidChar</xnt> characters.
@@ -816,11 +830,11 @@ output method.</td>
 <termref def="non-null-namespace-URI">non-null
 namespace URI</termref>,
 or with a <termref def="null-namespace-URI">null 
-namespace URI</termref> and a local name that <rfc2119>MUST</rfc2119> be equal 
+namespace URI</termref> and a local name that <rfc2119>MUST</rfc2119> be equal
 to one of <code>xml</code>, <code>xhtml</code>,
-<code>html</code>, <code>text</code>, 
-<code>json</code>, or <code>adaptive</code>, in which case, the output method specified <rfc2119>MUST</rfc2119> 
-be used for serializing. 
+<code>html</code>, <code>text</code>,
+<code>json</code>, <code>csv</code>, or <code>adaptive</code>, in which case, the output method specified <rfc2119>MUST</rfc2119>
+be used for serializing.
 If the namespace URI is non-null, 
 the parameter
 specifies an <termref def="impdef">implementation-defined</termref> 
@@ -899,10 +913,10 @@ specify the means by which an implementation can define such an additional
 serialization parameter, and implementations <rfc2119>MAY</rfc2119> provide
 mechanisms by which users can define such an additional serialization
 parameter.
-If the serialization method is one of the six
-methods <code>xml</code>, <code>html</code>, 
-<code>xhtml</code>, <code>text</code>, 
-<code>json</code>, or <code>adaptive</code>
+If the serialization method is one of the seven
+methods <code>xml</code>, <code>html</code>,
+<code>xhtml</code>, <code>text</code>,
+<code>json</code>, <code>csv</code>, or <code>adaptive</code>
  then the additional serialization parameters <rfc2119>MAY</rfc2119>
 affect the output of the <termref def="serializer">serializer</termref> to the extent (but only to the extent)
 that this specification leaves the output <termref def="impdef">implementation-defined</termref> or
@@ -1384,9 +1398,10 @@ comprises six phases of processing
 described in <specref ref="serdm"/>).<!--End of text replaced by erratum E2-->
 <!--Should the below be implementation-dependent?  -sb 3/16/05-->
 
-For the JSON and Adaptive
-output methods, serialization is described in <specref ref="json-output"/> and 
-  <specref ref="adaptive-output"/> respectively.
+For the JSON, CSV, and Adaptive
+output methods, serialization is described in <specref ref="json-output"/>,
+  <specref ref="csv-output"/>, and
+  <specref ref="adaptive-output"/>, respectively.
 
 
 </p>
@@ -4041,6 +4056,199 @@ according to the <bibref ref="JSON-LINES"/> format, as described in <specref ref
 </div3>
 
 </div2>
+</div1>
+
+<div1 id="csv-output">
+<head>CSV Output Method</head>
+
+  <changes>
+    <change issue="2748" date="2026-07-02">
+      The CSV output method was added, providing an inverse of the
+      <code>fn:parse-csv</code> and <code>fn:csv-to-arrays</code> functions.
+    </change>
+  </changes>
+
+  <p>The CSV output method serializes the <termref def="dt-input-tree"/> as CSV
+    (comma-separated values) data, following the conventions defined in <bibref ref="rfc4180"/>.
+    It is designed as an inverse of the <code>fn:parse-csv</code> and
+    <code>fn:csv-to-arrays</code> functions: applying the CSV output method to the result of
+    one of these functions recovers CSV data equivalent to the original input.
+    Sequence normalization is not performed for this output method.</p>
+
+  <p>The <termref def="dt-input-value"/> <rfc2119>MUST</rfc2119> take one of the following two
+    forms:</p>
+
+  <ulist>
+    <item><p>A single <termref def="dt-map-item">map</termref> having the structure returned by
+      the <code>fn:parse-csv</code> function (a <emph>parsed CSV structure</emph>). The map
+      <rfc2119>MUST</rfc2119> contain an entry whose key is the string <code>rows</code> and whose
+      associated value is a sequence of <termref def="dt-array-item">arrays</termref>, each array
+      representing one record. The map <rfc2119>MAY</rfc2119> contain an entry whose key is the
+      string <code>columns</code> and whose associated value is a sequence of atomic items
+      supplying the column names. Any other entries in the map are ignored.</p></item>
+
+    <item><p>A sequence of <termref def="dt-array-item">arrays</termref>, as returned by the
+      <code>fn:csv-to-arrays</code> function, each array representing one record.</p></item>
+  </ulist>
+
+  <div2 id="serializing-csv">
+    <head>Serializing a CSV Structure</head>
+
+    <p>The output consists of a sequence of <term>records</term>, one for each row, separated by
+      a single <char>U+000A</char> (line feed) character. A <char>U+000A</char> character is also
+      written after the final record. If the <code>line-ending</code> parameter is specified, its
+      value is written in place of each of these <char>U+000A</char> characters.</p>
+
+    <p>Records are written as follows:</p>
+
+    <olist>
+      <item><p>If the input is a map, and the <code>csv-header</code> parameter is
+        <code>true</code>, a header record is written first. This record is derived from the value
+        of the <code>columns</code> entry of the map; each field of the record is the
+        <termref def="dt-string-value">string value</termref> of the corresponding item. If the
+        map has no <code>columns</code> entry, a serialization error
+        <errorref code="0025" class="RE"/> occurs. If the <code>csv-header</code> parameter is
+        <code>false</code> (the default), no header record is written.</p></item>
+
+      <item><p>One record is then written for each array in the input (the value of the
+        <code>rows</code> entry if the input is a map, or the arrays of the input sequence
+        otherwise). The fields of the record are the
+        <termref def="dt-string-value">string values</termref> of the members of the array, in
+        order.</p></item>
+    </olist>
+
+    <p>Within a record, fields are separated by the character supplied in the
+      <code>csv-separator</code> parameter (default: <char>U+002C</char>, a comma). Each
+      field is written as follows: if the field contains the separator character,
+      the quote character, a <char>U+000A</char> character, or a <char>U+000D</char> character,
+      then the field is enclosed in the character supplied in the <code>csv-quote-character</code>
+      parameter (default: <char>U+0022</char>, a quotation mark), and any occurrence of the quote
+      character within the field is doubled. Otherwise the field is written unchanged.</p>
+
+    <p>The characters of each field are subject to
+      <termref def="unicode-normalization">Unicode Normalization</termref> if requested by the
+      <code>normalization-form</code> parameter, and to character mapping as defined by the
+      <code>use-character-maps</code> parameter (see <specref ref="character-maps"/>).</p>
+
+    <p>Line endings occurring in the content of a field (<char>U+000D</char>, <char>U+000A</char>,
+      or <char>U+000D</char> followed by <char>U+000A</char>) are replaced by the same string that
+      separates records: <char>U+000A</char>, or the value of the <code>line-ending</code>
+      parameter if specified.</p>
+
+    <note><p>The <code>fn:parse-csv</code> and <code>fn:csv-to-arrays</code> functions normalize
+      all line endings to <char>U+000A</char>, including line endings within quoted fields, so
+      this replacement does not affect the result of reparsing the serialized output.</p></note>
+
+    <p>A serialization error <errorref code="0025" class="RE"/> occurs if the
+      <termref def="dt-input-value"/> is not one of the two forms described above; in particular,
+      if a member of a row array is not a single <xtermref spec="XP40" ref="dt-atomic-item">atomic
+      value</xtermref>.</p>
+
+    <note><p>Because every field is written using its
+      <termref def="dt-string-value">string value</termref>, the distinction between the different
+      atomic types of the members is not preserved. When CSV data produced by
+      <code>fn:parse-csv</code> or <code>fn:csv-to-arrays</code> is serialized, all fields are
+      already strings, so this has no effect.</p></note>
+
+    <note><p>To reproduce a header row when serializing the result of
+      <code>fn:parse-csv($input, { "header": true() })</code>, the <code>csv-header</code>
+      parameter must be set to <code>true</code>; the column names are otherwise available in the
+      <code>columns</code> entry but are not written to the output.</p></note>
+  </div2>
+
+  <div2 id="CSV_PARAMS">
+    <head>The Influence of Serialization Parameters upon the CSV Output Method</head>
+
+    <p>The serialization parameters that affect the CSV output method are listed in the
+      following subsections.</p>
+
+    <p>Serialization parameters other than those listed are not applicable to this output
+      method. It is the responsibility of the
+      <termref def="host-language">host language</termref> to specify whether an error occurs if
+      such a parameter is specified in combination with the CSV output method, or whether the
+      parameter is ignored, or whether it is validated and then ignored.</p>
+
+    <div3 id="CSV_SEPARATOR">
+      <head>CSV Output Method: <code>csv-separator</code></head>
+      <p>The <code>csv-separator</code> parameter supplies the character used to separate the
+        fields within a record. The default is <char>U+002C</char> (a comma).
+        A <termref def="serial-err">serialization error</termref> <errorref code="0016" class="PM"/>
+        occurs if the value is <char>U+000A</char>, if it is not a string consisting of exactly
+        one character, or if it is the same character as the value of the
+        <code>csv-quote-character</code> parameter.</p>
+    </div3>
+
+    <div3 id="CSV_QUOTE-CHARACTER">
+      <head>CSV Output Method: <code>csv-quote-character</code></head>
+      <p>The <code>csv-quote-character</code> parameter supplies the character used to enclose a
+        field whose content requires quoting. The default is <char>U+0022</char> (a quotation
+        mark). A <termref def="serial-err">serialization error</termref> <errorref code="0016" class="PM"/>
+        occurs if the value is <char>U+000A</char>, if it is not a string consisting of exactly
+        one character, or if it is the same character as the value of the
+        <code>csv-separator</code> parameter.</p>
+    </div3>
+
+    <div3 id="CSV_HEADER">
+      <head>CSV Output Method: <code>csv-header</code></head>
+      <p>The <code>csv-header</code> parameter controls whether a header record is written from
+        the <code>columns</code> entry of a supplied map, as described in
+        <specref ref="serializing-csv"/>. The default is <code>false</code>. This parameter has no
+        effect when the <termref def="dt-input-value"/> is a sequence of arrays.</p>
+    </div3>
+
+    <div3 id="CSV_LINE-ENDING">
+      <head>CSV Output Method: <code>line-ending</code></head>
+      <p>The <code>line-ending</code> parameter is applicable to the CSV output method; see
+        <specref ref="XML_LINE-ENDING"/> for more information. Its value is used to separate
+        records, and it replaces line endings occurring in the content of fields, as described in
+        <specref ref="serializing-csv"/>. If the parameter is absent, <char>U+000A</char> is
+        used.</p>
+    </div3>
+
+    <div3 id="CSV_ENCODING">
+      <head>CSV Output Method: <code>encoding</code></head>
+      <p>The <code>encoding</code> parameter identifies the encoding that the CSV output method
+        <rfc2119>MUST</rfc2119> use to convert sequences of characters to sequences of bytes.
+        A <termref def="serial-err">serialization error</termref> <errorref code="0007" class="SU"/>
+        occurs if the <termref def="serializer">serializer</termref> does not support the encoding
+        specified by the <code>encoding</code> parameter. If the
+        <termref def="dt-input-tree"/> contains a character that cannot be represented in the
+        encoding that the <termref def="serializer">serializer</termref> is using for output, the
+        <termref def="serializer">serializer</termref> <rfc2119>MUST</rfc2119> raise a
+        <termref def="serial-err">serialization error</termref> <errorref code="0008" class="RE"/>.</p>
+    </div3>
+
+    <div3 id="CSV_NORMALIZATION-FORM">
+      <head>CSV Output Method: <code>normalization-form</code></head>
+      <p>The <code>normalization-form</code> parameter is applicable to the CSV output method, and
+        controls the Unicode normalization of the content of each field. The values <code>NFC</code>
+        and <code>none</code> <rfc2119>MUST</rfc2119> be supported by the
+        <termref def="serializer">serializer</termref>.
+        A <termref def="serial-err">serialization error</termref> <errorref code="0011" class="SU"/>
+        results if the value of the <code>normalization-form</code> parameter specifies a
+        normalization form that is not supported by the
+        <termref def="serializer">serializer</termref>; the
+        <termref def="serializer">serializer</termref> <rfc2119>MUST</rfc2119> raise the error.</p>
+    </div3>
+
+    <div3 id="CSV_MEDIA-TYPE">
+      <head>CSV Output Method: <code>media-type</code></head>
+      <p>The <code>media-type</code> parameter is applicable to the CSV output method.
+        See <specref ref="serparam"/> for more information.</p>
+    </div3>
+
+    <div3 id="CSV_USE-CHARACTER-MAPS">
+      <head>CSV Output Method: <code>use-character-maps</code></head>
+      <p>The <code>use-character-maps</code> parameter is applicable to the CSV output method.
+        See <specref ref="character-maps"/> for more information.</p>
+    </div3>
+
+    <div3 id="CSV_BYTE-ORDER-MARK">
+      <head>CSV Output Method: <code>byte-order-mark</code></head>
+      <p>The <code>byte-order-mark</code> parameter is applicable to the CSV output method.
+        See <specref ref="serparam"/> for more information.</p>
+    </div3>
+  </div2>
 </div1>
 
 <div1 id="adaptive-output">

--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -4118,22 +4118,29 @@ according to the <bibref ref="JSON-LINES"/> format, as described in <specref ref
     </olist>
 
     <p>Within a record, fields are separated by the character supplied in the
-      <code>csv-separator</code> parameter (default: <char>U+002C</char>, a comma). Each
-      field is written as follows: if the field contains the separator character,
-      the quote character, a <char>U+000A</char> character, or a <char>U+000D</char> character,
-      then the field is enclosed in the character supplied in the <code>csv-quote-character</code>
-      parameter (default: <char>U+0022</char>, a quotation mark), and any occurrence of the quote
-      character within the field is doubled. Otherwise the field is written unchanged.</p>
+      <code>csv-separator</code> parameter (default: <char>U+002C</char>, a comma). Each field is
+      derived from the <termref def="dt-string-value">string value</termref> of the corresponding
+      item by applying the following procedure:</p>
 
-    <p>The characters of each field are subject to
-      <termref def="unicode-normalization">Unicode Normalization</termref> if requested by the
-      <code>normalization-form</code> parameter, and to character mapping as defined by the
-      <code>use-character-maps</code> parameter (see <specref ref="character-maps"/>).</p>
+    <olist>
+      <item><p>Any character in the string for which character mapping is defined (see
+        <specref ref="character-maps"/>) is substituted by the replacement string defined in the
+        character map.</p></item>
 
-    <p>Line endings occurring in the content of a field (<char>U+000D</char>, <char>U+000A</char>,
-      or <char>U+000D</char> followed by <char>U+000A</char>) are replaced by the same string that
-      separates records: <char>U+000A</char>, or the value of the <code>line-ending</code>
-      parameter if specified.</p>
+      <item><p>Any other character in the string (but not a character produced by character mapping)
+        is a candidate for <termref def="unicode-normalization">Unicode Normalization</termref> if
+        requested by the <code>normalization-form</code> parameter. In addition, the field requires
+        quoting if it contains the separator character, the quote character, a <char>U+000A</char>
+        character, or a <char>U+000D</char> character; and any line ending (<char>U+000D</char>,
+        <char>U+000A</char>, or <char>U+000D</char> followed by <char>U+000A</char>) is replaced by
+        the string that separates records: <char>U+000A</char>, or the value of the
+        <code>line-ending</code> parameter if specified.</p></item>
+
+      <item><p>If the field requires quoting, each occurrence of the quote character (but not one
+        produced by character mapping) is doubled, and the resulting field is enclosed in the
+        character supplied in the <code>csv-quote-character</code> parameter (default:
+        <char>U+0022</char>, a quotation mark). Otherwise the field is written unchanged.</p></item>
+    </olist>
 
     <note><p>The <code>fn:parse-csv</code> and <code>fn:csv-to-arrays</code> functions normalize
       all line endings to <char>U+000A</char>, including line endings within quoted fields, so

--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -4232,22 +4232,29 @@ according to the <bibref ref="JSON-LINES"/> format, as described in <specref ref
     </olist>
 
     <p>Within a record, fields are separated by the character supplied in the
-      <code>csv-separator</code> parameter (default: <char>U+002C</char>, a comma). Each
-      field is written as follows: if the field contains the separator character,
-      the quote character, a <char>U+000A</char> character, or a <char>U+000D</char> character,
-      then the field is enclosed in the character supplied in the <code>csv-quote-character</code>
-      parameter (default: <char>U+0022</char>, a quotation mark), and any occurrence of the quote
-      character within the field is doubled. Otherwise the field is written unchanged.</p>
+      <code>csv-separator</code> parameter (default: <char>U+002C</char>, a comma). Each field is
+      derived from the <termref def="dt-string-value">string value</termref> of the corresponding
+      item by applying the following procedure:</p>
 
-    <p>The characters of each field are subject to
-      <termref def="unicode-normalization">Unicode Normalization</termref> if requested by the
-      <code>normalization-form</code> parameter, and to character mapping as defined by the
-      <code>use-character-maps</code> parameter (see <specref ref="character-maps"/>).</p>
+    <olist>
+      <item><p>Any character in the string for which character mapping is defined (see
+        <specref ref="character-maps"/>) is substituted by the replacement string defined in the
+        character map.</p></item>
 
-    <p>Line endings occurring in the content of a field (<char>U+000D</char>, <char>U+000A</char>,
-      or <char>U+000D</char> followed by <char>U+000A</char>) are replaced by the same string that
-      separates records: <char>U+000A</char>, or the value of the <code>line-ending</code>
-      parameter if specified.</p>
+      <item><p>Any other character in the string (but not a character produced by character mapping)
+        is a candidate for <termref def="unicode-normalization">Unicode Normalization</termref> if
+        requested by the <code>normalization-form</code> parameter. In addition, the field requires
+        quoting if it contains the separator character, the quote character, a <char>U+000A</char>
+        character, or a <char>U+000D</char> character; and any line ending (<char>U+000D</char>,
+        <char>U+000A</char>, or <char>U+000D</char> followed by <char>U+000A</char>) is replaced by
+        the string that separates records: <char>U+000A</char>, or the value of the
+        <code>line-ending</code> parameter if specified.</p></item>
+
+      <item><p>If the field requires quoting, each occurrence of the quote character (but not one
+        produced by character mapping) is doubled, and the resulting field is enclosed in the
+        character supplied in the <code>csv-quote-character</code> parameter (default:
+        <char>U+0022</char>, a quotation mark). Otherwise the field is written unchanged.</p></item>
+    </olist>
 
     <note><p>The <code>fn:parse-csv</code> and <code>fn:csv-to-arrays</code> functions normalize
       all line endings to <char>U+000A</char>, including line endings within quoted fields, so

--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -4176,7 +4176,7 @@ according to the <bibref ref="JSON-LINES"/> format, as described in <specref ref
 <head>CSV Output Method</head>
 
   <changes>
-    <change issue="2748" date="2026-07-02">
+    <change issue="2748" PR="2794" date="2026-07-02">
       The CSV output method was added, providing an inverse of the
       <code>fn:parse-csv</code> and <code>fn:csv-to-arrays</code> functions.
     </change>

--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -700,6 +700,10 @@ nodes.</p></note></div1>
     <change issue="1234" PR="2719" date="2025-07-28">
       Added the serialization parameters <code>indent-unit</code>, <code>indent-attributes</code>, and <code>line-ending</code>.
     </change>
+    <change issue="2748" PR="2794" date="2026-07-02">
+      Added the <code>csv-separator</code>, <code>csv-quote-character</code>, and
+      <code>csv-header</code> parameters for CSV serialization.
+    </change>
   </changes>
 <p>There are a number of parameters that influence how serialization
 is performed. <termref def="host-language">Host languages</termref> <rfc2119>MAY</rfc2119> allow users to specify any or all of these parameters, but
@@ -741,6 +745,16 @@ is specified, a serialization error <errorref code="0022" class="RE"/> may be ra
           this parameter is ignored.</td></tr>
 <tr><td rowspan="1" colspan="1" valign="top"><code>canonical</code></td><td rowspan="1" colspan="1">A boolean value, <code>true</code> or <code>false</code>.</td></tr>
 <tr><td rowspan="1" colspan="1" valign="top"><code>cdata-section-elements</code></td><td rowspan="1" colspan="1">A list of expanded QNames, possibly empty.</td></tr>
+<tr diff="add" at="2026-07-02"><td rowspan="1" colspan="1" valign="top"><code>csv-header</code></td>
+<td rowspan="1" colspan="1">A boolean value, <code>true</code> or <code>false</code>. This parameter indicates
+whether the CSV output method writes a header record derived from the <code>columns</code> entry
+of a supplied parsed CSV structure.</td></tr>
+<tr diff="add" at="2026-07-02"><td rowspan="1" colspan="1" valign="top"><code>csv-quote-character</code></td>
+<td rowspan="1" colspan="1">A string consisting of exactly one character. This parameter is used by the
+CSV output method to quote fields whose content requires quoting.</td></tr>
+<tr diff="add" at="2026-07-02"><td rowspan="1" colspan="1" valign="top"><code>csv-separator</code></td>
+<td rowspan="1" colspan="1">A string consisting of exactly one character. This parameter is used by the
+CSV output method to separate the fields within a record.</td></tr>
 <tr><td rowspan="1" colspan="1" valign="top"><code>doctype-public</code></td><!--Text replaced by erratum E10 change 1"-->
 <td>A string of
 <xnt spec="XML" ref="NT-PubidChar">PubidChar</xnt> characters.
@@ -857,11 +871,11 @@ output method.</td>
 <termref def="non-null-namespace-URI">non-null
 namespace URI</termref>,
 or with a <termref def="null-namespace-URI">null 
-namespace URI</termref> and a local name that <rfc2119>MUST</rfc2119> be equal 
+namespace URI</termref> and a local name that <rfc2119>MUST</rfc2119> be equal
 to one of <code>xml</code>, <code>xhtml</code>,
-<code>html</code>, <code>text</code>, 
-<code>json</code>, or <code>adaptive</code>, in which case, the output method specified <rfc2119>MUST</rfc2119> 
-be used for serializing. 
+<code>html</code>, <code>text</code>,
+<code>json</code>, <code>csv</code>, or <code>adaptive</code>, in which case, the output method specified <rfc2119>MUST</rfc2119>
+be used for serializing.
 If the namespace URI is non-null, 
 the parameter
 specifies an <termref def="impdef">implementation-defined</termref> 
@@ -940,10 +954,10 @@ specify the means by which an implementation can define such an additional
 serialization parameter, and implementations <rfc2119>MAY</rfc2119> provide
 mechanisms by which users can define such an additional serialization
 parameter.
-If the serialization method is one of the six
-methods <code>xml</code>, <code>html</code>, 
-<code>xhtml</code>, <code>text</code>, 
-<code>json</code>, or <code>adaptive</code>
+If the serialization method is one of the seven
+methods <code>xml</code>, <code>html</code>,
+<code>xhtml</code>, <code>text</code>,
+<code>json</code>, <code>csv</code>, or <code>adaptive</code>
  then the additional serialization parameters <rfc2119>MAY</rfc2119>
 affect the output of the <termref def="serializer">serializer</termref> to the extent (but only to the extent)
 that this specification leaves the output <termref def="impdef">implementation-defined</termref> or
@@ -1425,9 +1439,10 @@ comprises six phases of processing
 described in <specref ref="serdm"/>).<!--End of text replaced by erratum E2-->
 <!--Should the below be implementation-dependent?  -sb 3/16/05-->
 
-For the JSON and Adaptive
-output methods, serialization is described in <specref ref="json-output"/> and 
-  <specref ref="adaptive-output"/> respectively.
+For the JSON, CSV, and Adaptive
+output methods, serialization is described in <specref ref="json-output"/>,
+  <specref ref="csv-output"/>, and
+  <specref ref="adaptive-output"/>, respectively.
 
 
 </p>
@@ -4155,6 +4170,199 @@ according to the <bibref ref="JSON-LINES"/> format, as described in <specref ref
 </div3>
 
 </div2>
+</div1>
+
+<div1 id="csv-output">
+<head>CSV Output Method</head>
+
+  <changes>
+    <change issue="2748" date="2026-07-02">
+      The CSV output method was added, providing an inverse of the
+      <code>fn:parse-csv</code> and <code>fn:csv-to-arrays</code> functions.
+    </change>
+  </changes>
+
+  <p>The CSV output method serializes the <termref def="dt-input-tree"/> as CSV
+    (comma-separated values) data, following the conventions defined in <bibref ref="rfc4180"/>.
+    It is designed as an inverse of the <code>fn:parse-csv</code> and
+    <code>fn:csv-to-arrays</code> functions: applying the CSV output method to the result of
+    one of these functions recovers CSV data equivalent to the original input.
+    Sequence normalization is not performed for this output method.</p>
+
+  <p>The <termref def="dt-input-value"/> <rfc2119>MUST</rfc2119> take one of the following two
+    forms:</p>
+
+  <ulist>
+    <item><p>A single <termref def="dt-map-item">map</termref> having the structure returned by
+      the <code>fn:parse-csv</code> function (a <emph>parsed CSV structure</emph>). The map
+      <rfc2119>MUST</rfc2119> contain an entry whose key is the string <code>rows</code> and whose
+      associated value is a sequence of <termref def="dt-array-item">arrays</termref>, each array
+      representing one record. The map <rfc2119>MAY</rfc2119> contain an entry whose key is the
+      string <code>columns</code> and whose associated value is a sequence of atomic items
+      supplying the column names. Any other entries in the map are ignored.</p></item>
+
+    <item><p>A sequence of <termref def="dt-array-item">arrays</termref>, as returned by the
+      <code>fn:csv-to-arrays</code> function, each array representing one record.</p></item>
+  </ulist>
+
+  <div2 id="serializing-csv">
+    <head>Serializing a CSV Structure</head>
+
+    <p>The output consists of a sequence of <term>records</term>, one for each row, separated by
+      a single <char>U+000A</char> (line feed) character. A <char>U+000A</char> character is also
+      written after the final record. If the <code>line-ending</code> parameter is specified, its
+      value is written in place of each of these <char>U+000A</char> characters.</p>
+
+    <p>Records are written as follows:</p>
+
+    <olist>
+      <item><p>If the input is a map, and the <code>csv-header</code> parameter is
+        <code>true</code>, a header record is written first. This record is derived from the value
+        of the <code>columns</code> entry of the map; each field of the record is the
+        <termref def="dt-string-value">string value</termref> of the corresponding item. If the
+        map has no <code>columns</code> entry, a serialization error
+        <errorref code="0025" class="RE"/> occurs. If the <code>csv-header</code> parameter is
+        <code>false</code> (the default), no header record is written.</p></item>
+
+      <item><p>One record is then written for each array in the input (the value of the
+        <code>rows</code> entry if the input is a map, or the arrays of the input sequence
+        otherwise). The fields of the record are the
+        <termref def="dt-string-value">string values</termref> of the members of the array, in
+        order.</p></item>
+    </olist>
+
+    <p>Within a record, fields are separated by the character supplied in the
+      <code>csv-separator</code> parameter (default: <char>U+002C</char>, a comma). Each
+      field is written as follows: if the field contains the separator character,
+      the quote character, a <char>U+000A</char> character, or a <char>U+000D</char> character,
+      then the field is enclosed in the character supplied in the <code>csv-quote-character</code>
+      parameter (default: <char>U+0022</char>, a quotation mark), and any occurrence of the quote
+      character within the field is doubled. Otherwise the field is written unchanged.</p>
+
+    <p>The characters of each field are subject to
+      <termref def="unicode-normalization">Unicode Normalization</termref> if requested by the
+      <code>normalization-form</code> parameter, and to character mapping as defined by the
+      <code>use-character-maps</code> parameter (see <specref ref="character-maps"/>).</p>
+
+    <p>Line endings occurring in the content of a field (<char>U+000D</char>, <char>U+000A</char>,
+      or <char>U+000D</char> followed by <char>U+000A</char>) are replaced by the same string that
+      separates records: <char>U+000A</char>, or the value of the <code>line-ending</code>
+      parameter if specified.</p>
+
+    <note><p>The <code>fn:parse-csv</code> and <code>fn:csv-to-arrays</code> functions normalize
+      all line endings to <char>U+000A</char>, including line endings within quoted fields, so
+      this replacement does not affect the result of reparsing the serialized output.</p></note>
+
+    <p>A serialization error <errorref code="0025" class="RE"/> occurs if the
+      <termref def="dt-input-value"/> is not one of the two forms described above; in particular,
+      if a member of a row array is not a single <xtermref spec="XP40" ref="dt-atomic-item">atomic
+      value</xtermref>.</p>
+
+    <note><p>Because every field is written using its
+      <termref def="dt-string-value">string value</termref>, the distinction between the different
+      atomic types of the members is not preserved. When CSV data produced by
+      <code>fn:parse-csv</code> or <code>fn:csv-to-arrays</code> is serialized, all fields are
+      already strings, so this has no effect.</p></note>
+
+    <note><p>To reproduce a header row when serializing the result of
+      <code>fn:parse-csv($input, { "header": true() })</code>, the <code>csv-header</code>
+      parameter must be set to <code>true</code>; the column names are otherwise available in the
+      <code>columns</code> entry but are not written to the output.</p></note>
+  </div2>
+
+  <div2 id="CSV_PARAMS">
+    <head>The Influence of Serialization Parameters upon the CSV Output Method</head>
+
+    <p>The serialization parameters that affect the CSV output method are listed in the
+      following subsections.</p>
+
+    <p>Serialization parameters other than those listed are not applicable to this output
+      method. It is the responsibility of the
+      <termref def="host-language">host language</termref> to specify whether an error occurs if
+      such a parameter is specified in combination with the CSV output method, or whether the
+      parameter is ignored, or whether it is validated and then ignored.</p>
+
+    <div3 id="CSV_SEPARATOR">
+      <head>CSV Output Method: <code>csv-separator</code></head>
+      <p>The <code>csv-separator</code> parameter supplies the character used to separate the
+        fields within a record. The default is <char>U+002C</char> (a comma).
+        A <termref def="serial-err">serialization error</termref> <errorref code="0016" class="PM"/>
+        occurs if the value is <char>U+000A</char>, if it is not a string consisting of exactly
+        one character, or if it is the same character as the value of the
+        <code>csv-quote-character</code> parameter.</p>
+    </div3>
+
+    <div3 id="CSV_QUOTE-CHARACTER">
+      <head>CSV Output Method: <code>csv-quote-character</code></head>
+      <p>The <code>csv-quote-character</code> parameter supplies the character used to enclose a
+        field whose content requires quoting. The default is <char>U+0022</char> (a quotation
+        mark). A <termref def="serial-err">serialization error</termref> <errorref code="0016" class="PM"/>
+        occurs if the value is <char>U+000A</char>, if it is not a string consisting of exactly
+        one character, or if it is the same character as the value of the
+        <code>csv-separator</code> parameter.</p>
+    </div3>
+
+    <div3 id="CSV_HEADER">
+      <head>CSV Output Method: <code>csv-header</code></head>
+      <p>The <code>csv-header</code> parameter controls whether a header record is written from
+        the <code>columns</code> entry of a supplied map, as described in
+        <specref ref="serializing-csv"/>. The default is <code>false</code>. This parameter has no
+        effect when the <termref def="dt-input-value"/> is a sequence of arrays.</p>
+    </div3>
+
+    <div3 id="CSV_LINE-ENDING">
+      <head>CSV Output Method: <code>line-ending</code></head>
+      <p>The <code>line-ending</code> parameter is applicable to the CSV output method; see
+        <specref ref="XML_LINE-ENDING"/> for more information. Its value is used to separate
+        records, and it replaces line endings occurring in the content of fields, as described in
+        <specref ref="serializing-csv"/>. If the parameter is absent, <char>U+000A</char> is
+        used.</p>
+    </div3>
+
+    <div3 id="CSV_ENCODING">
+      <head>CSV Output Method: <code>encoding</code></head>
+      <p>The <code>encoding</code> parameter identifies the encoding that the CSV output method
+        <rfc2119>MUST</rfc2119> use to convert sequences of characters to sequences of bytes.
+        A <termref def="serial-err">serialization error</termref> <errorref code="0007" class="SU"/>
+        occurs if the <termref def="serializer">serializer</termref> does not support the encoding
+        specified by the <code>encoding</code> parameter. If the
+        <termref def="dt-input-tree"/> contains a character that cannot be represented in the
+        encoding that the <termref def="serializer">serializer</termref> is using for output, the
+        <termref def="serializer">serializer</termref> <rfc2119>MUST</rfc2119> raise a
+        <termref def="serial-err">serialization error</termref> <errorref code="0008" class="RE"/>.</p>
+    </div3>
+
+    <div3 id="CSV_NORMALIZATION-FORM">
+      <head>CSV Output Method: <code>normalization-form</code></head>
+      <p>The <code>normalization-form</code> parameter is applicable to the CSV output method, and
+        controls the Unicode normalization of the content of each field. The values <code>NFC</code>
+        and <code>none</code> <rfc2119>MUST</rfc2119> be supported by the
+        <termref def="serializer">serializer</termref>.
+        A <termref def="serial-err">serialization error</termref> <errorref code="0011" class="SU"/>
+        results if the value of the <code>normalization-form</code> parameter specifies a
+        normalization form that is not supported by the
+        <termref def="serializer">serializer</termref>; the
+        <termref def="serializer">serializer</termref> <rfc2119>MUST</rfc2119> raise the error.</p>
+    </div3>
+
+    <div3 id="CSV_MEDIA-TYPE">
+      <head>CSV Output Method: <code>media-type</code></head>
+      <p>The <code>media-type</code> parameter is applicable to the CSV output method.
+        See <specref ref="serparam"/> for more information.</p>
+    </div3>
+
+    <div3 id="CSV_USE-CHARACTER-MAPS">
+      <head>CSV Output Method: <code>use-character-maps</code></head>
+      <p>The <code>use-character-maps</code> parameter is applicable to the CSV output method.
+        See <specref ref="character-maps"/> for more information.</p>
+    </div3>
+
+    <div3 id="CSV_BYTE-ORDER-MARK">
+      <head>CSV Output Method: <code>byte-order-mark</code></head>
+      <p>The <code>byte-order-mark</code> parameter is applicable to the CSV output method.
+        See <specref ref="serparam"/> for more information.</p>
+    </div3>
+  </div2>
 </div1>
 
 <div1 id="adaptive-output">


### PR DESCRIPTION
Closes #2748

90% copy & paste; the relevant contents are in the serialization spec.
I anticipated the integration of the `line-ending` parameter of #1234 (however the exact syntax will look like).
