### PR TITLE
2830 Clarify the effect of the line-ending serialization parameter

### DIFF
--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -1407,10 +1407,9 @@ pairs, <code>(&#xAB;, &lt;%), (&#xBB;, %&gt;)</code>.</p>
 <!--Text replaced by erratum E2 change 1"-->
 <p>For the XML, HTML, XHTML and Text output methods, 
 serialization
-comprises six phases of processing 
+comprises seven phases of processing 
 (preceded by the sequence normalization process 
-described in <specref ref="serdm"/>).<!--End of text replaced by erratum E2-->
-<!--Should the below be implementation-dependent?  -sb 3/16/05-->
+described in <specref ref="serdm"/>).
 
 For the JSON and Adaptive
 output methods, serialization is described in <specref ref="json-output"/> and 
@@ -1473,103 +1472,142 @@ the following rules are applied in sequence.
 </p>
 
 <olist>
-<item><p>
-If the node is an attribute that is 
-a <termref def="uri-attribute-values">URI attribute value</termref> 
-and the <code>escape-uri-attributes</code> parameter is set to 
-require escaping of URI attributes, 
-apply <termref def="uri-escaping">URI escaping</termref> as defined below, 
-and skip rules b-e. Otherwise, continue with rule b.</p>
-<p><termdef term="URI Escaping" id="uri-escaping"><term>URI escaping</term> consists of the following three steps applied in sequence to the content of 
-<termref def="uri-attribute-values">URI attribute values</termref>:</termdef>
-</p><olist><item><p>normalize to NFC using the method defined in <xspecref spec="FO40" ref="func-normalize-unicode"/></p></item>
-<item><p>percent-encode any special characters in the URI using the method defined in <xspecref spec="FO40" ref="func-escape-html-uri"/></p></item>
-<item><p>escape according to
-<!-- Start of text changed for Bug 8206 (Erratum SE.E18) -->
-the rules of the XML or HTML output
-method, whichever is applicable, any characters that require
-<!-- End of text changed for Bug 8206 (Erratum SE.E18) -->
-escaping, and any characters that cannot be represented in the
-selected encoding. 
-For example, replace <code>&lt;</code> with <code>&amp;lt;</code>
-(See also section <specref ref="HTML_CHARDATA"/>).
-</p></item></olist><p>
-<termdef term="URI attribute values" id="uri-attribute-values"> The values of attributes listed in 
-<specref ref="list-of-uri-attributes"/> are <term>URI attribute values</term>. 
-Attributes are not considered to be URI attributes simply because they are namespace declaration attributes or have the type annotation <code>xs:anyURI</code>.</termdef></p></item>
-<item><p>
-If the node is a text node whose parent element is selected by the rules of the 
-<code>cdata-section-elements</code> parameter for the applicable output method, 
-create CDATA sections as described below, and skip rules c-e. Otherwise, continue with rule c.
-</p>
-<p>Apply the following two processes in sequence to create CDATA sections</p>
-<olist><item><p><termref def="unicode-normalization">Unicode Normalization</termref> if requested by the <code>normalization-form</code> parameter.</p></item>
-<item><p>The application of changes as detailed in the description of the <code>cdata-section-elements</code> parameter for the applicable output method.</p></item></olist>
+  <item><p>
+      If the node is an attribute that is 
+      a <termref def="uri-attribute-values">URI attribute value</termref> 
+      and the <code>escape-uri-attributes</code> parameter is set to 
+      require escaping of URI attributes, 
+      apply <termref def="uri-escaping">URI escaping</termref> as defined below, 
+      and skip rules b-e. Otherwise, continue with rule b.</p>
+  
+    <p><termdef term="URI Escaping" id="uri-escaping"><term>URI escaping</term> consists of the following three steps applied in sequence to the content of 
+    <termref def="uri-attribute-values">URI attribute values</termref>:</termdef>
+    </p>
+    
+    <olist>
+      <item><p>normalize to NFC using the method defined in <xspecref spec="FO40" ref="func-normalize-unicode"/></p></item>
+      <item><p>percent-encode any special characters in the URI using the method defined in <xspecref spec="FO40" ref="func-escape-html-uri"/></p></item>
+      <item><p>escape according to
+        <!-- Start of text changed for Bug 8206 (Erratum SE.E18) -->
+        the rules of the XML or HTML output
+        method, whichever is applicable, any characters that require
+        <!-- End of text changed for Bug 8206 (Erratum SE.E18) -->
+        escaping, and any characters that cannot be represented in the
+        selected encoding. 
+        For example, replace <code>&lt;</code> with <code>&amp;lt;</code>
+        (See also section <specref ref="HTML_CHARDATA"/>).
+        </p></item>
+    </olist>
+    
+    <p>
+      <termdef term="URI attribute values" id="uri-attribute-values"> The values of attributes listed in 
+      <specref ref="list-of-uri-attributes"/> are <term>URI attribute values</term>. 
+      Attributes are not considered to be URI attributes simply because they are namespace declaration attributes or have the type annotation <code>xs:anyURI</code>.</termdef>
+    </p>
+  </item>
+    
+  <item>
+    <p>
+      If the node is a text node whose parent element is selected by the rules of the 
+      <code>cdata-section-elements</code> parameter for the applicable output method, 
+      create CDATA sections as described below, and skip rules c-e. Otherwise, continue with rule c.
+     </p>
+     <p>Apply the following two processes in sequence to create CDATA sections</p>
+     <olist>
+       <item><p><termref def="unicode-normalization">Unicode Normalization</termref> if requested by the <code>normalization-form</code> parameter.</p></item>
+       <item><p>The application of changes as detailed in the description of the <code>cdata-section-elements</code> parameter for the applicable output method.</p></item>
+     </olist>
+  </item>
+    
+  <item><p>Apply character mapping as determined by the 
+        <code>use-character-maps</code> parameter for the applicable output method.  
+        For characters that were substituted by this process, skip rules d and e. 
+        For the remaining characters that were not modified by character mapping, continue with rule d. 
+        </p>
+        <p>Character mapping is applied to separator strings inserted during the process of sequence normalization,
+        based on the value of the <code>item-separator</code> property.</p>
+  </item>
+    
+  <item>
+    <p>Apply <termref def="unicode-normalization">Unicode Normalization</termref> if requested by the <code>normalization-form</code> parameter.  </p>
+    <p>
+      <termdef term="Unicode Normalization" id="unicode-normalization"><term>Unicode Normalization</term>
+      is the process of removing alternative representations of equivalent sequences from textual data,
+      to convert the data into a form that can be binary-compared for equivalence, as specified in 
+      <bibref ref="UNICODE-NORMALIZATION-FORM"/>.   
+      For specific recommendations for character normalization on the World Wide Web, 
+      see <bibref ref="charmod-norm"/>.</termdef>
+    </p>
+    <p>
+      The meanings associated with the possible values of the <code>normalization-form</code> parameter 
+      are defined in section <specref ref="XML_NORMALIZATION-FORM"/>. 
+    </p>
+    <p>
+      Continue with step e.
+    </p>
+  </item>
+  
+    <!-- Start of text changed for Bug 8206 (Erratum SE.E18) -->
+  <item>
+    <p>Escape according to
+      the rules of the XML or HTML output
+      method, whichever is applicable,
+      <!-- End of text changed for Bug 8206 (Erratum SE.E18) -->
+      any characters (such as <code>&lt;</code> and <code>&amp;</code>) where XML or HTML requires 
+      escaping, any characters that cannot be represented in the selected encoding, and any
+      characters such as <char>U+000D</char> that need to be escaped to ensure round-tripping.
+      For example, replace <code>&lt;</code> with <code>&amp;lt;</code>. 
+      (See also section <specref ref="HTML_CHARDATA"/>).
+      For characters such as <code>&gt;</code> where XML defines a built-in entity but does not 
+      require its use in all circumstances, it is <termref def="impdep">implementation-dependent</termref> whether the character 
+      is escaped.
+    </p>
+  </item>
+</olist>
+
 </item>
