### PR TITLE
2263 New named record types

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -703,6 +703,100 @@
          </fos:meaning>
       </fos:field>
    </fos:record-type>
+
+   <fos:record-type id="division-record" extensible="false" diff="add" at="issue2263">
+      <fos:summary>
+         <p>This record type is used to represent the result of a call on
+         the <function>fn:divide-decimals</function> function.</p>
+      </fos:summary>
+      <fos:field name="quotient" type="xs:decimal" required="true">
+         <fos:meaning>
+            <p>The result of the division, expressed to the requested precision.</p>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="remainder" type="xs:decimal" required="true">
+         <fos:meaning>
+            <p>The part of the dividend that is not accounted for by the quotient.</p>
+         </fos:meaning>
+      </fos:field>
+   </fos:record-type>
+
+   <fos:record-type id="sort-key-record" extensible="false" diff="add" at="issue2263">
+      <fos:summary>
+         <p>This record type is used to represent a sort key definition supplied to
+         the <function>fn:sort-by</function> function.</p>
+      </fos:summary>
+      <fos:field name="key" type="(fn($item as item()) as xs:anyAtomicType*)?" required="true">
+         <fos:meaning>
+            <p>A sort key function, applied to each item in the input sequence to determine
+            a sort key value. The default is <code>fn:data#1</code>.</p>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="collation" type="xs:string?" required="true">
+         <fos:meaning>
+            <p>A collation, used when comparing sort key values of type <code>xs:string</code>
+            or <code>xs:untypedAtomic</code>. The default is the default collation from the
+            static context.</p>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="order" type="enum('ascending', 'descending')?" required="true">
+         <fos:meaning>
+            <p>An order direction. The default is <code>"ascending"</code>.</p>
+         </fos:meaning>
+      </fos:field>
+   </fos:record-type>
+
+   <fos:record-type id="array-sort-key-record" extensible="false" diff="add" at="issue2263">
+      <fos:summary>
+         <p>This record type is used to represent a sort key definition supplied to
+         the <function>array:sort-by</function> function. It differs from
+         <code>fn:sort-key-record</code> in that the sort key function is applied to a member
+         of an array, which may be any sequence.</p>
+      </fos:summary>
+      <fos:field name="key" type="(fn($member as item()*) as xs:anyAtomicType*)?" required="true">
+         <fos:meaning>
+            <p>A sort key function, applied to each member of the input array to determine
+            a sort key value. The default is <code>fn:data#1</code>.</p>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="collation" type="xs:string?" required="true">
+         <fos:meaning>
+            <p>A collation, used when comparing sort key values of type <code>xs:string</code>
+            or <code>xs:untypedAtomic</code>. The default is the default collation from the
+            static context.</p>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="order" type="enum('ascending', 'descending')?" required="true">
+         <fos:meaning>
+            <p>An order direction. The default is <code>"ascending"</code>.</p>
+         </fos:meaning>
+      </fos:field>
+
+   </fos:record-type>
+
+   <fos:record-type id="validation-result-record" extensible="false" diff="add" at="issue2263">
+      <fos:summary>
+         <p>This record type is used to represent the outcome of validating a node against
+         a schema, as delivered by the function returned by
+         the <function>fn:xsd-validator</function> function.</p>
+      </fos:summary>
+      <fos:field name="is-valid" type="xs:boolean" required="true">
+         <fos:meaning>
+            <p>Whether the supplied node was found to be valid against the schema.</p>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="typed-node" type="node()?" required="false">
+         <fos:meaning>
+            <p>The root of a deep copy of the input tree, augmented with type annotations
+            and default values.</p>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="error-details" type="map(*)*" required="false">
+         <fos:meaning>
+            <p>A sequence of maps, each containing details of one invalidity that was found.</p>
+         </fos:meaning>
+      </fos:field>
+   </fos:record-type>
    
  
    
@@ -2704,7 +2798,7 @@ compare($N * $arg2, 0) eq compare($arg1, 0).</eg>
    
    <fos:function name="divide-decimals" prefix="fn">
       <fos:signatures>
-         <fos:proto name="divide-decimals" return-type="record(quotient as xs:decimal, remainder as xs:decimal)">
+         <fos:proto name="divide-decimals" return-type="fn:division-record">
             <fos:arg name="value" type="xs:decimal"/>
             <fos:arg name="divisor" type="xs:decimal"/>
             <fos:arg name="precision" type="xs:integer?" default="0" note="default-on-empty"/>
