### PR TITLE
2801 Align the output of matching-segments() and regex-groups()

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -8665,7 +8665,7 @@ Tak, tak, tak! - da kommen sie.
          <fos:change issue="1310 2655" PR="2470 2657" date="2026-04-20"><p>New in 4.0</p></fos:change>
          <fos:change issue="2660" date="2026-06-25"><p>A named capturing group is keyed in the
          <code>groups</code> map by its name rather than by its group number.</p></fos:change>
-         <fos:change issue="2801" date="2026-08-15"><p>The information available for each captured
+         <fos:change issue="2801" PR="2842" date="2026-08-15"><p>The information available for each captured
                group is aligned with the <code>regex-groups</code> function in XSLT 4.0.</p></fos:change>
       </fos:changes>
    </fos:function>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -399,12 +399,12 @@
             <p>The string value of the captured group.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="position" type="xs:string" required="true">
+      <fos:field name="position" type="xs:integer" required="true">
          <fos:meaning>
             <p>The one-based position of the captured group within the original input string.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="nr" type="xs:string" required="true">
+      <fos:field name="nr" type="xs:integer" required="true">
          <fos:meaning>
             <p>The numeric identifier of the captured group, based on counting left parentheses within the regular expression.</p>
          </fos:meaning>
@@ -8737,18 +8737,18 @@ return $regex?replace($title, fn { . + 1 })</eg></fos:expression>
   },
   { "substring": "C15",
     "position": 4,
-    "groups": {1: { "group": "C", "position": 4 },
-               2: { "group": "15", "position": 5 } }
+    "groups": {1: { "value": "C", "position": 4, "nr": 1, "name": () },
+               2: { "group": "15", "position": 5, "nr": 2, "name": () } }
   },
   { "substring": "D24",
     "position": 9,
-    "groups": {1: { "group": "D", "position": 9 },
-               2: { "group": "24", "position": 10 } }
+    "groups": {1: { "group": "D", "position": 9, "nr": 1, "name": () },
+               2: { "group": "24", "position": 10, "nr": 2, "name": () } }
   },
   { "substring": "X50",
     "position": 14,
-    "groups": {1: { "group": "X", "position": 14 },
-               2: { "group": "50", "position": 15 } }
+    "groups": {1: { "group": "X", "position": 14, "nr": 1, "name": () },
+               2: { "group": "50", "position": 15, "nr": 2, "name": () } }
   }</eg>
                </fos:result>
             </fos:test>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -367,12 +367,12 @@
             <p>The 1-based position of the matching segment within the original input string.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="groups" type="map((xs:integer | xs:string), record(group as xs:string, position as xs:integer))" required="true">
+      <fos:field name="groups" type="map((xs:integer | xs:string), fn:captured-group-record)" required="true">
          <fos:meaning>
             <p>The captured groups for this matching segment. This is represented as a map whose keys identify the
-            captured groups and whose values give details of each captured group: specifically, the 1-based start
-            position of the captured group within the original input string, and the string content of the capture.
-            Note that where groups are captured within a lookahead, the captured group is not necessarily a substring
+            captured groups and whose values give details of each captured group, in the form of a
+            <term>captured group record</term>: see <specref ref="captured-group-record"/>.</p>
+            <p>Note that where groups are captured within a lookahead, the captured group is not necessarily a substring
             of the matching segment.</p>
             <p>The key for a group that is a <termref def="dt-named-capturing-group">named capturing group</termref>
             is its name, supplied as an <code>xs:string</code>. The key for any other captured group is its group
@@ -386,6 +386,33 @@
             may be absent even though the regular expression contains an <code>N</code>th capturing subexpression.
             A numbered key is also absent if the corresponding group did not participate in the match (for example,
             a group within an alternative branch that was not taken).</p></note>
+         </fos:meaning>
+      </fos:field>
+   </fos:record-type>
+   
+   <fos:record-type id="captured-group-record" extensible="false">
+      <fos:summary>
+         <p>This record type represents a captured group appearing in the result of a regular expression match.</p>
+      </fos:summary>
+      <fos:field name="value" type="xs:string" required="true">
+         <fos:meaning>
+            <p>The string value of the captured group.</p>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="position" type="xs:string" required="true">
+         <fos:meaning>
+            <p>The one-based position of the captured group within the original input string.</p>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="nr" type="xs:string" required="true">
+         <fos:meaning>
+            <p>The numeric identifier of the captured group, based on counting left parentheses within the regular expression.</p>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="name" type="xs:string?" required="true">
+         <fos:meaning>
+            <p>The name of the captured group, present if the group was given a name using the syntax
+               <code>(?&lt;name&gt;…)</code> within the regular expression.</p>
          </fos:meaning>
       </fos:field>
    </fos:record-type>