-<item><p>Apply character mapping as determined by the 
-<code>use-character-maps</code> parameter for the applicable output method.  
-For characters that were substituted by this process, skip rules d and e. 
-For the remaining characters that were not modified by character mapping, continue with rule d. 
-</p></item>
-<item><p>Apply <termref def="unicode-normalization">Unicode Normalization</termref> if requested by the <code>normalization-form</code> parameter.  </p>
-<p>
-<termdef term="Unicode Normalization" id="unicode-normalization"><term>Unicode Normalization</term>
-is the process of removing alternative representations of equivalent sequences from textual data,
-to convert the data into a form that can be binary-compared for equivalence, as specified in 
-<bibref ref="UNICODE-NORMALIZATION-FORM"/>.   
-For specific recommendations for character normalization on the World Wide Web, 
-see <bibref ref="charmod-norm"/>.</termdef></p>
-<p>
-The meanings associated with the possible values of the <code>normalization-form</code> parameter 
-are defined in section <specref ref="XML_NORMALIZATION-FORM"/>. </p>
-<p>Continue with step e.
-</p></item>
-<!-- Start of text changed for Bug 8206 (Erratum SE.E18) -->
-<item><p>Escape according to
-the rules of the XML or HTML output
-method, whichever is applicable,
-<!-- End of text changed for Bug 8206 (Erratum SE.E18) -->
-any characters (such as <code>&lt;</code> and <code>&amp;</code>) where XML or HTML requires 
-escaping, 
-and any characters that cannot be represented in the selected encoding. 
-For example, replace <code>&lt;</code> with <code>&amp;lt;</code>. 
-(See also section <specref ref="HTML_CHARDATA"/>).
-For characters such as <code>&gt;</code> where XML defines a built-in entity but does not 
-require its use in all circumstances, it is <termref def="impdep">implementation-dependent</termref> whether the character 
-is escaped.
-</p>
-</item>
-</olist></item>
 
 <item><p><emph>Indentation</emph>, as controlled by
