### PR TITLE
2802 Function identity removed

### DIFF
--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -5906,6 +5906,9 @@ is returned.</p>
     <div2 id="function-items">
 <head>Function Items</head>
   <changes>
+    <change issue="1920" date="2026-07-20">
+      Reverts issue 520: function items again cannot be compared for identity.
+    </change>
     <change issue="520" PR="525" date="2023-05-30">
       Introduced the concept of function identity.
     </change>
@@ -5920,10 +5923,14 @@ is returned.</p>
   A <term>function item</term> is an <termref def="dt-item"/> that can be called with zero or more
   arguments to return a result.
 </termdef>
-Function items <phrase diff="del" at="2023-05-25">cannot be compared for
+Function items <phrase diff="add" at="2026-07-20">cannot be compared for
 identity, equality, or otherwise, and</phrase> have no serialization.
 </p>
-  
+
+<note diff="add" at="2026-07-20"><p>Maps and arrays are function items, but unlike other function
+items they can be compared by value; see <function>fn:deep-equal</function> and
+<xspecref spec="FO40" ref="dt-identical"/>.</p></note>
+
   <note diff="add" at="2023-03-11"><p>XDM 4.0 uses the term <term>function item</term> where XDM 3.1 used
     <term>function</term>. There is no distinction
     in meaning, but <term>function item</term> is preferred for clarity, because the unqualified
@@ -5941,18 +5948,6 @@ identity, equality, or otherwise, and</phrase> have no serialization.
       <termref def="dt-absent">absent</termref>. 
     </p>
   </item>
-  <item>
-    <p diff="add" at="2023-05-25">
-      <term role="property-definition" id="prop-function-identity">identity</term>: An abstract property that can be used to test whether
-      two variables refer to the same function or to different functions. This property
-      is exposed only for this purpose.
-    </p>
-    <note><p>Currently, the concept of function identity is used for two purposes: firstly,
-    when functions appear in the arguments supplied to the <code>fn:deep-equal</code> function;
-    and secondly, in establishing whether the arguments and results of a function are "the same"
-    when deciding whether the function is deterministic.</p></note>
-  </item>
-  
   <item>
     <p>
       <term role="property-definition" id="prop-function-signature">signature</term>
@@ -6091,11 +6086,6 @@ values, only on keys. The semantics of equality when comparing keys are describe
     <p>
       <term>name</term>:
       <termref def="dt-absent">absent</termref>. 
-    </p>
-  </item>
-  <item>
-    <p>
-      <term>identity</term>: <termref def="dt-implementation-dependent"/>.
     </p>
   </item>
   <item>
@@ -6350,11 +6340,6 @@ position, in the range 1 to the size of the array.</p>
     <p>
       <term>name</term>:
       <termref def="dt-absent">absent</termref>. 
-    </p>
-  </item>
-  <item>
-    <p>
-      <term>identity</term>: <termref def="dt-implementation-dependent"/>.
     </p>
   </item>
   <item>

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -5961,8 +5961,10 @@ is returned.</p>
     <div2 id="function-items">
 <head>Function Items</head>
   <changes>
-    <change issue="1920" date="2026-07-20">
-      Reverts issue 520: function items again cannot be compared for identity.
+    <change issue="2802" PR="2805" date="2026-08-19">
+      The <code>fn:function-identity</code> function and the identity property (issue 520) are
+      withdrawn; two function items may instead be tested for equivalence using
+      <code>fn:deep-equal</code>.
     </change>
     <change issue="520" PR="525" date="2023-05-30">
       Introduced the concept of function identity.
@@ -5978,13 +5980,11 @@ is returned.</p>
   A <term>function item</term> is an <termref def="dt-item"/> that can be called with zero or more
   arguments to return a result.
 </termdef>
-Function items <phrase diff="add" at="2026-07-20">cannot be compared for
-identity, equality, or otherwise, and</phrase> have no serialization.
+Function items <phrase diff="chg" at="2026-08-19">have no identity of their own, and</phrase> have no serialization.
+<phrase diff="add" at="2026-08-19">However, two function items may be tested for
+<xtermref spec="FO40" ref="dt-function-equivalent">equivalence</xtermref>, which is exposed through the
+<code>fn:deep-equal</code> function.</phrase>
 </p>
-
-<note diff="add" at="2026-07-20"><p>Maps and arrays are function items, but unlike other function
-items they can be compared by value; see <function>fn:deep-equal</function> and
-<xspecref spec="FO40" ref="dt-identical"/>.</p></note>
 
   <note diff="add" at="2023-03-11"><p>XDM 4.0 uses the term <term>function item</term> where XDM 3.1 used
     <term>function</term>. There is no distinction

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -5961,6 +5961,9 @@ is returned.</p>
     <div2 id="function-items">
 <head>Function Items</head>
   <changes>
+    <change issue="1920" date="2026-07-20">
+      Reverts issue 520: function items again cannot be compared for identity.
+    </change>
     <change issue="520" PR="525" date="2023-05-30">
       Introduced the concept of function identity.
     </change>
@@ -5975,10 +5978,14 @@ is returned.</p>
   A <term>function item</term> is an <termref def="dt-item"/> that can be called with zero or more
   arguments to return a result.
 </termdef>
-Function items <phrase diff="del" at="2023-05-25">cannot be compared for
+Function items <phrase diff="add" at="2026-07-20">cannot be compared for
 identity, equality, or otherwise, and</phrase> have no serialization.
 </p>
-  
+
+<note diff="add" at="2026-07-20"><p>Maps and arrays are function items, but unlike other function
+items they can be compared by value; see <function>fn:deep-equal</function> and
+<xspecref spec="FO40" ref="dt-identical"/>.</p></note>
+
   <note diff="add" at="2023-03-11"><p>XDM 4.0 uses the term <term>function item</term> where XDM 3.1 used
     <term>function</term>. There is no distinction
     in meaning, but <term>function item</term> is preferred for clarity, because the unqualified
@@ -5996,18 +6003,6 @@ identity, equality, or otherwise, and</phrase> have no serialization.
       <termref def="dt-absent">absent</termref>. 
     </p>
   </item>
-  <item>
-    <p diff="add" at="2023-05-25">
-      <term role="property-definition" id="prop-function-identity">identity</term>: An abstract property that can be used to test whether
-      two variables refer to the same function or to different functions. This property
-      is exposed only for this purpose.
-    </p>
-    <note><p>Currently, the concept of function identity is used for two purposes: firstly,
-    when functions appear in the arguments supplied to the <code>fn:deep-equal</code> function;
-    and secondly, in establishing whether the arguments and results of a function are "the same"
-    when deciding whether the function is deterministic.</p></note>
-  </item>
-  
   <item>
     <p>
       <term role="property-definition" id="prop-function-signature">signature</term>
@@ -6146,11 +6141,6 @@ values, only on keys. The semantics of equality when comparing keys are describe
     <p>
       <term>name</term>:
       <termref def="dt-absent">absent</termref>. 
-    </p>
-  </item>
-  <item>
-    <p>
-      <term>identity</term>: <termref def="dt-implementation-dependent"/>.
     </p>
   </item>
   <item>
@@ -6405,11 +6395,6 @@ position, in the range 1 to the size of the array.</p>
     <p>
       <term>name</term>:
       <termref def="dt-absent">absent</termref>. 
