### PR TITLE
2338 Nomenclature: node(), gnode(), xnode()

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -2738,9 +2738,9 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   </g:production>
   
   <g:production name="GNodeType" >
-    <g:string process-value="yes">gnode</g:string>
+    <g:string process-value="yes">node</g:string>
     <g:string>(</g:string>
-    <g:string>)</g:string>   
+    <g:string>)</g:string>
   </g:production>
   
   <g:production name="JNodeType" >
@@ -2783,7 +2783,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   </g:production>
 
   <g:production name="AnyXNodeType">
-    <g:string>node</g:string>
+    <g:string>xnode</g:string>
     <g:string>(</g:string>
     <g:string>)</g:string>
   </g:production>

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -2745,9 +2745,9 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   </g:production>
   
   <g:production name="GNodeType" >
-    <g:string process-value="yes">gnode</g:string>
+    <g:string process-value="yes">node</g:string>
     <g:string>(</g:string>
-    <g:string>)</g:string>   
+    <g:string>)</g:string>
   </g:production>
   
   <g:production name="JNodeType" >
@@ -2790,7 +2790,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   </g:production>
 
   <g:production name="AnyXNodeType">
-    <g:string>node</g:string>
+    <g:string>xnode</g:string>
     <g:string>(</g:string>
     <g:string>)</g:string>
   </g:production>

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -445,7 +445,7 @@ ref="sequences"/>.</p>
 
 <p><termdef id="dt-item" term="item">An <term>item</term>
 is either
-a <termref def="dt-node">node</termref>,
+a <termref def="dt-GNode">generic node</termref>,
 a <termref def="dt-function-item">function</termref>,
 or an <termref def="dt-atomic-item">atomic item</termref>.</termdef>
 </p>
@@ -1104,13 +1104,13 @@ constraints of the selected version of XML.</p></item>
       includes that type as a member type.</p></item>
     
     <item><p>A generic node (GNode) is either an XNode (for "XML node"), or a JNode (for "JSON node").
-      For continuity reasons, throughout these specifications the term <term>node</term>, when
-      used without qualification, means an XNode; furthermore the item type <code>node()</code>
-      refers exclusively to an XNode. The term <term>XNode</term> is used only when there
-      is a need to distinguish clearly from JNodes.</p>
+      For continuity reasons, throughout these specifications the term <term>node</term>, when used
+      without qualification, means an XNode; however the item type <code>node()</code> matches any
+      GNode, and the item type <code>xnode()</code> matches any XNode. The terms <term>XNode</term>
+      and <term>JNode</term> are used where it is necessary to distinguish the two kinds of node.</p>
       
       <p>XNodes represent the constructs found in an XML document.
-        Every <termref def="dt-node"/> (that is, every XNode) is an instance of the type <code>node()</code>, and more
+        Every XNode is an instance of the type <code>xnode()</code> (and therefore also of <code>node()</code>), and more
       specifically it is an instance of one of seven node kinds: <code>document()</code>,
       <code>element(*)</code>, <code>attribute(*)</code>, <code>text()</code>,
       <code>comment()</code>, <code>processing-instruction()</code>, or
@@ -2319,16 +2319,16 @@ or a complex type with simple content. For other kinds of
 
 <p>The typed value of &attributeNode;s and some &elementNode;s is a
 sequence of <termref def="dt-atomic-item">atomic items</termref>. The
-types of the items in the typed value of a node may differ from
-the type of the node itself. This section describes how the typed
-value of a node is derived from the properties of an information item
+types of the items in the typed value of an XNode may differ from
+the type of the XNode itself. This section describes how the typed
+value of an XNode is derived from the properties of an information item
 in a PSVI.</p>
 
-<p>The types of the items in the typed value of a node are determined as follows.
-The process begins with a type, <code>T</code>. If the schema type of the node itself, as
+<p>The types of the items in the typed value of an XNode are determined as follows.
+The process begins with a type, <code>T</code>. If the schema type of the XNode itself, as
 represented in the PSVI, is a complex type with simple content, then <code>T</code> is the
-{content type} of the schema type of the node; otherwise, <code>T</code> is the schema type
-of the node itself. For each primitive or ordinary simple type <code>T</code>, the W3C XML
+{content type} of the schema type of the XNode; otherwise, <code>T</code> is the schema type
+of the XNode itself. For each primitive or ordinary simple type <code>T</code>, the W3C XML
 Schema specification defines a function <code>M</code> mapping the lexical representation of
 a value onto the value itself.</p>
 
@@ -2349,7 +2349,7 @@ in cases where the lexical mapping proper maps to multiple values.
 
 <ulist>
 <item>
-<p>If the &dm.prop.nilled; property of the node in question is
+<p>If the &dm.prop.nilled; property of the XNode in question is
 <code>true</code>, then the typed value is the empty sequence.
 </p>
 </item>
@@ -2374,7 +2374,7 @@ is simply <code>T</code>.
 sequence of <termref def="dt-atomic-item">atomic items</termref>, 
   each having a well-defined atomic type. This
 sequence of atomic items, in turn, determines the
-typed-value property of the node in the data model.</p>
+typed-value property of the XNode in the data model.</p>
 </div5>
 
 <div5 id="typed-string-relationships">
@@ -2390,22 +2390,22 @@ the typed-value property only and derive the string-value property from it, or t
 both the string-value property and the typed-value property.</p>
 
 <p>To permit these various implementation strategies, some
-variations in the string value of a node are defined as insignificant.
-Implementations that store only the typed value of a node are permitted to
+variations in the string value of an XNode are defined as insignificant.
+Implementations that store only the typed value of an XNode are permitted to
 return a string value that is different from the original lexical form of
 the node content. For example, consider the following element:</p>
 
 <eg>&lt;offset xsi:type="xs:integer"&gt;0030&lt;/offset&gt;</eg>
 
-<p>Assuming that the node is valid, it has a typed value of 30 as an
+<p>Assuming that the XNode is valid, it has a typed value of 30 as an
 <code>xs:integer</code>. An implementation may return either “<code>30</code>” or
-“<code>0030</code>” as the string value of the node. Any string that is a valid
+“<code>0030</code>” as the string value of the XNode. Any string that is a valid
 lexical representation of the typed value is acceptable. In this
 specification, we express this rule by saying that the relationship
-between the string value of a node and its typed value must be
+between the string value of an XNode and its typed value must be
 “consistent with schema validation.”</p>
 
-<p>If an implementation stores only the string value of a node, the
+<p>If an implementation stores only the string value of an XNode, the
 following considerations apply:</p>
 
 <ulist>
@@ -2415,8 +2415,8 @@ the typed value as an instance of the appropriate member type. For
 example, if the type of 
 an element node is <code>my:integer-or-string</code>, which is
 defined as a union of <code>xs:integer</code> and <code>xs:string</code>, and the string value
-of the node is “47”, the implementation must be able to deliver the
-typed value of the node as either the integer <code>47</code> or the string <code>"47"</code>,
+of the XNode is “47”, the implementation must be able to deliver the
+typed value of the XNode as either the integer <code>47</code> or the string <code>"47"</code>,
 depending on which member type validated the element.</p>
 </item>
 <item>
@@ -2434,15 +2434,15 @@ occurs, it is an error to attempt to access the typed-value of the
 </item>
 </ulist>
 
-<p>If an implementation stores only the typed value of a node, it must
-be prepared to construct string values from not only the node, but in
+<p>If an implementation stores only the typed value of an XNode, it must
+be prepared to construct string values from not only the XNode, but in
 some cases also the descendants of that node. For example, an element
 with a complex type and element-only content has no typed value but
 does have a string value that is the concatenation of the
 string values of all its &textNode; descendants in document order.</p>
 
 <p>A further caveat applies if an implementation stores the typed
-value of a node. If a new data model is constructed by copying
+value of an XNode. If a new data model is constructed by copying
 portions of another data model, and the copy operation does not
 preserve inherited namespaces, and the type is a union type that is
 sensitive to the namespace context, then the typed value may be
@@ -2524,7 +2524,7 @@ not attempted or did not succeed, the
 <loc href="#CommentNode">comment</loc>. Each kind of
 node is described in the following sections.</p>
 
-<p>Each section consists of an overview of the node, followed by 
+<p>Each section consists of an overview of the XNode, followed by 
   information on accessors and methods construction from an Infoset or a PSVI.
   The final section provides a mapping to Infosets. No mapping 
   is provided, nor can it be provided, for producing a PSVI. 
@@ -2540,17 +2540,17 @@ the following general constraints:</p>
 distinct from all other nodes.
 </p></item>
 <item>
-<p>The &dm.prop.children; property of a node <rfc2119>must not</rfc2119>
+<p>The &dm.prop.children; property of an XNode <rfc2119>must not</rfc2119>
 contain two consecutive &textNode;s.</p>
 </item>
 <item>
-<p>The &dm.prop.children; property of a node <rfc2119>must not</rfc2119>
+<p>The &dm.prop.children; property of an XNode <rfc2119>must not</rfc2119>
 contain any empty &textNode;s.</p>
 </item>
 <item>
 
 <p>No node may appear more than once in the
-&dm.prop.children; or &dm.prop.attributes; properties of a node.</p>
+&dm.prop.children; or &dm.prop.attributes; properties of an XNode.</p>
 </item>
 </olist>
 
@@ -5585,7 +5585,7 @@ for determining the result.</imp-def-feature>
 
 <example role="signature">
   <proto class="dm" name="attributes" return-type="attribute()" returnSeq="yes">
-    <arg name="n" type="node()"/>
+    <arg name="n" type="xnode()"/>
   </proto>
 </example>
 
@@ -5604,11 +5604,11 @@ The order of &attributeNode;s is stable but implementation dependent.</p>
 
 <example role="signature">
   <proto class="dm" name="base-uri" return-type="xs:anyURI" returnEmptyOk="yes">
-    <arg name="n" type="node()"/>
+    <arg name="n" type="xnode()"/>
   </proto>
 </example>
 
-<p>The <function>base-uri</function> accessor returns the base URI of a node
+<p>The <function>base-uri</function> accessor returns the base URI of an XNode
 as a sequence containing zero or one URI reference. For more information
 about base URIs, see <bibref ref="xmlbase"/>.</p>
 
@@ -5620,12 +5620,12 @@ about base URIs, see <bibref ref="xmlbase"/>.</p>
 <head><code>children</code> Accessor</head>
 
 <example role="signature">
-  <proto class="dm" name="children" return-type="node()" returnSeq="yes">
-    <arg name="n" type="node()"/>
+  <proto class="dm" name="children" return-type="xnode()" returnSeq="yes">
+    <arg name="n" type="xnode()"/>
   </proto>
 </example>
 
-<p>The <function>children</function> accessor returns the children of a node
+<p>The <function>children</function> accessor returns the children of an XNode
 as a sequence containing zero or more nodes.</p>
 
 <p>It is defined on
@@ -5638,7 +5638,7 @@ as a sequence containing zero or more nodes.</p>
 
 <example role="signature">
   <proto class="dm" name="document-uri" return-type="xs:anyURI" returnEmptyOk="yes">
-    <arg name="node" type="node()"/>
+    <arg name="node" type="xnode()"/>
   </proto>
 </example>
 
@@ -5659,7 +5659,7 @@ the empty sequence is returned.
 
 <example role="signature">
   <proto class="dm" name="is-id" return-type="xs:boolean" returnEmptyOk="yes">
-    <arg name="node" type="node()"/>
+    <arg name="node" type="xnode()"/>
   </proto>
 </example>
 
@@ -5678,7 +5678,7 @@ node kinds.</p>
 
 <example role="signature">
   <proto class="dm" name="is-idrefs" return-type="xs:boolean" returnEmptyOk="yes">
-    <arg name="node" type="node()"/>
+    <arg name="node" type="xnode()"/>
   </proto>
 </example>
 
@@ -5698,8 +5698,8 @@ node kinds.</p>
 <head><code>namespace-nodes</code> Accessor</head>
 
 <example role="signature">
-  <proto class="dm" name="namespace-nodes" return-type="node()" returnSeq="yes">
-    <arg name="n" type="node()"/>
+  <proto class="dm" name="namespace-nodes" return-type="xnode()" returnSeq="yes">
+    <arg name="n" type="xnode()"/>
   </proto>
 </example>
 
@@ -5721,7 +5721,7 @@ but implementation dependent.</p>
 <example role="signature">
   <proto class="dm" name="nilled" return-type="xs:boolean" returnSeq="no"
 	 returnEmptyOk="yes">
-    <arg name="n" type="node()"/>
+    <arg name="n" type="xnode()"/>
   </proto>
 </example>
 
@@ -5742,7 +5742,7 @@ necessarily allow empty content.
 
 <example role="signature">
   <proto class="dm" name="node-kind" return-type="xs:string" returnEmptyOk="no">
-    <arg name="n" type="node()"/>
+    <arg name="n" type="xnode()"/>
   </proto>
 </example>
 
@@ -5768,11 +5768,11 @@ node:
 
 <example role="signature">
   <proto class="dm" name="node-name" return-type="xs:QName" returnEmptyOk="yes">
-    <arg name="n" type="node()"/>
+    <arg name="n" type="xnode()"/>
   </proto>
 </example>
 
-<p>The <function>node-name</function> accessor returns the name of the node
+<p>The <function>node-name</function> accessor returns the name of the XNode
 as a sequence of zero or one <code>xs:QName</code>s. Note that the
 QName value includes an optional prefix as described in
 <specref ref="qnames-and-notations"/>.</p>
@@ -5786,12 +5786,12 @@ QName value includes an optional prefix as described in
 <head><code>parent</code> Accessor</head>
 
 <example role="signature">
-  <proto class="dm" name="parent" return-type="node()" returnEmptyOk="yes">
-    <arg name="n" type="node()"/>
+  <proto class="dm" name="parent" return-type="xnode()" returnEmptyOk="yes">
+    <arg name="n" type="xnode()"/>
   </proto>
 </example>
 
-<p>The <function>parent</function> accessor returns the parent of a node
+<p>The <function>parent</function> accessor returns the parent of an XNode
 as a sequence containing zero or one nodes.</p>
 
 <p>It is defined on
@@ -5804,12 +5804,12 @@ as a sequence containing zero or one nodes.</p>
 
 <example role="signature">
   <proto class="dm" name="string-value" return-type="xs:string" returnEmptyOk="no">
-    <arg name="n" type="node()"/>
+    <arg name="n" type="xnode()"/>
   </proto>
 </example>
 
 <p>The <function>string-value</function> accessor returns the string value
-of a node.</p>
+of an XNode.</p>
 
 <p>It is defined on
 <loc href="#acc-summ-string-value">all seven</loc> node kinds.</p>
@@ -5821,12 +5821,12 @@ of a node.</p>
 
 <example role="signature">
   <proto class="dm" name="type-name" return-type="xs:QName" returnEmptyOk="yes">
-    <arg name="n" type="node()"/>
+    <arg name="n" type="xnode()"/>
   </proto>
 </example>
 
 <p>The <function>type-name</function> accessor returns the name of the schema type
-of a node as a sequence of zero or one <code>xs:QName</code>s.</p>
+of an XNode as a sequence of zero or one <code>xs:QName</code>s.</p>
 
 <p>It is defined on
 <loc href="#acc-summ-type-name">all seven</loc> node kinds.</p>
@@ -5838,12 +5838,12 @@ of a node as a sequence of zero or one <code>xs:QName</code>s.</p>
 
 <example role="signature">
   <proto class="dm" name="typed-value" return-type="xs:anyAtomicType" returnSeq="yes">
-    <arg name="n" type="node()"/>
+    <arg name="n" type="xnode()"/>
   </proto>
 </example>
 
 <p>The <function>typed-value</function> accessor returns the
-typed value of the node as a sequence of zero or more atomic
+typed value of the XNode as a sequence of zero or more atomic
 items.</p>
 
 <p>It is defined on
@@ -5856,7 +5856,7 @@ items.</p>
 
 <example role="signature">
   <proto class="dm" name="unparsed-entity-public-id" return-type="xs:string" returnEmptyOk="yes">
-    <arg name="node" type="node()"/>
+    <arg name="node" type="xnode()"/>
     <arg name="entityname" type="xs:string"/>
   </proto>
 </example>
@@ -5877,7 +5877,7 @@ sequence is returned.</p>
 
 <example role="signature">
   <proto class="dm" name="unparsed-entity-system-id" return-type="xs:anyURI" returnEmptyOk="yes">
-    <arg name="node" type="node()"/>
+    <arg name="node" type="xnode()"/>
     <arg name="entityname" type="xs:string"/>
   </proto>
 </example>

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -445,7 +445,7 @@ ref="sequences"/>.</p>
 
 <p><termdef id="dt-item" term="item">An <term>item</term>
 is either
-a <termref def="dt-node">node</termref>,
+a <termref def="dt-GNode">generic node</termref>,
 a <termref def="dt-function-item">function</termref>,
 or an <termref def="dt-atomic-item">atomic item</termref>.</termdef>
 </p>
@@ -1104,13 +1104,13 @@ constraints of the selected version of XML.</p></item>
       includes that type as a member type.</p></item>
     
     <item><p>A generic node (GNode) is either an XNode (for "XML node"), or a JNode (for "JSON node").