-the <code>indent</code> parameter and the
-<code>suppress-indentation</code> parameter, <rfc2119>MAY</rfc2119>
-add or remove
-whitespace according to the rules defined by the applicable output method.</p>
+  the <code>indent</code> and 
+  <code>suppress-indentation</code> parameters, <rfc2119>MAY</rfc2119>
+  add or remove
+  whitespace according to the rules defined by the applicable output method.</p>
 </item>
+  
+  <item>
+    <p><emph>Line-ending adjustment</emph>, as controlled by the <code>line-ending</code> parameter,
+    optionally replaces <code>U+000A</code> characters by a different end-of-line representation.
+    This applies to all newline characters including those introduced by indentation, by character mapping,
+    or by sequence normalization (based on the <code>item-separator</code> property).
+    It does not apply to newline characters in attribute values, which will already have been escaped as
+    <code>&amp;#xA;</code> or equivalent.</p>
+    
+    
+  </item>
 
-<item><p><emph>Encoding</emph>, as controlled by the
-<code>encoding</code> parameter, converts the character sequence
-produced by the previous phases into an octet stream.</p>
-<note><p>Serialization is defined only in terms of encoding the result as a stream of octets.  
-However, a <termref def="serializer">serializer</termref> <rfc2119>MAY</rfc2119> 
-provide an option that allows the encoding phase to be skipped, so
-that the result of serialization can be encoded in a way required by a particular destination (e.g., a Java StringBuffer).
-The effect of any such option is <termref def="impdef">implementation-defined</termref>, 
-and a <termref def="serializer">serializer</termref> is not required to support such an option.
-</p><imp-def-feature>The effect of providing an option that allows the encoding phase to be skipped, 
-so that the result of serialization can be encoded in a way required by a particular destination (e.g., a Java StringBuffer), 
-is <termref def="impdef">implementation-defined</termref>.  
-The <termref def="serializer">serializer</termref> is not required  to support such an option.
-<!--It's not clear to me that this should be a formal implementation-defined item, 
-since it's in a note, but it's here for review.  -sb 3/16/05--></imp-def-feature></note>
-</item>
+  <item><p><emph>Encoding</emph>, as controlled by the
+  <code>encoding</code> parameter, converts the character sequence
+    produced by the previous phases into an octet stream.</p>
+    <note><p>Serialization is defined only in terms of encoding the result as a stream of octets.  
+    However, a <termref def="serializer">serializer</termref> <rfc2119>MAY</rfc2119> 
+    provide an option that allows the encoding phase to be skipped, so
+    that the result of serialization can be encoded in a way required by a particular destination (e.g., a Java StringBuffer).
+    The effect of any such option is <termref def="impdef">implementation-defined</termref>, 
+    and a <termref def="serializer">serializer</termref> is not required to support such an option.
+    </p><imp-def-feature>The effect of providing an option that allows the encoding phase to be skipped, 
+    so that the result of serialization can be encoded in a way required by a particular destination (e.g., a Java StringBuffer), 
+    is <termref def="impdef">implementation-defined</termref>.  
+    The <termref def="serializer">serializer</termref> is not required  to support such an option.
+    </imp-def-feature></note>
+  </item>
+  
+  <item><p><emph>Canonicalization</emph>, as controlled by
+    the <code>canonical</code> parameter, <rfc2119>MAY</rfc2119>
+    revert any previous changes, or make new changes, according to the rules defined by the applicable output method.</p>
+  </item>
+</olist>
 