@@ -8499,7 +8526,7 @@ Tak, tak, tak! - da kommen sie.
                <fos:result><eg>{
   "substring": "a",
   "position": 1, 
-  "groups": { 1: { "group": "a", "position": 1 } }
+  "groups": { 1: { "value": "a", "position": 1, "nr": 1, "name": () } }
 }</eg></fos:result>
             </fos:test>
             <fos:test>
@@ -8527,9 +8554,9 @@ Tak, tak, tak! - da kommen sie.
   "substring": "08-12-03",
   "position": 1,
   "groups": {
-    1: { "group": "08", "position": 1 },
-    2: { "group": "12", "position": 4 },
-    3: { "group": "03", "position": 7 }
+    1: { "value": "08", "position": 1, "nr": 1, "name": () },
+    2: { "value": "12", "position": 4, "nr": 2, "name": () },
+    3: { "value": "03", "position": 7, "nr": 3, "name": () }
   }
 }
                 </eg></fos:result>
@@ -8540,32 +8567,32 @@ Tak, tak, tak! - da kommen sie.
   "substring": "A1",
   "position": 1,
   "groups": {
-    1: { "group": "A", "position": 1 },
-    2: { "group": "1", "position": 2 }
+    1: { "value": "A", "position": 1, "nr": 1, "name": () },
+    2: { "value": "1", "position": 2, "nr": 2, "name": () }
   }
 },
 {
   "substring": "C15",
   "position": 4,
   "groups": {
-    1: { "group": "C", "position": 4 },
-    2: { "group": "15", "position": 5 }
+    1: { "value": "C", "position": 4, "nr": 1, "name": () },
+    2: { "value": "15", "position": 5, "nr": 2, "name": () }
   }
 },
 {
   "substring": "D24",
   "position": 9,
   "groups": {
-    1: { "group": "D", "position": 9 },
-    2: { "group": "24", "position": 10 }
+    1: { "value": "D", "position": 9, "nr": 1, "name": () },
+    2: { "value": "24", "position": 10, "nr": 2, "name": () }
   }
 },
 {
   "substring": "X50",
   "position": 14,
   "groups": {
-    1: { "group": "X", "position": 14 },
-    2: { "group": "50", "position": 15 }
+    1: { "value": "X", "position": 14, "nr": 1, "name": () },
+    2: { "value": "50", "position": 15, "nr": 2, "name": () }
   }
 }</eg>
                </fos:result>
@@ -8576,8 +8603,8 @@ Tak, tak, tak! - da kommen sie.
   "substring": "Chapter",
   "position": 1,
   "groups": {
-    1: { "group": "Chapter", "position": 1 },
-    2: { "group": "5", "position": 9 }
+    1: { "value": "Chapter", "position": 1, "nr": 1, "name": () },
+    2: { "value": "5", "position": 9, "nr": 2, "name": () }
   }
 }                                               
                </eg></fos:result>
@@ -8587,17 +8614,17 @@ Tak, tak, tak! - da kommen sie.
                <fos:result><eg>{
   "substring": "",
   "position": 1,
-  "groups": { 1: { "group": "There", "position": 1 } }
+  "groups": { 1: { "value": "There", "position": 1, "nr": 1, "name": () } }
 },
 {
   "substring": "",
   "position": 7,
-  "groups": { 1: { "group": "we", "position": 7 } }
+  "groups": { 1: { "value": "we", "position": 7, "nr": 1, "name": () } }
 },
 {
   "substring": "",
   "position": 10,
-  "groups": { 1: { "group": "go", "position": 10 } }
+  "groups": { 1: { "value": "go", "position": 10, "nr": 1, "name": () } }
 }</eg>
                </fos:result>
             </fos:test>
@@ -8610,9 +8637,9 @@ Tak, tak, tak! - da kommen sie.
   "substring": "2026-06-25",
   "position": 1,
   "groups": {
-    "year": { "group": "2026", "position": 1 },
-    "month": { "group": "06", "position": 6 },
-    "day": { "group": "25", "position": 9 }
+    "year": { "value": "2026", "position": 1, "nr": 1, "name": "year" },
+    "month": { "value": "06", "position": 6, "nr": 2, "name": "month" },
+    "day": { "value": "25", "position": 9, "nr": 3, "name": "day" }
   }
 }</eg>
                </fos:result>
@@ -8620,15 +8647,15 @@ Tak, tak, tak! - da kommen sie.
          </fos:example>
          <fos:example>
             <p>Although a <termref def="dt-named-capturing-group">named capturing group</termref> has no