-      For continuity reasons, throughout these specifications the term <term>node</term>, when
-      used without qualification, means an XNode; furthermore the item type <code>node()</code>
-      refers exclusively to an XNode. The term <term>XNode</term> is used only when there
-      is a need to distinguish clearly from JNodes.</p>
+      For continuity reasons, throughout these specifications the term <term>node</term>, when used
+      without qualification, means an XNode; however the item type <code>node()</code> matches any
+      GNode, and the item type <code>xnode()</code> matches any XNode. The terms <term>XNode</term>
+      and <term>JNode</term> are used where it is necessary to distinguish the two kinds of node.</p>
       
       <p>XNodes represent the constructs found in an XML document.
-        Every <termref def="dt-node"/> (that is, every XNode) is an instance of the type <code>node()</code>, and more
+        Every XNode is an instance of the type <code>xnode()</code> (and therefore also of <code>node()</code>), and more
       specifically it is an instance of one of seven node kinds: <code>document()</code>,
       <code>element(*)</code>, <code>attribute(*)</code>, <code>text()</code>,
       <code>comment()</code>, <code>processing-instruction()</code>, or
@@ -2319,16 +2319,16 @@ or a complex type with simple content. For other kinds of
 
 <p>The typed value of &attributeNode;s and some &elementNode;s is a
 sequence of <termref def="dt-atomic-item">atomic items</termref>. The
-types of the items in the typed value of a node may differ from
-the type of the node itself. This section describes how the typed
-value of a node is derived from the properties of an information item
+types of the items in the typed value of an XNode may differ from
+the type of the XNode itself. This section describes how the typed
+value of an XNode is derived from the properties of an information item
 in a PSVI.</p>
 
-<p>The types of the items in the typed value of a node are determined as follows.
-The process begins with a type, <code>T</code>. If the schema type of the node itself, as
+<p>The types of the items in the typed value of an XNode are determined as follows.
+The process begins with a type, <code>T</code>. If the schema type of the XNode itself, as
 represented in the PSVI, is a complex type with simple content, then <code>T</code> is the
-{content type} of the schema type of the node; otherwise, <code>T</code> is the schema type
-of the node itself. For each primitive or ordinary simple type <code>T</code>, the W3C XML
+{content type} of the schema type of the XNode; otherwise, <code>T</code> is the schema type
+of the XNode itself. For each primitive or ordinary simple type <code>T</code>, the W3C XML
 Schema specification defines a function <code>M</code> mapping the lexical representation of
 a value onto the value itself.</p>
 
@@ -2349,7 +2349,7 @@ in cases where the lexical mapping proper maps to multiple values.
 
 <ulist>
 <item>
-<p>If the &dm.prop.nilled; property of the node in question is
+<p>If the &dm.prop.nilled; property of the XNode in question is
 <code>true</code>, then the typed value is the empty sequence.
 </p>
 </item>
@@ -2374,7 +2374,7 @@ is simply <code>T</code>.
 sequence of <termref def="dt-atomic-item">atomic items</termref>, 
   each having a well-defined atomic type. This
 sequence of atomic items, in turn, determines the
-typed-value property of the node in the data model.</p>
+typed-value property of the XNode in the data model.</p>
 </div5>
 
 <div5 id="typed-string-relationships">
@@ -2390,22 +2390,22 @@ the typed-value property only and derive the string-value property from it, or t
 both the string-value property and the typed-value property.</p>
 
 <p>To permit these various implementation strategies, some
-variations in the string value of a node are defined as insignificant.
-Implementations that store only the typed value of a node are permitted to
+variations in the string value of an XNode are defined as insignificant.
+Implementations that store only the typed value of an XNode are permitted to
 return a string value that is different from the original lexical form of
 the node content. For example, consider the following element:</p>
 
 <eg>&lt;offset xsi:type="xs:integer"&gt;0030&lt;/offset&gt;</eg>
 
-<p>Assuming that the node is valid, it has a typed value of 30 as an
+<p>Assuming that the XNode is valid, it has a typed value of 30 as an
 <code>xs:integer</code>. An implementation may return either “<code>30</code>” or
-“<code>0030</code>” as the string value of the node. Any string that is a valid
+“<code>0030</code>” as the string value of the XNode. Any string that is a valid
 lexical representation of the typed value is acceptable. In this
 specification, we express this rule by saying that the relationship
-between the string value of a node and its typed value must be
+between the string value of an XNode and its typed value must be
 “consistent with schema validation.”</p>
 
-<p>If an implementation stores only the string value of a node, the
+<p>If an implementation stores only the string value of an XNode, the
 following considerations apply:</p>
 
 <ulist>
@@ -2415,8 +2415,8 @@ the typed value as an instance of the appropriate member type. For
 example, if the type of 
 an element node is <code>my:integer-or-string</code>, which is
 defined as a union of <code>xs:integer</code> and <code>xs:string</code>, and the string value
-of the node is “47”, the implementation must be able to deliver the
-typed value of the node as either the integer <code>47</code> or the string <code>"47"</code>,
+of the XNode is “47”, the implementation must be able to deliver the
+typed value of the XNode as either the integer <code>47</code> or the string <code>"47"</code>,
 depending on which member type validated the element.</p>
 </item>
 <item>
@@ -2434,15 +2434,15 @@ occurs, it is an error to attempt to access the typed-value of the
 </item>
 </ulist>
 
-<p>If an implementation stores only the typed value of a node, it must
-be prepared to construct string values from not only the node, but in
+<p>If an implementation stores only the typed value of an XNode, it must
+be prepared to construct string values from not only the XNode, but in
 some cases also the descendants of that node. For example, an element
 with a complex type and element-only content has no typed value but
 does have a string value that is the concatenation of the
 string values of all its &textNode; descendants in document order.</p>
 
 <p>A further caveat applies if an implementation stores the typed
-value of a node. If a new data model is constructed by copying
+value of an XNode. If a new data model is constructed by copying
 portions of another data model, and the copy operation does not
 preserve inherited namespaces, and the type is a union type that is
 sensitive to the namespace context, then the typed value may be
@@ -2524,7 +2524,7 @@ not attempted or did not succeed, the
 <loc href="#CommentNode">comment</loc>. Each kind of
 node is described in the following sections.</p>
 
-<p>Each section consists of an overview of the node, followed by 
+<p>Each section consists of an overview of the XNode, followed by 
   information on accessors and methods construction from an Infoset or a PSVI.
   The final section provides a mapping to Infosets. No mapping 
   is provided, nor can it be provided, for producing a PSVI. 
@@ -2540,17 +2540,17 @@ the following general constraints:</p>
 distinct from all other nodes.
 </p></item>
 <item>
-<p>The &dm.prop.children; property of a node <rfc2119>must not</rfc2119>
+<p>The &dm.prop.children; property of an XNode <rfc2119>must not</rfc2119>
 contain two consecutive &textNode;s.</p>
 </item>
 <item>
-<p>The &dm.prop.children; property of a node <rfc2119>must not</rfc2119>
+<p>The &dm.prop.children; property of an XNode <rfc2119>must not</rfc2119>
 contain any empty &textNode;s.</p>
 </item>
 <item>
 
 <p>No node may appear more than once in the
-&dm.prop.children; or &dm.prop.attributes; properties of a node.</p>
+&dm.prop.children; or &dm.prop.attributes; properties of an XNode.</p>
 </item>
 </olist>
     
@@ -5590,7 +5590,7 @@ for determining the result.</imp-def-feature>
 
 <example role="signature">
   <proto class="dm" name="attributes" return-type="attribute()" returnSeq="yes">
-    <arg name="n" type="node()"/>
+    <arg name="n" type="xnode()"/>
   </proto>
 </example>
 
@@ -5609,11 +5609,11 @@ The order of &attributeNode;s is stable but implementation dependent.</p>
 
 <example role="signature">
   <proto class="dm" name="base-uri" return-type="xs:anyURI" returnEmptyOk="yes">
-    <arg name="n" type="node()"/>
+    <arg name="n" type="xnode()"/>
   </proto>
 </example>
 
-<p>The <function>base-uri</function> accessor returns the base URI of a node
+<p>The <function>base-uri</function> accessor returns the base URI of an XNode
 as a sequence containing zero or one URI reference. For more information
 about base URIs, see <bibref ref="xmlbase"/>.</p>
 
@@ -5625,12 +5625,12 @@ about base URIs, see <bibref ref="xmlbase"/>.</p>
 <head><code>children</code> Accessor</head>
 
 <example role="signature">
-  <proto class="dm" name="children" return-type="node()" returnSeq="yes">
-    <arg name="n" type="node()"/>
+  <proto class="dm" name="children" return-type="xnode()" returnSeq="yes">
+    <arg name="n" type="xnode()"/>
   </proto>
 </example>
 
-<p>The <function>children</function> accessor returns the children of a node
+<p>The <function>children</function> accessor returns the children of an XNode
 as a sequence containing zero or more nodes.</p>
 
 <p>It is defined on
@@ -5643,7 +5643,7 @@ as a sequence containing zero or more nodes.</p>
 
 <example role="signature">
   <proto class="dm" name="document-uri" return-type="xs:anyURI" returnEmptyOk="yes">
-    <arg name="node" type="node()"/>
+    <arg name="node" type="xnode()"/>
   </proto>
 </example>
 
@@ -5664,7 +5664,7 @@ the empty sequence is returned.
 
 <example role="signature">
   <proto class="dm" name="is-id" return-type="xs:boolean" returnEmptyOk="yes">
-    <arg name="node" type="node()"/>
+    <arg name="node" type="xnode()"/>
   </proto>
 </example>
 
@@ -5683,7 +5683,7 @@ node kinds.</p>
 
 <example role="signature">
   <proto class="dm" name="is-idrefs" return-type="xs:boolean" returnEmptyOk="yes">
-    <arg name="node" type="node()"/>
+    <arg name="node" type="xnode()"/>
   </proto>
 </example>
 
@@ -5703,8 +5703,8 @@ node kinds.</p>
 <head><code>namespace-nodes</code> Accessor</head>
 
 <example role="signature">
-  <proto class="dm" name="namespace-nodes" return-type="node()" returnSeq="yes">
-    <arg name="n" type="node()"/>
+  <proto class="dm" name="namespace-nodes" return-type="xnode()" returnSeq="yes">
+    <arg name="n" type="xnode()"/>
   </proto>
 </example>
 
@@ -5726,7 +5726,7 @@ but implementation dependent.</p>
 <example role="signature">
   <proto class="dm" name="nilled" return-type="xs:boolean" returnSeq="no"
 	 returnEmptyOk="yes">
-    <arg name="n" type="node()"/>
+    <arg name="n" type="xnode()"/>
   </proto>
 </example>
 
@@ -5747,7 +5747,7 @@ necessarily allow empty content.
 
 <example role="signature">
   <proto class="dm" name="node-kind" return-type="xs:string" returnEmptyOk="no">
-    <arg name="n" type="node()"/>
+    <arg name="n" type="xnode()"/>
   </proto>
 </example>
 
@@ -5773,11 +5773,11 @@ node:
 
 <example role="signature">
   <proto class="dm" name="node-name" return-type="xs:QName" returnEmptyOk="yes">
-    <arg name="n" type="node()"/>
+    <arg name="n" type="xnode()"/>
   </proto>
 </example>
 
-<p>The <function>node-name</function> accessor returns the name of the node
+<p>The <function>node-name</function> accessor returns the name of the XNode
 as a sequence of zero or one <code>xs:QName</code>s. Note that the
 QName value includes an optional prefix as described in
 <specref ref="qnames-and-notations"/>.</p>
@@ -5791,12 +5791,12 @@ QName value includes an optional prefix as described in
 <head><code>parent</code> Accessor</head>
 
 <example role="signature">
-  <proto class="dm" name="parent" return-type="node()" returnEmptyOk="yes">
-    <arg name="n" type="node()"/>
+  <proto class="dm" name="parent" return-type="xnode()" returnEmptyOk="yes">
+    <arg name="n" type="xnode()"/>
   </proto>
 </example>
 
-<p>The <function>parent</function> accessor returns the parent of a node
+<p>The <function>parent</function> accessor returns the parent of an XNode
 as a sequence containing zero or one nodes.</p>
 
 <p>It is defined on
@@ -5809,12 +5809,12 @@ as a sequence containing zero or one nodes.</p>
 
 <example role="signature">
   <proto class="dm" name="string-value" return-type="xs:string" returnEmptyOk="no">
-    <arg name="n" type="node()"/>
+    <arg name="n" type="xnode()"/>
   </proto>
 </example>
 
 <p>The <function>string-value</function> accessor returns the string value
-of a node.</p>
+of an XNode.</p>
 
 <p>It is defined on
 <loc href="#acc-summ-string-value">all seven</loc> node kinds.</p>
@@ -5826,12 +5826,12 @@ of a node.</p>
 
 <example role="signature">
   <proto class="dm" name="type-name" return-type="xs:QName" returnEmptyOk="yes">
-    <arg name="n" type="node()"/>
+    <arg name="n" type="xnode()"/>
   </proto>
 </example>
 
 <p>The <function>type-name</function> accessor returns the name of the schema type
-of a node as a sequence of zero or one <code>xs:QName</code>s.</p>
+of an XNode as a sequence of zero or one <code>xs:QName</code>s.</p>
 
 <p>It is defined on
 <loc href="#acc-summ-type-name">all seven</loc> node kinds.</p>
@@ -5843,12 +5843,12 @@ of a node as a sequence of zero or one <code>xs:QName</code>s.</p>
 
 <example role="signature">
   <proto class="dm" name="typed-value" return-type="xs:anyAtomicType" returnSeq="yes">
-    <arg name="n" type="node()"/>
+    <arg name="n" type="xnode()"/>
   </proto>
 </example>
 
 <p>The <function>typed-value</function> accessor returns the
-typed value of the node as a sequence of zero or more atomic
+typed value of the XNode as a sequence of zero or more atomic
 items.</p>
 
 <p>It is defined on
@@ -5861,7 +5861,7 @@ items.</p>
 
 <example role="signature">
   <proto class="dm" name="unparsed-entity-public-id" return-type="xs:string" returnEmptyOk="yes">
-    <arg name="node" type="node()"/>
+    <arg name="node" type="xnode()"/>
     <arg name="entityname" type="xs:string"/>
   </proto>
 </example>
@@ -5882,7 +5882,7 @@ sequence is returned.</p>
 
 <example role="signature">
   <proto class="dm" name="unparsed-entity-system-id" return-type="xs:anyURI" returnEmptyOk="yes">
-    <arg name="node" type="node()"/>
+    <arg name="node" type="xnode()"/>
     <arg name="entityname" type="xs:string"/>
   </proto>
 </example>
@@ -5908,7 +5908,7 @@ is returned.</p>
 
 <example role="signature">
   <proto class="dm" name="location" return-type="record(system-id as xs:anyURI?, public-id as xs:string?, line-number as xs:integer?, column-number as xs:integer?)" returnEmptyOk="yes">
-    <arg name="node" type="node()"/>
+    <arg name="node" type="xnode()"/>
   </proto>
 </example>
 

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -672,7 +672,7 @@
    <fos:function name="node-name" prefix="fn">
       <fos:signatures>
          <fos:proto name="node-name" return-type="xs:QName?">
-            <fos:arg name="node" type="node()?" default="." usage="inspection"/>
+            <fos:arg name="node" type="xnode()?" default="." usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -704,7 +704,7 @@
                      class="DY" code="0002" type="type"/>.</p>
             </item>
             <item>
-               <p>If the context value is not an instance of the sequence type <code>node()?</code>, 
+               <p>If the context value is not an instance of the sequence type <code>xnode()?</code>, 
                   type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
             </item>
@@ -945,7 +945,7 @@
    <fos:function name="nilled" prefix="fn">
       <fos:signatures>
          <fos:proto name="nilled" return-type="xs:boolean?">
-            <fos:arg name="node" type="node()?" default="." usage="inspection"/>
+            <fos:arg name="node" type="xnode()?" default="." usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -978,7 +978,7 @@
                      class="DY" code="0002" type="type"/></p>
             </item>
             <item>
-               <p>If the context value is not an instance of the sequence type <code>node()?</code>, type error <xerrorref spec="XP" class="TY"
+               <p>If the context value is not an instance of the sequence type <code>xnode()?</code>, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
             </item>
          </ulist>
@@ -1213,7 +1213,7 @@
    <fos:function name="base-uri" prefix="fn">
       <fos:signatures>
          <fos:proto name="base-uri" return-type="xs:anyURI?">
-            <fos:arg name="node" type="node()?" default="." usage="inspection"/>
+            <fos:arg name="node" type="xnode()?" default="." usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -1258,7 +1258,7 @@
                      class="DY" code="0002" type="type"/></p>
             </item>
             <item>
-               <p>If the context value is not an instance of the sequence type <code>node()?</code>, type error <xerrorref spec="XP" class="TY"
+               <p>If the context value is not an instance of the sequence type <code>xnode()?</code>, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
             </item>
          </ulist>
@@ -1275,7 +1275,7 @@
    <fos:function name="document-uri" prefix="fn">
       <fos:signatures>
          <fos:proto name="document-uri" return-type="xs:anyURI?">
-            <fos:arg name="node" type="node()?" default="." usage="inspection"/>
+            <fos:arg name="node" type="xnode()?" default="." usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -1311,7 +1311,7 @@
                      class="DY" code="0002" type="type"/></p>
             </item>
             <item>
-               <p>If the context value is not an instance of the sequence type <code>node()?</code>, type error <xerrorref spec="XP" class="TY"
+               <p>If the context value is not an instance of the sequence type <code>xnode()?</code>, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
             </item>
          </ulist>