-<item><p><emph>Canonicalization</emph>, as controlled by
-the <code>canonical</code> parameter, <rfc2119>MAY</rfc2119>
-revert any previous changes, or make new changes, according to the rules defined by the applicable output method.</p>
-</item>
-</olist></div1>
+</div1>
 
 <div1 id="xml-output">
   <head>XML Output Method</head>
@@ -2008,7 +2046,10 @@ with mixed content.</p></note>
 be based on whitespace stripped from either the source document or the
 stylesheet (in the case of XSLT), or
 guided by other means that might depend on the <termref def="host-language">host language</termref>,
-  in the case of an <termref def="dt-input-tree"/> created using some other process.</p></note></div3>
+  in the case of an <termref def="dt-input-tree"/> created using some other process.</p>
+<p>It may be difficult to achieve results that are visually appealing if existing whitespace text nodes use
+space characters while the <code>indent-unit</code> uses tab characters, or vice-versa.</p>
+</note></div3>
 
 <div3 id="XML_INDENT-UNIT" diff="add" at="2026-06-25">
   <head>XML Output Method: <code>indent-unit</code></head>
@@ -2026,6 +2067,18 @@ guided by other means that might depend on the <termref def="host-language">host
   nesting that encloses the item. If the value is a zero-length string, no indentation whitespace is
   added, although the serializer still emits line breaks between items. If the parameter is absent,
   the unit of indentation is <termref def="impdef">implementation-defined</termref>.</p>
+  
+  <note><p>Typically, for an element node with <var>N</var> element ancestors, the element's start tag or empty-element tag
+    and the corresponding end tag (if there is one) will each be
+  preceded by indentation comprising a single <char>U+000A</char> character followed by <var>N</var>
+  instances of the string of spaces or tabs indicated by the value of <code>indent-unit</code>. However,
+  the indentation rules allow this to be elided with existing whitespace text, so the final result
+  is to some extent <termref def="impdef">implementation-defined</termref>.</p>
+  <p>The initial newline is typically omitted for the outermost element if there is no XML declaration
+  or DOCTYPE declaration.</p>
+  <p>A newline introduced for indentation purposes may subsequently be replaced by a different line ending,
+  depending on the value of the <code>line-ending</code> parameter.</p>
+  <p>A comment or processing instruction is typically indented in the same way as an empty element node.</p></note>
 </div3>
 
 <div3 id="XML_INDENT-ATTRIBUTES" diff="add" at="2026-06-25">
@@ -2043,6 +2096,11 @@ guided by other means that might depend on the <termref def="host-language">host
   or empty-element tag on a line of its own. If it has the value
   <code>false</code>, the <termref def="serializer">serializer</termref> <rfc2119>SHOULD</rfc2119>
   output the attributes of an element on the same line as the element name.</p>
+  <note><p>Typically, if <code>indent-attributes</code> is <code>true</code>, the attributes of an element
+    will be vertically aligned with each other. The first attribute for an element <rfc2119>MAY</rfc2119>
+    be on the same line as the element name, or it <rfc2119>MAY</rfc2119> be on the following line.
+    The whitespace string used for indenting attributes <rfc2119>SHOULD</rfc2119> take into account the
+  value of the <code>indent-unit</code> parameter.</p></note>
 </div3>
 
 <div3 id="XML_LINE-ENDING" diff="add" at="2026-06-25">
@@ -2066,9 +2124,9 @@ guided by other means that might depend on the <termref def="host-language">host
   therefore takes place after character mapping (see <specref ref="character-maps"/>) and Unicode
   normalization. As a result, it affects only <char>U+000A</char> characters that survive those
   phases: a <char>U+000A</char> already replaced through a character map is not substituted again;