@@ -21565,7 +21659,7 @@ return { "width": $int16-at($loc + 5),
 
     <fos:function name="xsd-validator" prefix="fn">
       <fos:signatures>
-         <fos:proto name="xsd-validator" return-type="fn((document-node(*) | element() | attribute())?) as record(is-valid as xs:boolean, typed-node as node()?, error-details as map(*)*)">
+         <fos:proto name="xsd-validator" return-type="fn((document-node(*) | element() | attribute())?) as fn:validation-result-record">
             <fos:arg name="options" type="map(*)?" default="{}" note="default-on-empty"/>
          </fos:proto>
       </fos:signatures>
@@ -24609,7 +24703,7 @@ return sort(//name!string(), $SWEDISH)</eg></fos:expression>
       <fos:signatures>
          <fos:proto name="sort-by" return-type="item()*">
             <fos:arg name="input" type="item()*" usage="navigation"/>
-            <fos:arg name="keys" type="record(key as (fn($item as item()) as xs:anyAtomicType*)?, collation as xs:string?, order as enum('ascending', 'descending')?)*"/>
+            <fos:arg name="keys" type="fn:sort-key-record*"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -24626,28 +24720,21 @@ return sort(//name!string(), $SWEDISH)</eg></fos:expression>
          <p>The result of the function is a sequence that contains all the items from <code>$input</code>,
          typically in a different order, the order being defined by the supplied <term>sort key definitions</term>.</p>
          
-         <p>A <term>sort key definition</term> is a record with three parts:</p>
-         
-         <olist>
-            <item><p><code>key:</code> A <term>sort key function</term>, which is applied to each item in the input sequence to
-            determine a <term>sort key value</term>. If no function is supplied, the default is <code>fn:data#1</code>,
-            which atomizes the item.</p></item>
-            <item><p><code>collation:</code> A <term>collation</term>, which is used when comparing <term>sort key values</term>
-               that are of type <code>xs:string</code> or <code>xs:untypedAtomic</code>. If no collation is supplied, the default
-               collation from the static context is used.</p>
-               <p>When comparing values of types other than <code>xs:string</code> or <code>xs:untypedAtomic</code>,
-               the collation is ignored (but an error <rfc2119>may</rfc2119> be reported if it is
-               invalid). For more information see <specref ref="choosing-a-collation"/>.</p>
-            
-            </item>
-            <item><p><code>order:</code> An <term>order direction</term>, either <code>"ascending"</code> or
-            <code>"descending"</code>. The default is <code>"ascending"</code>.</p></item>
-         </olist>
-         
+         <p>A <term>sort key definition</term> is an instance of the record type
+            <code>fn:sort-key-record</code> (see <specref ref="sort-key-record"/>). Its <code>key</code>
+            field supplies a <term>sort key function</term>, which is applied to each item in the input
+            sequence to determine a <term>sort key value</term>; its <code>collation</code> field supplies
+            a <term>collation</term>, used when comparing <term>sort key values</term> of type
+            <code>xs:string</code> or <code>xs:untypedAtomic</code>; and its <code>order</code> field
+            supplies an <term>order direction</term>.</p>
+
+         <p>When comparing values of types other than <code>xs:string</code> or <code>xs:untypedAtomic</code>,
+            the collation is ignored (but an error <rfc2119>may</rfc2119> be reported if it is
+            invalid). For more information see <specref ref="choosing-a-collation"/>.</p>
+
          <p>The number of sort key definitions is determined by the number of records supplied
             in the <code>$keys</code> argument. If the argument is absent or empty, the default is
-            a single sort key definition using the function <code>data#1</code>, using the default collation
-            from the static context, and with order <code>ascending</code>.</p>
+            a single sort key definition in which every field takes its default value.</p>
          
         
          
@@ -32701,7 +32788,7 @@ fold-left($input, [], fn($array, $record) {
       <fos:signatures>
          <fos:proto name="sort-by" return-type="array(*)">
             <fos:arg name="array" type="array(*)" usage="navigation"/>
-            <fos:arg name="keys" type="record(key as (fn($member as item()*) as xs:anyAtomicType*)?, collation as xs:string?, order as enum('ascending', 'descending')?)*"/>
+            <fos:arg name="keys" type="fn:array-sort-key-record*"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -32718,28 +32805,21 @@ fold-left($input, [], fn($array, $record) {
          <p>The result of the function is an array that contains the same members as <code>$array</code>,
          typically in a different order, the order being defined by the supplied <term>sort key definitions</term>.</p>
          
-         <p>A <term>sort key definition</term> is a record with three parts:</p>
-         
-         <olist>
-            <item><p><code>key:</code> A <term>sort key function</term>, which is applied to each member of the input sequence to
-            determine a <term>sort key value</term>. If no function is supplied, the default is <code>fn:data#1</code>,
-            which atomizes the value of the array member.</p></item>
-            <item><p><code>collation:</code> A <term>collation</term>, which is used when comparing <term>sort key values</term>
-               that are of type <code>xs:string</code> or <code>xs:untypedAtomic</code>. If no collation is supplied, the default
-               collation from the static context is used.</p>
-               <p>When comparing values of types other than <code>xs:string</code> or <code>xs:untypedAtomic</code>,
-               the collation is ignored (but an error <rfc2119>may</rfc2119> be reported if it is
-               invalid). For more information see <specref ref="choosing-a-collation"/>.</p>
-            
-            </item>
-            <item><p><code>order:</code> An <term>order direction</term>, either <code>"ascending"</code> or
-            <code>"descending"</code>. The default is <code>"ascending"</code>.</p></item>
-         </olist>
-         
+         <p>A <term>sort key definition</term> is an instance of the record type
+            <code>fn:array-sort-key-record</code> (see <specref ref="array-sort-key-record"/>). Its
+            <code>key</code> field supplies a <term>sort key function</term>, which is applied to each
+            member of the input array to determine a <term>sort key value</term>; its
+            <code>collation</code> field supplies a <term>collation</term>, used when comparing
+            <term>sort key values</term> of type <code>xs:string</code> or <code>xs:untypedAtomic</code>;
+            and its <code>order</code> field supplies an <term>order direction</term>.</p>
+
+         <p>When comparing values of types other than <code>xs:string</code> or <code>xs:untypedAtomic</code>,
+            the collation is ignored (but an error <rfc2119>may</rfc2119> be reported if it is
+            invalid). For more information see <specref ref="choosing-a-collation"/>.</p>
+
          <p>The number of sort key definitions is determined by the number of records supplied
             in the <code>$keys</code> argument. If the argument is absent or empty, the default is
-            a single sort key definition using the function <code>data#1</code>, using the default collation
-            from the static context, and with order <code>ascending</code>.</p>
+            a single sort key definition in which every field takes its default value.</p>
          
         
          

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -1562,6 +1562,11 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
             <div3 id="func-sort-by">
                <head><?function fn:sort-by?></head>
             </div3>
+            <div3 id="sort-key-record" diff="add" at="issue2263">
+               <head><?record-description sort-key-record?></head>
+               <p>The corresponding record type for sorting the members of an array is
+               described in <specref ref="array-sort-key-record"/>.</p>
+            </div3>
             <div3 id="func-sort-with" diff="add" at="A">
                <head><?function fn:sort-with?></head>
             </div3>
@@ -2005,6 +2010,9 @@ This differs from <bibref ref="xmlschema-2"/>, which defines
             
             <div3 id="func-divide-decimals">
                <head><?function fn:divide-decimals?></head>
+            </div3>
+            <div3 id="division-record" diff="add" at="issue2263">
+               <head><?record-description division-record?></head>
             </div3>
  
             
@@ -8831,6 +8839,11 @@ map( xs:string,
             <div3 id="func-array-sort-by">
                <head><?function array:sort-by?></head>
             </div3>
+            <div3 id="array-sort-key-record" diff="add" at="issue2263">
+               <head><?record-description array-sort-key-record?></head>
+               <p>The corresponding record type for sorting the items of a sequence is
+               described in <specref ref="sort-key-record"/>.</p>
+            </div3>
             <div3 id="func-array-sort-with">
                <head><?function array:sort-with?></head>
             </div3>
@@ -9402,6 +9415,11 @@ map( xs:string,
             </div3>
             <div3 id="func-xsd-validator">
                <head><?function fn:xsd-validator?></head>
+            </div3>
+            <div3 id="validation-result-record" diff="add" at="issue2263">
+               <head><?record-description validation-result-record?></head>
+               <p>The fields <code>typed-node</code> and <code>error-details</code> are present
+               only under the conditions described in <specref ref="func-xsd-validator"/>.</p>
             </div3>
          </div2>
          


### PR DESCRIPTION
Closes #2263

Various of the comments in the issue were outdated. Worth discussing:

* Do we want record types for parameter types (specifically, `fn:sort-by` and `array:sort-by`)?
* Do we want to keep the rule alive that “all built-in record types live in the `fn` namespace”? Otherwise, we could change `fn:array-sort-key-record` to `array:sort-key-record`.
* I have skipped `bin:infer-encoding` as I didn’t know how to extend the record infrastructure to the EXPath modules.