-    </p>
-  </item>
-  <item>
-    <p>
-      <term>identity</term>: <termref def="dt-implementation-dependent"/>.
     </p>
   </item>
   <item>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -17701,15 +17701,6 @@ declare function equal-strings(
                   </item>
                </olist>
             </item>
-            <item diff="add" at="2023-05-25">
-               <p>All the following conditions are true:</p>
-               <olist>
-                  <item><p><code>$i1</code> is a function item and is not a map or array.</p></item>
-                  <item><p><code>$i2</code> is a function item and is not a map or array.</p></item>
-                  <item><p><code>$i1</code> and <code>$i2</code> have the same function identity.
-                     The concept of function identity is explained in <xspecref spec="DM40" ref="function-items"/>.</p></item>                 
-               </olist>
-            </item>
             <item>
                <p>All the following conditions are true:</p>
                <olist>
@@ -17952,6 +17943,10 @@ declare function equal-strings(
          <p>In all other cases the result is <code>false</code>.</p>
       </fos:rules>
       <fos:errors>
+         <p diff="add" at="2026-07-20">A type error is raised <errorref class="TY" code="0015" type="type"
+               /> if either input
+            sequence contains a function item <phrase>that is not a map or
+               array</phrase>. </p>
          <p>A type error is raised <xerrorref spec="XP" class="TY"
             code="0004" type="type"/> if the value of 
             <code>$options</code> includes an entry whose key is defined 
@@ -18220,6 +18215,7 @@ declare function equal-strings(
       <fos:see-also prefix="fn" name="index-of"/>
       <fos:see-also prefix="fn" name="index-where"/>
       <fos:changes>
+         <fos:change issue="1920" date="2026-07-20"><p>Reverts issue 520: comparing a function item other than a map or array again raises a type error.</p></fos:change>
          <fos:change issue="930" PR="933" date="2024-01-16">
             <p>When comments and processing instructions are ignored, any text nodes either side of the
             comment or processing instruction are now merged prior to comparison.</p>
@@ -22804,9 +22800,6 @@ serialize(
          only if they are statically visible at the location where the call to <function>fn:function-lookup</function>
          appears. This means that private functions, if they are not statically visible in the containing
          module, should not be accessible using <function>fn:function-lookup</function>.</p>
-         <p diff="add" at="2023-05-26">The function identity is determined in the same way as for
-         a named function reference. Specifically, if there is no context dependency, two calls
-         on <function>fn:function-lookup</function> with the same name and arity must return the same function.</p>
          <p>These specifications do not define any circumstances in which the dynamic context will
             contain functions that are not present in the static context, but neither do they rule
             this out. For example an API <rfc2119>may</rfc2119> provide the ability to add functions
@@ -22927,80 +22920,6 @@ return function-arity($initial)</eg></fos:expression>
             </fos:test>
          </fos:example>
       </fos:examples>
-   </fos:function>
-   <fos:function name="function-identity" prefix="fn">
-      <fos:signatures>
-	     <fos:proto name="function-identity" return-type="xs:string">
-            <fos:arg name="function" type="fn(*)"/>		    
-	     </fos:proto>
-	  </fos:signatures>
-      <fos:properties>
-         <fos:property>deterministic</fos:property>
-         <fos:property>context-independent</fos:property>
-         <fos:property>focus-independent</fos:property>         
-      </fos:properties>	 
-      <fos:summary>
-         <p>Returns a string representing the identity of a function item.</p>
-      </fos:summary>
-	  <fos:rules>
-         <p>The <function>fn:function-identity</function> function returns a string that represents
-            the identity of <code>$function</code>.</p>
-	      <p>The returned string has the property that <code>fn:function-identity($f1)</code>
-	      and <code>fn:function-identity($f2)</code> are codepoint-equal if and only if <code>$f1</code>
-	      and <code>$f2</code> have the same function identity. Apart from this property, the
-	      result is <termref def="implementation-dependent"/>.</p>
-	     
-	     <p>In the case of maps and arrays, the result follows the following rule:
-	        If <code>$X</code> and <code>$Y</code> are both maps or arrays then <code>fn:function-identity($X)</code>
-	        <rfc2119>must not</rfc2119> be codepoint-equal to <code>fn:function-identity($Y)</code> unless
-	        <code>$X</code> and <code>$Y</code> are indistinguishable, that is unless every operator or function applied
-	        to <code>$X</code> returns the same result as for <code>$Y</code>. Even in this case, however, the
-	        result of the comparison <code>fn:function-identity($X) eq fn:function-identity($Y)</code>
-	        is <termref def="implementation-dependent"/>.</p>
-      </fos:rules>
-	  <fos:notes>
-	     <p>This function enables applications to test whether two expressions or variables
-	        reference the same function item. This may be useful, for example, to allow caching
-	        of function results to avoid repeated evaluation. The results of previous function
-	        invocations might be held in a map whose key is the function identity.</p>
-		<p>The function identity, by definition, is generated upon the creation of a function item.
-		   Specific expressions that create function items have their own rules for the identity
-		   of the returned functions: for example, it is guaranteed that evaluation of a function
-		   reference to a system function with no captured context (such as <code>fn:abs#1</code>)
-		   will always return the same function item.</p>
-		   <p>It is not meaningful to store or compare the result of calling <function>fn:function-identity</function> 
-		   across different <termref def="execution-scope">execution scopes</termref>, because the string used 
-		   to represent the function identity will generally vary from one execution scope to another.</p>
-	     <p>The result of an expression such as <code>function-identity(abs#1) eq function-identity(abs(?))</code>
-	     may be either <code>true</code> or <code>false</code>, because it is <termref def="implementation-dependent"/> 
-	        whether <code>abs#1</code> and <code>abs(?)</code> return the same function item.</p>
-	     <p>Similarly, <code>function-identity({ 1:() }) eq function-identity(map:entry(1, ()))</code>
-	     may be either <code>true</code> or <code>false</code>.</p>
-	     
-	  </fos:notes>
-      <fos:examples>
-         <fos:example>
-            <fos:test>
-               <fos:expression>function-identity(abs#1) eq function-identity(abs#1)</fos:expression>
-               <fos:result>true()</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>function-identity(abs#1) eq function-identity(round#1)</fos:expression>
-               <fos:result>false()</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>function-identity({ 1: 0 }) eq function-identity({ 1: 1 })</fos:expression>
-               <fos:result>false()</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>function-identity([ 0 ]) eq function-identity([ 1 ])</fos:expression>
-               <fos:result>false()</fos:result>
-            </fos:test>
-         </fos:example>
-      </fos:examples>
-      <fos:changes>
-         <fos:change issue="1798" PR="1801" date="2025-03-05"><p>New in 4.0</p></fos:change>
-      </fos:changes>
    </fos:function>
 
    <fos:function name="function-annotations" prefix="fn">
@@ -24841,10 +24760,6 @@ declare function transitive-closure (
                         <item>
                            <p><term>name</term>: absent.
                            </p>
-                        </item>
-                        <item><p><term>identity</term>: A new function
-                           identity distinct from the identity of any other function item.</p>
-                           <note><p>See also <xspecref spec="XP40" ref="id-function-identity"/>.</p></note>
                         </item>
                         <item>
                            <p><term>arity</term>: The arity of <code>$function</code> minus the
@@ -29661,7 +29576,7 @@ return csv-to-arrays(
          </fos:proto>
       </fos:signatures>
       <fos:properties>
-         <fos:property>deterministic</fos:property>
+         <fos:property>nondeterministic</fos:property>
          <fos:property dependency="executable-base-uri">context-dependent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
@@ -29997,6 +29912,7 @@ return document {
          </fos:example>
       </fos:examples>
       <fos:changes>
+         <fos:change issue="1920" date="2026-07-20"><p>Corrected to nondeterministic with respect to node identity.</p></fos:change>
          <fos:change PR="533 719 834 1066 1605" issue="413 1052" date="2023-07-25"><p>New in 4.0</p></fos:change>
       </fos:changes>
    </fos:function>
@@ -36859,14 +36775,11 @@ return $result
          <p>The returned JNode acts as the root of a tree, from which further JNodes
             may be reached by navigation using axis steps: see <xspecref spec="XP40" ref="id-axis-steps"/>.</p>
          
-         <p>The function typically returns a new JNode with its own identity. However,
-            if the function is called repeatedly with the same map or array as input,
-            then it <rfc2119>may</rfc2119> return the same JNode each time. However,
-            the concept of identity for maps and arrays is only weakly defined: maps
-            and arrays have identity (determined by the <function>fn:function-identity</function>)
-            by virtue of being functions, but it is not always predictable whether two
-            maps or arrays with equivalent content will have the same identity, so applications
-            <rfc2119>should</rfc2119> avoid relying on this. 
+         <p diff="chg" at="2026-07-20">The function typically returns a new JNode with its own identity. There is,
+            however, no guarantee that it constructs a new JNode on each call: two calls
+            with equal input <rfc2119>may</rfc2119> return the same JNode, or distinct (but deep-equal) JNodes.
+            Since maps and arrays have no identity of their own, applications
+            <rfc2119>should</rfc2119> not rely on the identity of the JNodes returned by separate calls.
             See also <xspecref spec="XP40" ref="functional-purity"/>.</p>
          
          
@@ -36878,21 +36791,13 @@ return $result
          JNode each time it is called. This is a deliberate decision, to give
          processors more freedom for optimization.</p>
          
-         <p>As defined in <xspecref spec="DM40" ref="functions-maps-arrays"/>, maps and
-         arrays have a <term>function identity</term> by virtue of being 
-         function items. However, there are situations where it is not
-         entirely predictable whether two maps or arrays will have the same
-         identity. For example, the expression <code>(1 to 3) ! {}</code>
-            delivers a sequence of three empty maps, but the specification
-            does not say whether these three maps share the same identity.
-            The only thing that can be reliably stated is that if the maps or
-         arrays have different content, then they will also have different identity.
-         It is therefore unwise for applications to place heavy reliance on 
-         function identity; and by implication, it is unwise to
-         rely on the identity of JNodes returned by this function.
-         </p>
-         
-         
+         <p diff="chg" at="2026-07-20">Maps and arrays are values: they have no identity of their own, and
+         two maps or arrays are distinguishable only by their content. An implementation is therefore
+         free to return the same JNode, or distinct JNodes, when <function>fn:jtree</function> is called
+         more than once with equal input, and applications <rfc2119>should</rfc2119> not rely on the
+         identity of the JNodes so returned.</p>
+
+
          <p>The identity of JNodes usually becomes significant only when eliminating duplicates,
             for example when the <code>union</code> operator is used; and then, only when
             multiple JTrees are involved, since the identity of JNodes obtained by navigation
@@ -36973,9 +36878,10 @@ return jtree($data)//languages[. = 'German']/../capital =!> string()</eg></fos:e
                <fos:result>"Berlin"</fos:result>
             </fos:test>
          </fos:example>
-         
+
       </fos:examples>
       <fos:changes>
+         <fos:change issue="1920" date="2026-07-20"><p>References to function identity removed.</p></fos:change>
          <fos:change issue="2025" PR="2031" date="2025-06-12"><p>New in 4.0</p></fos:change>
       </fos:changes>
    </fos:function>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -17670,7 +17670,8 @@ else error(#Q{http://www.w3.org/2005/xqt-errors}FORG0005))
             deep-equal, they must contain items that are pairwise deep-equal; and for two items to
             be deep-equal, they must either be atomic items that compare equal, or nodes of the
             same kind, with the same name, whose children are deep-equal<phrase>,
-               or maps with matching entries, or arrays with matching members.</phrase></p>
+               or maps with matching entries, or arrays with matching members<phrase diff="add" at="2026-08-19">,
+               or other function items that are equivalent</phrase>.</phrase></p>
       </fos:summary>
       <fos:rules>
 
@@ -18252,14 +18253,19 @@ declare function equal-strings(
                   
                
             
+            <item diff="add" at="2026-08-19">
+               <p>All the following conditions are true:</p>
+               <olist>
+                  <item><p><code>$i1</code> is a function item, and is neither a map nor an array.</p></item>
+                  <item><p><code>$i2</code> is a function item, and is neither a map nor an array.</p></item>
+                  <item><p><code>$i1</code> and <code>$i2</code> are
+                     <termref def="dt-function-equivalent">equivalent</termref>.</p></item>
+               </olist>
+            </item>
           </olist>
          <p>In all other cases the result is <code>false</code>.</p>
       </fos:rules>
       <fos:errors>
-         <p diff="add" at="2026-07-20">A type error is raised <errorref class="TY" code="0015" type="type"
-               /> if either input
-            sequence contains a function item <phrase>that is not a map or
-               array</phrase>. </p>
          <p>A type error is raised <xerrorref spec="XP" class="TY"
             code="0004" type="type"/> if the value of 
             <code>$options</code> includes an entry whose key is defined 
@@ -18517,6 +18523,21 @@ declare function equal-strings(
                <fos:postamble>The callback function traces which items are being compared,
                   without changing the result of the comparison.</fos:postamble>
             </fos:test>
+            <fos:test>
+               <fos:expression><eg>deep-equal(fn($x) { $x }, fn($y) { $y })</eg></fos:expression>
+               <fos:result>true()</fos:result>
+               <fos:postamble>The two functions differ only in the name of a bound variable.</fos:postamble>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>deep-equal(fn($x) { $x }, fn($x) { $x + 1 })</eg></fos:expression>
+               <fos:result>false()</fos:result>
+               <fos:postamble>The two functions do not always return deep-equal results.</fos:postamble>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>deep-equal(true#0, true#0)</eg></fos:expression>
+               <fos:result>true()</fos:result>
+               <fos:postamble>Two references to the same function are equivalent.</fos:postamble>
+            </fos:test>
             
          </fos:example>
          
@@ -18528,7 +18549,7 @@ declare function equal-strings(
       <fos:see-also prefix="fn" name="index-of"/>
       <fos:see-also prefix="fn" name="index-where"/>
       <fos:changes>
-         <fos:change issue="1920" date="2026-07-20"><p>Reverts issue 520: comparing a function item other than a map or array again raises a type error.</p></fos:change>
+         <fos:change issue="2802" PR="2805" date="2026-08-19"><p>Function items other than maps and arrays are compared for <termref def="dt-function-equivalent">equivalence</termref> (replacing the function-identity comparison of issue 520).</p></fos:change>
          <fos:change issue="930" PR="933" date="2024-01-16">
             <p>When comments and processing instructions are ignored, any text nodes either side of the
             comment or processing instruction are now merged prior to comparison.</p>
@@ -30439,7 +30460,7 @@ return document {
          </fos:example>
       </fos:examples>
       <fos:changes>
-         <fos:change issue="1920" date="2026-07-20"><p>Corrected to nondeterministic with respect to node identity.</p></fos:change>
+         <fos:change issue="1920" PR="2805" date="2026-07-20"><p>Corrected to nondeterministic with respect to node identity.</p></fos:change>
          <fos:change PR="533 719 834 1066 1605" issue="413 1052" date="2023-07-25"><p>New in 4.0</p></fos:change>
       </fos:changes>
    </fos:function>
@@ -37419,7 +37440,7 @@ return jtree($data)//languages[. = 'German']/../capital =!> string()</eg></fos:e
 
       </fos:examples>
       <fos:changes>
-         <fos:change issue="1920" date="2026-07-20"><p>References to function identity removed.</p></fos:change>
+         <fos:change issue="2802" PR="2805" date="2026-07-20"><p>References to function identity removed.</p></fos:change>
          <fos:change issue="2025" PR="2031" date="2025-06-12"><p>New in 4.0</p></fos:change>
       </fos:changes>
    </fos:function>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -18014,15 +18014,6 @@ declare function equal-strings(
                   </item>
                </olist>
             </item>
-            <item diff="add" at="2023-05-25">
-               <p>All the following conditions are true:</p>
-               <olist>
-                  <item><p><code>$i1</code> is a function item and is not a map or array.</p></item>
-                  <item><p><code>$i2</code> is a function item and is not a map or array.</p></item>
-                  <item><p><code>$i1</code> and <code>$i2</code> have the same function identity.
-                     The concept of function identity is explained in <xspecref spec="DM40" ref="function-items"/>.</p></item>                 
-               </olist>
-            </item>
             <item>
                <p>All the following conditions are true:</p>
                <olist>
@@ -18265,6 +18256,10 @@ declare function equal-strings(
          <p>In all other cases the result is <code>false</code>.</p>
       </fos:rules>
       <fos:errors>
+         <p diff="add" at="2026-07-20">A type error is raised <errorref class="TY" code="0015" type="type"
+               /> if either input
+            sequence contains a function item <phrase>that is not a map or
+               array</phrase>. </p>
          <p>A type error is raised <xerrorref spec="XP" class="TY"
             code="0004" type="type"/> if the value of 
             <code>$options</code> includes an entry whose key is defined 
@@ -18533,6 +18528,7 @@ declare function equal-strings(
       <fos:see-also prefix="fn" name="index-of"/>
       <fos:see-also prefix="fn" name="index-where"/>
       <fos:changes>
+         <fos:change issue="1920" date="2026-07-20"><p>Reverts issue 520: comparing a function item other than a map or array again raises a type error.</p></fos:change>
          <fos:change issue="930" PR="933" date="2024-01-16">
             <p>When comments and processing instructions are ignored, any text nodes either side of the
             comment or processing instruction are now merged prior to comparison.</p>
@@ -23249,9 +23245,6 @@ serialize(
          only if they are statically visible at the location where the call to <function>fn:function-lookup</function>
          appears. This means that private functions, if they are not statically visible in the containing
          module, should not be accessible using <function>fn:function-lookup</function>.</p>
-         <p diff="add" at="2023-05-26">The function identity is determined in the same way as for
-         a named function reference. Specifically, if there is no context dependency, two calls
-         on <function>fn:function-lookup</function> with the same name and arity must return the same function.</p>
          <p>These specifications do not define any circumstances in which the dynamic context will
             contain functions that are not present in the static context, but neither do they rule
             this out. For example an API <rfc2119>may</rfc2119> provide the ability to add functions
@@ -23372,80 +23365,6 @@ return function-arity($initial)</eg></fos:expression>
             </fos:test>
          </fos:example>
       </fos:examples>
-   </fos:function>
-   <fos:function name="function-identity" prefix="fn">
-      <fos:signatures>
-	     <fos:proto name="function-identity" return-type="xs:string">
-            <fos:arg name="function" type="fn(*)"/>		    
-	     </fos:proto>
-	  </fos:signatures>
-      <fos:properties>
-         <fos:property>deterministic</fos:property>
-         <fos:property>context-independent</fos:property>
-         <fos:property>focus-independent</fos:property>         
-      </fos:properties>	 
-      <fos:summary>
-         <p>Returns a string representing the identity of a function item.</p>
-      </fos:summary>
-	  <fos:rules>
-         <p>The <function>fn:function-identity</function> function returns a string that represents
-            the identity of <code>$function</code>.</p>
-	      <p>The returned string has the property that <code>fn:function-identity($f1)</code>
-	      and <code>fn:function-identity($f2)</code> are codepoint-equal if and only if <code>$f1</code>
-	      and <code>$f2</code> have the same function identity. Apart from this property, the
-	      result is <termref def="implementation-dependent"/>.</p>
-	     
-	     <p>In the case of maps and arrays, the result follows the following rule:
-	        If <code>$X</code> and <code>$Y</code> are both maps or arrays then <code>fn:function-identity($X)</code>
-	        <rfc2119>must not</rfc2119> be codepoint-equal to <code>fn:function-identity($Y)</code> unless
-	        <code>$X</code> and <code>$Y</code> are indistinguishable, that is unless every operator or function applied
-	        to <code>$X</code> returns the same result as for <code>$Y</code>. Even in this case, however, the
-	        result of the comparison <code>fn:function-identity($X) eq fn:function-identity($Y)</code>
-	        is <termref def="implementation-dependent"/>.</p>
-      </fos:rules>
-	  <fos:notes>
-	     <p>This function enables applications to test whether two expressions or variables
-	        reference the same function item. This may be useful, for example, to allow caching
-	        of function results to avoid repeated evaluation. The results of previous function
-	        invocations might be held in a map whose key is the function identity.</p>
-		<p>The function identity, by definition, is generated upon the creation of a function item.
-		   Specific expressions that create function items have their own rules for the identity
-		   of the returned functions: for example, it is guaranteed that evaluation of a function
-		   reference to a system function with no captured context (such as <code>fn:abs#1</code>)
-		   will always return the same function item.</p>
-		   <p>It is not meaningful to store or compare the result of calling <function>fn:function-identity</function> 
-		   across different <termref def="execution-scope">execution scopes</termref>, because the string used 
-		   to represent the function identity will generally vary from one execution scope to another.</p>
-	     <p>The result of an expression such as <code>function-identity(abs#1) eq function-identity(abs(?))</code>
-	     may be either <code>true</code> or <code>false</code>, because it is <termref def="implementation-dependent"/> 
-	        whether <code>abs#1</code> and <code>abs(?)</code> return the same function item.</p>
-	     <p>Similarly, <code>function-identity({ 1:() }) eq function-identity(map:entry(1, ()))</code>
-	     may be either <code>true</code> or <code>false</code>.</p>
-	     
-	  </fos:notes>
-      <fos:examples>
-         <fos:example>
-            <fos:test>
-               <fos:expression>function-identity(abs#1) eq function-identity(abs#1)</fos:expression>
-               <fos:result>true()</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>function-identity(abs#1) eq function-identity(round#1)</fos:expression>
-               <fos:result>false()</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>function-identity({ 1: 0 }) eq function-identity({ 1: 1 })</fos:expression>
-               <fos:result>false()</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>function-identity([ 0 ]) eq function-identity([ 1 ])</fos:expression>
-               <fos:result>false()</fos:result>
-            </fos:test>
-         </fos:example>
-      </fos:examples>
-      <fos:changes>
-         <fos:change issue="1798" PR="1801" date="2025-03-05"><p>New in 4.0</p></fos:change>
-      </fos:changes>
    </fos:function>
 
    <fos:function name="function-annotations" prefix="fn">
@@ -25279,10 +25198,6 @@ declare function transitive-closure (
                         <item>
                            <p><term>name</term>: absent.
                            </p>
-                        </item>
-                        <item><p><term>identity</term>: A new function
-                           identity distinct from the identity of any other function item.</p>
-                           <note><p>See also <xspecref spec="XP40" ref="id-function-identity"/>.</p></note>
                         </item>
                         <item>
                            <p><term>arity</term>: The arity of <code>$function</code> minus the
@@ -30188,7 +30103,7 @@ return csv-to-arrays(
          </fos:proto>
       </fos:signatures>
       <fos:properties>
-         <fos:property>deterministic</fos:property>
+         <fos:property>nondeterministic</fos:property>
          <fos:property dependency="executable-base-uri">context-dependent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
@@ -30524,6 +30439,7 @@ return document {
          </fos:example>
       </fos:examples>
       <fos:changes>
+         <fos:change issue="1920" date="2026-07-20"><p>Corrected to nondeterministic with respect to node identity.</p></fos:change>
          <fos:change PR="533 719 834 1066 1605" issue="413 1052" date="2023-07-25"><p>New in 4.0</p></fos:change>
       </fos:changes>
    </fos:function>
@@ -37397,14 +37313,11 @@ return $result
          <p>The returned JNode acts as the root of a tree, from which further JNodes
             may be reached by navigation using axis steps: see <xspecref spec="XP40" ref="id-axis-steps"/>.</p>
          
-         <p>The function typically returns a new JNode with its own identity. However,
-            if the function is called repeatedly with the same map or array as input,
-            then it <rfc2119>may</rfc2119> return the same JNode each time. However,
-            the concept of identity for maps and arrays is only weakly defined: maps
-            and arrays have identity (determined by the <function>fn:function-identity</function>)
-            by virtue of being functions, but it is not always predictable whether two
-            maps or arrays with equivalent content will have the same identity, so applications
-            <rfc2119>should</rfc2119> avoid relying on this. 
+         <p diff="chg" at="2026-07-20">The function typically returns a new JNode with its own identity. There is,
+            however, no guarantee that it constructs a new JNode on each call: two calls
+            with equal input <rfc2119>may</rfc2119> return the same JNode, or distinct (but deep-equal) JNodes.
+            Since maps and arrays have no identity of their own, applications
+            <rfc2119>should</rfc2119> not rely on the identity of the JNodes returned by separate calls.
             See also <xspecref spec="XP40" ref="functional-purity"/>.</p>
          
          
@@ -37416,21 +37329,13 @@ return $result
          JNode each time it is called. This is a deliberate decision, to give
          processors more freedom for optimization.</p>
          
-         <p>As defined in <xspecref spec="DM40" ref="functions-maps-arrays"/>, maps and
-         arrays have a <term>function identity</term> by virtue of being 
-         function items. However, there are situations where it is not
-         entirely predictable whether two maps or arrays will have the same
-         identity. For example, the expression <code>(1 to 3) ! {}</code>
-            delivers a sequence of three empty maps, but the specification
-            does not say whether these three maps share the same identity.
-            The only thing that can be reliably stated is that if the maps or
-         arrays have different content, then they will also have different identity.
-         It is therefore unwise for applications to place heavy reliance on 
-         function identity; and by implication, it is unwise to
-         rely on the identity of JNodes returned by this function.
-         </p>
-         
-         
+         <p diff="chg" at="2026-07-20">Maps and arrays are values: they have no identity of their own, and
+         two maps or arrays are distinguishable only by their content. An implementation is therefore
+         free to return the same JNode, or distinct JNodes, when <function>fn:jtree</function> is called
+         more than once with equal input, and applications <rfc2119>should</rfc2119> not rely on the
+         identity of the JNodes so returned.</p>
+
+
          <p>The identity of JNodes usually becomes significant only when eliminating duplicates,
             for example when the <code>union</code> operator is used; and then, only when
             multiple JTrees are involved, since the identity of JNodes obtained by navigation
@@ -37511,9 +37416,10 @@ return jtree($data)//languages[. = 'German']/../capital =!> string()</eg></fos:e
                <fos:result>"Berlin"</fos:result>
             </fos:test>
          </fos:example>
-         
+
       </fos:examples>
       <fos:changes>
+         <fos:change issue="1920" date="2026-07-20"><p>References to function identity removed.</p></fos:change>
          <fos:change issue="2025" PR="2031" date="2025-06-12"><p>New in 4.0</p></fos:change>
       </fos:changes>
    </fos:function>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -1118,7 +1118,7 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                
                <p>The following definition explains more precisely what it means for two function calls to return the same result:</p>
                
-               <p><termdef id="dt-identical" term="identical" diff="chg" at="2023-05-25">Two values <code>$V1</code> and <code>$V2</code> are
+               <p><termdef id="dt-identical" term="identical" diff="chg" at="2026-07-20">Two values <code>$V1</code> and <code>$V2</code> are
                   defined to be <term>identical</term> if they contain the same number of items and the items are pairwise identical. Two items are identical
                   if and only if one of the following conditions applies:</termdef></p>
                   
@@ -1134,9 +1134,11 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                      and the corresponding values <var>V1</var> and <var>V2</var> are <termref def="dt-identical"/>.</p></item>
                   <item><p>Both items are arrays, both arrays have the same number of members, and the members
                      are pairwise <termref def="dt-identical"/>.</p></item>
-                  <item><p>Both items are function items, 
-                     neither item is a map or array, and the two function items have the same function identity.
-                  The concept of function identity is explained in <xspecref spec="DM40" ref="function-items"/>.</p>
+                  <item><p diff="chg" at="2026-07-20">Both items are function items, neither is a map or array,
+                     and they are indistinguishable in their observable effect.</p>
+                     <note><p>No operator tests this, and the determination is
+                     <termref def="implementation-dependent"/>: two function items definitely differ if they differ in
+                     name or arity, but positive determination is implementation-dependent.</p></note>
                   </item>
                </olist>
   
@@ -1262,7 +1264,8 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                
                <item><p>Some functions (such as <function>fn:analyze-string</function>,
                   <function>fn:parse-xml</function>, <function>fn:parse-xml-fragment</function>, 
-                  <function>fn:parse-html</function>, and <function>fn:json-to-xml</function>) 
+                  <function>fn:parse-html</function>, <function>fn:json-to-xml</function>, and
+                  <function>fn:csv-to-xml</function>)
                   construct a tree of nodes to
                represent their results. There is no guarantee that repeated calls with the same
                arguments will return the same identical node (in the sense of the <code>is</code>
@@ -6428,9 +6431,6 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             </div2>
             <div2 id="func-function-arity">
                <head><?function fn:function-arity?></head>
-            </div2>
-            <div2 id="func-function-identity">
-               <head><?function fn:function-identity?></head>
             </div2>
             <div2 id="func-function-annotations">
                <head><?function fn:function-annotations?></head>
@@ -14756,11 +14756,11 @@ ISBN 0 521 77752 6.</bibl>
                <p>Raised by <function>fn:string</function>, or by implicit string conversion, if the input sequence contains
                   a function item.</p>
             </error>
-            <!--<error class="TY" code="0015" label="An argument to fn:deep-equal contains a function item."
+            <error class="TY" code="0015" label="An argument to fn:deep-equal contains a function item."
                type="dynamic">
                <p>Raised by <function>fn:deep-equal</function> if either input sequence contains a
-                  function item.</p> 
-            </error>-->
+                  function item that is not a map or array.</p>
+            </error>
             <error class="TY" code="0016" label="Key value not defined in record type"
                type="type">
                <p>Raised by <function>map:get</function> when requesting

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -1170,12 +1170,8 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                      pairwise deep-equal argument lists always return deep-equal results.</p></item>
                </olist>
 
-               <p diff="add" at="2026-08-19"><code>$F1</code> and <code>$F2</code> are never equivalent if there is
-                  any argument list for which one could return a result that is not deep-equal to the other’s; in
-                  particular, function items of different arity are never equivalent.</p>
-
-               <p diff="add" at="2026-08-19">Maps and arrays, although they are function items, are compared by
-                  their content; see <function>fn:deep-equal</function>.</p>
+               <p diff="add" at="2026-08-19">Maps and arrays are compared by their content;
+                  see <function>fn:deep-equal</function>.</p>
 
                <p diff="add" at="2026-08-19">For example, applying the first rule and without any further optimizations:</p>
 

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -1148,37 +1148,44 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                
                <p diff="add" at="2026-08-19"><termdef id="dt-function-equivalent" term="equivalent">Two
                   function items <code>$F1</code> and <code>$F2</code> that are neither maps nor arrays are
-                  <term>equivalent</term> if any of the following applies:</termdef></p>
+                  <term>equivalent</term> if either of the following applies:</termdef></p>
 
                <olist diff="add" at="2026-08-19">
-                  <item><p><code>$F1</code> and <code>$F2</code> are the same function item.</p></item>
-                  <item><p><code>$F1</code> and <code>$F2</code> have the same <term>static form</term> and their
-                     <term>captured values</term> are pairwise deep-equal. The static form is the expression from which
-                     a function item was constructed, compared up to the renaming of bound variables and ignoring any
-                     optimizations the processor may have applied; the captured values are the values bound to the
-                     variables that the function body references from outside the function.</p></item>
-                  <item><p>The processor is able to establish that calls on <code>$F1</code> and <code>$F2</code> with
-                     pairwise deep-equal argument lists always return deep-equal results. Whether a given pair of
-                     function items is recognized in this way is <termref def="implementation-dependent"/>.</p></item>
+                  <item><p><code>$F1</code> and <code>$F2</code> have both of the following:</p>
+                     <olist>
+                        <item><p>the same <term>static form</term>: the abstract syntax of the expression from which the
+                           function item was constructed (for a function supplied by the processor or implemented in
+                           external code, a reference to that implementation), compared ignoring the function’s name and
+                           annotations, up to the renaming of bound variables, and ignoring any optimizations the
+                           processor may have applied; and</p></item>
+                        <item><p>the same captured context (see <xspecref spec="DM40" ref="function-items"/>): the
+                           nonlocal variable bindings, the focus, and the static context captured when the function item
+                           was created. Two function items need agree only on the parts of the captured context on which
+                           the result of calling them depends, and captured variable values are compared using
+                           deep-equal.</p></item>
+                     </olist>
+                  </item>
+                  <item><p>It is <termref def="implementation-dependent"/> whether the processor additionally treats
+                     <code>$F1</code> and <code>$F2</code> as equivalent by establishing that calls on them with
+                     pairwise deep-equal argument lists always return deep-equal results.</p></item>
                </olist>
 
                <p diff="add" at="2026-08-19"><code>$F1</code> and <code>$F2</code> are never equivalent if there is
-                  any argument list for which one could return a result that is not deep-equal to the other's; in
+                  any argument list for which one could return a result that is not deep-equal to the other’s; in
                   particular, function items of different arity are never equivalent.</p>
 
                <p diff="add" at="2026-08-19">Maps and arrays, although they are function items, are compared by
                   their content; see <function>fn:deep-equal</function>.</p>
 
-               <p diff="add" at="2026-08-19">For example, applying the second rule and without any further optimizations:</p>
+               <p diff="add" at="2026-08-19">For example, applying the first rule and without any further optimizations:</p>
 
                <ulist diff="add" at="2026-08-19">
                   <item><p><code>true#0</code> and <code>true#0</code> are equivalent: both references identify the
                      same function.</p></item>
-                  <item><p><code>fn($x) { $x }</code> and <code>fn($y) { $y }</code> are equivalent: they differ only
-                     in the name of a bound variable.</p></item>
+                  <item><p><code>fn($x) { $x }</code> and <code>fn($y) {  $y  }</code> are equivalent: they differ only
+                     in the name of a bound variable and in whitespace.</p></item>
                   <item><p>The two function items in <code>let $n := &lt;a/&gt; return (fn() { $n }, fn() { $n })</code>
-                     are equivalent: they have the same static form, and their captured values are equal by
-                     content.</p></item>
+                     are equivalent: they have the same static form and the same captured context.</p></item>
                   <item><p><code>fn() { error() }</code> and <code>fn() { error() }</code> are equivalent: they have
                      the same static form; they are compared without being called.</p></item>
                   <item><p><code>fn($x) { $x }</code> and <code>fn($x) { $x + 1 }</code> are not equivalent: they can
@@ -1186,12 +1193,17 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                   <item><p><code>fn($x) { $x }</code> and <code>fn($x, $y) { $x }</code> are not equivalent: they have
                      different arity.</p></item>
                   <item><p>The two function items in <code>(let $n := 1 return fn() { $n }, let $m := 2 return fn()
-                     { $m })</code> are not equivalent: their captured values differ.</p></item>
+                     { $m })</code> are not equivalent: their captured context differs.</p></item>
+                  <item><p>The two function items in <code>for $x in (1, 2) return fn() { $x }</code> are not
+                     equivalent: they have the same static form but a different captured context (a different value of
+                     <code>$x</code>).</p></item>
+                  <item><p>The two function items in <code>(&lt;a/&gt;, &lt;b/&gt;) ! fn:name#0</code> are not equivalent:
+                     <code>fn:name#0</code> is context-dependent, so each captures a different context node.</p></item>
                </ulist>
 
                <p diff="add" at="2026-08-19">Whether the two function items in each of the following pairs are
                   equivalent is <termref def="implementation-dependent"/>. In every case they always return equal
-                  results, so the third rule permits a processor to treat them as equivalent; but their static forms
+                  results, so the second rule permits a processor to treat them as equivalent; but their static forms
                   differ, so no processor is required to do so:</p>
 
                <ulist diff="add" at="2026-08-19">

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -1141,18 +1141,73 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                      and the corresponding values <var>V1</var> and <var>V2</var> are <termref def="dt-identical"/>.</p></item>
                   <item><p>Both items are arrays, both arrays have the same number of members, and the members
                      are pairwise <termref def="dt-identical"/>.</p></item>
-                  <item><p diff="chg" at="2026-07-20">Both items are function items, neither is a map or array,
-                     and they are indistinguishable in their observable effect.</p>
-                     <note><p>No operator tests this, and the determination is
-                     <termref def="implementation-dependent"/>: two function items definitely differ if they differ in
-                     name or arity, but positive determination is implementation-dependent.</p></note>
-                  </item>
+                  <item><p diff="chg" at="2026-08-19">Both items are function items, neither is a map or array,
+                     and they are <termref def="dt-function-equivalent">equivalent</termref>.</p></item>
                </olist>
   
                
-               <p>Some functions produce results that depend not only on their explicit arguments, 
+               <p diff="add" at="2026-08-19"><termdef id="dt-function-equivalent" term="equivalent">Two
+                  function items <code>$F1</code> and <code>$F2</code> that are neither maps nor arrays are
+                  <term>equivalent</term> if any of the following applies:</termdef></p>
+
+               <olist diff="add" at="2026-08-19">
+                  <item><p><code>$F1</code> and <code>$F2</code> are the same function item.</p></item>
+                  <item><p><code>$F1</code> and <code>$F2</code> have the same <term>static form</term> and their
+                     <term>captured values</term> are pairwise deep-equal. The static form is the expression from which
+                     a function item was constructed, compared up to the renaming of bound variables and ignoring any
+                     optimizations the processor may have applied; the captured values are the values bound to the
+                     variables that the function body references from outside the function.</p></item>
+                  <item><p>The processor is able to establish that calls on <code>$F1</code> and <code>$F2</code> with
+                     pairwise deep-equal argument lists always return deep-equal results. Whether a given pair of
+                     function items is recognized in this way is <termref def="implementation-dependent"/>.</p></item>
+               </olist>
+
+               <p diff="add" at="2026-08-19"><code>$F1</code> and <code>$F2</code> are never equivalent if there is
+                  any argument list for which one could return a result that is not deep-equal to the other's; in
+                  particular, function items of different arity are never equivalent.</p>
+
+               <p diff="add" at="2026-08-19">Maps and arrays, although they are function items, are compared by
+                  their content; see <function>fn:deep-equal</function>.</p>
+
+               <p diff="add" at="2026-08-19">For example, applying the second rule and without any further optimizations:</p>
+
+               <ulist diff="add" at="2026-08-19">
+                  <item><p><code>true#0</code> and <code>true#0</code> are equivalent: both references identify the
+                     same function.</p></item>
+                  <item><p><code>fn($x) { $x }</code> and <code>fn($y) { $y }</code> are equivalent: they differ only
+                     in the name of a bound variable.</p></item>
+                  <item><p>The two function items in <code>let $n := &lt;a/&gt; return (fn() { $n }, fn() { $n })</code>
+                     are equivalent: they have the same static form, and their captured values are equal by
+                     content.</p></item>
+                  <item><p><code>fn() { error() }</code> and <code>fn() { error() }</code> are equivalent: they have
+                     the same static form; they are compared without being called.</p></item>
+                  <item><p><code>fn($x) { $x }</code> and <code>fn($x) { $x + 1 }</code> are not equivalent: they can
+                     return different results.</p></item>
+                  <item><p><code>fn($x) { $x }</code> and <code>fn($x, $y) { $x }</code> are not equivalent: they have
+                     different arity.</p></item>
+                  <item><p>The two function items in <code>(let $n := 1 return fn() { $n }, let $m := 2 return fn()
+                     { $m })</code> are not equivalent: their captured values differ.</p></item>
+               </ulist>
+
+               <p diff="add" at="2026-08-19">Whether the two function items in each of the following pairs are
+                  equivalent is <termref def="implementation-dependent"/>. In every case they always return equal
+                  results, so the third rule permits a processor to treat them as equivalent; but their static forms
+                  differ, so no processor is required to do so:</p>
+
+               <ulist diff="add" at="2026-08-19">
+                  <item><p><code>fn($x) { $x + $x }</code> and <code>fn($x) { 2 * $x }</code>: the two functions are
+                     equal by an arithmetic identity that a processor may or may not recognize.</p></item>
+                  <item><p><code>fn() { 1 + 1 }</code> and <code>fn() { 2 }</code>: a processor that folds constants
+                     may treat the two bodies as equal.</p></item>
+                  <item><p><code>fn($x) { $x }</code> and <code>fn:identity#1</code>: both compute the identity
+                     function, but one is written inline and the other is a reference to a built-in function.</p></item>
+                  <item><p><code>fn { . + 1 }</code> and <code>fn($n) { $n + 1 }</code>: both add one to their
+                     argument, but one uses the context-item shorthand and the other a named parameter.</p></item>
+               </ulist>
+
+               <p>Some functions produce results that depend not only on their explicit arguments,
                   but also on the static and dynamic context.</p>
-               
+
                <p><termdef id="dt-context-dependent" term="context-dependent">A 
                   <phrase diff="chg" at="2023-03-12"><xtermref spec="XP40" ref="dt-function-definition">function definition</xtermref></phrase> 
                   may have  the property of being <term>context-dependent</term>: the result of such a
@@ -14982,11 +15037,6 @@ ISBN 0 521 77752 6.</bibl>
                type="dynamic">
                <p>Raised by <function>fn:string</function>, or by implicit string conversion, if the input sequence contains
                   a function item.</p>
-            </error>
-            <error class="TY" code="0015" label="An argument to fn:deep-equal contains a function item."
-               type="dynamic">
-               <p>Raised by <function>fn:deep-equal</function> if either input sequence contains a
-                  function item that is not a map or array.</p>
             </error>
             <error class="TY" code="0016" label="Key value not defined in record type"
                type="type">

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -1125,7 +1125,7 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                
                <p>The following definition explains more precisely what it means for two function calls to return the same result:</p>
                
-               <p><termdef id="dt-identical" term="identical" diff="chg" at="2023-05-25">Two values <code>$V1</code> and <code>$V2</code> are
+               <p><termdef id="dt-identical" term="identical" diff="chg" at="2026-07-20">Two values <code>$V1</code> and <code>$V2</code> are
                   defined to be <term>identical</term> if they contain the same number of items and the items are pairwise identical. Two items are identical
                   if and only if one of the following conditions applies:</termdef></p>
                   
@@ -1141,9 +1141,11 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                      and the corresponding values <var>V1</var> and <var>V2</var> are <termref def="dt-identical"/>.</p></item>
                   <item><p>Both items are arrays, both arrays have the same number of members, and the members
                      are pairwise <termref def="dt-identical"/>.</p></item>
-                  <item><p>Both items are function items, 
-                     neither item is a map or array, and the two function items have the same function identity.
-                  The concept of function identity is explained in <xspecref spec="DM40" ref="function-items"/>.</p>
+                  <item><p diff="chg" at="2026-07-20">Both items are function items, neither is a map or array,
+                     and they are indistinguishable in their observable effect.</p>
+                     <note><p>No operator tests this, and the determination is
+                     <termref def="implementation-dependent"/>: two function items definitely differ if they differ in
+                     name or arity, but positive determination is implementation-dependent.</p></note>
                   </item>
                </olist>
   
@@ -1269,7 +1271,8 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                
                <item><p>Some functions (such as <function>fn:analyze-string</function>,
                   <function>fn:parse-xml</function>, <function>fn:parse-xml-fragment</function>, 
-                  <function>fn:parse-html</function>, and <function>fn:json-to-xml</function>) 
+                  <function>fn:parse-html</function>, <function>fn:json-to-xml</function>, and
+                  <function>fn:csv-to-xml</function>)
                   construct a tree of nodes to
                represent their results. There is no guarantee that repeated calls with the same
                arguments will return the same identical node (in the sense of the <code>is</code>
@@ -6473,9 +6476,6 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             </div2>
             <div2 id="func-function-arity">
                <head><?function fn:function-arity?></head>
-            </div2>
-            <div2 id="func-function-identity">
-               <head><?function fn:function-identity?></head>
             </div2>
             <div2 id="func-function-annotations">
                <head><?function fn:function-annotations?></head>
@@ -14983,11 +14983,11 @@ ISBN 0 521 77752 6.</bibl>
                <p>Raised by <function>fn:string</function>, or by implicit string conversion, if the input sequence contains
                   a function item.</p>
             </error>
-            <!--<error class="TY" code="0015" label="An argument to fn:deep-equal contains a function item."
+            <error class="TY" code="0015" label="An argument to fn:deep-equal contains a function item."
                type="dynamic">
                <p>Raised by <function>fn:deep-equal</function> if either input sequence contains a
-                  function item.</p> 
-            </error>-->
+                  function item that is not a map or array.</p>
+            </error>
             <error class="TY" code="0016" label="Key value not defined in record type"
                type="type">
                <p>Raised by <function>map:get</function> when requesting

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -8703,11 +8703,6 @@ declare record Particle (
             The name of <var>F</var> <phrase diff="add" at="B">(if not absent)</phrase>.
           </p>
                            </item>
-           <item><p diff="add" at="2023-05-25"><term>identity</term>: A new function
-              identity distinct from the identity of any other function item.</p>
-              <note><p>See also <specref ref="id-function-identity"/>.</p></note>
-           </item>
- 
                            <item>
                               <p>
                                  <term>signature</term>:
@@ -11364,10 +11359,6 @@ return $vat(doc('wares.xml')/shop/article)
                               Otherwise, the name is absent.
                            </p>
                         </item>
-                        <item><p diff="add" at="2023-05-25"><term>identity</term>: A new function
-                           identity distinct from the identity of any other function item.</p>
-                           <note><p>See also <specref ref="id-function-identity"/>.</p></note>
-                        </item>
                         <item>
                            <p><term>arity</term>: The number of placeholders in the function call.</p>
                         </item>
@@ -11668,36 +11659,6 @@ return $a("A")]]></eg>
                   <item>
                      <p><term>name</term>: The name of <var>FD</var>.</p>
                   </item>
-                  <item><p diff="add" at="2023-05-25"><term>identity</term>:</p>
-                     <ulist>
-                        <item><p>If <var>FD</var> is <termref def="dt-context-dependent"/> for the given arity, then a new function
-                        identity distinct from the identity of any other function item.</p>
-                           <note><p>In the general case, a function reference to a context-dependent function
-                           will produce different results every time it is evaluated, because the resulting function
-                           item has a <term>captured context</term> 
-                              (see <xspecref spec="DM40" ref="function-items"/>) that includes the dynamic context
-                           of the particular evaluation. Optimizers, however, are allowed to detect cases where
-                           the captured context happens to be the same, or where any variations are immaterial,
-                           and where it is therefore safe to return the same function item each time. This might be
-                           the case, for example, where the only context dependency of a function is on the default
-                           collation, and the default collation for both evaluations is known to be the same.</p></note></item>
-                        <item><p>Otherwise, a function identity that is the same as that produced by the evaluation
-                           of any other named function reference with the same function name and arity.</p>
-                             <p>This rule applies even across different 
-                                <xtermref spec="FO40" ref="execution-scope">execution scopes</xtermref>:
-                             for example if a parameter to a call to <function>fn:transform</function> is set to the
-                             result of the expression <function>fn:abs#1</function>, then the function item passed as the parameter
-                                value will be identical to that obtained by evaluating the expression <function>fn:abs#1</function>
-                             within the target XSLT stylesheet.</p>
-                           <p>This rule also applies when the target function definition is 
-                           <xtermref spec="FO40" ref="dt-nondeterministic">nondeterministic</xtermref>. 
-                           For example all evaluations of the named function reference <function>map:keys#2</function>
-                           return identical function items, even though two evaluations of <function>map:keys</function>
-                           with the same arguments may produce different results.</p>
-                        </item>
-                     </ulist>
-                     <note><p>See also <specref ref="id-function-identity"/>.</p></note>
-                  </item>
                   <item>
                      <p><term>arity</term>: As specified in the named function reference.</p>
                   </item>
@@ -11898,10 +11859,6 @@ return $a("A")]]></eg>
               Absent.
             </p>
                      </item>
-                     <item><p diff="add" at="2023-05-25"><term>identity</term>: A new function
-                              identity distinct from the identity of any other function item.</p>
-                        <note><p>See also <specref ref="id-function-identity"/>.</p></note>
-                     </item>
                      <item>
                         <p>
                            <term>signature</term>:
@@ -12017,52 +11974,6 @@ return $incrementors[2](4)]]></eg>
          </div3>
 
             
-            <div3 id="id-function-identity">
-               <head>Function Identity</head>
-               <p>It is sometimes useful to be able to establish whether two variables refer to the same function
-               or to different functions. For this purpose, every function item has an identity. Functions with the
-               same identity are indistinguishable in every way; in particular, any function call with identical
-               arguments will produce an identical result.</p>
-               <p>In general, evaluation of an expression that returns a function item other than one that was
-               present in its operands delivers a function item whose identity is unique, and thus distinct
-               from any other function item. There are two exceptions to this rule:</p>
-               
-               <ulist>
-                  <item><p>Evaluating a function reference such as <code>count#1</code> returns the same function
-                  every time. Specifically, if the function name identifies a <termref def="dt-function-definition"/>
-                  that is not <termref def="dt-context-dependent"/> (which is the most usual case), then all 
-                     function references using this function name and arity return the same function.
-                  For more details see <specref ref="id-named-function-ref"/>.</p>
-                  </item>
-                  <item><p>An optimizer is permitted to rewrite <xtermref spec="FO40" ref="dt-deterministic"/>
-                     expressions in such a way that repeated evaluation is avoided, and this may be
-                     done without consideration of function identity. For example:</p>
-                     <ulist>
-                        <item><p>If the expression
-                           <code>contains(?, "e")</code> appears within the body of a <code>for</code>
-                           clause, or if the same expression is written repeatedly in a query, then an
-                           optimizer may decide to evaluate it once only, and thus return the same function
-                           item each time.</p></item>
-                        <item><p>Similarly, if the expression <code>fn($x) { $x + 1 }</code>
-                           appears more than once, or is evaluated repeatedly, then it may return the same
-                           function each time.</p></item>
-                        <item><p>Optimizers are allowed to replace any expression with an
-                           equivalent expression. For example, <code>count(?)</code> may be rewritten as
-                           <code>count#1</code>. Similarly, <code>fn($x) { $x + 1 }</code> may be
-                           rewritten as <code>fn($y) { $y + 1 }</code>. This may lead to different
-                           expressions returning identical function items.</p></item>
-                        <item><p>In principle, two function items are not identical if they
-                           differ in their captured context. Optimizers, however, will often
-                           be able to eliminate parts of the captured context that a function does
-                           not actually use. For example, an inline function expression delivers
-                           a function item whose captured context includes the values of all nonlocal
-                           in-scope variables; but in practice the implementation is unlikely to retain the
-                           values of such variables unless they are actually referenced.
-                        </p></item>
-                     </ulist>
-                  </item>
-               </ulist>
-            </div3>
        
          
          


### PR DESCRIPTION
The attempt… which closes #2802 if accepted. Much of the prose is derived from the original version of the spec.

I revived the strict type error for `fn:deep-equal($fn1, $fn)`. I believe we shouldn’t re-introduce implementation-dependent behavior; I don’t think it would have enough added value.