-  a carriage return in content, serialized as <code>&amp;#xD;</code>, and a newline in an attribute
-  value, serialized as <code>&amp;#xA;</code>, are not affected, since neither is emitted as a
-  <char>U+000A</char>.</p></note>
+    by contrast, a <char>U+000A</char> generated by character mapping is substituted.
+    A <char>U+000D</char> in content, serialized as <code>&amp;#xD;</code>, and a <char>U+000A</char> in an attribute
+  value, serialized as <code>&amp;#xA;</code>, are not affected, since escaping precedes end-of-line adjustment.</p></note>
 </div3>
 
 <div3 id="XML_CDATA-SECTION-ELEMENTS">
@@ -2680,17 +2738,33 @@ would render the output, assuming the serialized document does
 not refer to any HTML style sheets.</p>
       <!--End of text replaced by erratum E9--><p>The HTML definition of whitespace is different from the XML
   definition: see section 9.1 of  <bibref ref="html401"/> 4.01 specification.</p></note></div3>
-<div3 id="XHTML_INDENT-UNIT" diff="add" at="2026-06-25"><head>XHTML Output Method: <code>indent-unit</code></head><p>The behavior for the <code>indent-unit</code> parameter for the XHTML output method is described in <specref ref="XML_INDENT-UNIT"/>.</p></div3>
-<div3 id="XHTML_INDENT-ATTRIBUTES" diff="add" at="2026-06-25"><head>XHTML Output Method: <code>indent-attributes</code></head><p>The behavior for the <code>indent-attributes</code> parameter for the XHTML output method is described in <specref ref="XML_INDENT-ATTRIBUTES"/>.</p></div3>
-<div3 id="XHTML_LINE-ENDING" diff="add" at="2026-06-25"><head>XHTML Output Method: <code>line-ending</code></head><p>The behavior for the <code>line-ending</code> parameter for the XHTML output method is described in <specref ref="XML_LINE-ENDING"/>.</p></div3>
-<div3 id="XHTML_CDATA-SECTION-ELEMENTS"><head>XHTML Output Method: <code>cdata-section-elements</code></head><p>The behavior for <code>cdata-section-elements</code> parameter for the XHTML output method is described in <specref ref="XML_CDATA-SECTION-ELEMENTS"/>.</p></div3>
-<div3 id="XHTML_OMIT-XML-DECLARATION"><head>XHTML Output Method: <code>omit-xml-declaration</code> and <code>standalone</code></head>
-  <p>The behavior for <code>omit-xml-declaration</code> and  <code>standalone</code> parameters for the XHTML output method is described in <specref ref="XML_OMIT-XML-DECLARATION"/>.</p><note><p>As with the XML output method, the XHTML
+<div3 id="XHTML_INDENT-UNIT" diff="add" at="2026-06-25">
+  <head>XHTML Output Method: <code>indent-unit</code></head>
+  <p>The behavior for the <code>indent-unit</code> parameter for the XHTML output method is described in <specref ref="XML_INDENT-UNIT"/>.</p>
+</div3>
+<div3 id="XHTML_INDENT-ATTRIBUTES" diff="add" at="2026-06-25">
+  <head>XHTML Output Method: <code>indent-attributes</code></head>
+  <p>The behavior for the <code>indent-attributes</code> parameter for the XHTML output method is described in <specref ref="XML_INDENT-ATTRIBUTES"/>.</p>
+</div3>
+<div3 id="XHTML_LINE-ENDING" diff="add" at="2026-06-25">
+  <head>XHTML Output Method: <code>line-ending</code></head><p>The behavior for the <code>line-ending</code> parameter for the XHTML output 
+    method is described in <specref ref="XML_LINE-ENDING"/>.</p>
+</div3>
+<div3 id="XHTML_CDATA-SECTION-ELEMENTS">
+  <head>XHTML Output Method: <code>cdata-section-elements</code></head><p>The behavior for <code>cdata-section-elements</code> parameter for the 
+    XHTML output method is described in <specref ref="XML_CDATA-SECTION-ELEMENTS"/>.</p>
+</div3>
+<div3 id="XHTML_OMIT-XML-DECLARATION">
+  <head>XHTML Output Method: <code>omit-xml-declaration</code> and <code>standalone</code></head>
+  <p>The behavior for <code>omit-xml-declaration</code> and  <code>standalone</code> parameters for the XHTML output method is 
+    described in <specref ref="XML_OMIT-XML-DECLARATION"/>.</p>
+  <note><p>As with the XML output method, the XHTML
 output method specifies that an XML declaration will be output unless it is suppressed using
 the <code>omit-xml-declaration</code> parameter. Appendix C.1 of 
 <bibref ref="xhtml1"/>
 provides advice on the consequences of including,
