### PR TITLE
2393 array:members and array:of-members using JNodes

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -30659,11 +30659,11 @@ array:size($array) eq 0
       <fos:equivalent style="xpath-expression" covers-error-cases="false">
 (: For the two-argument form: :)           
     if ($position = (1 to array:size($array)))
-    then items-at(array:members($array), $position) => map:get('value'))
+    then items-at(array:members($array), $position) => jvalue())
     else error(),
 (: For the three-argument form: :)           
     if ($position = (1 to array:size($array)))
-    then items-at(array:members($array), $position) => map:get('value'))
+    then items-at(array:members($array), $position) => jvalue())
     else $default
       </fos:equivalent>
       <fos:errors>
@@ -31319,7 +31319,7 @@ $array
       <fos:equivalent style="xpath-expression" covers-error-cases="false"><![CDATA[
 $array 
 => array:members() 
-=> insert-before($position, { 'value': $member })
+=> insert-before($position, array:members([$member]) })
 => array:of-members()
        ]]></fos:equivalent>
       <fos:errors>
@@ -31613,7 +31613,7 @@ $array
 array:of-members(
   for-each(array:members($array), 
            fn($member, $pos) {
-              { 'value': $action(map:get($member, 'value'), $pos) }
+              [$action(jvalue($member))], $pos) }
            })
 )
       </fos:equivalent>
@@ -31682,7 +31682,7 @@ array:of-members(
 array:of-members(
   filter(
     array:members($array),
-    fn($item, $pos) { $predicate(map:get($item, 'value'), $pos) }
+    fn($item, $pos) { $predicate(jvalue($item)), $pos) }
   )
 )      </fos:equivalent>
       <fos:errors>
@@ -31758,7 +31758,7 @@ return array:filter(
 fold-left(
   array:members($array),
   $init,
-  fn($result, $member) { $action($result, map:get($member, 'value')) }
+  fn($result, $member) { $action($result, jvalue($member) }
 )
        ]]></fos:equivalent>
       <fos:notes>
@@ -31834,7 +31834,7 @@ fold-left(
 fold-right(
   array:members($array),
   $init,
-  fn($member, $result) { $action(map:get($member, 'value'), $result) }
+  fn($member, $result) { $action(jvalue($member), $result) }
 )
        ]]></fos:equivalent>
       <fos:notes>
@@ -31914,7 +31914,7 @@ array:of-members(
     array:members($array1),
     array:members($array2),
     fn($v1, $v2, $pos) {
-      { 'value': $action(map:get($v1, 'value'), map:get($v2, 'value'), $pos) }
+      [$action(jvalue($v1), jvalue($v2), $pos)]/.
     }
   )
 )       ]]></fos:equivalent>