-               integer key in the <code>groups</code> map, the entries of the map retain the order of the
-               capturing groups. If every capturing group participates in the match, a group can still be
+               integer key in the <code>groups</code> map, the entries of the map hold the
+               group number, so a group can still be
                selected by position. The following expression returns the second group:</p>
             <fos:test>
                <fos:expression><eg>matching-segments(
   "2026-06-25",
   "(?&lt;year&gt;\d{4})-(?&lt;month&gt;\d{2})-(?&lt;day&gt;\d{2})"
-)/groups/*[2] ! jvalue()</eg></fos:expression>
-               <fos:result><eg>{ "group": "06", "position": 6 }</eg></fos:result>
+)/groups/*[?nr = 2]/value</eg></fos:expression>
+               <fos:result><eg>"06"</eg></fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -8638,6 +8665,8 @@ Tak, tak, tak! - da kommen sie.
          <fos:change issue="1310 2655" PR="2470 2657" date="2026-04-20"><p>New in 4.0</p></fos:change>
          <fos:change issue="2660" date="2026-06-25"><p>A named capturing group is keyed in the
          <code>groups</code> map by its name rather than by its group number.</p></fos:change>
+         <fos:change issue="2801" date="2026-08-15"><p>The information available for each captured
+               group is aligned with the <code>regex-groups</code> function in XSLT 4.0.</p></fos:change>
       </fos:changes>
    </fos:function>
    

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -8649,7 +8649,7 @@ Tak, tak, tak! - da kommen sie.
             <p>Although a <termref def="dt-named-capturing-group">named capturing group</termref> has no
                integer key in the <code>groups</code> map, the entries of the map hold the
                group number, so a group can still be
-               selected by position. The following expression returns the second group:</p>
+               selected by number. The following expression returns the second group:</p>
             <fos:test>
                <fos:expression><eg>matching-segments(
   "2026-06-25",

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -4185,6 +4185,9 @@ WildcardEsc         ::= '.'
             <div3 id="matching-segment-record">
               <head><?record-description matching-segment-record?></head>
             </div3>
+             <div3 id="captured-group-record">
+              <head><?record-description captured-group-record?></head>
+            </div3>
             <div3 id="func-regex">
                <head><?function fn:regex?></head>
             </div3>

--- a/specifications/xslt-40/src/function-catalog.xml
+++ b/specifications/xslt-40/src/function-catalog.xml
@@ -800,7 +800,7 @@
             <p>A named capturing group is keyed in the result map by its name rather than by its
             group number.</p>
          </fos:change>
-         <fos:change issue="2801" date="2026-08-15"><p>The information available for each captured
+         <fos:change issue="2801" PR="2842" date="2026-08-15"><p>The information available for each captured
                group is aligned with the <function>fn:matching-segments</function>.</p></fos:change>
       </fos:changes>
    </fos:function>

--- a/specifications/xslt-40/src/function-catalog.xml
+++ b/specifications/xslt-40/src/function-catalog.xml
@@ -700,7 +700,7 @@
    
    <fos:function name="regex-groups">
       <fos:signatures>
-         <fos:proto name="regex-groups" return-type="map((xs:integer | xs:string), record(value as xs:string, position as xs:integer))"/>
+         <fos:proto name="regex-groups" return-type="map((xs:integer | xs:string), fn:captured-group-record)"/>
       </fos:signatures>
       <fos:properties>
          <fos:property>deterministic</fos:property>
@@ -719,7 +719,9 @@
                capturing subexpressions of the regular expression.</termdef> These captured
             groups are accessible using the <function>regex-groups</function>
             and <function>regex-group</function> functions. </p>
-         <p>The <function>regex-groups</function> function returns this information as a map.</p>
+         <p>The <function>regex-groups</function> function returns this information as a map. Each entry
+         in the map has a key, which is the group number or name, and an associated value, which is
+         an instance of the record type <code>captured group-record</code>, defined in <xspecref spec="XP40" ref="captured-group-record"/>.</p>
          <p>The <var>N</var>th captured group (where <var>N</var> &gt; 0) is the segment of the input string matched
             by the subexpression contained by the <var>N</var>th left parenthesis in the regex,
                excluding any non-capturing parenthesized expressions. The zeroth captured substring is the segment
@@ -789,6 +791,7 @@
          situation a segment returned in the result of <function>regex-groups</function> may be positioned
          beyond the end of the corresponding matching segment.</p>
       </fos:notes>
+      
       <fos:changes>
          <fos:change issue="2233" PR="2246" date="2025-11-18">
             <p>New in 4.0</p>
@@ -797,6 +800,8 @@
             <p>A named capturing group is keyed in the result map by its name rather than by its
             group number.</p>
          </fos:change>
+         <fos:change issue="2801" date="2026-08-15"><p>The information available for each captured
+               group is aligned with the <function>fn:matching-segments</function>.</p></fos:change>
       </fos:changes>
    </fos:function>
 


### PR DESCRIPTION
Fix #2801