-or omitting, the XML declaration.</p></note></div3>
+or omitting, the XML declaration.</p></note>
+</div3>
 <div3 id="XHTML_DOCTYPE"><head>XHTML Output Method: <code>doctype-system</code> and <code>doctype-public</code></head>
 <p><termref def="id-with-html5">With HTML5</termref>, if the
 <!-- Start of text removed in response to bug 20264 -->
@@ -3355,9 +3429,18 @@ HTML user agent would render the output, assuming the serialized document does
 not refer to any HTML style sheets.</p>
       <!--End of text replaced by erratum E9--><p>Note that the HTML definition of whitespace is different from the XML definition
 (see section 9.1 of the <bibref ref="html401"/> specification).</p></note></div3>
-<div3 id="HTML_INDENT-UNIT" diff="add" at="2026-06-25"><head>HTML Output Method: <code>indent-unit</code></head><p>The behavior for the <code>indent-unit</code> parameter for the HTML output method is described in <specref ref="XML_INDENT-UNIT"/>.</p></div3>
-<div3 id="HTML_INDENT-ATTRIBUTES" diff="add" at="2026-06-25"><head>HTML Output Method: <code>indent-attributes</code></head><p>The behavior for the <code>indent-attributes</code> parameter for the HTML output method is described in <specref ref="XML_INDENT-ATTRIBUTES"/>.</p></div3>
-<div3 id="HTML_LINE-ENDING" diff="add" at="2026-06-25"><head>HTML Output Method: <code>line-ending</code></head><p>The behavior for the <code>line-ending</code> parameter for the HTML output method is described in <specref ref="XML_LINE-ENDING"/>.</p></div3>
+<div3 id="HTML_INDENT-UNIT" diff="add" at="2026-06-25">
+  <head>HTML Output Method: <code>indent-unit</code></head>
+  <p>The behavior for the <code>indent-unit</code> parameter for the HTML output method is described in <specref ref="XML_INDENT-UNIT"/>.</p>
+</div3>
+<div3 id="HTML_INDENT-ATTRIBUTES" diff="add" at="2026-06-25">
+  <head>HTML Output Method: <code>indent-attributes</code></head>
+  <p>The behavior for the <code>indent-attributes</code> parameter for the HTML output method is described in <specref ref="XML_INDENT-ATTRIBUTES"/>.</p>
+</div3>
+<div3 id="HTML_LINE-ENDING" diff="add" at="2026-06-25">
+  <head>HTML Output Method: <code>line-ending</code></head>
+  <p>The behavior for the <code>line-ending</code> parameter for the HTML output method is described in <specref ref="XML_LINE-ENDING"/>.</p>
+</div3>
 <div3 id="HTML_CDATA-SECTION-ELEMENTS">
   <head>HTML Output Method: <code>cdata-section-elements</code></head>
   <p>The <code>cdata-section-elements</code> parameter is not applicable to the HTML output method, except in the case of <termref def="XML-ISLAND">XML Islands</termref>.</p></div3>
@@ -3651,7 +3734,10 @@ information.</p></div3>
 applicable to the Text output method.  See
 <specref ref="serparam"/> for more information.</p></div3>
    
-<div3 id="TEXT_LINE-ENDING" diff="add" at="2026-06-25"><head>Text Output Method: <code>line-ending</code></head><p>The behavior for the <code>line-ending</code> parameter for the Text output method is described in <specref ref="XML_LINE-ENDING"/>.</p></div3>
+<div3 id="TEXT_LINE-ENDING" diff="add" at="2026-06-25">
+  <head>Text Output Method: <code>line-ending</code></head>
+  <p>The behavior for the <code>line-ending</code> parameter for the Text output method is described in <specref ref="XML_LINE-ENDING"/>.</p>
+</div3>
 
 <div3 id="TEXT_ITEM-SEPARATOR">
 <head>Text Output Method: <code>item-separator</code></head>
@@ -4051,8 +4137,27 @@ the characters <char>U+000A</char> or <char>U+000D</char>.</p>
 
 
 
