### PR TITLE
2836 Add fn:location function

### DIFF
--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -5936,6 +5936,10 @@ is returned.</p>
   is numbered 1 (one).</p></item>
 </ulist>
     
+    <p>The location property will generally be available only for a node constructed directly by an XML parser.
+    The property will not be available on nodes constructed programmatically (for example in XQuery or XSLT),
+    or on nodes produced by copying another node.</p>
+    
     <note><p>Location information is not provided in a standardized way either in the Infoset or in the PSVI.
     Many XML parsers return location information, but they do so in different ways. Some return location information
     for some kinds of nodes and not others (for example, for elements but not for attributes); and the values

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -2553,6 +2553,11 @@ contain any empty &textNode;s.</p>
 &dm.prop.children; or &dm.prop.attributes; properties of a node.</p>
 </item>
 </olist>
+    
+    <p>The <code>dm:location</code> accessor of a node, described in
+    <specref ref="dm-location"/>, is potentially available on all seven node
+    kinds and is not described further in this section.</p>
+  
 
 <div3 id="DocumentNode">
 <head>Document nodes</head>
@@ -5895,6 +5900,52 @@ exists, or if the entity is not an external unparsed entity, the empty sequence
 is returned.</p>
 
 <p>It is defined on
+<loc href="#acc-summ-unparsed-entity-system-id">all seven</loc> node kinds.</p>
+</div3>
+  
+  <div3 id="dm-location">
+<head><code>location</code> Accessor</head>
+
+<example role="signature">
+  <proto class="dm" name="location" return-type="record(system-id as xs:anyURI?, public-id as xs:string?, line-number as xs:integer?, column-number as xs:integer?)" returnEmptyOk="yes">
+    <arg name="node" type="node()"/>
+  </proto>
+</example>
+
+<p>The <function>location</function> accessor returns information about the position
+  of a node in the source XML text from which the node was derived. The accessor
+  may return an empty sequence if no location information is available for a node;
+  furthermore, any of the four components may also be absent from the result if the relevant
+  information is not available.</p>
+    
+<p>The intended meaning of the four components of the returned location is as follows:</p>
+
+<ulist>
+  <item><p><term>system-id</term> is the URI of the document or external entity in which the lexical representation
+  of the node is found. In the absence of <code>xml:base</code> attributes, this will typically
+  be the same as the base URI of the node.</p></item>
+  <item><p><term>public-id</term> is the public identifier of the document or external entity in which the lexical representation
+  of the node is found. A value of <code>()</code> indicates either that the information is not available, or that
+  the relevant entity has no public identifier.</p></item>
+  <item><p><term>line-number</term> is the line number within the containing document or external entity at which the lexical representation
+  of the node is found. If the lexical representation spans several lines then it is implementation-defined which
+  of the relevant line numbers is returned. The first line of a resource is numbered 1 (one).</p></item>
+  <item><p><term>column-number</term> is the column number within the containing document or external entity at which the lexical representation
+  of the node is found. Within the range of columns occupied by the lexical representation of a node,
+  it is implementation-defined which of the relevant column numbers is returned. The first column of a line 
+  is numbered 1 (one).</p></item>
+</ulist>
+    
+    <note><p>Location information is not provided in a standardized way either in the Infoset or in the PSVI.
+    Many XML parsers return location information, but they do so in different ways. Some return location information
+    for some kinds of nodes and not others (for example, for elements but not for attributes); and the values
+    returned may also vary (a Java SAX parser, for example, returns the line and column number at which the final
+    <code>">"</code> of an element's start tag appears).</p>
+    <p>For all these reasons, the location information associated with a node is not interoperable across
+    implementations, and it should be used only for diagnostic purposes.</p>
+    </note>
+
+<p>The accessor is defined on
 <loc href="#acc-summ-unparsed-entity-system-id">all seven</loc> node kinds.</p>
 </div3>
 </div2>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -1441,6 +1441,10 @@
          position of the <code>">"</code> character at the end of the start tag. A third implementation might return a line
          number but no column number.</p>
          
+         <p>Location information will generally be available only for a node constructed directly by an XML parser.
+            The property will not be available on nodes constructed programmatically (for example in XQuery or XSLT),
+            or on nodes produced by copying another node.</p>
+         
          
       </fos:notes>
       <fos:see-also prefix="fn" name="base-uri"/>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -135,6 +135,40 @@
          </fos:meaning>
       </fos:field>
    </fos:record-type>
+   
+   <fos:record-type id="location-record" extensible="false">
+      <fos:summary>
+         <p>This record type represents location information identifying the position
+            within source XML text of the lexical representation of a particular node.</p>
+      </fos:summary>
+      <fos:field name="system-id" type="xs:anyURI?" required="false">
+         <fos:meaning>
+            <p>Defines the URI of the document or external entity in which the lexical
+               representation of a node is found.</p>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="public-id" type="xs:string?" required="false">
+         <fos:meaning>
+            <p>Defines the public identifier of the document or external entity in which the lexical
+               representation of a node is found.</p>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="line-number" type="xs:positive-integer?" required="false">
+         <fos:meaning>
+            <p>Defines the line number within the containing document or external entity at which the lexical representation
+  of a node is found. If the lexical representation spans several lines then it is implementation-defined which
+  of the relevant line numbers is returned. The first line of a resource is numbered 1 (one)..</p>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="column-number" type="xs:positive-integer?" required="false">
+         <fos:meaning>
+            <p>Defines the column number within the containing document or external entity at which the lexical representation
+  of a node is found. Within the range of columns occupied by the lexical representation of a node,
+  it is implementation-defined which of the relevant column numbers is returned. The first column of a line is numbered 1 (one).</p>
+         </fos:meaning>
+      </fos:field>
+      
+   </fos:record-type>
 
    <fos:record-type id="schema-type-record" extensible="false">
       <fos:summary>
@@ -1357,6 +1391,66 @@
          </fos:change>
       </fos:changes>
    </fos:function>
+   
+   <fos:function name="location" prefix="fn">
+      <fos:signatures>
+         <fos:proto name="location" return-type="fn:location-record?">
+            <fos:arg name="node" type="node()?" default="." usage="inspection"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties arity="0">
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-dependent</fos:property>
+         <fos:property>focus-dependent</fos:property>
+      </fos:properties>
+      <fos:properties arity="1">
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:summary>
+         <p>Returns information about the location of the lexical representation of a node
+            within the XML source document from which it was derived, if the information
+            is available.</p>
+      </fos:summary>
+      <fos:rules>
+         <p>If <code>$node</code> is the empty sequence, the function returns the empty sequence.</p>
+         <p>Otherwise, the function returns the value of the <code>location</code> accessor
+            applied to <code>$node</code>, as defined in <bibref
+               ref="xpath-datamodel-40"/> (See
+               <xspecref spec="DM40"
+               ref="dm-location"/>).</p>
+         <p>If location information is available, it is returned as 
+            a <loc href="#location-record">location-record</loc></p>
+      </fos:rules>
+      
+      <fos:notes>
+         <p>It is <termref def="implementation-defined"/> whether and under what circumstances
+            location information is available for a node. If no location information is available,
+            the function typically returns an empty sequence; alternatively it may return a record each of whose
+            four fields (<code>system-id</code>, <code>public-id</code>, <code>line-number</code>,
+            and <code>column-number</code>) is an empty sequence.</p>
+         
+         <p>Functions such as <function>fn:doc</function> and <function>fn:parse-xml</function>
+         allow the caller to request that location information be maintained in nodes of the returned
+         tree. There is no guarantee, however, that an implementation will act on this request.</p>
+         
+         <p>Two implementations that both return location information for a node may differ in the
+         information that they return. For example, one implementation might return the line and column
+         number of the <code>"&lt;"</code> character at the start of an element's start tag, another might return the
+         position of the <code>">"</code> character at the end of the start tag. A third implementation might return a line
+         number but no column number.</p>
+         
+         
+      </fos:notes>
+      <fos:see-also prefix="fn" name="base-uri"/>
+      <fos:changes>
+         <fos:change issue="2836">
+            <p>New in 4.0.</p>
+         </fos:change>
+      </fos:changes>
+   </fos:function>
+   
    <fos:function name="error" prefix="fn">
       <fos:signatures>
          <fos:proto name="error" return-type="xs:error">
@@ -19609,6 +19703,19 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                  
                </fos:values>
             </fos:option>
+            <fos:option key="retain-location">
+               <fos:meaning>Indicates whether the application wants location information to be retained
+               for nodes in the returned tree.</fos:meaning>
+               <fos:type>xs:boolean</fos:type>
+               <fos:default>false</fos:default>
+               <fos:values>
+                  <fos:value value="true">Represents a request that the nodes in the returned
+                  tree should include location information, accessible using the <function>fn:location</function>
+                  function. The implementation <rfc2119>may</rfc2119> ignore the request.</fos:value>
+                  <fos:value value="false">Indicates that location information is not required: but the
+                  implementation <rfc2119>may</rfc2119> provide it anyway.</fos:value>                
+               </fos:values>
+            </fos:option>
          </fos:options>
          
          <p diff="chg" at="issue2300">The determinism of this function depends on the value of the
@@ -19779,6 +19886,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       <fos:see-also prefix="fn" name="parse-xml"/>
       <fos:see-also prefix="fn" name="doc-available"/>
       <fos:see-also prefix="fn" name="collection"/>
+      <fos:see-also prefix="fn" name="location"/>
       <fos:changes>
          <fos:change issue="898" PR="905" date="2024-01-09">
             <p>The rule that multiple calls on <function>fn:doc</function>
@@ -19797,6 +19905,10 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             same document node is now stated as a normative rule that is conditional on the
             <code>stable</code> option, and the function is explicitly defined to be nondeterministic
             if <code>stable</code> is set to <code>false</code>.</p>
+         </fos:change>
+         <fos:change issue="2836">
+            <p>An option has been added to request that location information (for example, line numbers)
+               be maintained.</p>
          </fos:change>
       </fos:changes>
    </fos:function>
@@ -21123,6 +21235,19 @@ return { "width": $int16-at($loc + 5),
                   <fos:value value="false">Any <code>xsi:schemaLocation</code> and <code>xsi:noNamespaceSchemaLocation</code>
                   attributes in the document are ignored.</fos:value>
                  
+               </fos:values>              
+            </fos:option>
+            <fos:option key="retain-location">
+               <fos:meaning>Indicates whether the application wants location information to be retained
+               for nodes in the returned tree.</fos:meaning>
+               <fos:type>xs:boolean</fos:type>
+               <fos:default>false</fos:default>
+               <fos:values>
+                  <fos:value value="true">Represents a request that the nodes in the returned
+                  tree should include location information, accessible using the <function>fn:location</function>
+                  function. The implementation <rfc2119>may</rfc2119> ignore the request.</fos:value>
+                  <fos:value value="false">Indicates that location information is not required: but the
+                  implementation <rfc2119>may</rfc2119> provide it anyway.</fos:value>                
                </fos:values>
             </fos:option>
          </fos:options>
@@ -21219,6 +21344,7 @@ return { "width": $int16-at($loc + 5),
       </fos:examples>
       <fos:see-also prefix="fn" name="parse-xml-fragment"/>
       <fos:see-also prefix="fn" name="doc"/>
+      <fos:see-also prefix="fn" name="location"/>
       <fos:changes>
          <fos:change issue="305" PR="1257" date="2024-06-11">
             <p>The <code>$options</code> parameter has been added.</p>
@@ -21231,6 +21357,10 @@ return { "width": $int16-at($loc + 5),
          </fos:change>
          <fos:change issue="748" PR="2013" date="2025-05-20">
             <p>Support for binary input has been added.</p>
+         </fos:change>
+         <fos:change issue="2836">
+            <p>An option has been added to request that location information (for example, line numbers)
+               be maintained.</p>
          </fos:change>
       </fos:changes>
    </fos:function>
@@ -21297,6 +21427,19 @@ return { "width": $int16-at($loc + 5),
                   </fos:value>
                   <fos:value value="false">All whitespace-only text nodes are preserved.
                   </fos:value>
+               </fos:values>
+            </fos:option>
+            <fos:option key="retain-location">
+               <fos:meaning>Indicates whether the application wants location information to be retained
+               for nodes in the returned tree.</fos:meaning>
+               <fos:type>xs:boolean</fos:type>
+               <fos:default>false</fos:default>
+               <fos:values>
+                  <fos:value value="true">Represents a request that the nodes in the returned
+                  tree should include location information, accessible using the <function>fn:location</function>
+                  function. The implementation <rfc2119>may</rfc2119> ignore the request.</fos:value>
+                  <fos:value value="false">Indicates that location information is not required: but the
+                  implementation <rfc2119>may</rfc2119> provide it anyway.</fos:value>                
                </fos:values>
             </fos:option>
            
@@ -21385,12 +21528,17 @@ return { "width": $int16-at($loc + 5),
          </fos:example>
       </fos:examples>
       <fos:see-also prefix="fn" name="parse-xml"/>
+      <fos:see-also prefix="fn" name="location"/>
       <fos:changes>
          <fos:change issue="305" PR="1257" date="2024-06-11">
             <p>The <code>$options</code> parameter has been added.</p>
          </fos:change>
          <fos:change issue="748" PR="2013" date="2025-05-20">
             <p>Support for binary input has been added.</p>
+         </fos:change>
+         <fos:change issue="2836">
+            <p>An option has been added to request that location information (for example, line numbers)
+               be maintained.</p>
          </fos:change>
       </fos:changes>
    </fos:function>
@@ -21661,9 +21809,9 @@ return { "width": $int16-at($loc + 5),
                         model, the invalid node is <var>C</var>, not <var>D</var>.</p></item>
                      <item><p><code>error-node</code>. The node whose presence led to detection of the invalidity. In the
                      above example, this would be <var>D</var>.</p></item>
-                     <item><p><code>error-uri</code>. The URI of the XML entity in which the error was detected.</p></item>
-                     <item><p><code>line-number</code>. The line number where the error was detected, within its external entity.</p></item>
-                     <item><p><code>column-number</code>. The column number where the error was detected, within the error line number.</p></item>
+                     <item><p><code>location</code>. The location of the error, as an instance of the
+                     <loc href="#location-record">location-record</loc> record type.</p></item>
+    
                   </ulist>
                   
                   

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -6308,6 +6308,17 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                      <td><code>xs:anyURI</code> (optional)
                            </td>
                   </tr>
+                  <tr>
+                     <td>
+                               <function>fn:location</function>
+                           </td>
+                     <td>
+                               <code>location</code>
+                           </td>
+                     <td>node (optional)</td>
+                     <td><code>location-record</code> (optional) (see <specref ref="location-record"/>)
+                           </td>
+                  </tr>
                </tbody>
             </table>
             <?local-function-index?>
@@ -6317,6 +6328,9 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             </div3>
             <div3 id="func-document-uri">
                <head><?function fn:document-uri?></head>
+   		   </div3>
+            <div3 id="func-location">
+               <head><?function fn:location?></head>
    		   </div3>
             <div3 id="func-nilled">
                <head><?function fn:nilled?></head>
@@ -6330,6 +6344,10 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             </div3>
             <div3 id="func-data">
                <head><?function fn:data?></head>
+            </div3>
+            
+            <div3 id="location-record">
+              <head><?record-description location-record?></head>
             </div3>
             
          </div2>

--- a/specifications/xslt-40/src/function-catalog.xml
+++ b/specifications/xslt-40/src/function-catalog.xml
@@ -1321,6 +1321,19 @@
                   attribute if present).</fos:default-description>
                
             </fos:option>
+            <fos:option key="retain-location">
+               <fos:meaning>Indicates whether the application wants location information to be retained
+               for nodes in the returned tree.</fos:meaning>
+               <fos:type>xs:boolean</fos:type>
+               <fos:default>false</fos:default>
+               <fos:values>
+                  <fos:value value="true">Represents a request that the nodes in the returned
+                  tree should include location information, accessible using the <function>fn:location</function>
+                  function. The implementation <rfc2119>may</rfc2119> ignore the request.</fos:value>
+                  <fos:value value="false">Indicates that location information is not required: but the
+                  implementation <rfc2119>may</rfc2119> provide it anyway.</fos:value>                
+               </fos:values>
+            </fos:option>
          </fos:options>      
                
             


### PR DESCRIPTION
Fix #2836

Adds a dm:location accessor in the data model and a corresponding fn:location function in F+O; a location is a four-part record containing system id, public id, line number, and column number.

Allows maintenance of location information to be requested in fn:doc, fn:parse-xml, etc.

Changes the diagnostics returned by xsd-validator to include a location record.