@@ -13893,7 +13893,7 @@ fn:parse-QName("xmp:person")</eg></fos:expression>
    <fos:function name="name" prefix="fn">
       <fos:signatures>
          <fos:proto name="name" return-type="xs:string">
-            <fos:arg name="node" type="node()?" default="." usage="inspection"/>
+            <fos:arg name="node" type="xnode()?" default="." usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -13928,7 +13928,7 @@ fn:parse-QName("xmp:person")</eg></fos:expression>
                      class="DY" code="0002" type="type"/></p>
             </item>
             <item>
-               <p>If the context value is not an instance of the sequence type <code>node()?</code>, type error <xerrorref spec="XP" class="TY"
+               <p>If the context value is not an instance of the sequence type <code>xnode()?</code>, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
             </item>
          </ulist>
@@ -13984,7 +13984,7 @@ fn:parse-QName("xmp:person")</eg></fos:expression>
    <fos:function name="local-name" prefix="fn">
       <fos:signatures>
          <fos:proto name="local-name" return-type="xs:string">
-            <fos:arg name="node" type="node()?" default="." usage="inspection"/>
+            <fos:arg name="node" type="xnode()?" default="." usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -14073,7 +14073,7 @@ fn:parse-QName("xmp:person")</eg></fos:expression>
    <fos:function name="namespace-uri" prefix="fn">
       <fos:signatures>
          <fos:proto name="namespace-uri" return-type="xs:anyURI">
-            <fos:arg name="node" type="node()?" default="." usage="inspection"/>
+            <fos:arg name="node" type="xnode()?" default="." usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -14113,7 +14113,7 @@ fn:parse-QName("xmp:person")</eg></fos:expression>
                      class="DY" code="0002" type="type"/></p>
             </item>
             <item>
-               <p>If the context value is not an instance of the sequence type <code>node()?</code>, type error <xerrorref spec="XP" class="TY"
+               <p>If the context value is not an instance of the sequence type <code>xnode()?</code>, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
             </item>
          </ulist>
@@ -14256,7 +14256,7 @@ fn:parse-QName("xmp:person")</eg></fos:expression>
       <fos:signatures>
          <fos:proto name="lang" return-type="xs:boolean">
             <fos:arg name="language" type="xs:string?"/>
-            <fos:arg name="node" type="node()" default="." usage="inspection"/>
+            <fos:arg name="node" type="xnode()" default="." usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="1">
@@ -14354,7 +14354,7 @@ fn:parse-QName("xmp:person")</eg></fos:expression>
    <fos:function name="path" prefix="fn">
       <fos:signatures>
          <fos:proto name="path" return-type="xs:string?">
-            <fos:arg name="node" type="gnode()?" default="." usage="navigation"/>
+            <fos:arg name="node" type="node()?" default="." usage="navigation"/>
             <fos:arg name="options" type="map(*)?" default="{}" note="default-on-empty"/>
          </fos:proto>
       </fos:signatures>
@@ -14391,7 +14391,7 @@ fn:parse-QName("xmp:person")</eg></fos:expression>
                   starting from the supplied origin node, rather than from the root of the
                   containing tree.
                </fos:meaning>
-               <fos:type>gnode()?</fos:type>
+               <fos:type>node()?</fos:type>
                <fos:default>()</fos:default>
             </fos:option>
             <fos:option key="lexical">