-<div3 id="JSON_INDENT-UNIT" diff="add" at="2026-06-25"><head>JSON Output Method: <code>indent-unit</code></head><p>The <code>indent-unit</code> parameter is applicable to the JSON output method when the <code>indent</code> parameter has the value <code>true</code>. Its effect is described in <specref ref="XML_INDENT-UNIT"/>.</p></div3>
-<div3 id="JSON_LINE-ENDING" diff="add" at="2026-06-25"><head>JSON Output Method: <code>line-ending</code></head><p>The behavior for the <code>line-ending</code> parameter for the JSON output method is described in <specref ref="XML_LINE-ENDING"/>.</p></div3>
+<div3 id="JSON_INDENT-UNIT" diff="add" at="2026-06-25">
+  <head>JSON Output Method: <code>indent-unit</code></head><p>The <code>indent-unit</code> parameter is applicable to the JSON output 
+    method when the <code>indent</code> parameter has the value <code>true</code>. Its effect is analogous to the behavior with the XML output
+    method, as described in <specref ref="XML_INDENT-UNIT"/>.</p>
+  <p>The value of <code>indent-unit</code> is ignored if the value of <code>json-lines</code> is true.</p>
+  <note>
+    <p>Software tools that serialize JSON in indented form adopt a variety of strategies designed to maximize readability: for example
+    a sufficiently small array or map might be rendered on a single
+    line. This specification does not attempt to restrict the use of such strategies. The string provided as the value of 
+    <code>indent-unit</code> <rfc2119>MAY</rfc2119> therefore be used in different ways by different processors.</p>
+  </note>
+</div3>
+<div3 id="JSON_LINE-ENDING" diff="add" at="2026-06-25">
+  <head>JSON Output Method: <code>line-ending</code></head>
+  <p>The behavior for the <code>line-ending</code> parameter for the JSON output method 
+    is described in <specref ref="XML_LINE-ENDING"/>.</p>
+  <note>
+    <p>Newlines within JSON strings will have been escaped (as <code>\n</code>) before line endings are adjusted. The <code>line-ending</code>
+    parameter therefore affects only newline characters that are inserted during the indentation process.</p>
+  </note>
+</div3>
 
 <div3 id="JSON_NORMALIZATION-FORM">
   <head>JSON Output Method: <code>normalization-form</code></head>
@@ -4491,7 +4596,9 @@ Therefore, this parameter does not get passed down to any delegated output metho
   
 
 
-<div3 id="ADAPTIVE_LINE-ENDING" diff="add" at="2026-06-25"><head>Adaptive Output Method: <code>line-ending</code></head><p>The behavior for the <code>line-ending</code> parameter for the Adaptive output method is described in <specref ref="XML_LINE-ENDING"/>.</p></div3>
+<div3 id="ADAPTIVE_LINE-ENDING" diff="add" at="2026-06-25">
+  <head>Adaptive Output Method: <code>line-ending</code></head>
+  <p>The behavior for the <code>line-ending</code> parameter for the Adaptive output method is described in <specref ref="XML_LINE-ENDING"/>.</p></div3>
 
 <div3 id="ADAPTIVE_ITEM-SEPARATOR">
 <head>Adaptive Output Method: <code>item-separator</code></head>

--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -631,11 +631,9 @@ instruction:</p>
                           else ()"/>
 
     <xsl:choose>
-      <xsl:when test=". instance of node()">
-        <xsl:sequence select="."/>
-      </xsl:when>
+      <xsl:when test=". instance of node()" select="."/>
       <xsl:otherwise>
-        <xsl:value-of select="."/>
+        <xsl:text select="."/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:for-each>
@@ -683,7 +681,19 @@ if
 <!-- Part of text added for defect 20416 -->
 <code>$seq</code> contains functions,
 attribute nodes or namespace
-nodes.</p></note></div1>
+nodes.</p>
+
+<p>The value of the <code>item-separator</code> property, once injected into the normalized sequence, 
+  is processed in the same way as any other text node appearing in that sequence. 
+  This means, for example, that character maps will be
+  applied, special characters will be escaped, and newlines will be adjusted based on the value
+  of the <code>line-ending</code> parameter.</p>
+
+</note>
+
+
+
+</div1>
 
 <div1 id="serparam">
 <head>Serialization Parameters</head>


### PR DESCRIPTION
Fix #2830 

Essentially editorial, though it makes some technical decisions on the interaction of parameters such as `line-ending` and `item-separator` which may be non-obvious.