@@ -31986,7 +31986,7 @@ array:for-each-pair(
       <fos:equivalent style="xpath-expression">
 array:of-members(
   for-each($input, 
-    fn($item, $pos) { { 'value': $action($item, $pos) } }
+    fn($item, $pos) { [$action($item, $pos)]/. }
   )
 )
       </fos:equivalent>
@@ -32038,7 +32038,7 @@ array:build(
    
    <fos:function name="members" prefix="array">
       <fos:signatures>
-         <fos:proto name="members" return-type="record(value as item()*)*">
+         <fos:proto name="members" return-type="jnode()*">
             <fos:arg name="array" type="array(*)" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
@@ -32048,19 +32048,45 @@ array:build(
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Delivers the contents of an array as a sequence of <term>value records</term>.</p>
+         <p>Delivers the contents of an array as a sequence of JNodes.</p>
       </fos:summary>
       <fos:rules>
-         <p>The members of the array are delivered as a sequence of <term>value records</term>. 
-            A value record is an item that encapsulates an arbitrary sequence <code>$S</code>: specifically
-            it is a map comprising a single entry whose key is the <code>xs:string</code> value
-            <code>"value"</code> and whose corresponding value is <code>$S</code>. The content encapsulated
-         by a value record <code>$V</code> can be obtained using the expression <code>$V?value</code>.</p>
+         <p>The members of the array are delivered as a sequence of JNodes. 
+            The effect of the function is equivalent to the expression <code>jtree($array)/child::*</code>.
+         </p>
+         <p>The JNodes that are returned have the following properties:</p>
+         
+         <table>
+            <thead>
+               <tr>
+                  <th>Property</th>
+                  <th>Value</th>
+               </tr>
+            </thead>
+            <tbody>
+               <tr>
+                  <td>·jvalue·</td>
+                  <td>The content of the array member</td>
+               </tr>
+               <tr>
+                  <td>·jparent·</td>
+                  <td>The root JNode that encapsulates the array as a whole</td>
+               </tr>
+               <tr>
+                  <td>·jposition·</td>
+                  <td>The integer value 1</td>
+               </tr>
+               <tr>
+                  <td>·jkey·</td>
+                  <td>The one-based index of the member within the array.</td>
+               </tr>
+            </tbody>
+         </table>
          
          
       </fos:rules>
-      <fos:equivalent style="dm-primitive">
-            dm:iterate-array($array, array:member#1)
+      <fos:equivalent style="xpath-expression">
+         jtree($array)/child::*
       </fos:equivalent>     
       <fos:notes>
          <p>This function is the inverse of <function>array:of-members</function>.</p>   
@@ -32073,12 +32099,12 @@ array:build(
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:members([ 1 to 5 ])?value</fos:expression>
+               <fos:expression>array:members([ 1 to 5 ]) =!> jvalue()</fos:expression>
                <fos:result>1, 2, 3, 4, 5</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>array:members([ (1, 1), (2, 4), (3, 9), (4, 16), (5, 25) ])
-! sum(?value)</eg></fos:expression>
+! sum(jvalue())</eg></fos:expression>
                <fos:result>2, 6, 12, 20, 30</fos:result>
             </fos:test>
             <fos:test>
@@ -32091,11 +32117,12 @@ return deep-equal(
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:see-also prefix="array" name="of-members"/>
+      <fos:see-also prefix="array" name="split"/>
       <fos:changes>
          <fos:change issue="29 113 314" PR="360 476"><p>New in 4.0</p></fos:change>
-         <fos:change issue="2351">
-            <p>The group may remove this function, it is considered <loc href="#at-risk">at risk</loc>.
-            </p>
+         <fos:change issue="2351" date="2026-07-22">
+            <p>The function now returns JNodes.</p>
          </fos:change>
       </fos:changes>
    </fos:function>
@@ -32165,6 +32192,8 @@ return deep-equal(
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:see-also prefix="array" name="of-members"/>
+      <fos:see-also prefix="array" name="join"/>
       <fos:changes>
          <fos:change issue="508" PR="609" date="2023-07-25"><p>New in 4.0</p></fos:change>
       </fos:changes>
@@ -32173,7 +32202,7 @@ return deep-equal(
    <fos:function name="of-members" prefix="array">
       <fos:signatures>
          <fos:proto name="of-members" return-type="array(*)">
-            <fos:arg name="input" type="record(value as item()*)*" usage="inspection"/>
+            <fos:arg name="input" type="jnode()*" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -32182,27 +32211,29 @@ return deep-equal(
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Constructs an array from the contents of a sequence of <term>value records</term>.</p>
+         <p>Constructs an array from a sequence of JNodes.</p>
       </fos:summary>
       <fos:rules>
-         <p>The input items must be <term>value records</term>, as defined in the type signature.  
-            A value record is an item that encapsulates 
-            an arbitrary sequence <code>$S</code>: specifically
-            it is a map comprising a single entry whose key is the <code>xs:string</code> value
-            <code>"value"</code> and whose corresponding value is <code>$S</code>. The content encapsulated
-            by a value record <code>$V</code> can be obtained using the expression <code>$V?value</code>.</p>
+         <p>The input items must be JNodes, as defined in the type signature. 
+            Each JNode in the input produces one member in the constructed array; the value
+            of the member is the ·jvalue· property of the JNode. The other properties
+            of the input JNodes are ignored. Order is retained.</p>
         
 
       </fos:rules>
       
-      <fos:equivalent style="xquery-expression">
-fold-left($input, [], fn($array, $record) { 
-  array:append($array, map:get($record, 'value'))
+      <fos:equivalent style="xpath-expression">
+fold-left($input, [], fn($array, $jnode) { 
+  array:append($array, jvalue($jnode))
 })
       </fos:equivalent>
 
       <fos:notes>
-         <p>This function is the inverse of <function>array:members</function>.</p>       
+         <p>This function is the inverse of <function>array:members</function>. The two functions,
+         used in conjunction, allow arrays to be decmoposed and reconstructed in arbitrary ways.
+         For example, given two arrays <code>$A</code> and <code>$B</code> of the same length,
+         the can be combined pairwise into a single array with the expression:</p>
+         <eg>array:of-members(for-each-pair(array:of-members($A), array:of-members($B), op(',')))</eg>     
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -32211,23 +32242,26 @@ fold-left($input, [], fn($array, $record) {
                <fos:result>[]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:of-members({ 'value': (1 to 5) })</fos:expression>
+               <fos:expression>array:of-members({'x':23, 'y':(1 to 5)}/y)</fos:expression>
                <fos:result>[ (1, 2, 3, 4, 5) ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:of-members((1 to 5) ! { 'value': . })</fos:expression>
+               <fos:expression>array:of-members((1 to 5) =!> jtree())</fos:expression>
                <fos:result>[ 1, 2, 3, 4, 5 ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:of-members((1 to 3) ! { 'value': (., . * .) })</fos:expression>
+               <fos:expression>array:of-members((1 to 3) ! jtree((., . × .)) })</fos:expression>
                <fos:result>[ (1, 1), (2, 4), (3, 9) ]</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:see-also prefix="array" name="members"/>
+      <fos:see-also prefix="array" name="join"/>
+      <fos:see-also prefix="fn" name="jtree"/>
       <fos:changes>
          <fos:change issue="29 113 314" PR="360 476" date="2023-03-21"><p>New in 4.0</p></fos:change>
-         <fos:change issue="2351">
-            <p>The group may remove this function, it is considered <loc href="#at-risk">at risk</loc>.
+         <fos:change issue="2351" date="2026-07-23">
+            <p>The input to the function is now a sequence of JNodes.
             </p>
          </fos:change>
       </fos:changes>
@@ -36845,8 +36879,8 @@ return $result
    
    <fos:function name="jtree" prefix="fn">
       <fos:signatures>
-         <fos:proto name="jtree" return-type="jnode((), (map(*)|array(*)))">
-            <fos:arg name="input" type="(map(*)|array(*))"/>
+         <fos:proto name="jtree" return-type="jnode((), item()*">
+            <fos:arg name="input" type="item()*"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -36856,27 +36890,25 @@ return $result
       </fos:properties>
       <fos:summary>
          <p>Delivers a root <xtermref spec="DM40" ref="dt-JNode"/> wrapping 
-            a map or array, enabling the use of lookup expression
+            a value such as map or array, enabling the use of lookup expression
             to navigate a <xtermref spec="DM40" ref="dt-JTree"/> rooted at that map or array.</p>
       </fos:summary>
       <fos:rules>
          <p>The function returns a <xtermref spec="DM40" ref="dt-JNode"/>
-            that wraps the supplied map or array. Specifically, it returns a root JNode
+            that wraps the supplied value. Specifically, it returns a root JNode
             whose <term>·jvalue·</term> property is <code>$input</code>, and whose
             <term>·jparent·</term>, <term>·jposition·</term>, and <term>·jkey·</term> 
             properties are absent.</p>
          
-         <p>The returned JNode acts as the root of a tree, from which further JNodes
+         <p>The returned JNode acts as the root of a tree. Typical usage is for
+            <code>$input</code> to be a map or array, from which further JNodes
             may be reached by navigation using axis steps: see <xspecref spec="XP40" ref="id-axis-steps"/>.</p>
          
-         <p>The function typically returns a new JNode with its own identity. However,
-            if the function is called repeatedly with the same map or array as input,
+         <p>The function typically returns a new JNode with its own identity. But
+            if the function is called repeatedly with the same value as input,
             then it <rfc2119>may</rfc2119> return the same JNode each time. However,
-            the concept of identity for maps and arrays is only weakly defined: maps
-            and arrays have identity (determined by the <function>fn:function-identity</function>)
-            by virtue of being functions, but it is not always predictable whether two
-            maps or arrays with equivalent content will have the same identity, so applications
-            <rfc2119>should</rfc2119> avoid relying on this. 
+            the concept of "same value" is not well defined, so applications
+            should not rely on this.
             See also <xspecref spec="XP40" ref="functional-purity"/>.</p>
          
          
@@ -36909,11 +36941,11 @@ return $result
             within a single tree is unambiguously defined.</p>
          
          
-         <p>The coercion rules ensure that if an existing JNode is supplied as <code>$input</code>,
+         <!--<p>The coercion rules ensure that if an existing JNode is supplied as <code>$input</code>,
          the wrapped value will be extracted, and then rewrapped as a root JNode. If the supplied
          JNode is the root of a JTree, then it can be returned unchanged; in other cases the result
          must differ from the supplied JNode, in that it must be the root of a new JTree, with
-         absent <term>·jparent·</term>, <term>·jposition·</term>, and <term>·jkey·</term> properties.</p>
+         absent <term>·jparent·</term>, <term>·jposition·</term>, and <term>·jkey·</term> properties.</p>-->
          
          <p>Although <function>fn:jtree</function> is available as a function for user applications
          to call explicitly, it is also invoked implicitly by some expressions, notably when
@@ -36944,6 +36976,8 @@ return $result
          
          <p>An alternative way of wrapping a map or array, rather than calling <code>jtree($X)</code>,
          is to use the path expression <code>$X/.</code>.</p>
+         
+         <p>The <code>jtree</code> function can be useful to construct the input to <function>array:of-members</function>.</p>
          
          
          
@@ -36985,6 +37019,8 @@ return jtree($data)//languages[. = 'German']/../capital =!> string()</eg></fos:e
          </fos:example>
          
       </fos:examples>
+      <fos:see-also prefix="array" name="members"/>
+      <fos:see-also prefix="array" name="of-members"/>
       <fos:changes>
          <fos:change issue="2025" PR="2031" date="2025-06-12"><p>New in 4.0</p></fos:change>
       </fos:changes>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -31133,11 +31133,11 @@ array:size($array) eq 0
       <fos:equivalent style="xpath-expression" covers-error-cases="false">
 (: For the two-argument form: :)           
     if ($position = (1 to array:size($array)))
-    then items-at(array:members($array), $position) => map:get('value'))
+    then items-at(array:members($array), $position) => jvalue())
     else error(),
 (: For the three-argument form: :)           
     if ($position = (1 to array:size($array)))
-    then items-at(array:members($array), $position) => map:get('value'))
+    then items-at(array:members($array), $position) => jvalue())
     else $default
       </fos:equivalent>
       <fos:errors>
@@ -31793,7 +31793,7 @@ $array
       <fos:equivalent style="xpath-expression" covers-error-cases="false"><![CDATA[
 $array 
 => array:members() 
-=> insert-before($position, { 'value': $member })
+=> insert-before($position, array:members([$member]) })
 => array:of-members()
        ]]></fos:equivalent>
       <fos:errors>
@@ -32087,7 +32087,7 @@ $array
 array:of-members(
   for-each(array:members($array), 
            fn($member, $pos) {
-              { 'value': $action(map:get($member, 'value'), $pos) }
+              [$action(jvalue($member))], $pos) }
            })
 )
       </fos:equivalent>
@@ -32156,7 +32156,7 @@ array:of-members(
 array:of-members(
   filter(
     array:members($array),
-    fn($item, $pos) { $predicate(map:get($item, 'value'), $pos) }
+    fn($item, $pos) { $predicate(jvalue($item)), $pos) }
   )
 )      </fos:equivalent>
       <fos:errors>
@@ -32232,7 +32232,7 @@ return array:filter(
 fold-left(
   array:members($array),
   $init,
-  fn($result, $member) { $action($result, map:get($member, 'value')) }
+  fn($result, $member) { $action($result, jvalue($member) }
 )
        ]]></fos:equivalent>
       <fos:notes>
@@ -32308,7 +32308,7 @@ fold-left(
 fold-right(
   array:members($array),
   $init,
-  fn($member, $result) { $action(map:get($member, 'value'), $result) }
+  fn($member, $result) { $action(jvalue($member), $result) }
 )
        ]]></fos:equivalent>
       <fos:notes>
@@ -32388,7 +32388,7 @@ array:of-members(
     array:members($array1),
     array:members($array2),
     fn($v1, $v2, $pos) {
-      { 'value': $action(map:get($v1, 'value'), map:get($v2, 'value'), $pos) }
+      [$action(jvalue($v1), jvalue($v2), $pos)]/.
     }
   )
 )       ]]></fos:equivalent>
@@ -32460,7 +32460,7 @@ array:for-each-pair(
       <fos:equivalent style="xpath-expression">
 array:of-members(
   for-each($input, 
-    fn($item, $pos) { { 'value': $action($item, $pos) } }
+    fn($item, $pos) { [$action($item, $pos)]/. }
   )
 )
       </fos:equivalent>
@@ -32512,7 +32512,7 @@ array:build(
    
    <fos:function name="members" prefix="array">
       <fos:signatures>
-         <fos:proto name="members" return-type="record(value as item()*)*">
+         <fos:proto name="members" return-type="jnode()*">
             <fos:arg name="array" type="array(*)" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
@@ -32522,19 +32522,45 @@ array:build(
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Delivers the contents of an array as a sequence of <term>value records</term>.</p>
+         <p>Delivers the contents of an array as a sequence of JNodes.</p>
       </fos:summary>
       <fos:rules>
-         <p>The members of the array are delivered as a sequence of <term>value records</term>. 
-            A value record is an item that encapsulates an arbitrary sequence <code>$S</code>: specifically
-            it is a map comprising a single entry whose key is the <code>xs:string</code> value
-            <code>"value"</code> and whose corresponding value is <code>$S</code>. The content encapsulated
-         by a value record <code>$V</code> can be obtained using the expression <code>$V?value</code>.</p>
+         <p>The members of the array are delivered as a sequence of JNodes. 
+            The effect of the function is equivalent to the expression <code>jtree($array)/child::*</code>.
+         </p>
+         <p>The JNodes that are returned have the following properties:</p>
+         
+         <table>
+            <thead>
+               <tr>
+                  <th>Property</th>
+                  <th>Value</th>
+               </tr>
+            </thead>
+            <tbody>
+               <tr>
+                  <td>·jvalue·</td>
+                  <td>The content of the array member</td>
+               </tr>
+               <tr>
+                  <td>·jparent·</td>
+                  <td>The root JNode that encapsulates the array as a whole</td>
+               </tr>
+               <tr>
+                  <td>·jposition·</td>
+                  <td>The integer value 1</td>
+               </tr>
+               <tr>
+                  <td>·jkey·</td>
+                  <td>The one-based index of the member within the array.</td>
+               </tr>
+            </tbody>
+         </table>
          
          
       </fos:rules>
-      <fos:equivalent style="dm-primitive">
-            dm:iterate-array($array, array:member#1)
+      <fos:equivalent style="xpath-expression">
+         jtree($array)/child::*
       </fos:equivalent>     
       <fos:notes>
          <p>This function is the inverse of <function>array:of-members</function>.</p>   
@@ -32547,12 +32573,12 @@ array:build(
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:members([ 1 to 5 ])?value</fos:expression>
+               <fos:expression>array:members([ 1 to 5 ]) =!> jvalue()</fos:expression>
                <fos:result>1, 2, 3, 4, 5</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>array:members([ (1, 1), (2, 4), (3, 9), (4, 16), (5, 25) ])
-! sum(?value)</eg></fos:expression>
+! sum(jvalue())</eg></fos:expression>
                <fos:result>2, 6, 12, 20, 30</fos:result>
             </fos:test>
             <fos:test>
@@ -32565,11 +32591,12 @@ return deep-equal(
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:see-also prefix="array" name="of-members"/>
+      <fos:see-also prefix="array" name="split"/>
       <fos:changes>
          <fos:change issue="29 113 314" PR="360 476"><p>New in 4.0</p></fos:change>
-         <fos:change issue="2351">
-            <p>The group may remove this function, it is considered <loc href="#at-risk">at risk</loc>.
-            </p>
+         <fos:change issue="2351" date="2026-07-22">
+            <p>The function now returns JNodes.</p>
          </fos:change>
       </fos:changes>
    </fos:function>
@@ -32639,6 +32666,8 @@ return deep-equal(
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:see-also prefix="array" name="of-members"/>
+      <fos:see-also prefix="array" name="join"/>
       <fos:changes>
          <fos:change issue="508" PR="609" date="2023-07-25"><p>New in 4.0</p></fos:change>
       </fos:changes>
@@ -32647,7 +32676,7 @@ return deep-equal(
    <fos:function name="of-members" prefix="array">
       <fos:signatures>
          <fos:proto name="of-members" return-type="array(*)">
-            <fos:arg name="input" type="record(value as item()*)*" usage="inspection"/>
+            <fos:arg name="input" type="jnode()*" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -32656,27 +32685,29 @@ return deep-equal(
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Constructs an array from the contents of a sequence of <term>value records</term>.</p>
+         <p>Constructs an array from a sequence of JNodes.</p>
       </fos:summary>
       <fos:rules>
-         <p>The input items must be <term>value records</term>, as defined in the type signature.  
-            A value record is an item that encapsulates 
-            an arbitrary sequence <code>$S</code>: specifically
-            it is a map comprising a single entry whose key is the <code>xs:string</code> value
-            <code>"value"</code> and whose corresponding value is <code>$S</code>. The content encapsulated
-            by a value record <code>$V</code> can be obtained using the expression <code>$V?value</code>.</p>
+         <p>The input items must be JNodes, as defined in the type signature. 
+            Each JNode in the input produces one member in the constructed array; the value
+            of the member is the ·jvalue· property of the JNode. The other properties
+            of the input JNodes are ignored. Order is retained.</p>
         
 
       </fos:rules>
       
-      <fos:equivalent style="xquery-expression">
-fold-left($input, [], fn($array, $record) { 
-  array:append($array, map:get($record, 'value'))
+      <fos:equivalent style="xpath-expression">
+fold-left($input, [], fn($array, $jnode) { 
+  array:append($array, jvalue($jnode))
 })
       </fos:equivalent>
 
       <fos:notes>
-         <p>This function is the inverse of <function>array:members</function>.</p>       
+         <p>This function is the inverse of <function>array:members</function>. The two functions,
+         used in conjunction, allow arrays to be decmoposed and reconstructed in arbitrary ways.
+         For example, given two arrays <code>$A</code> and <code>$B</code> of the same length,
+         the can be combined pairwise into a single array with the expression:</p>
+         <eg>array:of-members(for-each-pair(array:of-members($A), array:of-members($B), op(',')))</eg>     
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -32685,23 +32716,26 @@ fold-left($input, [], fn($array, $record) {
                <fos:result>[]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:of-members({ 'value': (1 to 5) })</fos:expression>
+               <fos:expression>array:of-members({'x':23, 'y':(1 to 5)}/y)</fos:expression>
                <fos:result>[ (1, 2, 3, 4, 5) ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:of-members((1 to 5) ! { 'value': . })</fos:expression>
+               <fos:expression>array:of-members((1 to 5) =!> jtree())</fos:expression>
                <fos:result>[ 1, 2, 3, 4, 5 ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:of-members((1 to 3) ! { 'value': (., . * .) })</fos:expression>
+               <fos:expression>array:of-members((1 to 3) ! jtree((., . × .)) })</fos:expression>
                <fos:result>[ (1, 1), (2, 4), (3, 9) ]</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:see-also prefix="array" name="members"/>
+      <fos:see-also prefix="array" name="join"/>
+      <fos:see-also prefix="fn" name="jtree"/>
       <fos:changes>
          <fos:change issue="29 113 314" PR="360 476" date="2023-03-21"><p>New in 4.0</p></fos:change>
-         <fos:change issue="2351">
-            <p>The group may remove this function, it is considered <loc href="#at-risk">at risk</loc>.
+         <fos:change issue="2351" date="2026-07-23">
+            <p>The input to the function is now a sequence of JNodes.
             </p>
          </fos:change>
       </fos:changes>
@@ -37330,8 +37364,8 @@ return $result
    
    <fos:function name="jtree" prefix="fn">
       <fos:signatures>
-         <fos:proto name="jtree" return-type="jnode((), (map(*)|array(*)))">
-            <fos:arg name="input" type="(map(*)|array(*))"/>
+         <fos:proto name="jtree" return-type="jnode((), item()*">
+            <fos:arg name="input" type="item()*"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -37341,23 +37375,24 @@ return $result
       </fos:properties>
       <fos:summary>
          <p>Delivers a root <xtermref spec="DM40" ref="dt-JNode"/> wrapping 
-            a map or array, enabling the use of lookup expression
+            a value such as map or array, enabling the use of lookup expression
             to navigate a <xtermref spec="DM40" ref="dt-JTree"/> rooted at that map or array.</p>
       </fos:summary>
       <fos:rules>
          <p>The function returns a <xtermref spec="DM40" ref="dt-JNode"/>
-            that wraps the supplied map or array. Specifically, it returns a root JNode
+            that wraps the supplied value. Specifically, it returns a root JNode
             whose <term>·jvalue·</term> property is <code>$input</code>, and whose
             <term>·jparent·</term>, <term>·jposition·</term>, and <term>·jkey·</term> 
             properties are absent.</p>
          
-         <p>The returned JNode acts as the root of a tree, from which further JNodes
+         <p>The returned JNode acts as the root of a tree. Typical usage is for
+            <code>$input</code> to be a map or array, from which further JNodes
             may be reached by navigation using axis steps: see <xspecref spec="XP40" ref="id-axis-steps"/>.</p>
-         
+
          <p diff="chg" at="2026-07-20">The function typically returns a new JNode with its own identity. There is,
             however, no guarantee that it constructs a new JNode on each call: two calls
             with equal input <rfc2119>may</rfc2119> return the same JNode, or distinct (but deep-equal) JNodes.
-            Since maps and arrays have no identity of their own, applications
+            Applications
             <rfc2119>should</rfc2119> not rely on the identity of the JNodes returned by separate calls.
             See also <xspecref spec="XP40" ref="functional-purity"/>.</p>
          
@@ -37383,11 +37418,11 @@ return $result
             within a single tree is unambiguously defined.</p>
          
          
-         <p>The coercion rules ensure that if an existing JNode is supplied as <code>$input</code>,
+         <!--<p>The coercion rules ensure that if an existing JNode is supplied as <code>$input</code>,
          the wrapped value will be extracted, and then rewrapped as a root JNode. If the supplied
          JNode is the root of a JTree, then it can be returned unchanged; in other cases the result
          must differ from the supplied JNode, in that it must be the root of a new JTree, with
-         absent <term>·jparent·</term>, <term>·jposition·</term>, and <term>·jkey·</term> properties.</p>
+         absent <term>·jparent·</term>, <term>·jposition·</term>, and <term>·jkey·</term> properties.</p>-->
          
          <p>Although <function>fn:jtree</function> is available as a function for user applications
          to call explicitly, it is also invoked implicitly by some expressions, notably when
@@ -37418,6 +37453,8 @@ return $result
          
          <p>An alternative way of wrapping a map or array, rather than calling <code>jtree($X)</code>,
          is to use the path expression <code>$X/.</code>.</p>
+         
+         <p>The <code>jtree</code> function can be useful to construct the input to <function>array:of-members</function>.</p>
          
          
          
@@ -37459,6 +37496,8 @@ return jtree($data)//languages[. = 'German']/../capital =!> string()</eg></fos:e
          </fos:example>
 
       </fos:examples>
+      <fos:see-also prefix="array" name="members"/>
+      <fos:see-also prefix="array" name="of-members"/>
       <fos:changes>
          <fos:change issue="2802" PR="2805" date="2026-07-20"><p>References to function identity removed.</p></fos:change>
          <fos:change issue="2025" PR="2031" date="2025-06-12"><p>New in 4.0</p></fos:change>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -32087,7 +32087,7 @@ $array
 array:of-members(
   for-each(array:members($array), 
            fn($member, $pos) {
-              [$action(jvalue($member))], $pos) }
+              jtree($action(jvalue($member), $pos)) }
            })
 )
       </fos:equivalent>
@@ -32156,7 +32156,7 @@ array:of-members(
 array:of-members(
   filter(
     array:members($array),
-    fn($item, $pos) { $predicate(jvalue($item)), $pos) }
+    fn($item, $pos) { $predicate(jvalue($item), $pos) }
   )
 )      </fos:equivalent>
       <fos:errors>
@@ -32595,7 +32595,7 @@ return deep-equal(
       <fos:see-also prefix="array" name="split"/>
       <fos:changes>
          <fos:change issue="29 113 314" PR="360 476"><p>New in 4.0</p></fos:change>
-         <fos:change issue="2351" date="2026-07-22">
+         <fos:change issue="2351 2393" PR="2814" date="2026-07-23">
             <p>The function now returns JNodes.</p>
          </fos:change>
       </fos:changes>
@@ -32704,10 +32704,13 @@ fold-left($input, [], fn($array, $jnode) {
 
       <fos:notes>
          <p>This function is the inverse of <function>array:members</function>. The two functions,
-         used in conjunction, allow arrays to be decmoposed and reconstructed in arbitrary ways.
+         used in conjunction, allow arrays to be decomposed and reconstructed in arbitrary ways.
          For example, given two arrays <code>$A</code> and <code>$B</code> of the same length,
-         the can be combined pairwise into a single array with the expression:</p>
-         <eg>array:of-members(for-each-pair(array:of-members($A), array:of-members($B), op(',')))</eg>     
+         they can be combined pairwise into a single array with the expression:</p>
+         <eg>array:of-members(
+            for-each-pair(array:of-members($A), 
+                          array:of-members($B), 
+                          op(',')))</eg>     
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -32724,7 +32727,7 @@ fold-left($input, [], fn($array, $jnode) {
                <fos:result>[ 1, 2, 3, 4, 5 ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:of-members((1 to 3) ! jtree((., . × .)) })</fos:expression>
+               <fos:expression>array:of-members((1 to 3) ! jtree((., . × .)) )</fos:expression>
                <fos:result>[ (1, 1), (2, 4), (3, 9) ]</fos:result>
             </fos:test>
          </fos:example>
@@ -32734,9 +32737,8 @@ fold-left($input, [], fn($array, $jnode) {
       <fos:see-also prefix="fn" name="jtree"/>
       <fos:changes>
          <fos:change issue="29 113 314" PR="360 476" date="2023-03-21"><p>New in 4.0</p></fos:change>
-         <fos:change issue="2351" date="2026-07-23">
-            <p>The input to the function is now a sequence of JNodes.
-            </p>
+         <fos:change issue="2351 2393" PR="2814" date="2026-07-23">
+            <p>The input to the function is now a sequence of JNodes.</p>
          </fos:change>
       </fos:changes>
    </fos:function>
@@ -37364,7 +37366,7 @@ return $result
    
    <fos:function name="jtree" prefix="fn">
       <fos:signatures>
-         <fos:proto name="jtree" return-type="jnode((), item()*">
+         <fos:proto name="jtree" return-type="jnode((), item()*)">
             <fos:arg name="input" type="item()*"/>
          </fos:proto>
       </fos:signatures>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -8539,15 +8539,12 @@ map( xs:string,
             
             <ulist diff="chg" at="2023-02-20">
                <item><p>The function <function>array:members</function> decomposes an array to a sequence of 
-                  <term>value records</term>.</p></item>
+                  JNodes.</p></item>
                <item><p>The function <function>array:of-members</function> composes an array from a sequence of 
-               <term>value records</term>.</p></item>
+               JNodes.</p></item>
             </ulist>
             
-            <p diff="chg" at="2023-02-20">A <term>value record</term> here is an item that encapsulates an arbitrary value; the representation
-            chosen for a value record is <code>record(value as item()*)</code>, that is, a map containing a single
-            entry whose key is the string <code>"value"</code> and whose value is the encapsulated sequence.</p>
- 
+            
             <p>Note that when the required type of an argument to a function such as <function>array:build</function>
             is an array type, then the coercion rules ensure that a JNode can be supplied in the function call:
             if the <term>·jvalue·</term> property of the JNode is an array, then the array is automatically

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -8812,15 +8812,12 @@ map( xs:string,
             
             <ulist diff="chg" at="2023-02-20">
                <item><p>The function <function>array:members</function> decomposes an array to a sequence of 
-                  <term>value records</term>.</p></item>
+                  JNodes.</p></item>
                <item><p>The function <function>array:of-members</function> composes an array from a sequence of 
-               <term>value records</term>.</p></item>
+               JNodes.</p></item>
             </ulist>
             
-            <p diff="chg" at="2023-02-20">A <term>value record</term> here is an item that encapsulates an arbitrary value; the representation
-            chosen for a value record is <code>record(value as item()*)</code>, that is, a map containing a single
-            entry whose key is the string <code>"value"</code> and whose value is the encapsulated sequence.</p>
- 
+            
             <p>Note that when the required type of an argument to a function such as <function>array:build</function>
             is an array type, then the coercion rules ensure that a JNode can be supplied in the function call:
             if the <term>·jvalue·</term> property of the JNode is an array, then the array is automatically

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -15941,21 +15941,19 @@ return $tree =?> depth()]]></eg>
 ]</eg>
             <p>The following code processes this array to produce an XML representation of the same information. The
                cities are sorted by name:</p>
-               <eg><![CDATA[<xsl:for-each select="json-doc('input.json')?*">
+               <eg><![CDATA[<xsl:for-each select="json-doc('input.json')/*">
    <xsl:sort select="?city"/>
    <city number="{position()}" 
          name="{?city}" 
          latitude="{?latitude}" 
          longitude="{?longitude}"/>
 </xsl:for-each>]]></eg>
-               <p>In this example it is possible to use the expression <code>$array?*</code> to convert an array to a sequence.
-               This works because the members of the array are all single items. In the more general case (a member
-               of the array might be the empty sequence, corresponding to the JSON value <code>null</code>, or it
-               might be a sequence containing several items), <phrase diff="chg" at="2023-04-04">the function <code>array:members</code> can be
-               used to deliver the contents of the array as a sequence of JNodes. This is 
-               illustrated in the next example.</phrase></p>
+               <p>The expression <code>json-doc('input.json')/*</code> returns a sequence of JNodes representing the members of <code>$array</code>,
+                  that is, the three maps representing cities. The lookup expressions <code>?city</code>, <code>?latitude</code>, and <code>?longitude</code>
+                  coerce the JNode to the contained map, and return value of the relevant entry in the map.
+               </p>
             </example>
-            <example diff="chg" at="2022-11-01">
+            <!--<example diff="chg" at="2022-11-01">
                <head>Using <elcode>xsl:for-each</elcode> to process an array containing nulls</head>
                <p>Consider a JSON document of the form:</p>
                <eg>[
@@ -15982,7 +15980,7 @@ return $tree =?> depth()]]></eg>
                   the function <xfunction>array:members</xfunction> is used to create a sequence of
                   JNodes: a JNode can wrap an arbitrary XDM value, including an empty sequence.</p>
 
-            </example>
+            </example>-->
             <example diff="add" at="2022-11-01">
                <head>Using <elcode>xsl:for-each</elcode> to process a map</head>
                <p>Consider a JSON document of the form:</p>
@@ -15993,16 +15991,16 @@ return $tree =?> depth()]]></eg>
 }</eg>
                <p>The following code processes this map to produce an XML representation of the same information. The
                   cities are sorted by name:</p>
-               <eg><![CDATA[<xsl:for-each select="map:pairs(json-doc('input.json'))">
-   <xsl:sort select="?key"/>
+               <eg><![CDATA[<xsl:for-each select="json-doc('input.json')/*">
+   <xsl:sort select="jkey()"/>
    <city number="{position()}" 
-         name="{?key}" 
-         latitude="{?value?latitude}" 
-         longitude="{?value?longitude}"/>
+         name="{jkey()}" 
+         latitude="{jvalue()?latitude}" 
+         longitude="{jvalue()?longitude}"/>
 </xsl:for-each>]]></eg>
-               <p>In this example the map is decomposed to a sequence of key-value pairs, each represented as
-               a map with two entries, <code>"key"</code> and <code>"value"</code>, which can be accessed using
-               the lookup expressions <code>?key</code> and <code>?value</code>.</p>
+               <p>The expression <code>json-doc('input.json')/*</code> returns a sequence of JNodes representing the entries in the top-level
+                  map, that is, the entries representing cities. For each of these JNodes, the <function>jkey</function> function returns
+                  the key (that is, the city name), and the <function>jvalue</function> function returns the corresponding value.</p>
             </example>
             <div3 id="for-each-separator" diff="add" at="2022-01-01">
                <head>The <code>separator</code> attribute</head>
@@ -16063,7 +16061,7 @@ return $tree =?> depth()]]></eg>
    </xsl:next-iteration>   
 </xsl:iterate>]]></eg>
                <p>Using <code>json-doc()/*</code> returns a sequence of JNodes representing the members of the
-                  array, which in this case are maps representing individual transactions. Subsequent lookup
+                  array, that is, the individual transactions. Subsequent lookup
                expressions such as <code>?credit</code> return entries in the map that is encapsulated by the JNode.</p>
  
               
@@ -29337,7 +29335,8 @@ the same group, and the-->
             
             <note><p>The <elcode>xsl:array</elcode> and <elcode>xsl:array-member</elcode> instructions
             are designed to be used in conjunction with the <function>array:members</function> and <function>array:of-members</function>
-            functions. All of these instructions and functions represent array members as JNodes.</p></note>
+            functions, and with path expressions operating on JTrees. 
+            All of these instructions and functions represent array members as JNodes.</p></note>
             
             <p>If the <elcode>xsl:array</elcode> instruction has a <code>select</code> attribute then
             the sequence constructor must be empty, except for any <elcode>xsl:fallback</elcode> instructions
@@ -29448,10 +29447,12 @@ the same group, and the-->
             <example>
                <head>Constructing an array based on an existing array</head>
                <p>The <elcode>xsl:array</elcode> instruction can be used in conjunction with
-               the <xfunction>array:members</xfunction> function to construct an array from the members
-               of an existing array. For example, the following code combines two arrays <code>$A1</code>
+               path expressions that extract the contents of an existing array as JNodes.
+               For example, the following code combines two arrays <code>$A1</code>
                   and <code>$A2</code>, and sorts the result:</p>
-               <eg><![CDATA[<xsl:array select="($A1/*, $A2/*) => sort(fn{count(jvalue())})"/>]]></eg>
+               <eg><![CDATA[<xsl:array select="($A1/*, $A2/*) => sort(jvalue#1)"/>]]></eg>
+               <p>If the input arrays are <code>[1, (5, 7), 8]</code> and <code>[9, (5, 2), 3]</code>,
+               the result will be <code>[1, (5, 2), (5, 7), 8, 9]</code>.</p>
                <p>The following code transposes a regular nested array (such as <code>[ [ 1, 2, 3 ], [ 4, 5, 6 ], [ 7, 8, 9 ] ]</code>)
                so the result is organized by columns rather than rows (<code>[ [ 1, 4, 7 ], [ 2, 5, 8 ], [ 3, 6, 9 ] ]</code>):</p>
                <eg><![CDATA[<xsl:array for-each="1 to array:size($input?1)">

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -15288,7 +15288,7 @@ return $tree =?> depth()]]></eg>
                is exactly the same as <code>shallow-copy</code>.</p>
                
                <p>For arrays, the processing is as follows. A new result array is created, and its content
-                  is populated by decomposing the input array to a sequence of <term>value records</term>
+                  is populated by decomposing the input array to a sequence of JNodes
                using the function <function>array:members</function>. Each of these value records is processed
                   by a call on <elcode>xsl:apply-templates</elcode> (using the current mode, and passing
                   on the values of all template parameters); the result of the called template
@@ -15301,7 +15301,7 @@ return $tree =?> depth()]]></eg>
   <xsl:apply-templates select="array:members(.)" mode="#current"/>
 </xsl:array>  
     ]]></eg>
-               <ednote><edtext>TODO: the use attribute is no more. Example need reworking.</edtext></ednote>
+               <ednote><edtext>TODO: the use attribute is no more, and array:members() now delivers JNodes. Example needs reworking.</edtext></ednote>
                
                <note><p>A <term>value record</term> is a single-entry map: it has a single key-value pair with the key <code>"value"</code>,
                the corresponding value being a member of the original array. The default processing for a value
@@ -15952,7 +15952,7 @@ return $tree =?> depth()]]></eg>
                This works because the members of the array are all single items. In the more general case (a member
                of the array might be the empty sequence, corresponding to the JSON value <code>null</code>, or it
                might be a sequence containing several items), <phrase diff="chg" at="2023-04-04">the function <code>array:members</code> can be
-               used to deliver the contents of the array as a sequence of <emph>value records</emph>. This is 
+               used to deliver the contents of the array as a sequence of JNodes. This is 
                illustrated in the next example.</phrase></p>
             </example>
             <example diff="chg" at="2022-11-01">
@@ -15973,15 +15973,14 @@ return $tree =?> depth()]]></eg>
                <eg><![CDATA[<xsl:for-each select="json-doc('input.json')?*">
    <city name="{?city}">
      <xsl:for-each select="array:members(?data)">
-       <xsl:attribute name="Q{position()}" select="?value"/>
+       <xsl:attribute name="Q{position()}" select="jvalue(.)"/>
      </xsl:for-each>
    </city>  
 </xsl:for-each>]]></eg>
                <p>In this example the expression <code>$array?*</code> cannot be used on the inner arrays
                   because JSON nulls (which translate to the empty sequence in XDM) would be lost. Instead
                   the function <xfunction>array:members</xfunction> is used to create a sequence of
-                  value records: a non-null entry is represented by a value such as <code>{ 'value': 12.3 }</code>,
-                  while a null entry would be <code>{ 'value': () }</code>.</p>
+                  JNodes: a JNode can wrap an arbitrary XDM value, including an empty sequence.</p>
 
             </example>
             <example diff="add" at="2022-11-01">
@@ -16053,21 +16052,7 @@ return $tree =?> depth()]]></eg>
   { "date": "2008-09-02", credit: 12.00 }
 ]</eg>
                <p>The following code converts this to an XML representation that includes a running balance:</p>
-               <eg><![CDATA[<xsl:iterate select="json-doc('account.json') => array:members()">
-   <xsl:param name="balance" as="xs:decimal" select="0"/>               
-   <xsl:variable name="delta" select="?value?credit otherwise -?value?debit"/>               
-   <entry date="{ ?value?date }"
-          amount="{ $delta }"
-          balance="{ $balance + $delta }"/>
-   <xsl:next-iteration>
-      <xsl:with-param name="balance" select="$balance + $delta"/>
-   </xsl:next-iteration>   
-</xsl:iterate>]]></eg>
-               <p>Using <code>array:members()</code> in this way makes it possible to process any array, including one whose members
-               are arbitrary sequences rather than single items. In this particular case, if it is known that the JSON array
-               will not contain any <code>null</code> entries, or if any <code>null</code> entries are to be ignored,
-                  it becomes possible to simplify the code as follows:</p>
-               <eg><![CDATA[<xsl:iterate select="json-doc('account.json')?*">
+               <eg><![CDATA[<xsl:iterate select="json-doc('account.json')/*">
    <xsl:param name="balance" as="xs:decimal" select="0"/>               
    <xsl:variable name="delta" select="?credit otherwise -?debit"/>               
    <entry date="{ ?date }"
@@ -16077,6 +16062,10 @@ return $tree =?> depth()]]></eg>
       <xsl:with-param name="balance" select="$balance + $delta"/>
    </xsl:next-iteration>   
 </xsl:iterate>]]></eg>
+               <p>Using <code>json-doc()/*</code> returns a sequence of JNodes representing the members of the
+                  array, which in this case are maps representing individual transactions. Subsequent lookup
+               expressions such as <code>?credit</code> return entries in the map that is encapsulated by the JNode.</p>
+ 
               
             </example>
             
@@ -29222,7 +29211,7 @@ the same group, and the-->
                <p>This returns the array <code>[ (1, 2, 3, 4), (5, 6, 7, 8, 9), 10 ]</code>.</p>
                </item>
                <item>
-                  <p>An array can be constructed by selecting members of an existing array, and appending
+                  <p>An array can be constructed by selecting members of an existing array, and adding
                   additional members:</p>
                <eg><![CDATA[<xsl:array>
    <xsl:array-member select="'start'"/>               
@@ -29328,7 +29317,7 @@ the same group, and the-->
                         </item>
                      </olist>
                   </item>
-            </olist>
+                 </olist>
                </item>
             </olist>
             
@@ -29345,6 +29334,10 @@ the same group, and the-->
                if and only if the <code>select</code> and <code>for-each</code> attributes
                of <code>xsl:array</code> are both absent.</emph></p>
             </note>
+            
+            <note><p>The <elcode>xsl:array</elcode> and <elcode>xsl:array-member</elcode> instructions
+            are designed to be used in conjunction with the <function>array:members</function> and <function>array:of-members</function>
+            functions. All of these instructions and functions represent array members as JNodes.</p></note>
             
             <p>If the <elcode>xsl:array</elcode> instruction has a <code>select</code> attribute then
             the sequence constructor must be empty, except for any <elcode>xsl:fallback</elcode> instructions
@@ -29458,9 +29451,7 @@ the same group, and the-->
                the <xfunction>array:members</xfunction> function to construct an array from the members
                of an existing array. For example, the following code combines two arrays <code>$A1</code>
                   and <code>$A2</code>, and sorts the result:</p>
-               <eg><![CDATA[<xsl:array 
-   for-each="(array:members($A1), array:members($A2)) => sort(fn{count(?value)})"
-   select="?value"/>]]></eg>
+               <eg><![CDATA[<xsl:array select="($A1/*, $A2/*) => sort(fn{count(jvalue())})"/>]]></eg>
                <p>The following code transposes a regular nested array (such as <code>[ [ 1, 2, 3 ], [ 4, 5, 6 ], [ 7, 8, 9 ] ]</code>)
                so the result is organized by columns rather than rows (<code>[ [ 1, 4, 7 ], [ 2, 5, 8 ], [ 3, 6, 9 ] ]</code>):</p>
                <eg><![CDATA[<xsl:array for-each="1 to array:size($input?1)">

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -15940,21 +15940,19 @@ return $tree =?> depth()]]></eg>
 ]</eg>
             <p>The following code processes this array to produce an XML representation of the same information. The
                cities are sorted by name:</p>
-               <eg><![CDATA[<xsl:for-each select="json-doc('input.json')?*">
+               <eg><![CDATA[<xsl:for-each select="json-doc('input.json')/*">
    <xsl:sort select="?city"/>
    <city number="{position()}" 
          name="{?city}" 
          latitude="{?latitude}" 
          longitude="{?longitude}"/>
 </xsl:for-each>]]></eg>
-               <p>In this example it is possible to use the expression <code>$array?*</code> to convert an array to a sequence.
-               This works because the members of the array are all single items. In the more general case (a member
-               of the array might be the empty sequence, corresponding to the JSON value <code>null</code>, or it
-               might be a sequence containing several items), <phrase diff="chg" at="2023-04-04">the function <code>array:members</code> can be
-               used to deliver the contents of the array as a sequence of JNodes. This is 
-               illustrated in the next example.</phrase></p>
+               <p>The expression <code>json-doc('input.json')/*</code> returns a sequence of JNodes representing the members of <code>$array</code>,
+                  that is, the three maps representing cities. The lookup expressions <code>?city</code>, <code>?latitude</code>, and <code>?longitude</code>
+                  coerce the JNode to the contained map, and return value of the relevant entry in the map.
+               </p>
             </example>
-            <example diff="chg" at="2022-11-01">
+            <!--<example diff="chg" at="2022-11-01">
                <head>Using <elcode>xsl:for-each</elcode> to process an array containing nulls</head>
                <p>Consider a JSON document of the form:</p>
                <eg>[
@@ -15981,7 +15979,7 @@ return $tree =?> depth()]]></eg>
                   the function <xfunction>array:members</xfunction> is used to create a sequence of
                   JNodes: a JNode can wrap an arbitrary XDM value, including an empty sequence.</p>
 
-            </example>
+            </example>-->
             <example diff="add" at="2022-11-01">
                <head>Using <elcode>xsl:for-each</elcode> to process a map</head>
                <p>Consider a JSON document of the form:</p>
@@ -15992,16 +15990,16 @@ return $tree =?> depth()]]></eg>
 }</eg>
                <p>The following code processes this map to produce an XML representation of the same information. The
                   cities are sorted by name:</p>
-               <eg><![CDATA[<xsl:for-each select="map:pairs(json-doc('input.json'))">
-   <xsl:sort select="?key"/>
+               <eg><![CDATA[<xsl:for-each select="json-doc('input.json')/*">
+   <xsl:sort select="jkey()"/>
    <city number="{position()}" 
-         name="{?key}" 
-         latitude="{?value?latitude}" 
-         longitude="{?value?longitude}"/>
+         name="{jkey()}" 
+         latitude="{jvalue()?latitude}" 
+         longitude="{jvalue()?longitude}"/>
 </xsl:for-each>]]></eg>
-               <p>In this example the map is decomposed to a sequence of key-value pairs, each represented as
-               a map with two entries, <code>"key"</code> and <code>"value"</code>, which can be accessed using
-               the lookup expressions <code>?key</code> and <code>?value</code>.</p>
+               <p>The expression <code>json-doc('input.json')/*</code> returns a sequence of JNodes representing the entries in the top-level
+                  map, that is, the entries representing cities. For each of these JNodes, the <function>jkey</function> function returns
+                  the key (that is, the city name), and the <function>jvalue</function> function returns the corresponding value.</p>
             </example>
             <div3 id="for-each-separator" diff="add" at="2022-01-01">
                <head>The <code>separator</code> attribute</head>
@@ -16062,7 +16060,7 @@ return $tree =?> depth()]]></eg>
    </xsl:next-iteration>   
 </xsl:iterate>]]></eg>
                <p>Using <code>json-doc()/*</code> returns a sequence of JNodes representing the members of the
-                  array, which in this case are maps representing individual transactions. Subsequent lookup
+                  array, that is, the individual transactions. Subsequent lookup
                expressions such as <code>?credit</code> return entries in the map that is encapsulated by the JNode.</p>
  
               
@@ -29371,7 +29369,8 @@ the same group, and the-->
             
             <note><p>The <elcode>xsl:array</elcode> and <elcode>xsl:array-member</elcode> instructions
             are designed to be used in conjunction with the <function>array:members</function> and <function>array:of-members</function>
-            functions. All of these instructions and functions represent array members as JNodes.</p></note>
+            functions, and with path expressions operating on JTrees. 
+            All of these instructions and functions represent array members as JNodes.</p></note>
             
             <p>If the <elcode>xsl:array</elcode> instruction has a <code>select</code> attribute then
             the sequence constructor must be empty, except for any <elcode>xsl:fallback</elcode> instructions
@@ -29482,10 +29481,12 @@ the same group, and the-->
             <example>
                <head>Constructing an array based on an existing array</head>
                <p>The <elcode>xsl:array</elcode> instruction can be used in conjunction with
-               the <xfunction>array:members</xfunction> function to construct an array from the members
-               of an existing array. For example, the following code combines two arrays <code>$A1</code>
+               path expressions that extract the contents of an existing array as JNodes.
+               For example, the following code combines two arrays <code>$A1</code>
                   and <code>$A2</code>, and sorts the result:</p>
-               <eg><![CDATA[<xsl:array select="($A1/*, $A2/*) => sort(fn{count(jvalue())})"/>]]></eg>
+               <eg><![CDATA[<xsl:array select="($A1/*, $A2/*) => sort(jvalue#1)"/>]]></eg>
+               <p>If the input arrays are <code>[1, (5, 7), 8]</code> and <code>[9, (5, 2), 3]</code>,
+               the result will be <code>[1, (5, 2), (5, 7), 8, 9]</code>.</p>
                <p>The following code transposes a regular nested array (such as <code>[ [ 1, 2, 3 ], [ 4, 5, 6 ], [ 7, 8, 9 ] ]</code>)
                so the result is organized by columns rather than rows (<code>[ [ 1, 4, 7 ], [ 2, 5, 8 ], [ 3, 6, 9 ] ]</code>):</p>
                <eg><![CDATA[<xsl:array for-each="1 to array:size($input?1)">

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -15287,7 +15287,7 @@ return $tree =?> depth()]]></eg>
                is exactly the same as <code>shallow-copy</code>.</p>
                
                <p>For arrays, the processing is as follows. A new result array is created, and its content
-                  is populated by decomposing the input array to a sequence of <term>value records</term>
+                  is populated by decomposing the input array to a sequence of JNodes
                using the function <function>array:members</function>. Each of these value records is processed
                   by a call on <elcode>xsl:apply-templates</elcode> (using the current mode, and passing
                   on the values of all template parameters); the result of the called template
@@ -15300,7 +15300,7 @@ return $tree =?> depth()]]></eg>
   <xsl:apply-templates select="array:members(.)" mode="#current"/>
 </xsl:array>  
     ]]></eg>
-               <ednote><edtext>TODO: the use attribute is no more. Example need reworking.</edtext></ednote>
+               <ednote><edtext>TODO: the use attribute is no more, and array:members() now delivers JNodes. Example needs reworking.</edtext></ednote>
                
                <note><p>A <term>value record</term> is a single-entry map: it has a single key-value pair with the key <code>"value"</code>,
                the corresponding value being a member of the original array. The default processing for a value
@@ -15951,7 +15951,7 @@ return $tree =?> depth()]]></eg>
                This works because the members of the array are all single items. In the more general case (a member
                of the array might be the empty sequence, corresponding to the JSON value <code>null</code>, or it
                might be a sequence containing several items), <phrase diff="chg" at="2023-04-04">the function <code>array:members</code> can be
-               used to deliver the contents of the array as a sequence of <emph>value records</emph>. This is 
+               used to deliver the contents of the array as a sequence of JNodes. This is 
                illustrated in the next example.</phrase></p>
             </example>
             <example diff="chg" at="2022-11-01">
@@ -15972,15 +15972,14 @@ return $tree =?> depth()]]></eg>
                <eg><![CDATA[<xsl:for-each select="json-doc('input.json')?*">
    <city name="{?city}">
      <xsl:for-each select="array:members(?data)">
-       <xsl:attribute name="Q{position()}" select="?value"/>
+       <xsl:attribute name="Q{position()}" select="jvalue(.)"/>
      </xsl:for-each>
    </city>  
 </xsl:for-each>]]></eg>
                <p>In this example the expression <code>$array?*</code> cannot be used on the inner arrays
                   because JSON nulls (which translate to the empty sequence in XDM) would be lost. Instead
                   the function <xfunction>array:members</xfunction> is used to create a sequence of
-                  value records: a non-null entry is represented by a value such as <code>{ 'value': 12.3 }</code>,
-                  while a null entry would be <code>{ 'value': () }</code>.</p>
+                  JNodes: a JNode can wrap an arbitrary XDM value, including an empty sequence.</p>
 
             </example>
             <example diff="add" at="2022-11-01">
@@ -16052,21 +16051,7 @@ return $tree =?> depth()]]></eg>
   { "date": "2008-09-02", credit: 12.00 }
 ]</eg>
                <p>The following code converts this to an XML representation that includes a running balance:</p>
-               <eg><![CDATA[<xsl:iterate select="json-doc('account.json') => array:members()">
-   <xsl:param name="balance" as="xs:decimal" select="0"/>               
-   <xsl:variable name="delta" select="?value?credit otherwise -?value?debit"/>               
-   <entry date="{ ?value?date }"
-          amount="{ $delta }"
-          balance="{ $balance + $delta }"/>
-   <xsl:next-iteration>
-      <xsl:with-param name="balance" select="$balance + $delta"/>
-   </xsl:next-iteration>   
-</xsl:iterate>]]></eg>
-               <p>Using <code>array:members()</code> in this way makes it possible to process any array, including one whose members
-               are arbitrary sequences rather than single items. In this particular case, if it is known that the JSON array
-               will not contain any <code>null</code> entries, or if any <code>null</code> entries are to be ignored,
-                  it becomes possible to simplify the code as follows:</p>
-               <eg><![CDATA[<xsl:iterate select="json-doc('account.json')?*">
+               <eg><![CDATA[<xsl:iterate select="json-doc('account.json')/*">
    <xsl:param name="balance" as="xs:decimal" select="0"/>               
    <xsl:variable name="delta" select="?credit otherwise -?debit"/>               
    <entry date="{ ?date }"
@@ -16076,6 +16061,10 @@ return $tree =?> depth()]]></eg>
       <xsl:with-param name="balance" select="$balance + $delta"/>
    </xsl:next-iteration>   
 </xsl:iterate>]]></eg>
+               <p>Using <code>json-doc()/*</code> returns a sequence of JNodes representing the members of the
+                  array, which in this case are maps representing individual transactions. Subsequent lookup
+               expressions such as <code>?credit</code> return entries in the map that is encapsulated by the JNode.</p>
+ 
               
             </example>
             
@@ -29256,7 +29245,7 @@ the same group, and the-->
                <p>This returns the array <code>[ (1, 2, 3, 4), (5, 6, 7, 8, 9), 10 ]</code>.</p>
                </item>
                <item>
-                  <p>An array can be constructed by selecting members of an existing array, and appending
+                  <p>An array can be constructed by selecting members of an existing array, and adding
                   additional members:</p>
                <eg><![CDATA[<xsl:array>
    <xsl:array-member select="'start'"/>               
@@ -29362,7 +29351,7 @@ the same group, and the-->
                         </item>
                      </olist>
                   </item>
-            </olist>
+                 </olist>
                </item>
             </olist>
             
@@ -29379,6 +29368,10 @@ the same group, and the-->
                if and only if the <code>select</code> and <code>for-each</code> attributes
                of <code>xsl:array</code> are both absent.</emph></p>
             </note>
+            
+            <note><p>The <elcode>xsl:array</elcode> and <elcode>xsl:array-member</elcode> instructions
+            are designed to be used in conjunction with the <function>array:members</function> and <function>array:of-members</function>
+            functions. All of these instructions and functions represent array members as JNodes.</p></note>
             
             <p>If the <elcode>xsl:array</elcode> instruction has a <code>select</code> attribute then
             the sequence constructor must be empty, except for any <elcode>xsl:fallback</elcode> instructions
@@ -29492,9 +29485,7 @@ the same group, and the-->
                the <xfunction>array:members</xfunction> function to construct an array from the members
                of an existing array. For example, the following code combines two arrays <code>$A1</code>
                   and <code>$A2</code>, and sorts the result:</p>
-               <eg><![CDATA[<xsl:array 
-   for-each="(array:members($A1), array:members($A2)) => sort(fn{count(?value)})"
-   select="?value"/>]]></eg>
+               <eg><![CDATA[<xsl:array select="($A1/*, $A2/*) => sort(fn{count(jvalue())})"/>]]></eg>
                <p>The following code transposes a regular nested array (such as <code>[ [ 1, 2, 3 ], [ 4, 5, 6 ], [ 7, 8, 9 ] ]</code>)
                so the result is organized by columns rather than rows (<code>[ [ 1, 4, 7 ], [ 2, 5, 8 ], [ 3, 6, 9 ] ]</code>):</p>
                <eg><![CDATA[<xsl:array for-each="1 to array:size($input?1)">


### PR DESCRIPTION
Fix #2351
Fix #2393

Changes the `array:members()` and `array:of-members()` functions to use JNodes to represent array members rather than using value records.

Generalizes the `jtree()` function so it can wrap any value as a JNode, not only a map or array -- useful when constructing the input to array:of-members.

Makes corresponding changes to XSLT examples. This is generally a simplification because xsl:array and xsl:array-members already use JNodes for this purpose.

Satisfies action QT4CG-167-05