@@ -14789,8 +14789,8 @@ return path($in//a[. = 2])</eg></fos:expression>
    </fos:function>
    <fos:function name="root" prefix="fn">
       <fos:signatures>
-         <fos:proto name="root" return-type="gnode()?">
-            <fos:arg name="node" type="gnode()?" default="." usage="inspection"/>
+         <fos:proto name="root" return-type="node()?">
+            <fos:arg name="node" type="node()?" default="." usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -14812,7 +14812,7 @@ return path($in//a[. = 2])</eg></fos:expression>
       </fos:summary>
       <fos:rules>
          <p>The function returns the value of the expression
-               <code>$node/ancestor-or-self::gnode()[last()]</code>.</p>
+               <code>$node/ancestor-or-self::node()[last()]</code>.</p>
          
         
       </fos:rules>
@@ -14827,7 +14827,7 @@ return path($in//a[. = 2])</eg></fos:expression>
             </item>
             <item>
                <p>If the context value is not an instance of the sequence type
-               <code>gnode()?</code>, type error
+               <code>node()?</code>, type error
                <xerrorref spec="XP" class="TY" code="0004" type="type"/>.</p>
             </item>
          </ulist>
@@ -14890,7 +14890,7 @@ let $newi := $o/tool</eg>
    <fos:function name="has-children" prefix="fn">
       <fos:signatures>
          <fos:proto name="has-children" return-type="xs:boolean">
-            <fos:arg name="node" type="gnode()?" default="." usage="inspection"/>
+            <fos:arg name="node" type="node()?" default="." usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -14908,9 +14908,9 @@ let $newi := $o/tool</eg>
       </fos:summary>
       <fos:rules>
          <p>Provided that the supplied argument <code>$node</code> matches the expected type
-               <code>gnode()?</code>, the result of the function call
+               <code>node()?</code>, the result of the function call
                <code>fn:has-children($node)</code> is defined to be the same as the result of the
-            expression <code>fn:exists($node/child::gnode())</code>.</p>
+            expression <code>fn:exists($node/child::node())</code>.</p>
       </fos:rules>
       <fos:errors>
          <p>The following errors may be raised when <code>$node</code> is omitted:</p>
@@ -14922,7 +14922,7 @@ let $newi := $o/tool</eg>
                      class="DY" code="0002" type="type"/></p>
             </item>
             <item>
-               <p>If the context value is not an instance of the sequence type <code>gnode()?</code>, type error <xerrorref spec="XP" class="TY"
+               <p>If the context value is not an instance of the sequence type <code>node()?</code>, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
             </item>
          </ulist>
@@ -15012,8 +15012,8 @@ let $newi := $o/tool</eg>
    
    <fos:function name="distinct-ordered-nodes" prefix="fn">
       <fos:signatures>
-         <fos:proto name="distinct-ordered-nodes" return-type="gnode()*">
-            <fos:arg name="nodes" type="gnode()*" usage="navigation"/>
+         <fos:proto name="distinct-ordered-nodes" return-type="node()*">
+            <fos:arg name="nodes" type="node()*" usage="navigation"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -15068,8 +15068,8 @@ return count(distinct-ordered-nodes(
    </fos:function>
    <fos:function name="innermost" prefix="fn">
       <fos:signatures>
-         <fos:proto name="innermost" return-type="gnode()*">
-            <fos:arg name="nodes" type="gnode()*" usage="navigation"/>
+         <fos:proto name="innermost" return-type="node()*">
+            <fos:arg name="nodes" type="node()*" usage="navigation"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -15086,7 +15086,7 @@ return count(distinct-ordered-nodes(
       <fos:rules>
          <p>The effect of the function call <code>fn:innermost($nodes)</code> is defined to be
             equivalent to the result of the expression:</p>
-         <eg>$nodes except $nodes/ancestor::gnode()</eg>
+         <eg>$nodes except $nodes/ancestor::node()</eg>
          <p>That is, the function takes as input a sequence of GNodes, and returns every GNode within
             the sequence that is not an ancestor of another GNode within the sequence; the GNodes are
             returned in document order with duplicates eliminated.</p>
@@ -15123,8 +15123,8 @@ return count(distinct-ordered-nodes(
    </fos:function>
    <fos:function name="outermost" prefix="fn">
       <fos:signatures>
-         <fos:proto name="outermost" return-type="gnode()*">
-            <fos:arg name="nodes" type="gnode()*" usage="transmission"/>
+         <fos:proto name="outermost" return-type="node()*">
+            <fos:arg name="nodes" type="node()*" usage="transmission"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -15141,7 +15141,7 @@ return count(distinct-ordered-nodes(
       <fos:rules>
          <p>The effect of the function call <code>fn:outermost($nodes)</code> is defined to be
             equivalent to the result of the expression:</p>
-         <eg>$nodes[not(ancestor::gnode() intersect $nodes)]/.</eg>
+         <eg>$nodes[not(ancestor::node() intersect $nodes)]/.</eg>
          <!--bug 17029-->
          <p>That is, the function takes as input a sequence of GNodes, and returns every GNode within
             the sequence that does not have another GNode within the sequence as an ancestor; the
@@ -15356,8 +15356,8 @@ return empty($break)
    
    <fos:function name="siblings" prefix="fn">
       <fos:signatures>
-         <fos:proto name="siblings" return-type="gnode()*">
-            <fos:arg name="node" type="gnode()?" default="." usage="navigation"/>
+         <fos:proto name="siblings" return-type="node()*">
+            <fos:arg name="node" type="node()?" default="." usage="navigation"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -15378,7 +15378,7 @@ return empty($break)
          
          <p>If <code>$node</code> is a child of some parent GNode <var>P</var>, the function returns all the
          children of <var>P</var> (including <code>$node</code>), in document order, as determined
-            by the value of <code>$node/child::gnode()</code>.</p>
+            by the value of <code>$node/child::node()</code>.</p>
          
          <p>Otherwise (specifically, if <code>$node</code> is parentless, or if it is an attribute or namespace node),
          the function returns <code>$node</code>.</p>
@@ -18869,7 +18869,7 @@ else head($c) + sum(tail($c))</eg>
       <fos:signatures>
          <fos:proto name="id" return-type="element()*">
             <fos:arg name="values" type="xs:string*"/>
-            <fos:arg name="node" type="node()" default="." usage="navigation"/>
+            <fos:arg name="node" type="xnode()" default="." usage="navigation"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="1">
@@ -19034,7 +19034,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       <fos:signatures>
          <fos:proto name="element-with-id" return-type="element()*">
             <fos:arg name="values" type="xs:string*"/>
-            <fos:arg name="node" type="node()" default="." usage="navigation"/>
+            <fos:arg name="node" type="xnode()" default="." usage="navigation"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="1">
@@ -19204,9 +19204,9 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
    </fos:function>
    <fos:function name="idref" prefix="fn">
       <fos:signatures>
-         <fos:proto name="idref" return-type="node()*">
+         <fos:proto name="idref" return-type="xnode()*">
             <fos:arg name="values" type="xs:string*"/>
-            <fos:arg name="node" type="node()" default="." usage="navigation"/>
+            <fos:arg name="node" type="xnode()" default="." usage="navigation"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="1">
@@ -20806,7 +20806,7 @@ return { "width": $int16-at($loc + 5),
    <fos:function name="generate-id" prefix="fn">
       <fos:signatures>
          <fos:proto name="generate-id" return-type="xs:string">
-            <fos:arg name="node" type="gnode()?" usage="inspection" default="."/>
+            <fos:arg name="node" type="node()?" usage="inspection" default="."/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -20848,7 +20848,7 @@ return { "width": $int16-at($loc + 5),
             </item>
             <item>
                <p>If the context value is not an instance of the sequence type
-               <code>gnode()?</code>, type error <xerrorref spec="XP" class="TY" code="0004" type="type"/>.</p>
+               <code>node()?</code>, type error <xerrorref spec="XP" class="TY" code="0004" type="type"/>.</p>
             </item>
          </ulist>
 
@@ -21311,7 +21311,7 @@ return { "width": $int16-at($loc + 5),
    
     <fos:function name="xsd-validator" prefix="fn">
       <fos:signatures>
-         <fos:proto name="xsd-validator" return-type="fn((document-node(*) | element() | attribute())?) as record(is-valid as xs:boolean, typed-node? as node(), error-details? as map(*)*)">
+         <fos:proto name="xsd-validator" return-type="fn((document-node(*) | element() | attribute())?) as record(is-valid as xs:boolean, typed-node? as xnode(), error-details? as map(*)*)">
             <fos:arg name="options" type="map(*)?" default="{}" note="default-on-empty"/>
          </fos:proto>
       </fos:signatures>
@@ -24611,9 +24611,9 @@ return sort-with($persons/person, (
    
    <fos:function name="transitive-closure" prefix="fn">
       <fos:signatures>
-         <fos:proto name="transitive-closure" return-type="gnode()*">
-            <fos:arg name="node" type="gnode()?" usage="navigation"/>
-            <fos:arg name="step" type="fn($node as gnode()) as gnode()*" usage="inspection"/>
+         <fos:proto name="transitive-closure" return-type="node()*">
+            <fos:arg name="node" type="node()?" usage="navigation"/>
+            <fos:arg name="step" type="fn($node as node()) as node()*" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -24642,9 +24642,9 @@ return sort-with($persons/person, (
       </fos:rules>
       <fos:equivalent style="xquery-function">
 declare %private function tc-inclusive(
-  $nodes as gnode()*,
-  $step  as fn($node as gnode()) as gnode()*
-) as gnode()* {
+  $nodes as node()*,
+  $step  as fn($node as node()) as node()*
+) as node()* {
   let $nextStep := $nodes/$step(.)
   let $newNodes := $nextStep except $nodes
   return if (exists($newNodes))
@@ -24653,9 +24653,9 @@ declare %private function tc-inclusive(
 };
 
 declare function transitive-closure (
-  $node as gnode(),
-  $step as fn($node as gnode()) as gnode()*
-) as gnode()* {
+  $node as node(),
+  $step as fn($node as node()) as node()*
+) as node()* {
   tc-inclusive($node/$step(.), $step)
 };
 
@@ -28320,7 +28320,7 @@ return json-to-xml($json, $options)]]></eg>
    <fos:function name="xml-to-json" prefix="fn">
       <fos:signatures>
          <fos:proto name="xml-to-json" return-type="xs:string?">
-            <fos:arg name="node" type="node()?" usage="absorption" example="()"/>
+            <fos:arg name="node" type="xnode()?" usage="absorption" example="()"/>
             <fos:arg name="options" type="map(*)?" usage="inspection" default="{}" note="default-on-empty"/>
          </fos:proto>
       </fos:signatures>
@@ -33424,7 +33424,7 @@ return $variables( #Q{http://example.com/dyn}value )</eg></fos:expression>
                <fos:applies-to>3.0, 4.0</fos:applies-to>
                <fos:meaning>A document or element node containing the top-level stylesheet
             package</fos:meaning>
-               <fos:type>node()</fos:type>
+               <fos:type>xnode()</fos:type>
                <fos:default-description>n/a</fos:default-description>
             </fos:option>
             <fos:option key="package-text">
@@ -33546,7 +33546,7 @@ return $variables( #Q{http://example.com/dyn}value )</eg></fos:expression>
                   applying templates to this node. If the initial mode is streamable
                   and a streaming XSLT 3.0 or XSLT 4.0 processor is used,
                   then the supplied document is processed in streaming mode.</fos:meaning>
-               <fos:type>node()</fos:type>
+               <fos:type>xnode()</fos:type>
                <fos:default>n/a</fos:default>
             </fos:option>
             
@@ -33558,7 +33558,7 @@ return $variables( #Q{http://example.com/dyn}value )</eg></fos:expression>
             invocation, the <code>source-node</code> acts as the
                 <code>initial-match-selection</code>, that is, stylesheet execution starts by
             applying templates to this node.</fos:meaning>
-               <fos:type>node()</fos:type>
+               <fos:type>xnode()</fos:type>
                <fos:default-description>n/a</fos:default-description>
             </fos:option>
 
@@ -33604,7 +33604,7 @@ return $variables( #Q{http://example.com/dyn}value )</eg></fos:expression>
                <fos:meaning>Root of the tree containing the principal stylesheet module, as a document or
             element node. The base URI of the node acts as the default for
             stylesheet-base-uri.</fos:meaning>
-               <fos:type>node()</fos:type>
+               <fos:type>xnode()</fos:type>
                <fos:default-description>n/a</fos:default-description>
             </fos:option>
             <fos:option key="stylesheet-params">

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -810,7 +810,7 @@
             <p>Whether the supplied node was found to be valid against the schema.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="typed-node" type="node()?">
+      <fos:field name="typed-node" type="xnode()?">
          <fos:meaning>
             <p>The root of a deep copy of the input tree, augmented with type annotations
             and default values.</p>
@@ -828,7 +828,7 @@
    <fos:function name="node-name" prefix="fn">
       <fos:signatures>
          <fos:proto name="node-name" return-type="xs:QName?">
-            <fos:arg name="node" type="node()?" default="." usage="inspection"/>
+            <fos:arg name="node" type="xnode()?" default="." usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -860,7 +860,7 @@
                      class="DY" code="0002" type="type"/>.</p>
             </item>
             <item>
-               <p>If the context value is not an instance of the sequence type <code>node()?</code>, 
+               <p>If the context value is not an instance of the sequence type <code>xnode()?</code>, 
                   type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
             </item>
@@ -1101,7 +1101,7 @@
    <fos:function name="nilled" prefix="fn">
       <fos:signatures>
          <fos:proto name="nilled" return-type="xs:boolean?">
-            <fos:arg name="node" type="node()?" default="." usage="inspection"/>
+            <fos:arg name="node" type="xnode()?" default="." usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -1134,7 +1134,7 @@
                      class="DY" code="0002" type="type"/></p>
             </item>
             <item>
-               <p>If the context value is not an instance of the sequence type <code>node()?</code>, type error <xerrorref spec="XP" class="TY"
+               <p>If the context value is not an instance of the sequence type <code>xnode()?</code>, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
             </item>
          </ulist>
@@ -1369,7 +1369,7 @@
    <fos:function name="base-uri" prefix="fn">
       <fos:signatures>
          <fos:proto name="base-uri" return-type="xs:anyURI?">
-            <fos:arg name="node" type="node()?" default="." usage="inspection"/>
+            <fos:arg name="node" type="xnode()?" default="." usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -1414,7 +1414,7 @@
                      class="DY" code="0002" type="type"/></p>
             </item>
             <item>
-               <p>If the context value is not an instance of the sequence type <code>node()?</code>, type error <xerrorref spec="XP" class="TY"
+               <p>If the context value is not an instance of the sequence type <code>xnode()?</code>, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
             </item>
          </ulist>
@@ -1431,7 +1431,7 @@
    <fos:function name="document-uri" prefix="fn">
       <fos:signatures>
          <fos:proto name="document-uri" return-type="xs:anyURI?">
-            <fos:arg name="node" type="node()?" default="." usage="inspection"/>
+            <fos:arg name="node" type="xnode()?" default="." usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -1467,7 +1467,7 @@
                      class="DY" code="0002" type="type"/></p>
             </item>
             <item>
-               <p>If the context value is not an instance of the sequence type <code>node()?</code>, type error <xerrorref spec="XP" class="TY"
+               <p>If the context value is not an instance of the sequence type <code>xnode()?</code>, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
             </item>
          </ulist>
@@ -1518,7 +1518,7 @@
    <fos:function name="location" prefix="fn">
       <fos:signatures>
          <fos:proto name="location" return-type="fn:location-record?">
-            <fos:arg name="node" type="node()?" default="." usage="inspection"/>
+            <fos:arg name="node" type="xnode()?" default="." usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -14192,7 +14192,7 @@ fn:parse-QName("xmp:person")</eg></fos:expression>
    <fos:function name="name" prefix="fn">
       <fos:signatures>
          <fos:proto name="name" return-type="xs:string">
-            <fos:arg name="node" type="node()?" default="." usage="inspection"/>
+            <fos:arg name="node" type="xnode()?" default="." usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -14227,7 +14227,7 @@ fn:parse-QName("xmp:person")</eg></fos:expression>
                      class="DY" code="0002" type="type"/></p>
             </item>
             <item>
-               <p>If the context value is not an instance of the sequence type <code>node()?</code>, type error <xerrorref spec="XP" class="TY"
+               <p>If the context value is not an instance of the sequence type <code>xnode()?</code>, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
             </item>
          </ulist>
@@ -14283,7 +14283,7 @@ fn:parse-QName("xmp:person")</eg></fos:expression>
    <fos:function name="local-name" prefix="fn">
       <fos:signatures>
          <fos:proto name="local-name" return-type="xs:string">
-            <fos:arg name="node" type="node()?" default="." usage="inspection"/>
+            <fos:arg name="node" type="xnode()?" default="." usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -14372,7 +14372,7 @@ fn:parse-QName("xmp:person")</eg></fos:expression>
    <fos:function name="namespace-uri" prefix="fn">
       <fos:signatures>
          <fos:proto name="namespace-uri" return-type="xs:anyURI">
-            <fos:arg name="node" type="node()?" default="." usage="inspection"/>
+            <fos:arg name="node" type="xnode()?" default="." usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -14412,7 +14412,7 @@ fn:parse-QName("xmp:person")</eg></fos:expression>
                      class="DY" code="0002" type="type"/></p>
             </item>
             <item>
-               <p>If the context value is not an instance of the sequence type <code>node()?</code>, type error <xerrorref spec="XP" class="TY"
+               <p>If the context value is not an instance of the sequence type <code>xnode()?</code>, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
             </item>
          </ulist>
@@ -14555,7 +14555,7 @@ fn:parse-QName("xmp:person")</eg></fos:expression>
       <fos:signatures>
          <fos:proto name="lang" return-type="xs:boolean">
             <fos:arg name="language" type="xs:string?"/>
-            <fos:arg name="node" type="node()" default="." usage="inspection"/>
+            <fos:arg name="node" type="xnode()" default="." usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="1">
@@ -14653,7 +14653,7 @@ fn:parse-QName("xmp:person")</eg></fos:expression>
    <fos:function name="path" prefix="fn">
       <fos:signatures>
          <fos:proto name="path" return-type="xs:string?">
-            <fos:arg name="node" type="gnode()?" default="." usage="navigation"/>
+            <fos:arg name="node" type="node()?" default="." usage="navigation"/>
             <fos:arg name="options" type="map(*)?" default="{}" note="default-on-empty"/>
          </fos:proto>
       </fos:signatures>
@@ -14690,7 +14690,7 @@ fn:parse-QName("xmp:person")</eg></fos:expression>
                   starting from the supplied origin node, rather than from the root of the
                   containing tree.
                </fos:meaning>
-               <fos:type>gnode()?</fos:type>
+               <fos:type>node()?</fos:type>
                <fos:default>()</fos:default>
             </fos:option>
             <fos:option key="lexical">
@@ -15088,8 +15088,8 @@ return path($in//a[. = 2])</eg></fos:expression>
    </fos:function>
    <fos:function name="root" prefix="fn">
       <fos:signatures>
-         <fos:proto name="root" return-type="gnode()?">
-            <fos:arg name="node" type="gnode()?" default="." usage="inspection"/>
+         <fos:proto name="root" return-type="node()?">
+            <fos:arg name="node" type="node()?" default="." usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -15111,7 +15111,7 @@ return path($in//a[. = 2])</eg></fos:expression>
       </fos:summary>
       <fos:rules>
          <p>The function returns the value of the expression
-               <code>$node/ancestor-or-self::gnode()[last()]</code>.</p>
+               <code>$node/ancestor-or-self::node()[last()]</code>.</p>
          
         
       </fos:rules>
@@ -15126,7 +15126,7 @@ return path($in//a[. = 2])</eg></fos:expression>
             </item>
             <item>
                <p>If the context value is not an instance of the sequence type
-               <code>gnode()?</code>, type error
+               <code>node()?</code>, type error
                <xerrorref spec="XP" class="TY" code="0004" type="type"/>.</p>
             </item>
          </ulist>
@@ -15189,7 +15189,7 @@ let $newi := $o/tool</eg>
    <fos:function name="has-children" prefix="fn">
       <fos:signatures>
          <fos:proto name="has-children" return-type="xs:boolean">
-            <fos:arg name="node" type="gnode()?" default="." usage="inspection"/>
+            <fos:arg name="node" type="node()?" default="." usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -15207,9 +15207,9 @@ let $newi := $o/tool</eg>
       </fos:summary>
       <fos:rules>
          <p>Provided that the supplied argument <code>$node</code> matches the expected type
-               <code>gnode()?</code>, the result of the function call
+               <code>node()?</code>, the result of the function call
                <code>fn:has-children($node)</code> is defined to be the same as the result of the
-            expression <code>fn:exists($node/child::gnode())</code>.</p>
+            expression <code>fn:exists($node/child::node())</code>.</p>
       </fos:rules>
       <fos:errors>
          <p>The following errors may be raised when <code>$node</code> is omitted:</p>
@@ -15221,7 +15221,7 @@ let $newi := $o/tool</eg>
                      class="DY" code="0002" type="type"/></p>
             </item>
             <item>
-               <p>If the context value is not an instance of the sequence type <code>gnode()?</code>, type error <xerrorref spec="XP" class="TY"
+               <p>If the context value is not an instance of the sequence type <code>node()?</code>, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
             </item>
          </ulist>
@@ -15311,8 +15311,8 @@ let $newi := $o/tool</eg>
    
    <fos:function name="distinct-ordered-nodes" prefix="fn">
       <fos:signatures>
-         <fos:proto name="distinct-ordered-nodes" return-type="gnode()*">
-            <fos:arg name="nodes" type="gnode()*" usage="navigation"/>
+         <fos:proto name="distinct-ordered-nodes" return-type="node()*">
+            <fos:arg name="nodes" type="node()*" usage="navigation"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -15368,8 +15368,8 @@ return count(distinct-ordered-nodes(
    </fos:function>
    <fos:function name="innermost" prefix="fn">
       <fos:signatures>
-         <fos:proto name="innermost" return-type="gnode()*">
-            <fos:arg name="nodes" type="gnode()*" usage="navigation"/>
+         <fos:proto name="innermost" return-type="node()*">
+            <fos:arg name="nodes" type="node()*" usage="navigation"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -15386,7 +15386,7 @@ return count(distinct-ordered-nodes(
       <fos:rules>
          <p>The effect of the function call <code>fn:innermost($nodes)</code> is defined to be
             equivalent to the result of the expression:</p>
-         <eg>$nodes except $nodes/ancestor::gnode()</eg>
+         <eg>$nodes except $nodes/ancestor::node()</eg>
          <p>That is, the function takes as input a sequence of GNodes, and returns every GNode within
             the sequence that is not an ancestor of another GNode within the sequence; the GNodes are
             returned in document order with duplicates eliminated.</p>
@@ -15423,8 +15423,8 @@ return count(distinct-ordered-nodes(
    </fos:function>
    <fos:function name="outermost" prefix="fn">
       <fos:signatures>
-         <fos:proto name="outermost" return-type="gnode()*">
-            <fos:arg name="nodes" type="gnode()*" usage="transmission"/>
+         <fos:proto name="outermost" return-type="node()*">
+            <fos:arg name="nodes" type="node()*" usage="transmission"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -15441,7 +15441,7 @@ return count(distinct-ordered-nodes(
       <fos:rules>
          <p>The effect of the function call <code>fn:outermost($nodes)</code> is defined to be
             equivalent to the result of the expression:</p>
-         <eg>$nodes[not(ancestor::gnode() intersect $nodes)]/.</eg>
+         <eg>$nodes[not(ancestor::node() intersect $nodes)]/.</eg>
          <!--bug 17029-->
          <p>That is, the function takes as input a sequence of GNodes, and returns every GNode within
             the sequence that does not have another GNode within the sequence as an ancestor; the
@@ -15656,8 +15656,8 @@ return empty($break)
    
    <fos:function name="siblings" prefix="fn">
       <fos:signatures>
-         <fos:proto name="siblings" return-type="gnode()*">
-            <fos:arg name="node" type="gnode()?" default="." usage="navigation"/>
+         <fos:proto name="siblings" return-type="node()*">
+            <fos:arg name="node" type="node()?" default="." usage="navigation"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -15678,7 +15678,7 @@ return empty($break)
          
          <p>If <code>$node</code> is a child of some parent GNode <var>P</var>, the function returns all the
          children of <var>P</var> (including <code>$node</code>), in document order, as determined
-            by the value of <code>$node/child::gnode()</code>.</p>
+            by the value of <code>$node/child::node()</code>.</p>
          
          <p>Otherwise (specifically, if <code>$node</code> is parentless, or if it is an attribute or namespace node),
          the function returns <code>$node</code>.</p>
@@ -19197,7 +19197,7 @@ else head($c) + sum(tail($c))</eg>
       <fos:signatures>
          <fos:proto name="id" return-type="element()*">
             <fos:arg name="values" type="xs:string*"/>
-            <fos:arg name="node" type="node()" default="." usage="navigation"/>
+            <fos:arg name="node" type="xnode()" default="." usage="navigation"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="1">
@@ -19362,7 +19362,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       <fos:signatures>
          <fos:proto name="element-with-id" return-type="element()*">
             <fos:arg name="values" type="xs:string*"/>
-            <fos:arg name="node" type="node()" default="." usage="navigation"/>
+            <fos:arg name="node" type="xnode()" default="." usage="navigation"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="1">
@@ -19532,9 +19532,9 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
    </fos:function>
    <fos:function name="idref" prefix="fn">
       <fos:signatures>
-         <fos:proto name="idref" return-type="node()*">
+         <fos:proto name="idref" return-type="xnode()*">
             <fos:arg name="values" type="xs:string*"/>
-            <fos:arg name="node" type="node()" default="." usage="navigation"/>
+            <fos:arg name="node" type="xnode()" default="." usage="navigation"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="1">
@@ -21151,7 +21151,7 @@ return { "width": $int16-at($loc + 5),
    <fos:function name="generate-id" prefix="fn">
       <fos:signatures>
          <fos:proto name="generate-id" return-type="xs:string">
-            <fos:arg name="node" type="gnode()?" usage="inspection" default="."/>
+            <fos:arg name="node" type="node()?" usage="inspection" default="."/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -21193,7 +21193,7 @@ return { "width": $int16-at($loc + 5),
             </item>
             <item>
                <p>If the context value is not an instance of the sequence type
-               <code>gnode()?</code>, type error <xerrorref spec="XP" class="TY" code="0004" type="type"/>.</p>
+               <code>node()?</code>, type error <xerrorref spec="XP" class="TY" code="0004" type="type"/>.</p>
             </item>
          </ulist>
 
@@ -25004,9 +25004,9 @@ return sort-with($persons/person, (
    
    <fos:function name="transitive-closure" prefix="fn">
       <fos:signatures>
-         <fos:proto name="transitive-closure" return-type="gnode()*">
-            <fos:arg name="node" type="gnode()?" usage="navigation"/>
-            <fos:arg name="step" type="fn($node as gnode()) as gnode()*" usage="inspection"/>
+         <fos:proto name="transitive-closure" return-type="node()*">
+            <fos:arg name="node" type="node()?" usage="navigation"/>
+            <fos:arg name="step" type="fn($node as node()) as node()*" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -25035,9 +25035,9 @@ return sort-with($persons/person, (
       </fos:rules>
       <fos:equivalent style="xquery-function">
 declare %private function tc-inclusive(
-  $nodes as gnode()*,
-  $step  as fn($node as gnode()) as gnode()*
-) as gnode()* {
+  $nodes as node()*,
+  $step  as fn($node as node()) as node()*
+) as node()* {
   let $nextStep := $nodes/$step(.)
   let $newNodes := $nextStep except $nodes
   return if (exists($newNodes))
@@ -25046,9 +25046,9 @@ declare %private function tc-inclusive(
 };
 
 declare function transitive-closure (
-  $node as gnode(),
-  $step as fn($node as gnode()) as gnode()*
-) as gnode()* {
+  $node as node(),
+  $step as fn($node as node()) as node()*
+) as node()* {
   tc-inclusive($node/$step(.), $step)
 };
 
@@ -28709,7 +28709,7 @@ return json-to-xml($json, $options)]]></eg>
    <fos:function name="xml-to-json" prefix="fn">
       <fos:signatures>
          <fos:proto name="xml-to-json" return-type="xs:string?">
-            <fos:arg name="node" type="node()?" usage="absorption" example="()"/>
+            <fos:arg name="node" type="xnode()?" usage="absorption" example="()"/>
             <fos:arg name="options" type="map(*)?" usage="inspection" default="{}" note="default-on-empty"/>
          </fos:proto>
       </fos:signatures>
@@ -33962,7 +33962,7 @@ return $variables( #Q{http://example.com/dyn}value )</eg></fos:expression>
                <fos:applies-to>3.0, 4.0</fos:applies-to>
                <fos:meaning>A document or element node containing the top-level stylesheet
             package</fos:meaning>
-               <fos:type>node()</fos:type>
+               <fos:type>xnode()</fos:type>
                <fos:default-description>n/a</fos:default-description>
             </fos:option>
             <fos:option key="package-text">
@@ -34084,7 +34084,7 @@ return $variables( #Q{http://example.com/dyn}value )</eg></fos:expression>
                   applying templates to this node. If the initial mode is streamable
                   and a streaming XSLT 3.0 or XSLT 4.0 processor is used,
                   then the supplied document is processed in streaming mode.</fos:meaning>
-               <fos:type>node()</fos:type>
+               <fos:type>xnode()</fos:type>
                <fos:default>n/a</fos:default>
             </fos:option>
             
@@ -34096,7 +34096,7 @@ return $variables( #Q{http://example.com/dyn}value )</eg></fos:expression>
             invocation, the <code>source-node</code> acts as the
                 <code>initial-match-selection</code>, that is, stylesheet execution starts by
             applying templates to this node.</fos:meaning>
-               <fos:type>node()</fos:type>
+               <fos:type>xnode()</fos:type>
                <fos:default-description>n/a</fos:default-description>
             </fos:option>
 
@@ -34142,7 +34142,7 @@ return $variables( #Q{http://example.com/dyn}value )</eg></fos:expression>
                <fos:meaning>Root of the tree containing the principal stylesheet module, as a document or
             element node. The base URI of the node acts as the default for
             stylesheet-base-uri.</fos:meaning>
-               <fos:type>node()</fos:type>
+               <fos:type>xnode()</fos:type>
                <fos:default-description>n/a</fos:default-description>
             </fos:option>
             <fos:option key="stylesheet-params">

--- a/specifications/xquery-40/src/ebnf.xml
+++ b/specifications/xquery-40/src/ebnf.xml
@@ -905,8 +905,9 @@
         <sitem>node</sitem>
         <sitem>processing-instruction</sitem>
         <sitem>schema-attribute</sitem>
-        <sitem>schema-element</sitem> 
-        <sitem>text</sitem>       
+        <sitem>schema-element</sitem>
+        <sitem>text</sitem>
+        <sitem>xnode</sitem>
       </slist>
     
     <p>Names used as syntactic keywords:</p>
@@ -916,7 +917,6 @@
       <sitem>enum</sitem>
       <sitem>fn</sitem>
       <sitem>function</sitem>
-      <sitem>gnode</sitem>
       <sitem>if</sitem>
       <sitem>item</sitem>
       <sitem>jnode</sitem>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -143,9 +143,10 @@ declaration contains construction of new nodes.)</phrase>
                The term <term>atomic value</term> has been replaced by <termref def="dt-atomic-item"/>.
             </change>
             <change issue="2025" PR="2031" date="2025-06-13">
-               The terms <term>XNode</term> and <code>JNode</code> are introduced; the existing
-               term <term>node</term> remains in use as a synonym for <term>XNode</term> where
-               the context does not specify otherwise.
+               The terms <term>XNode</term> and <term>JNode</term> are introduced; the item type
+               <code>node()</code> now matches any <term>GNode</term> (that is, an XNode or a JNode),
+               and the new item type <code>xnode()</code> matches any XNode. The unqualified term
+               <term>node</term> continues to be used as a synonym for <term>XNode</term>.
             </change>
          </changes>
       
@@ -161,8 +162,8 @@ declaration contains construction of new nodes.)</phrase>
                def="dt-item">items</termref>.</termdef></p>
          <p><termdef id="dt-item" term="item">
   An <term>item</term> is either an <termref
-               def="dt-atomic-item">atomic item</termref>, a <termref def="dt-node"
-               >node</termref>,
+               def="dt-atomic-item">atomic item</termref>, a <termref def="dt-GNode"
+               >generic node</termref>,
 or a <termref def="dt-function-item">function item</termref>.</termdef></p>
          
       <p><termdef id="dt-atomic-item" term="atomic item">An <term>atomic
@@ -2303,8 +2304,8 @@ but it does not place any constraints on how XDM instances are constructed.</p>
                      >XDM instance</termref> has a <term>type annotation</term> (described in <xspecref
                      spec="DM40" ref="types"
                   />). 
-The type annotation of a node is a reference to a <termref def="dt-schema-type"/>. 
-</termdef>  The <code>type-name</code> of a node is the name of the type referenced by its <termref
+The type annotation of an XNode is a reference to a <termref def="dt-schema-type"/>. 
+</termdef>  The <code>type-name</code> of an XNode is the name of the type referenced by its <termref
                   def="dt-type-annotation">type annotation</termref> (but note that the
                type annotation can be a reference to an anonymous type). 
 If the <termref
@@ -2827,14 +2828,14 @@ The prefix <code>xmlns</code> must not be bound to any namespace URI, and no pre
             <item><p>Evaluation of expressions may raise errors. The implications of this
                   are discussed in <specref ref="errors"/>.</p></item>
             
-            <item><p>Some expressions construct new nodes (see <specref ref="id-constructors"/>).
+            <item><p>Some expressions construct new XNodes (see <specref ref="id-constructors"/>).
             These expressions are not functionally pure, because evaluating the same expression twice
-            creates two nodes, each with distinct identity. An optimizer <rfc2119>should</rfc2119>
+            creates two XNodes, each with distinct identity. An optimizer <rfc2119>should</rfc2119>
             avoid rewriting such expressions in a way that changes the number of times they are evaluated.
             However, it is not always possible to detect statically that an expression constructs new
             nodes, for example when a dynamic function call invokes a function whose body
             includes a node constructor. Applications <rfc2119>should</rfc2119> therefore avoid over-reliance
-            on newly constructed nodes having distinct identity.</p></item>
+            on newly constructed XNodes having distinct identity.</p></item>
             
             <item><p>Some expressions access information in the external environment.
             Examples are calls on functions such as <function>fn:doc</function>, <function>fn:unparsed-text</function>,
@@ -3634,49 +3635,49 @@ tree <var>T2</var>.</p>
                
                <termdef term="typed value" id="dt-typed-value"
                   >The <term>typed
-                     value</term> of a node is a sequence of atomic items and can be
+                     value</term> of an XNode is a sequence of atomic items and can be
                   extracted by applying the <function>data</function> function to the
                   node.</termdef>
                <termdef id="dt-string-value" term="string value"
                   >The
-                  <term>string value</term> of a node is a string and can be extracted
+                  <term>string value</term> of an XNode is a string and can be extracted
                   by applying the <function>string</function>
-                  function to the node.</termdef>
+                  function to the XNode.</termdef>
             </p>
             
             
             <p>An implementation may store both the <termref def="dt-typed-value"
                >typed value</termref> and the <termref def="dt-string-value"
-                  >string value</termref> of a node, or it may store only one of these and derive the other as needed.
-               The string value of a node must be a valid lexical representation of the typed value of the node,
-               but the node is not required to preserve the string representation from the original source document.
-               For example, if the typed value of a node is the <code>xs:integer</code> value <code>30</code>,
+                  >string value</termref> of an XNode, or it may store only one of these and derive the other as needed.
+               The string value of an XNode must be a valid lexical representation of the typed value of the XNode,
+               but the XNode is not required to preserve the string representation from the original source document.
+               For example, if the typed value of an XNode is the <code>xs:integer</code> value <code>30</code>,
                its string value might be <code>"30"</code> or <code>"0030"</code>.</p>
             <p role="xpath">The <termref def="dt-typed-value">typed value</termref>, <termref
                def="dt-string-value">string value</termref>, and <termref
                   def="dt-type-annotation"
-                  >type annotation</termref> of a node are closely related.  If the node was created by mapping from an Infoset or PSVI, the relationships among these properties are defined by rules in <xspecref
+                  >type annotation</termref> of an XNode are closely related.  If the XNode was created by mapping from an Infoset or PSVI, the relationships among these properties are defined by rules in <xspecref
                      spec="DM40" ref="types"/>.</p>
             <p role="xquery">The <termref def="dt-typed-value">typed value</termref>, <termref
                def="dt-string-value">string value</termref>, and <termref
                   def="dt-type-annotation"
-                  >type annotation</termref> of a node are closely related, and are defined by rules found in the following locations:</p>
+                  >type annotation</termref> of an XNode are closely related, and are defined by rules found in the following locations:</p>
             
             <ulist role="xquery">
                
                <item>
-                  <p>If the node was created by mapping from an Infoset or PSVI, see rules in <xspecref
+                  <p>If the XNode was created by mapping from an Infoset or PSVI, see rules in <xspecref
                      spec="DM40" ref="types"/>.</p>
                </item>
                
                <item>
-                  <p>If the node was created by an XQuery node constructor, see rules in <specref
+                  <p>If the XNode was created by an XQuery node constructor, see rules in <specref
                      ref="id-element-constructor"/>, <specref ref="id-computedElements"
                      />, or <specref ref="id-computedAttributes"/>.</p>
                </item>
                
                <item>
-                  <p>If the node was created by a <code>validate</code> expression, see rules in <specref
+                  <p>If the XNode was created by a <code>validate</code> expression, see rules in <specref
                      ref="id-validate"/>.</p>
                </item>
             </ulist>
@@ -3689,7 +3690,7 @@ tree <var>T2</var>.</p>
             <olist>
                
                <item>
-                  <p>For text and document nodes, the typed value of the node is the same as its
+                  <p>For text and document nodes, the typed value of the XNode is the same as its
                      string value, as an instance of  the type <code>xs:untypedAtomic</code>. The
                      string value of a document node is formed by concatenating the string
                      values of all its descendant text nodes, in <termref
@@ -3723,8 +3724,8 @@ tree <var>T2</var>.</p>
                      <code>"bar baz faz"</code>. The typed value of A2 is a sequence of
                      three atomic items (<code>"bar"</code>, <code>"baz"</code>",
                      <code>"faz"</code>"), each of type <code>xs:IDREF</code>. The typed
-                     value of a node is never treated as an instance of a named list
-                     type. Instead, if the type annotation of a node is a list type (such
+                     value of an XNode is never treated as an instance of a named list
+                     type. Instead, if the type annotation of an XNode is a list type (such
                      as <code>xs:IDREFS</code>), its typed value is treated as a sequence
                      of the <termref
                         def="dt-generalized-atomic-type"
@@ -3748,7 +3749,7 @@ tree <var>T2</var>.</p>
                            denotes a complex type with mixed content (including <code>xs:anyType</code>), then the typed value of the
                            node is equal to its string value, as an instance of
                            <code>xs:untypedAtomic</code>.  However, if the <code>nilled</code>
-                           property of the node is <code>true</code>, then its typed value is the empty sequence.</p>
+                           property of the XNode is <code>true</code>, then its typed value is the empty sequence.</p>
                         
                         
                         
@@ -3773,10 +3774,10 @@ tree <var>T2</var>.</p>
                      <item>
                         <p>If the type
                            annotation denotes a simple type or a complex type with simple
-                           content, then the typed value of the node is derived from its string
+                           content, then the typed value of the XNode is derived from its string
                            value and its type annotation in a way that is consistent with schema
                            validation. However, if the <code>nilled</code>
-                           property of the node is <code>true</code>, then its typed value is the empty sequence.</p>
+                           property of the XNode is <code>true</code>, then its typed value is the empty sequence.</p>
                         <p>Example: E3 is an element node with the type
                            annotation <code>cost</code>, which is a complex type that has several
                            attributes and a simple content type of <code>xs:decimal</code>. The
@@ -3795,10 +3796,10 @@ tree <var>T2</var>.</p>
                            which is a union type with member types <code>xs:integer</code> and <code>xs:string</code>.
                            The string value of E5 is <code>"47"</code>. The typed value of E5 is <code>47</code> as a
                            <code>xs:integer</code>, since <code>xs:integer</code> is the member type that validated the
-                           content of E5. In general, when the type annotation of a node is a union type,
-                           the typed value of the node will be an instance of one of the member types of the union.</p>
+                           content of E5. In general, when the type annotation of an XNode is a union type,
+                           the typed value of the XNode will be an instance of one of the member types of the union.</p>
                         <note>
-                           <p>If an implementation stores only the string value of a node, and the type annotation of the node is a union type, the implementation must be able to deliver the typed value of the node as an instance of the appropriate member type.</p>
+                           <p>If an implementation stores only the string value of an XNode, and the type annotation of the XNode is a union type, the implementation must be able to deliver the typed value of the XNode as an instance of the appropriate member type.</p>
                         </note>
                      </item>
                      
@@ -3811,13 +3812,13 @@ tree <var>T2</var>.</p>
                      <item>
                         <p>If the type annotation
                            denotes a complex type with element-only content, then the typed value
-                           of the node is <xtermref
+                           of the XNode is <xtermref
                               spec="DM40" ref="dt-absent"
                            />. The <function>fn:data</function> function raises a
                            <termref
                               def="dt-type-error">type error</termref>
                            <xerrorref spec="FO40" class="TY" code="0012"
-                           /> when applied to such a node. The string value of such a node is equal to the concatenated string values of all its text node descendants, in document order.</p>
+                           /> when applied to such a node. The string value of such an XNode is equal to the concatenated string values of all its text node descendants, in document order.</p>
                         <p>Example: E6 is an
                            element node with the type annotation <code>weather</code>, which is a
                            complex type whose content type specifies
@@ -3868,7 +3869,7 @@ its <termref def="dt-typed-value"
                         >typed value</termref> is returned (a <termref def="dt-type-error"
                         >type error</termref>
                      <xerrorref spec="FO40" class="TY" code="0012"
-                     /> is raised if the node has no typed value.)</p>
+                     /> is raised if the XNode has no typed value.)</p>
                </item>
                
                <item>
@@ -4207,12 +4208,12 @@ of applying the <function>fn:boolean</function> function to the value.</termdef>
             <item><p><termref def="dt-XNode">XNodes</termref> 
                (which are another kind of <termref def="dt-item"/>) have a property
             called a <termref def="dt-type-annotation"/> which determines the type of their content.
-            The type annotation is a <termref def="dt-schema-type"/>. The type annotation of a node
-            must not be confused with the item type of the node. For example, an element 
+            The type annotation is a <termref def="dt-schema-type"/>. The type annotation of an XNode
+            must not be confused with the item type of the XNode. For example, an element 
             <code><![CDATA[<age>23</age>]]></code> might have been validated against a schema
                that defines this element as having <code>xs:integer</code> content. If this
-               is the case, the <termref def="dt-type-annotation"/> of the node will be
-               <code>xs:integer</code>, and in the <?inject language?> type system, the node will
+               is the case, the <termref def="dt-type-annotation"/> of the XNode will be
+               <code>xs:integer</code>, and in the <?inject language?> type system, the XNode will
                match the <termref def="dt-item-type"/> <code>element(age, xs:integer)</code>.
             </p></item>
          </ulist>
@@ -4564,7 +4565,7 @@ types</term> (such as <code>xs:integer</code>) and function types
          
          <p>In most cases, the set of items matched by an item type consists either
          exclusively of <termref def="dt-atomic-item">atomic items</termref>,
-         exclusively of <termref def="dt-node">nodes</termref>, 
+         exclusively of <termref def="dt-GNode">generic nodes</termref>,
          or exclusively of <xtermref spec="DM40" ref="dt-function-item">function items</xtermref>.
          Exceptions include the generic types <code>item()</code>, which matches all items, <code>xs:error</code>,
          which matches no items, and <termref def="dt-choice-item-type">choice item types</termref>,
@@ -5032,8 +5033,8 @@ declare variable $orange-fruit as my:fruit := "orange";
                   </change>
                </changes>
                
-               <p>Node types are <termref def="dt-item-type">item types</termref> whose 
-                  instances are all <termref def="dt-node">nodes</termref>.</p>
+               <p>Node types are <termref def="dt-item-type">item types</termref> whose
+                  instances are all <termref def="dt-GNode">generic nodes</termref>.</p>
                
                <p>The syntax for node types is also used for <termref def="dt-node-test">node tests</termref>
                within path expressions. This explains why the production rules have names such as
@@ -6733,7 +6734,7 @@ declare record Particle (
                   <prodrecap ref="GNodeType"/>
                </scrap>
                
-               <p>The type <code>gnode()</code> is equivalent to the choice type <code>jnode() | node()</code>.</p>
+               <p>The type <code>node()</code> is equivalent to the choice type <code>jnode() | xnode()</code>.</p>
                
             </div3>
             <div3 id="id-xs-error">
@@ -7086,12 +7087,12 @@ declare record Particle (
                            <item><p><code>xs:anyAtomicType</code> is treated as a choice of the 19 XSD primitive
                            atomic types (<code>xs:string</code>, <code>xs:boolean</code>, etc), plus
                            <code>xs:untypedAtomic</code>;</p></item>
-                           <item><p><code>node()</code> is treated as <code>(document-node() | element() | attribute() 
+                           <item><p><code>xnode()</code> is treated as <code>(document-node() | element() | attribute()
                                     | text() | comment() | processing-instruction() | namespace-node())</code>;</p></item>
-                           <item><p><code>gnode()</code> is treated as <code>(node() | jnode())</code>, where <code>node()</code>
+                           <item><p><code>node()</code> is treated as <code>(xnode() | jnode())</code>, where <code>xnode()</code>
                            is then further expanded as above;</p></item>
-                           <item><p><code>item()</code> is treated as <code>(gnode() | xs:anyAtomicType | function(*))</code>,
-                           where <code>gnode()</code> and <code>xs:anyAtomicType</code> are then expanded as above.</p></item>
+                           <item><p><code>item()</code> is treated as <code>(node() | xs:anyAtomicType | function(*))</code>,
+                           where <code>node()</code> and <code>xs:anyAtomicType</code> are then expanded as above.</p></item>
                         </ulist>
                      </item>
                      <item>
@@ -7109,8 +7110,8 @@ declare record Particle (
                   <ulist>
                      <item><p><code>(xs:int | xs:long)</code> is a subtype of <code>(xs:decimal | xs:date)</code>
                   because both <code>xs:int</code> and <code>xs:long</code> are subtypes of <code>xs:decimal</code>.</p></item>
-                     <item><p><code>node()</code> is a subtype of <code>(element() | attribute() | text() |
-                     comment() | processing-instruction() | document-node() | jnode())</code> because <code>node()</code>
+                     <item><p><code>xnode()</code> is a subtype of <code>(element() | attribute() | text() |
+                     comment() | processing-instruction() | document-node() | jnode())</code> because <code>xnode()</code>
                      is an abstract type that is expanded to a choice of the seven kinds of XNode.</p></item>
                   </ulist>
                   
@@ -7215,10 +7216,10 @@ declare record Particle (
                   
                      <olist>
                         <item>
-                           <p><var>A</var> is an <nt def="XNodeType"/> and <var>B</var> is <code>node()</code>.</p>
+                           <p><var>A</var> is an <nt def="XNodeType"/> and <var>B</var> is <code>xnode()</code>.</p>
                            <example>
                               <head>Example:</head>
-                              <p><code>comment() ⊆ node()</code></p>
+                              <p><code>comment() ⊆ xnode()</code></p>
                            </example>
                         </item>
                         <item>
@@ -7591,7 +7592,7 @@ declare record Particle (
                   <olist>
                      <item>
                         <p><var>A</var> is <code>jnode()</code> (or equivalently, <code>jnode(*)</code>)
-                         and <var>B</var> is <code>gnode()</code>.</p>
+                         and <var>B</var> is <code>node()</code>.</p>
                      </item>
                      <item>
                         <p><var>A</var> is <code>jnode(<var>C</var>)</code> and <var>B</var> is <code>jnode()</code>, for any constant 
@@ -12283,7 +12284,7 @@ return $incrementors[2](4)]]></eg>
 
          <p>An expression of the form <code>//<var>PP</var></code> (that is, an <termref def="dt-absolute-path-expression"/>
             with a leading <code>//</code>) is treated as an abbreviation for
-            the expression <code>./(fn:root(.) treat as (document-node()|jnode())/descendant-or-self::gnode()/<var>PP</var></code>. 
+            the expression <code>./(fn:root(.) treat as (document-node()|jnode())/descendant-or-self::node()/<var>PP</var></code>. 
             The effect of this expansion is that every item <var>N</var> 
             in the context value <var>V</var> is processed as follows, depending on its type:</p>
 
@@ -12517,9 +12518,9 @@ return $incrementors[2](4)]]></eg>
                      <code>fn:distinct-ordered-nodes($R)</code> has the effect of 
                      eliminating duplicates and sorting nodes into document order):</p>
                   <eg><![CDATA[let $R := E1 ! E2
-return if (every $r in $R satisfies $r instance of gnode())
+return if (every $r in $R satisfies $r instance of node())
        then (fn:distinct-ordered-nodes($R))
-       else if (every $r in $R satisfies not($r instance of gnode()))
+       else if (every $r in $R satisfies not($r instance of node()))
        then $R
        else error()]]></eg>
                   <p>For a table comparing the step operator to the map operator, see <specref ref="id-map-operator"/>.</p>
@@ -12532,15 +12533,15 @@ return if (every $r in $R satisfies $r instance of gnode())
            <head>Recursive Path Operator (<code>//</code>)</head>
             
            <p>When <code>//</code> is used as an infix operator, it can be treated as an abbreviation
-           for <code>/descendant-or-self::gnode()/</code>.</p>
+           for <code>/descendant-or-self::node()/</code>.</p>
             
             <p>In simple cases, an expression such as <code>$x//y</code> is equivalent to
             <code>$x/descendant::y</code>. But in some cases the semantics are more complex, for example:</p>
             
             <ulist>
-               <item><p><code>$x//@a</code> expands to <code>$x/descendant-or-self::gnode()/attribute::a</code>, which selects
+               <item><p><code>$x//@a</code> expands to <code>$x/descendant-or-self::node()/attribute::a</code>, which selects
                all attributes having <code>$x</code> as an ancestor.</p></item>
-               <item><p><code>$x//y[1]</code> expands to <code>$x/descendant-or-self::gnode()/child::y[1]</code>,
+               <item><p><code>$x//y[1]</code> expands to <code>$x/descendant-or-self::node()/child::y[1]</code>,
                which selects every descendant element of <code>$x</code> named <code>y</code> that is the 
                      first child of its parent. This is <emph>not</emph> the same as <code>($x//y)[1]</code>, which selects
                the first descendant of <code>$x</code> that is named <code>y</code>.</p></item>
@@ -12556,13 +12557,13 @@ return if (every $r in $R satisfies $r instance of gnode())
             
             <p>It is valid, but rarely useful, to use the <code>//</code> operator in conjunction with an axis other than
             <code>child</code> or <code>attribute</code>. For example, <code>$x//following-sibling::y</code>
-            expands to <code>$x/descendant-or-self::gnode()/following-sibling::y</code>, which selects every <code>y</code>
+            expands to <code>$x/descendant-or-self::node()/following-sibling::y</code>, which selects every <code>y</code>
                descendant of <code>$x</code> that is not the first child of its parent, as well as the following siblings
                of <code>$x</code> itself.</p>
             
             <p>It is also valid to follow <code>//</code> with an expression other than an axis step. For example,
             <code>distinct-values($x//node-name())</code> has the same effect as 
-               <code>$x/descendant-or-self::gnode() =!> node-name() => distinct-values()</code></p>
+               <code>$x/descendant-or-self::node() =!> node-name() => distinct-values()</code></p>
             
             <p>The effect of <code>//</code> at the start of an expression is explained in
                <specref ref="id-absolute-path-expressions"/>.</p>
@@ -12723,16 +12724,16 @@ return if (every $r in $R satisfies $r instance of gnode())
 			 axis is defined as the transitive closure of
 			 the child axis; it contains the descendants
 			 of the origin (the children, the children of the children, and so on).</p>
-                     <p>More formally, <code>$node/descendant::gnode()</code> delivers the result
-                     of <code>fn:transitive-closure($node, fn { child::gnode() })</code>.</p>
+                     <p>More formally, <code>$node/descendant::node()</code> delivers the result
+                     of <code>fn:transitive-closure($node, fn { child::node() })</code>.</p>
                      
                   </item>
                   
                   <item>
                      <p>The <code>descendant-or-self</code> axis contains the origin and the descendants 
                         of the origin.</p>
-                     <p>More formally, <code>$node/descendant-or-self::gnode()</code> delivers the result
-                     of <code>$node/(. | descendant::gnode())</code>.</p>
+                     <p>More formally, <code>$node/descendant-or-self::node()</code> delivers the result
+                     of <code>$node/(. | descendant::node())</code>.</p>
                   </item>
 
 
@@ -12760,8 +12761,8 @@ return if (every $r in $R satisfies $r instance of gnode())
                         contains the ancestors of the origin (the parent, the
                         parent of the parent, and so on).</p>
                      
-                     <p>More formally, <code>$node/ancestor::gnode()</code> delivers the result
-                     of <code>fn:transitive-closure($node, fn { parent::gnode() })</code>.</p>
+                     <p>More formally, <code>$node/ancestor::node()</code> delivers the result
+                     of <code>fn:transitive-closure($node, fn { parent::node() })</code>.</p>
 
                      <note>
                         <p>The ancestor axis includes the root GNode of the
@@ -12775,8 +12776,8 @@ return if (every $r in $R satisfies $r instance of gnode())
                      <p>The <code>ancestor-or-self</code> axis contains the origin and the ancestors of the origin;
 				            thus, the ancestor-or-self axis will always include the root.</p>
                      
-                     <p>More formally, <code>$node/ancestor-or-self::gnode()</code> delivers the result
-                     of <code>$node/(. | ancestor::gnode())</code>.</p>
+                     <p>More formally, <code>$node/ancestor-or-self::node()</code> delivers the result
+                     of <code>$node/(. | ancestor::node())</code>.</p>
                   </item>
 
 
@@ -12790,7 +12791,7 @@ return if (every $r in $R satisfies $r instance of gnode())
 			 is an attribute or namespace node, the
 			 <code>following-sibling</code> axis is
 			 empty.</p>
-                     <p>More formally, <code>$node/following-sibling::gnode()</code> delivers the result
+                     <p>More formally, <code>$node/following-sibling::node()</code> delivers the result
                      of <code>fn:siblings($node)[. >> $node])</code>.</p>
                   </item>
                   
@@ -12798,7 +12799,7 @@ return if (every $r in $R satisfies $r instance of gnode())
                      <p>The <code>following-sibling-or-self</code> axis contains the origin,
                      together with the contents of the <code>following-sibling</code> axis.</p>
                      
-                     <p>More formally, <code>$node/following-sibling-or-self::gnode()</code> delivers the result
+                     <p>More formally, <code>$node/following-sibling-or-self::node()</code> delivers the result
                      of <code><![CDATA[fn:siblings($node)[not(. << $node)]]]></code></p>
                   </item>
 
@@ -12814,14 +12815,14 @@ return if (every $r in $R satisfies $r instance of gnode())
 			 is an attribute or namespace node, the
 			 <code>preceding-sibling</code> axis is
 			 empty.</p>
-                     <p>More formally, <code>$node/preceding-sibling::gnode()</code> delivers the result
+                     <p>More formally, <code>$node/preceding-sibling::node()</code> delivers the result
                      of <code><![CDATA[fn:siblings($node)[. << $node]]]></code>.</p>
                   </item>
                   
                   <item>
                      <p>The <code>preceding-sibling-or-self</code> axis contains the origin,
                      together with the contents of the <code>preceding-sibling</code> axis.</p>
-                     <p>More formally, <code>$node/preceding-sibling-or-self::gnode()</code> delivers the result
+                     <p>More formally, <code>$node/preceding-sibling-or-self::node()</code> delivers the result
                      of <code><![CDATA[fn:siblings($node)[not(. >> $node)]]></code>.</p>
                   </item>
 
@@ -12837,16 +12838,16 @@ return if (every $r in $R satisfies $r instance of gnode())
 				and occur after the origin in
 				<termref def="dt-document-order">document order</termref>.
                      </p>
-                     <p>More formally, <code>$node/following::gnode()</code> delivers the result
-                     of <code>$node/ancestor-or-self::gnode()/following-sibling::gnode()/descendant-or-self::gnode()</code></p>
+                     <p>More formally, <code>$node/following::node()</code> delivers the result
+                     of <code>$node/ancestor-or-self::node()/following-sibling::node()/descendant-or-self::node()</code></p>
 
                   </item>
 
                   <item>
                      <p>The <code>following-or-self</code> axis contains the origin,
                      together with the contents of the <code>following</code> axis.</p>
-                     <p>More formally, <code>$node/following-or-self::gnode()</code> delivers the result
-                     of <code>$node/(. | following::gnode())</code>.</p>
+                     <p>More formally, <code>$node/following-or-self::node()</code> delivers the result
+                     of <code>$node/(. | following::node())</code>.</p>
                   </item>        
 
                   <item>
@@ -12860,16 +12861,16 @@ return if (every $r in $R satisfies $r instance of gnode())
 				<termref
                            def="dt-document-order">document order</termref>.
                      </p>
-                     <p>More formally, <code>$node/preceding::gnode()</code> delivers the result
-                     of <code>$node/ancestor-or-self::gnode()/preceding-sibling::gnode()/descendant-or-self::gnode()</code>.</p>
+                     <p>More formally, <code>$node/preceding::node()</code> delivers the result
+                     of <code>$node/ancestor-or-self::node()/preceding-sibling::node()/descendant-or-self::node()</code>.</p>
 
                   </item>
 
                   <item>
                      <p>The <code>preceding-or-self</code> axis returns the origin,
                      together with the contents of the <code>preceding</code> axis.</p>
-                     <p>More formally, <code>$node/preceding-or-self::gnode()</code> delivers the result
-                     of <code>$node/(. | preceding::gnode())</code>.</p>
+                     <p>More formally, <code>$node/preceding-or-self::node()</code> delivers the result
+                     of <code>$node/(. | preceding::node())</code>.</p>
                   </item>  
 
                   <item>
@@ -12892,7 +12893,7 @@ return if (every $r in $R satisfies $r instance of gnode())
                      <p>The <code>self</code> axis contains just the origin itself.</p>
                      <p>The <code>self</code> axis is primarily useful when testing whether the origin
                      satisfies particular conditions, for example <code>if ($x[self::chapter])</code>.</p>
-                     <p>More formally, <code>$node/self::gnode()</code> delivers the result
+                     <p>More formally, <code>$node/self::node()</code> delivers the result
                      of <code>$node</code>.</p>
                   </item>
 
@@ -13374,7 +13375,7 @@ return <var>AXIS</var>::*[some $a in $A, $n in (node-name(.), local-name(.))
 
                   <item>
                      <p>
-                        <code role="parse-test">node()</code> matches any XNode.</p>
+                        <code role="parse-test">xnode()</code> matches any XNode.</p>
                   </item>
 
                   <item>
@@ -14108,10 +14109,10 @@ last <code>chapter</code> or <code>appendix</code> child of the context node.</p
                   <p>A step consisting
 of <code role="parse-test">..</code> is short
 for <code
-                        role="parse-test">parent::gnode()</code>. For example (assuming the context
+                        role="parse-test">parent::node()</code>. For example (assuming the context
                      item is an XNode), <code
                         role="parse-test">../title</code> is short for <code role="parse-test"
-                        >parent::gnode()/child::title</code> and so will select the 
+                        >parent::node()/child::title</code> and so will select the 
                      <code>title</code> children of the parent of the context node.</p>
                   
                   <p>Similarly, if <code>$dateOfBirth</code> is a JNode resulting from the expression

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -143,9 +143,10 @@ declaration contains construction of new nodes.)</phrase>
                The term <term>atomic value</term> has been replaced by <termref def="dt-atomic-item"/>.
             </change>
             <change issue="2025" PR="2031" date="2025-06-13">
-               The terms <term>XNode</term> and <code>JNode</code> are introduced; the existing
-               term <term>node</term> remains in use as a synonym for <term>XNode</term> where
-               the context does not specify otherwise.
+               The terms <term>XNode</term> and <term>JNode</term> are introduced; the item type
+               <code>node()</code> now matches any <term>GNode</term> (that is, an XNode or a JNode),
+               and the new item type <code>xnode()</code> matches any XNode. The unqualified term
+               <term>node</term> continues to be used as a synonym for <term>XNode</term>.
             </change>
          </changes>
       
@@ -161,8 +162,8 @@ declaration contains construction of new nodes.)</phrase>
                def="dt-item">items</termref>.</termdef></p>
          <p><termdef id="dt-item" term="item">
   An <term>item</term> is either an <termref
-               def="dt-atomic-item">atomic item</termref>, a <termref def="dt-node"
-               >node</termref>,
+               def="dt-atomic-item">atomic item</termref>, a <termref def="dt-GNode"
+               >generic node</termref>,
 or a <termref def="dt-function-item">function item</termref>.</termdef></p>
          
       <p><termdef id="dt-atomic-item" term="atomic item">An <term>atomic
@@ -2359,8 +2360,8 @@ but it does not place any constraints on how XDM instances are constructed.</p>
                      >XDM instance</termref> has a <term>type annotation</term> (described in <xspecref
                      spec="DM40" ref="types"
                   />). 
-The type annotation of a node is a reference to a <termref def="dt-schema-type"/>. 
-</termdef>  The <code>type-name</code> of a node is the name of the type referenced by its <termref
+The type annotation of an XNode is a reference to a <termref def="dt-schema-type"/>. 
+</termdef>  The <code>type-name</code> of an XNode is the name of the type referenced by its <termref
                   def="dt-type-annotation">type annotation</termref> (but note that the
                type annotation can be a reference to an anonymous type). 
 If the <termref
@@ -2883,14 +2884,14 @@ The prefix <code>xmlns</code> must not be bound to any namespace URI, and no pre
             <item><p>Evaluation of expressions may raise errors. The implications of this
                   are discussed in <specref ref="errors"/>.</p></item>
             
-            <item><p>Some expressions construct new nodes (see <specref ref="id-constructors"/>).
+            <item><p>Some expressions construct new XNodes (see <specref ref="id-constructors"/>).
             These expressions are not functionally pure, because evaluating the same expression twice
-            creates two nodes, each with distinct identity. An optimizer <rfc2119>should</rfc2119>
+            creates two XNodes, each with distinct identity. An optimizer <rfc2119>should</rfc2119>
             avoid rewriting such expressions in a way that changes the number of times they are evaluated.
             However, it is not always possible to detect statically that an expression constructs new
             nodes, for example when a dynamic function call invokes a function whose body
             includes a node constructor. Applications <rfc2119>should</rfc2119> therefore avoid over-reliance
-            on newly constructed nodes having distinct identity.</p></item>
+            on newly constructed XNodes having distinct identity.</p></item>
             
             <item><p>Some expressions access information in the external environment.
             Examples are calls on functions such as <function>fn:doc</function>, <function>fn:unparsed-text</function>,
@@ -3690,49 +3691,49 @@ tree <var>T2</var>.</p>
                
                <termdef term="typed value" id="dt-typed-value"
                   >The <term>typed
-                     value</term> of a node is a sequence of atomic items and can be
+                     value</term> of an XNode is a sequence of atomic items and can be
                   extracted by applying the <function>data</function> function to the
                   node.</termdef>
                <termdef id="dt-string-value" term="string value"
                   >The
-                  <term>string value</term> of a node is a string and can be extracted
+                  <term>string value</term> of an XNode is a string and can be extracted
                   by applying the <function>string</function>
-                  function to the node.</termdef>
+                  function to the XNode.</termdef>
             </p>
             
             
             <p>An implementation may store both the <termref def="dt-typed-value"
                >typed value</termref> and the <termref def="dt-string-value"
-                  >string value</termref> of a node, or it may store only one of these and derive the other as needed.
-               The string value of a node must be a valid lexical representation of the typed value of the node,
-               but the node is not required to preserve the string representation from the original source document.
-               For example, if the typed value of a node is the <code>xs:integer</code> value <code>30</code>,
+                  >string value</termref> of an XNode, or it may store only one of these and derive the other as needed.
+               The string value of an XNode must be a valid lexical representation of the typed value of the XNode,
+               but the XNode is not required to preserve the string representation from the original source document.
+               For example, if the typed value of an XNode is the <code>xs:integer</code> value <code>30</code>,
                its string value might be <code>"30"</code> or <code>"0030"</code>.</p>
             <p role="xpath">The <termref def="dt-typed-value">typed value</termref>, <termref
                def="dt-string-value">string value</termref>, and <termref
                   def="dt-type-annotation"
-                  >type annotation</termref> of a node are closely related.  If the node was created by mapping from an Infoset or PSVI, the relationships among these properties are defined by rules in <xspecref
+                  >type annotation</termref> of an XNode are closely related.  If the XNode was created by mapping from an Infoset or PSVI, the relationships among these properties are defined by rules in <xspecref
                      spec="DM40" ref="types"/>.</p>
             <p role="xquery">The <termref def="dt-typed-value">typed value</termref>, <termref
                def="dt-string-value">string value</termref>, and <termref
                   def="dt-type-annotation"
-                  >type annotation</termref> of a node are closely related, and are defined by rules found in the following locations:</p>
+                  >type annotation</termref> of an XNode are closely related, and are defined by rules found in the following locations:</p>
             
             <ulist role="xquery">
                
                <item>
-                  <p>If the node was created by mapping from an Infoset or PSVI, see rules in <xspecref
+                  <p>If the XNode was created by mapping from an Infoset or PSVI, see rules in <xspecref
                      spec="DM40" ref="types"/>.</p>
                </item>
                
                <item>
-                  <p>If the node was created by an XQuery node constructor, see rules in <specref
+                  <p>If the XNode was created by an XQuery node constructor, see rules in <specref
                      ref="id-element-constructor"/>, <specref ref="id-computedElements"
                      />, or <specref ref="id-computedAttributes"/>.</p>
                </item>
                
                <item>
-                  <p>If the node was created by a <code>validate</code> expression, see rules in <specref
+                  <p>If the XNode was created by a <code>validate</code> expression, see rules in <specref
                      ref="id-validate"/>.</p>
                </item>
             </ulist>
@@ -3745,7 +3746,7 @@ tree <var>T2</var>.</p>
             <olist>
                
                <item>
-                  <p>For text and document nodes, the typed value of the node is the same as its
+                  <p>For text and document nodes, the typed value of the XNode is the same as its
                      string value, as an instance of  the type <code>xs:untypedAtomic</code>. The
                      string value of a document node is formed by concatenating the string
                      values of all its descendant text nodes, in <termref
@@ -3779,8 +3780,8 @@ tree <var>T2</var>.</p>
                      <code>"bar baz faz"</code>. The typed value of A2 is a sequence of
                      three atomic items (<code>"bar"</code>, <code>"baz"</code>",
                      <code>"faz"</code>"), each of type <code>xs:IDREF</code>. The typed
-                     value of a node is never treated as an instance of a named list
-                     type. Instead, if the type annotation of a node is a list type (such
+                     value of an XNode is never treated as an instance of a named list
+                     type. Instead, if the type annotation of an XNode is a list type (such
                      as <code>xs:IDREFS</code>), its typed value is treated as a sequence
                      of the <termref
                         def="dt-generalized-atomic-type"
@@ -3804,7 +3805,7 @@ tree <var>T2</var>.</p>
                            denotes a complex type with mixed content (including <code>xs:anyType</code>), then the typed value of the
                            node is equal to its string value, as an instance of
                            <code>xs:untypedAtomic</code>.  However, if the <code>nilled</code>
-                           property of the node is <code>true</code>, then its typed value is the empty sequence.</p>
+                           property of the XNode is <code>true</code>, then its typed value is the empty sequence.</p>
                         
                         
                         
@@ -3829,10 +3830,10 @@ tree <var>T2</var>.</p>
                      <item>
                         <p>If the type
                            annotation denotes a simple type or a complex type with simple
-                           content, then the typed value of the node is derived from its string
+                           content, then the typed value of the XNode is derived from its string
                            value and its type annotation in a way that is consistent with schema
                            validation. However, if the <code>nilled</code>
-                           property of the node is <code>true</code>, then its typed value is the empty sequence.</p>
+                           property of the XNode is <code>true</code>, then its typed value is the empty sequence.</p>
                         <p>Example: E3 is an element node with the type
                            annotation <code>cost</code>, which is a complex type that has several
                            attributes and a simple content type of <code>xs:decimal</code>. The
@@ -3851,10 +3852,10 @@ tree <var>T2</var>.</p>
                            which is a union type with member types <code>xs:integer</code> and <code>xs:string</code>.
                            The string value of E5 is <code>"47"</code>. The typed value of E5 is <code>47</code> as a
                            <code>xs:integer</code>, since <code>xs:integer</code> is the member type that validated the
-                           content of E5. In general, when the type annotation of a node is a union type,
-                           the typed value of the node will be an instance of one of the member types of the union.</p>
+                           content of E5. In general, when the type annotation of an XNode is a union type,
+                           the typed value of the XNode will be an instance of one of the member types of the union.</p>
                         <note>
-                           <p>If an implementation stores only the string value of a node, and the type annotation of the node is a union type, the implementation must be able to deliver the typed value of the node as an instance of the appropriate member type.</p>
+                           <p>If an implementation stores only the string value of an XNode, and the type annotation of the XNode is a union type, the implementation must be able to deliver the typed value of the XNode as an instance of the appropriate member type.</p>
                         </note>
                      </item>
                      
@@ -3867,13 +3868,13 @@ tree <var>T2</var>.</p>
                      <item>
                         <p>If the type annotation
                            denotes a complex type with element-only content, then the typed value
-                           of the node is <xtermref
+                           of the XNode is <xtermref
                               spec="DM40" ref="dt-absent"
                            />. The <function>fn:data</function> function raises a
                            <termref
                               def="dt-type-error">type error</termref>
                            <xerrorref spec="FO40" class="TY" code="0012"
-                           /> when applied to such a node. The string value of such a node is equal to the concatenated string values of all its text node descendants, in document order.</p>
+                           /> when applied to such a node. The string value of such an XNode is equal to the concatenated string values of all its text node descendants, in document order.</p>
                         <p>Example: E6 is an
                            element node with the type annotation <code>weather</code>, which is a
                            complex type whose content type specifies
@@ -3924,7 +3925,7 @@ its <termref def="dt-typed-value"
                         >typed value</termref> is returned (a <termref def="dt-type-error"
                         >type error</termref>
                      <xerrorref spec="FO40" class="TY" code="0012"
-                     /> is raised if the node has no typed value.)</p>
+                     /> is raised if the XNode has no typed value.)</p>
                </item>
                
                <item>
@@ -4263,12 +4264,12 @@ of applying the <function>fn:boolean</function> function to the value.</termdef>
             <item><p><termref def="dt-XNode">XNodes</termref> 
                (which are another kind of <termref def="dt-item"/>) have a property
             called a <termref def="dt-type-annotation"/> which determines the type of their content.
-            The type annotation is a <termref def="dt-schema-type"/>. The type annotation of a node
-            must not be confused with the item type of the node. For example, an element 
+            The type annotation is a <termref def="dt-schema-type"/>. The type annotation of an XNode
+            must not be confused with the item type of the XNode. For example, an element 
             <code><![CDATA[<age>23</age>]]></code> might have been validated against a schema
                that defines this element as having <code>xs:integer</code> content. If this
-               is the case, the <termref def="dt-type-annotation"/> of the node will be
-               <code>xs:integer</code>, and in the <?inject language?> type system, the node will
+               is the case, the <termref def="dt-type-annotation"/> of the XNode will be
+               <code>xs:integer</code>, and in the <?inject language?> type system, the XNode will
                match the <termref def="dt-item-type"/> <code>element(age, xs:integer)</code>.
             </p></item>
          </ulist>
@@ -4620,7 +4621,7 @@ types</term> (such as <code>xs:integer</code>) and function types
          
          <p>In most cases, the set of items matched by an item type consists either
          exclusively of <termref def="dt-atomic-item">atomic items</termref>,
-         exclusively of <termref def="dt-node">nodes</termref>, 
+         exclusively of <termref def="dt-GNode">generic nodes</termref>,
          or exclusively of <xtermref spec="DM40" ref="dt-function-item">function items</xtermref>.
          Exceptions include the generic types <code>item()</code>, which matches all items, <code>xs:error</code>,
          which matches no items, and <termref def="dt-choice-item-type">choice item types</termref>,
@@ -5088,8 +5089,8 @@ declare variable $orange-fruit as my:fruit := "orange";
                   </change>
                </changes>
                
-               <p>Node types are <termref def="dt-item-type">item types</termref> whose 
-                  instances are all <termref def="dt-node">nodes</termref>.</p>
+               <p>Node types are <termref def="dt-item-type">item types</termref> whose
+                  instances are all <termref def="dt-GNode">generic nodes</termref>.</p>
                
                <p>The syntax for node types is also used for <termref def="dt-node-test">node tests</termref>
                within path expressions. This explains why the production rules have names such as
@@ -6789,7 +6790,7 @@ declare record Particle (
                   <prodrecap ref="GNodeType"/>
                </scrap>
                
-               <p>The type <code>gnode()</code> is equivalent to the choice type <code>jnode() | node()</code>.</p>
+               <p>The type <code>node()</code> is equivalent to the choice type <code>jnode() | xnode()</code>.</p>
                
             </div3>
             <div3 id="id-xs-error">
@@ -7142,12 +7143,12 @@ declare record Particle (
                            <item><p><code>xs:anyAtomicType</code> is treated as a choice of the 19 XSD primitive
                            atomic types (<code>xs:string</code>, <code>xs:boolean</code>, etc), plus
                            <code>xs:untypedAtomic</code>;</p></item>
-                           <item><p><code>node()</code> is treated as <code>(document-node() | element() | attribute() 
+                           <item><p><code>xnode()</code> is treated as <code>(document-node() | element() | attribute()
                                     | text() | comment() | processing-instruction() | namespace-node())</code>;</p></item>
-                           <item><p><code>gnode()</code> is treated as <code>(node() | jnode())</code>, where <code>node()</code>
+                           <item><p><code>node()</code> is treated as <code>(xnode() | jnode())</code>, where <code>xnode()</code>
                            is then further expanded as above;</p></item>
-                           <item><p><code>item()</code> is treated as <code>(gnode() | xs:anyAtomicType | function(*))</code>,
-                           where <code>gnode()</code> and <code>xs:anyAtomicType</code> are then expanded as above.</p></item>
+                           <item><p><code>item()</code> is treated as <code>(node() | xs:anyAtomicType | function(*))</code>,
+                           where <code>node()</code> and <code>xs:anyAtomicType</code> are then expanded as above.</p></item>
                         </ulist>
                      </item>
                      <item>
@@ -7165,8 +7166,8 @@ declare record Particle (
                   <ulist>
                      <item><p><code>(xs:int | xs:long)</code> is a subtype of <code>(xs:decimal | xs:date)</code>
                   because both <code>xs:int</code> and <code>xs:long</code> are subtypes of <code>xs:decimal</code>.</p></item>
-                     <item><p><code>node()</code> is a subtype of <code>(element() | attribute() | text() |
-                     comment() | processing-instruction() | document-node() | jnode())</code> because <code>node()</code>
+                     <item><p><code>xnode()</code> is a subtype of <code>(element() | attribute() | text() |
+                     comment() | processing-instruction() | document-node() | jnode())</code> because <code>xnode()</code>
                      is an abstract type that is expanded to a choice of the seven kinds of XNode.</p></item>
                   </ulist>
                   
@@ -7271,10 +7272,10 @@ declare record Particle (
                   
                      <olist>
                         <item>
-                           <p><var>A</var> is an <nt def="XNodeType"/> and <var>B</var> is <code>node()</code>.</p>
+                           <p><var>A</var> is an <nt def="XNodeType"/> and <var>B</var> is <code>xnode()</code>.</p>
                            <example>
                               <head>Example:</head>
-                              <p><code>comment() ⊆ node()</code></p>
+                              <p><code>comment() ⊆ xnode()</code></p>
                            </example>
                         </item>
                         <item>
@@ -7647,7 +7648,7 @@ declare record Particle (
                   <olist>
                      <item>
                         <p><var>A</var> is <code>jnode()</code> (or equivalently, <code>jnode(*)</code>)
-                         and <var>B</var> is <code>gnode()</code>.</p>
+                         and <var>B</var> is <code>node()</code>.</p>
                      </item>
                      <item>
                         <p><var>A</var> is <code>jnode(<var>C</var>)</code> and <var>B</var> is <code>jnode()</code>, for any constant 
@@ -12254,7 +12255,7 @@ return $incrementors[2](4)]]></eg>
 
          <p>An expression of the form <code>//<var>PP</var></code> (that is, an <termref def="dt-absolute-path-expression"/>
             with a leading <code>//</code>) is treated as an abbreviation for
-            the expression <code>./(fn:root(.) treat as (document-node()|jnode())/descendant-or-self::gnode()/<var>PP</var></code>. 
+            the expression <code>./(fn:root(.) treat as (document-node()|jnode())/descendant-or-self::node()/<var>PP</var></code>. 
             The effect of this expansion is that every item <var>N</var> 
             in the context value <var>V</var> is processed as follows, depending on its type:</p>
 
@@ -12594,7 +12595,7 @@ return $incrementors[2](4)]]></eg>
                         <p>The steps in a path expression for searching a JTree will often be literals or simple context-free expressions
                            that evaluate to strings for selection within a map, or integers for selection within an array. For example,
                            in the path <code>$booklist/$category//author/1/"last name"</code>, the first subexpression selects the root of the JTree,
-                           and the subsequent steps (with the exception of the implicit <code>descendant-or-self::gnode()</code> step implied by the <code>//</code>
+                           and the subsequent steps (with the exception of the implicit <code>descendant-or-self::node()</code> step implied by the <code>//</code>
                            operator) are context-free expressions that evaluate to map keys or array subscripts to be selected within the child axis.</p>
                         <p>An unquoted string such as <code>author</code> is equivalent to the quoted string <code>"author"</code>, and enables the
                         path to be written more concisely when the keys are simple NCNames.</p>
@@ -12636,9 +12637,9 @@ return $incrementors[2](4)]]></eg>
                      <code>fn:distinct-ordered-nodes($R)</code> has the effect of 
                      eliminating duplicates and sorting nodes into document order):</p>
                   <eg><![CDATA[let $R := E1 ! E2
-return if (every $r in $R satisfies $r instance of gnode())
+return if (every $r in $R satisfies $r instance of node())
        then (fn:distinct-ordered-nodes($R))
-       else if (every $r in $R satisfies not($r instance of gnode()))
+       else if (every $r in $R satisfies not($r instance of node()))
        then $R
        else error()]]></eg>
                   <p>For a table comparing the step operator to the map operator, see <specref ref="id-map-operator"/>.</p>
@@ -12651,15 +12652,15 @@ return if (every $r in $R satisfies $r instance of gnode())
            <head>Recursive Path Operator (<code>//</code>)</head>
             
            <p>When <code>//</code> is used as an infix operator, it can be treated as an abbreviation
-           for <code>/descendant-or-self::gnode()/</code>.</p>
+           for <code>/descendant-or-self::node()/</code>.</p>
             
             <p>In simple cases, an expression such as <code>$x//y</code> is equivalent to
             <code>$x/descendant::y</code>. But in some cases the semantics are more complex, for example:</p>
             
             <ulist>
-               <item><p><code>$x//@a</code> expands to <code>$x/descendant-or-self::gnode()/attribute::a</code>, which selects
+               <item><p><code>$x//@a</code> expands to <code>$x/descendant-or-self::node()/attribute::a</code>, which selects
                all attributes having <code>$x</code> as an ancestor.</p></item>
-               <item><p><code>$x//y[1]</code> expands to <code>$x/descendant-or-self::gnode()/child::y[1]</code>,
+               <item><p><code>$x//y[1]</code> expands to <code>$x/descendant-or-self::node()/child::y[1]</code>,
                which selects every descendant element of <code>$x</code> named <code>y</code> that is the 
                      first child of its parent. This is <emph>not</emph> the same as <code>($x//y)[1]</code>, which selects
                the first descendant of <code>$x</code> that is named <code>y</code>.</p></item>
@@ -12675,13 +12676,13 @@ return if (every $r in $R satisfies $r instance of gnode())
             
             <p>It is valid, but rarely useful, to use the <code>//</code> operator in conjunction with an axis other than
             <code>child</code> or <code>attribute</code>. For example, <code>$x//following-sibling::y</code>
-            expands to <code>$x/descendant-or-self::gnode()/following-sibling::y</code>, which selects every <code>y</code>
+            expands to <code>$x/descendant-or-self::node()/following-sibling::y</code>, which selects every <code>y</code>
                descendant of <code>$x</code> that is not the first child of its parent, as well as the following siblings
                of <code>$x</code> itself.</p>
             
             <p>It is also valid to follow <code>//</code> with an expression other than an axis step. For example,
             <code>distinct-values($x//node-name())</code> has the same effect as 
-               <code>$x/descendant-or-self::gnode() =!> node-name() => distinct-values()</code></p>
+               <code>$x/descendant-or-self::node() =!> node-name() => distinct-values()</code></p>
             
             <p>The effect of <code>//</code> at the start of an expression is explained in
                <specref ref="id-absolute-path-expressions"/>.</p>
@@ -12842,16 +12843,16 @@ return if (every $r in $R satisfies $r instance of gnode())
 			 axis is defined as the transitive closure of
 			 the child axis; it contains the descendants
 			 of the origin (the children, the children of the children, and so on).</p>
-                     <p>More formally, <code>$node/descendant::gnode()</code> delivers the result
-                     of <code>fn:transitive-closure($node, fn { child::gnode() })</code>.</p>
+                     <p>More formally, <code>$node/descendant::node()</code> delivers the result
+                     of <code>fn:transitive-closure($node, fn { child::node() })</code>.</p>
                      
                   </item>
                   
                   <item>
                      <p>The <code>descendant-or-self</code> axis contains the origin and the descendants 
                         of the origin.</p>
-                     <p>More formally, <code>$node/descendant-or-self::gnode()</code> delivers the result
-                     of <code>$node/(. | descendant::gnode())</code>.</p>
+                     <p>More formally, <code>$node/descendant-or-self::node()</code> delivers the result
+                     of <code>$node/(. | descendant::node())</code>.</p>
                   </item>
 
 
@@ -12879,8 +12880,8 @@ return if (every $r in $R satisfies $r instance of gnode())
                         contains the ancestors of the origin (the parent, the
                         parent of the parent, and so on).</p>
                      
-                     <p>More formally, <code>$node/ancestor::gnode()</code> delivers the result
-                     of <code>fn:transitive-closure($node, fn { parent::gnode() })</code>.</p>
+                     <p>More formally, <code>$node/ancestor::node()</code> delivers the result
+                     of <code>fn:transitive-closure($node, fn { parent::node() })</code>.</p>
 
                      <note>
                         <p>The ancestor axis includes the root GNode of the
@@ -12894,8 +12895,8 @@ return if (every $r in $R satisfies $r instance of gnode())
                      <p>The <code>ancestor-or-self</code> axis contains the origin and the ancestors of the origin;
 				            thus, the ancestor-or-self axis will always include the root.</p>
                      
-                     <p>More formally, <code>$node/ancestor-or-self::gnode()</code> delivers the result
-                     of <code>$node/(. | ancestor::gnode())</code>.</p>
+                     <p>More formally, <code>$node/ancestor-or-self::node()</code> delivers the result
+                     of <code>$node/(. | ancestor::node())</code>.</p>
                   </item>
 
 
@@ -12909,7 +12910,7 @@ return if (every $r in $R satisfies $r instance of gnode())
 			 is an attribute or namespace node, the
 			 <code>following-sibling</code> axis is
 			 empty.</p>
-                     <p>More formally, <code>$node/following-sibling::gnode()</code> delivers the result
+                     <p>More formally, <code>$node/following-sibling::node()</code> delivers the result
                      of <code>fn:siblings($node)[. >> $node])</code>.</p>
                   </item>
                   
@@ -12917,7 +12918,7 @@ return if (every $r in $R satisfies $r instance of gnode())
                      <p>The <code>following-sibling-or-self</code> axis contains the origin,
                      together with the contents of the <code>following-sibling</code> axis.</p>
                      
-                     <p>More formally, <code>$node/following-sibling-or-self::gnode()</code> delivers the result
+                     <p>More formally, <code>$node/following-sibling-or-self::node()</code> delivers the result
                      of <code><![CDATA[fn:siblings($node)[not(. << $node)]]]></code></p>
                   </item>
 
@@ -12933,14 +12934,14 @@ return if (every $r in $R satisfies $r instance of gnode())
 			 is an attribute or namespace node, the
 			 <code>preceding-sibling</code> axis is
 			 empty.</p>
-                     <p>More formally, <code>$node/preceding-sibling::gnode()</code> delivers the result
+                     <p>More formally, <code>$node/preceding-sibling::node()</code> delivers the result
                      of <code><![CDATA[fn:siblings($node)[. << $node]]]></code>.</p>
                   </item>
                   
                   <item>
                      <p>The <code>preceding-sibling-or-self</code> axis contains the origin,
                      together with the contents of the <code>preceding-sibling</code> axis.</p>
-                     <p>More formally, <code>$node/preceding-sibling-or-self::gnode()</code> delivers the result
+                     <p>More formally, <code>$node/preceding-sibling-or-self::node()</code> delivers the result
                      of <code><![CDATA[fn:siblings($node)[not(. >> $node)]]></code>.</p>
                   </item>
 
@@ -12956,16 +12957,16 @@ return if (every $r in $R satisfies $r instance of gnode())
 				and occur after the origin in
 				<termref def="dt-document-order">document order</termref>.
                      </p>
-                     <p>More formally, <code>$node/following::gnode()</code> delivers the result
-                     of <code>$node/ancestor-or-self::gnode()/following-sibling::gnode()/descendant-or-self::gnode()</code></p>
+                     <p>More formally, <code>$node/following::node()</code> delivers the result
+                     of <code>$node/ancestor-or-self::node()/following-sibling::node()/descendant-or-self::node()</code></p>
 
                   </item>
 
                   <item>
                      <p>The <code>following-or-self</code> axis contains the origin,
                      together with the contents of the <code>following</code> axis.</p>
-                     <p>More formally, <code>$node/following-or-self::gnode()</code> delivers the result
-                     of <code>$node/(. | following::gnode())</code>.</p>
+                     <p>More formally, <code>$node/following-or-self::node()</code> delivers the result
+                     of <code>$node/(. | following::node())</code>.</p>
                   </item>        
 
                   <item>
@@ -12979,16 +12980,16 @@ return if (every $r in $R satisfies $r instance of gnode())
 				<termref
                            def="dt-document-order">document order</termref>.
                      </p>
-                     <p>More formally, <code>$node/preceding::gnode()</code> delivers the result
-                     of <code>$node/ancestor-or-self::gnode()/preceding-sibling::gnode()/descendant-or-self::gnode()</code>.</p>
+                     <p>More formally, <code>$node/preceding::node()</code> delivers the result
+                     of <code>$node/ancestor-or-self::node()/preceding-sibling::node()/descendant-or-self::node()</code>.</p>
 
                   </item>
 
                   <item>
                      <p>The <code>preceding-or-self</code> axis returns the origin,
                      together with the contents of the <code>preceding</code> axis.</p>
-                     <p>More formally, <code>$node/preceding-or-self::gnode()</code> delivers the result
-                     of <code>$node/(. | preceding::gnode())</code>.</p>
+                     <p>More formally, <code>$node/preceding-or-self::node()</code> delivers the result
+                     of <code>$node/(. | preceding::node())</code>.</p>
                   </item>  
 
                   <item>
@@ -13011,7 +13012,7 @@ return if (every $r in $R satisfies $r instance of gnode())
                      <p>The <code>self</code> axis contains just the origin itself.</p>
                      <p>The <code>self</code> axis is primarily useful when testing whether the origin
                      satisfies particular conditions, for example <code>if ($x[self::chapter])</code>.</p>
-                     <p>More formally, <code>$node/self::gnode()</code> delivers the result
+                     <p>More formally, <code>$node/self::node()</code> delivers the result
                      of <code>$node</code>.</p>
                   </item>
 
@@ -13498,7 +13499,7 @@ return if (every $r in $R satisfies $r instance of gnode())
 
                   <item>
                      <p>
-                        <code role="parse-test">node()</code> matches any XNode.</p>
+                        <code role="parse-test">xnode()</code> matches any XNode.</p>
                   </item>
 
                   <item>
@@ -14232,10 +14233,10 @@ last <code>chapter</code> or <code>appendix</code> child of the context node.</p
                   <p>A step consisting
 of <code role="parse-test">..</code> is short
 for <code
-                        role="parse-test">parent::gnode()</code>. For example (assuming the context
+                        role="parse-test">parent::node()</code>. For example (assuming the context
                      item is an XNode), <code
                         role="parse-test">../title</code> is short for <code role="parse-test"
-                        >parent::gnode()/child::title</code> and so will select the 
+                        >parent::node()/child::title</code> and so will select the 
                      <code>title</code> children of the parent of the context node.</p>
                   
                   <p>Similarly, if <code>$dateOfBirth</code> is a JNode resulting from the expression

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -12453,8 +12453,8 @@ return $tree =?> depth()]]></eg>
                         <item>
                            <p><code>~item()</code> matches any item.</p>
                         </item>
-                        <item><p><code>~node()</code> matches any XNode. (This is not the same as the pattern
-                           <code>node()</code>, which for historical reasons only matches  element, text, comment, 
+                        <item><p><code>~xnode()</code> matches any XNode. (This is not the same as the pattern
+                           <code>node()</code>, which for historical reasons only matches element, text, comment,
                            and processing instruction nodes).</p></item>
                         <item>
                            <p><code>~xs:date</code> matches any
@@ -12697,7 +12697,7 @@ return $tree =?> depth()]]></eg>
                               node.</p>
                         </item>
                         <item>
-                           <p><code>node()</code> matches any node other than an attribute node,
+                           <p><code>node()</code> matches any XNode other than an attribute node,
                               namespace node, or document node.</p>
                         </item>
                         <item>
@@ -12851,7 +12851,7 @@ return $tree =?> depth()]]></eg>
                            also phrased to ensure that positional patterns of the form
                               <code>para[1]</code> continue to count nodes relative to their parent,
                            if they have one. To match any XNode at all,
-                              XSLT 4.0 allows the pattern <code>~node()</code> to be
+                              XSLT 4.0 allows the pattern <code>~xnode()</code> to be
                               used.</p>
                         
                      </note>
@@ -12932,7 +12932,10 @@ return $tree =?> depth()]]></eg>
                      nodes because for backwards compatibility reasons the <code>child-or-top</code>
                      axis does not match a document node.</p>
                   <note>
-                     <p>The pattern <code>~node()</code> matches all XNodes.</p>
+                     <p>The pattern <code>~xnode()</code> matches all XNodes. Since patterns in path
+                        form match only XNodes, the pattern <code>node()</code> never matches a JNode;
+                        a JNode is matched using a <nt def="JNodePattern">JNodePattern</nt>
+                        (see <specref ref="id-jnode-patterns"/>).</p>
                   </note>
                   <p>The <termref def="dt-xnode-pattern"/>
                      <code>$V</code> matches all XNodes selected by the expression
@@ -13425,14 +13428,14 @@ return $tree =?> depth()]]></eg>
                      priority is the same as that of the corresponding XNode Pattern: 
                      see <specref ref="default-priority-for-xnode-patterns"/>.</p></item>
                   
-                  <item><p>The default priority of the pattern <code>~gnode()</code> is -0.75.</p></item>
+                  <item><p>The default priority of the pattern <code>~node()</code> is -0.75.</p></item>
                                    
                   <!--<item><p>For any item type that is a 
                         <nt def="GNodeType"/>, <nt def="XNodeType"/>
                         or <nt def="JNodeType"/>
                   (for example <code>jnode(*)</code>, <code>element()</code> or <code>element(N)</code>), the default
                   priority is the same as that of the corresponding GNode Pattern: 
-                  see <specref ref="default-priority-for-gnode-patterns"/>.</p></item>-->
+                  see <specref ref="default-priority-for-node-patterns"/>.</p></item>-->
                   
                   <item><p>For the item type <code>function(*)</code>,
                   the default priority is -0.5.</p></item>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -12431,8 +12431,8 @@ return $tree =?> depth()]]></eg>
                         <item>
                            <p><code>~item()</code> matches any item.</p>
                         </item>
-                        <item><p><code>~node()</code> matches any XNode. (This is not the same as the pattern
-                           <code>node()</code>, which for historical reasons only matches  element, text, comment, 
+                        <item><p><code>~xnode()</code> matches any XNode. (This is not the same as the pattern
+                           <code>node()</code>, which for historical reasons only matches element, text, comment,
                            and processing instruction nodes).</p></item>
                         <item>
                            <p><code>~xs:date</code> matches any
@@ -12675,7 +12675,7 @@ return $tree =?> depth()]]></eg>
                               node.</p>
                         </item>
                         <item>
-                           <p><code>node()</code> matches any node other than an attribute node,
+                           <p><code>node()</code> matches any XNode other than an attribute node,
                               namespace node, or document node.</p>
                         </item>
                         <item>
@@ -12829,7 +12829,7 @@ return $tree =?> depth()]]></eg>
                            also phrased to ensure that positional patterns of the form
                               <code>para[1]</code> continue to count nodes relative to their parent,
                            if they have one. To match any XNode at all,
-                              XSLT 4.0 allows the pattern <code>~node()</code> to be
+                              XSLT 4.0 allows the pattern <code>~xnode()</code> to be
                               used.</p>
                         
                      </note>
@@ -12910,7 +12910,10 @@ return $tree =?> depth()]]></eg>
                      nodes because for backwards compatibility reasons the <code>child-or-top</code>
                      axis does not match a document node.</p>
                   <note>
-                     <p>The pattern <code>~node()</code> matches all XNodes.</p>
+                     <p>The pattern <code>~xnode()</code> matches all XNodes. Since patterns in path
+                        form match only XNodes, the pattern <code>node()</code> never matches a JNode;
+                        a JNode is matched using a <nt def="JNodePattern">JNodePattern</nt>
+                        (see <specref ref="id-jnode-patterns"/>).</p>
                   </note>
                   <p>The <termref def="dt-xnode-pattern"/>
                      <code>$V</code> matches all XNodes selected by the expression
@@ -13403,14 +13406,14 @@ return $tree =?> depth()]]></eg>
                      priority is the same as that of the corresponding XNode Pattern: 
                      see <specref ref="default-priority-for-xnode-patterns"/>.</p></item>
                   
-                  <item><p>The default priority of the pattern <code>~gnode()</code> is -0.75.</p></item>
+                  <item><p>The default priority of the pattern <code>~node()</code> is -0.75.</p></item>
                                    
                   <!--<item><p>For any item type that is a 
                         <nt def="GNodeType"/>, <nt def="XNodeType"/>
                         or <nt def="JNodeType"/>
                   (for example <code>jnode(*)</code>, <code>element()</code> or <code>element(N)</code>), the default
                   priority is the same as that of the corresponding GNode Pattern: 
-                  see <specref ref="default-priority-for-gnode-patterns"/>.</p></item>-->
+                  see <specref ref="default-priority-for-node-patterns"/>.</p></item>-->
                   
                   <item><p>For the item type <code>function(*)</code>,
                   the default priority is -0.5.</p></item>

--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -466,10 +466,10 @@ of serialization.  These are:</p>
 </ulist>
 <p>Wherever an element node or attribute node is said to be in a
 particular namespace, it is understood that the namespace URI of the
-node is equal to the namespace URI corresponding to that namespace.
+XNode is equal to the namespace URI corresponding to that namespace.
 Wherever a namespace node is said to be a namespace node for a
 particular namespace, it is understood that the
-<termref def="dt-string-value">string value</termref> of the node is
+<termref def="dt-string-value">string value</termref> of the XNode is
 equal to the namespace URI corresponding to that namespace.</p>
 </div2>
 </div1>
@@ -1072,7 +1072,7 @@ in-scope schema components
 function signatures</td>
 <td>Both</td>
 <td>{<code>fn:data($arg as item()*) as xs:anyAtomicType*</code>},
-{<code>fn:local-name($arg as node()?) as xs:string</code>}</td></tr>
+{<code>fn:local-name($arg as xnode()?) as xs:string</code>}</td></tr>
 <tr><td>Statically known collations</td>
 <td>Both</td>
 <td> { (http://www.w3.org/2005/xpath-functions/collation/codepoint,
@@ -1612,7 +1612,7 @@ parameters.</p></item></ulist>
 expansion of default and fixed values in its DTD or schema;
 also, in the presence of a DTD, non-CDATA attributes may lose whitespace
 characters as a result of attribute value normalization.</p></item>
-<item><p>The type annotations of the nodes in the two trees <rfc2119>MAY</rfc2119> be different. 
+<item><p>The type annotations of the XNodes in the two trees <rfc2119>MAY</rfc2119> be different.
 Type annotations in a <termref def="result-tree">result tree</termref> are discarded when the tree is serialized. 
 Any new type annotations obtained by parsing the document will depend on whether the serialized XML document is assessed against a schema, 
 and this <rfc2119>MAY</rfc2119> result in type annotations that are different from

--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -466,10 +466,10 @@ of serialization.  These are:</p>
 </ulist>
 <p>Wherever an element node or attribute node is said to be in a
 particular namespace, it is understood that the namespace URI of the
-node is equal to the namespace URI corresponding to that namespace.
+XNode is equal to the namespace URI corresponding to that namespace.
 Wherever a namespace node is said to be a namespace node for a
 particular namespace, it is understood that the
-<termref def="dt-string-value">string value</termref> of the node is
+<termref def="dt-string-value">string value</termref> of the XNode is
 equal to the namespace URI corresponding to that namespace.</p>
 </div2>
 </div1>
@@ -1137,7 +1137,7 @@ in-scope schema components
 function signatures</td>
 <td>Both</td>
 <td>{<code>fn:data($arg as item()*) as xs:anyAtomicType*</code>},
-{<code>fn:local-name($arg as node()?) as xs:string</code>}</td></tr>
+{<code>fn:local-name($arg as xnode()?) as xs:string</code>}</td></tr>
 <tr><td>Statically known collations</td>
 <td>Both</td>
 <td> { (http://www.w3.org/2005/xpath-functions/collation/codepoint,
@@ -1716,7 +1716,7 @@ parameters.</p></item></ulist>
 expansion of default and fixed values in its DTD or schema;
 also, in the presence of a DTD, non-CDATA attributes may lose whitespace
 characters as a result of attribute value normalization.</p></item>
-<item><p>The type annotations of the nodes in the two trees <rfc2119>MAY</rfc2119> be different. 
+<item><p>The type annotations of the XNodes in the two trees <rfc2119>MAY</rfc2119> be different.
 Type annotations in a <termref def="result-tree">result tree</termref> are discarded when the tree is serialized. 
 Any new type annotations obtained by parsing the document will depend on whether the serialized XML document is assessed against a schema, 
 and this <rfc2119>MAY</rfc2119> result in type annotations that are different from


### PR DESCRIPTION
Closes #2338

90% mechanical, but it also includes substantial prose.

The editing of the XSLT spec may be incomplete. For example, it still needs to formally state what the `node()` pattern matches now that `node()` means any node.