### PR TITLE
2853 Default values of function parameters

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -892,7 +892,13 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:ref name="VarNameAndType"/>
     <g:optional name="OptionalDefaultForParam">
       <g:string>:=</g:string>
-      <g:ref name="ExprSingle"/>
+      <g:choice>
+        <g:ref name="ExprSingle"/>
+        <g:sequence>
+          <g:string>context</g:string>
+          <g:string>value</g:string>
+        </g:sequence>
+      </g:choice>     
     </g:optional>
   </g:production>
 

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -606,20 +606,22 @@ Michael Sperberg-McQueen (1954–2024).</p>
                      an ellipsis (<code>...</code>)</p></item>-->
                   <item><p>If the parameter is optional, then an expression giving the default value 
                      (preceded by the symbol <code>:=</code>).</p>
-                        <p diff="add" at="2023-12-04">The default value expression is evaluated using the static and
+                        <p>Although the syntax for parameter defaults corresponds to the syntax
+                           used in XQuery function declarations, the semantics are different.
+                           Specifically, the default value expression is evaluated using the static and
                         dynamic context of the function caller (or of a named function reference). For example, 
                         if the default value is given as <code>.</code>, then it evaluates to the context value 
                         from the dynamic context of the function caller; if it is given as <code>default-collation</code>,
                         then its value is the default collation from the static context of the function caller;
-                        if it is given as <code>deep-equal#2</code>, then the third argument supplied to <code>deep-equal</code>
-                        is the default collation from the static context of the caller.</p></item>
+                        if it is given as <code>deep-equal#2</code>, then the options supplied to <code>deep-equal</code>
+                        include the default collation from the static context of the caller.</p></item>
                </ulist>
                <note><p id="default-on-empty">
                   If no argument is supplied for a parameter that has a default value, the default
                   value is used. If the parameter is marked <code role="arg-note">(:default-on-empty:)</code>,
                   the default value is also used when the supplied argument is the empty sequence.
                   Otherwise, the empty sequence is treated according to the function-specific rules.</p>
-                  <p>The marker is only used on parameters that have default values.</p>
+                  <p>This marker is only used on parameters that have default values.</p>
                </note>
 
                <p>If there are two or more parameter declarations, they are separated by a comma.</p> 

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -11342,6 +11342,11 @@ return $vat(doc('wares.xml')/shop/article)
                      fails if there is no context node, and <code>fn:id(?)</code> <rfc2119>should</rfc2119>
                      fail likewise.</p>
                      
+                     <note><p>Where the function defines context-dependent defaults for any of its parameters,
+                     the relevant values are taken from the static and dynamic context of the
+                     partial function application, not from the context of a subsequent dynamic
+                     function call.</p></note>
+                     
                      
                      
 

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -1894,15 +1894,30 @@ local:summary(doc("acme_corp.xml")//employee[location = "Denver"])</eg>
         <code>item()*</code>. If the result type is omitted from a function declaration, its default
         result type is <code>item()*</code>.</p>
       
-      <p diff="add" at="variadicity">The function body defines the implementation of the <termref def="dt-function-definition"/>. 
+      <p>The function body defines the implementation of the <termref def="dt-function-definition"/>. 
         The rules for static function calls (see <specref ref="id-eval-static-function-call"/>)
         ensure that a value is available for each parameter, whether required or optional, and that the value
         will always be an instance of the declared type.
       </p>
       
       
-      <p>A parameter is
-    optional if a default value is supplied using the construct <code>:= ExprSingle</code>; otherwise it is required. If a parameter
+      <p>A parameter is optional if a default value is supplied. There are two ways a default value
+        can be defined:</p>
+      
+      <ulist>
+        <item><p>The construct <code>:= ExprSingle</code> defines a fixed default; all function calls
+        that default the relevant argument will supply the same value. The <code>ExprSingle</code>
+        is evaluated in the same way as the <termref def="dt-initializing-expression"/> of
+        a variable declaration (see <specref ref="id-variable-declarations"/>).</p></item>
+        <item><p>The construct <code>:= context value</code> indicates that the default value of the
+        relevant argument is the context value from the dynamic context of the function call.
+        This will typically be different for every function call that defaults the argument; it may
+        also lead to a type error if the context value is absent or has the wrong type. Using this option
+        is equivalent to expanding the function call with the expression <code>.</code> in the
+        relevant argument position.</p></item>
+      </ulist>
+        
+       <p>If a parameter
     is optional, then all subsequent parameters in the list must also be optional; otherwise, a
     <termref def="dt-static-error">static error</termref> is raised <errorref class="ST" code="0148"/>.
     In other words, the parameter list includes
@@ -1912,16 +1927,7 @@ local:summary(doc("acme_corp.xml")//employee[location = "Denver"])</eg>
     where <var>M</var> is the number of required parameters, and <var>N</var> is the total number of parameters (whether required or optional).
     This is refered to as the <termref def="dt-arity-range"/> of the <termref def="dt-function-definition"/>.</p>
       
-     <p diff="add" at="2023-05-19">The default value for an optional parameter will often be supplied using a 
-       simple literal or constant expression, for example
-     <code>$married as xs:boolean := false()</code> or <code>$options as map(*) := { }</code>. However, to allow greater flexibility,
-     the initial value can also be context-dependent. For example, <code>$node as node() := .</code> declares a parameter whose
-     default value is the context value from the dynamic context of the caller, while <code>$collation as xs:string := default-collation()</code>
-     declares a parameter whose default value is the default collation from the dynamic context of the caller.
-     The detailed rules are as follows. In these rules, the term <term>caller</term> means the function call or function reference
-     that invokes the function being defined.</p>
-      
-      <p diff="add" at="2023-05-19">The <termref def="dt-static-context"/> for the initializing expression of an optional parameter is the same as the static
+     <!--<p diff="add" at="2023-05-19">The <termref def="dt-static-context"/> for the initializing expression of an optional parameter is the same as the static
       context for the <termref def="dt-initializing-expression"/> of a variable declaration (see <specref ref="id-variable-declarations"/>),
       with the following exceptions:</p>
       
@@ -1940,8 +1946,15 @@ local:summary(doc("acme_corp.xml")//employee[location = "Denver"])</eg>
         <item><p>The <termref def="dt-variable-values"/> component is empty.</p></item>
         <item><p>The <termref def="dt-dynamically-known-function-definitions"/> excludes all user-defined functions.</p></item>
       </ulist>
-      
-      
+      -->
+      <note><p>It is not possible in a user-defined function to define a default value that 
+          depends on the static or dynamic context of the caller, except for the special 
+          case of the context value itself.
+          There are system-defined functions that declare such defaults (for example, defaulting
+          a parameter to the default collation or the static base URI of the caller); indeed,
+          some functions such as <function>fn:position</function> or <function>fn:static-base-uri</function>
+          exist for the sole purpose of obtaining information from the context of the caller.
+          User-defined functions are not able to emulate this behavior.</p></note>
     
     
     </div3> 

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -1654,11 +1654,11 @@ declare context value as document-node()* := collection($uri); </eg>
     <head>Function Declarations</head>
     
     <changes>
-      <change>
+      <change issue="2853" PR="2858" date="2026-08-22">
         Function definitions in the static context may now have optional parameters,
         provided this does not cause ambiguity across multiple function definitions with the same name.
-        Optional parameters are given a default value, which can be any expression, including one that
-        depends on the context of the caller (so an argument can default to the context value).
+        Optional parameters are given a default value, with an option to default the value using the
+        context value from the dynamic context of the caller.
       </change>
       <change issue="657">
         A user-defined function whose name is given as an unprefixed QName is now in no namespace.

--- a/specifications/xslt-40/src/function-catalog.xml
+++ b/specifications/xslt-40/src/function-catalog.xml
@@ -151,6 +151,12 @@
             operator, the current item is generally different from the context item.</p>
          <p>If the <function>current</function> function is used within a <termref def="dt-pattern">pattern</termref>, its value is the item that is
             being matched against the pattern.</p>
+         <p>If the <function>current</function> function is used within the <code>select</code> expression that
+         defines the default value of a <termref def="dt-function-parameter"/>, then it evaluates to the
+         <termref def="dt-context-value"/> from the dynamic context of the construct invoking the function (a static function call,
+         partial function application, or named function reference). This special usage does not apply when the default
+         value is defined using a sequence constructor as a child of the <elcode>xsl:param</elcode> element, where
+         <code>current()</code> has its normal meaning.</p>
 
       </fos:rules>
       <fos:errors>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -20058,7 +20058,13 @@ return $tree =?> depth()]]></eg>
             </div3>
             <div3 id="function-arguments">
                <head>Parameters</head>
-               <p diff="chg" at="variadicity">The <elcode>xsl:param</elcode> elements define the formal parameters to the
+               <change issue="2853" PR="2858" date="2026-08-22">
+                  Function definitions may now have optional parameters,
+                  provided this does not cause ambiguity across multiple function definitions with the same name.
+                  Optional parameters are given a default value, with an option to default the value using the
+                  context value from the dynamic context of the caller.
+                </change>
+               <p>The <elcode>xsl:param</elcode> elements define the formal parameters to the
                   function. In a static function call, these are referenced either positionally or by name.
                   The rules for associating arguments in a static function call with parameter definitions
                   in the function declaration are given in <xspecref spec="XP40" ref="id-eval-static-function-call"/>.</p>
@@ -20091,43 +20097,14 @@ return $tree =?> depth()]]></eg>
                <p>If the <code>as</code> attribute is omitted, no conversion takes place and any
                   value is accepted.</p>
                
-               <p diff="add" at="2023-05-19">The default value for an optional parameter 
-                  (one with <code>required="no"</code>) will often be supplied using a 
-                  simple literal or constant expression, for example
-                  <code>&lt;xsl:param name="married" as="xs:boolean" select="false()"/></code>,
-                  or <code>&lt;xsl:param name="options" as="map(*)" select="{}"/></code>. 
-                  However, to allow greater flexibility,
-                  the default value can also be context-dependent. For example, 
-                  <code>&lt;xsl:param name="node" as="node()" select="."/></code> declares a parameter whose
-                  default value is the context item from the dynamic context of the caller, while 
-                  <code>&lt;xsl:param name="collation" as="xs:string" select="default-collation()"/></code>
-                  declares a parameter whose default value is the default collation from the dynamic context of the caller.
+               <p>The default value for an optional function parameter is evaluated in the same way as the initial value
+                  of a global variable declaration, with one exception: a call on <function>fn:current</function> within
+                  the <code>select</code> expression — but not within a contained sequence constructor — is interpreted
+                  as a reference to the context value from the dynamic context of the function caller.
+                  It is not possible for a user-defined function to reference other aspects of the static or dynamic
+                  context of the caller, such as the static base URI or the default collation.
                   The detailed rules are as follows. In these rules, the term <term>caller</term> means the function call or function reference
                   that invokes the function being defined.</p>
-               
-               <p diff="add" at="2023-05-19">The <xtermref spec="XP40" ref="dt-static-context"/> for the 
-                  initializing expression of an optional parameter of an <elcode>xsl:function</elcode> declaration
-                  is the same as the static context for a <termref def="dt-static-expression"/>.</p>
-
-               
-               <p diff="add" at="2023-05-19">The <xtermref  spec="XP40" ref="dt-dynamic-context"/> for the initializing 
-                  expression of an optional parameter 
-                  is the same as the dynamic context for the evaluation of a <termref def="dt-static-expression"/>, 
-                  with the following exceptions:</p>
-               
-               <ulist diff="add" at="2023-05-19">
-                  <item><p>The <xtermref spec="XP40" ref="dt-context-value"/>, <xtermref spec="XP40" ref="dt-context-position"/>,
-                     and <xtermref spec="XP40" ref="dt-context-size"/> are taken from the dynamic context of the caller.</p></item>
-                  <item><p>The <xtermref spec="XP40" ref="dt-def-collation"/> and <xtermref spec="XP40" ref="dt-executable-base-uri"/>
-                  are taken from the dynamic context of the caller.</p></item>
-               </ulist>
-               
-               <note><p>The effect of these rules is that the <code>select</code> expression for an optional parameter
-               is evaluated in the same way as a static expression, except that it may contain context-dependent
-               subexpressions such as <code>.</code>, <code>position()</code>, <code>last()</code>,
-               <code>static-base-uri()</code>, and <code>default-collation()</code> to access the
-               dynamic context of the caller. It may also contain expressions such as <code>name()</code>
-               or <code>@x = "abc"</code> that have an implicit dependency on the dynamic context of the caller.</p></note>
                
                
             </div3>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -17771,8 +17771,15 @@ return $tree =?> depth()]]></eg>
                         <code>yes</code>.</termdef> If a parameter is explicitly mandatory, then the
                      <elcode>xsl:param</elcode> element <rfc2119>must</rfc2119> be empty and
                      <rfc2119>must not</rfc2119> have a <code>select</code> attribute.</p>
+               
+               <p>If a parameter is not <termref def="dt-explicitly-mandatory"/>, then it may have a
+                  default value. The default value is obtained by evaluating the 
+                  <termref def="dt-expression">expression</termref> given in the <code>select</code>
+                  attribute or the contained <termref def="dt-sequence-constructor">sequence
+                     constructor</termref>, as described in <specref ref="variable-values"/>.</p>
 
-               <p diff="add" at="2022-01-01">The static context for evaluating the default value depends on where the
+
+               <p>The static context for evaluating the default value depends on where the
                relevant expression appears in the stylesheet, in the usual way. Note however that
                for <elcode>xsl:param</elcode> elements defining <termref def="dt-function-parameter">function parameters</termref>,
                   the static context does not include variables bound in preceding-sibling <elcode>xsl:param</elcode> elements.</p>
@@ -17788,22 +17795,23 @@ return $tree =?> depth()]]></eg>
                   earlier. It also means, for example, that if the evaluation of the default value invokes
                   <elcode>xsl:next-match</elcode>, the <termref def="dt-current-template-rule"/> is the called
                   template rather than the calling template.</p></item>
-                  <item><p>For <termref def="dt-function-parameter">function parameters</termref>, the dynamic
-                     context for evaluating defaults is the dynamic context of the caller, except that no
-                     local variables are in scope. This means that it is possible to declare a parameter
-                     with <code>&lt;xsl:param name="dot" required="no" select="."/></code> to take its
-                     default value from the context item of the caller.
+                  <item><p>For <termref def="dt-function-parameter">function parameters</termref>, the context
+                        is the same as the context for evaluating global variables, with one exception: if the
+                        expression defining the default value includes a call on the <function>current</function>
+                        function, this evaluates to the context value of the invoking expression.
+                        (The invoking expression is typically a static function
+                        call, but it can also be a named function reference or a partial function application).
+                        The <code>select</code> expression can invoke <code>current()</code> directly
+                        (<code>select="current()")</code>, and 
+                        it is also possible to call <function>current</function> function within
+                        a more complex expression, for example <code>select="string(current())"</code>.
                      
               </p>
                   
                   </item>
                </ulist>
 
-               <p>If a parameter is not <termref def="dt-explicitly-mandatory"/>, then it may have a
-                  default value. The default value is obtained by evaluating the <termref def="dt-expression">expression</termref> given in the <code>select</code>
-                  attribute or the contained <termref def="dt-sequence-constructor">sequence
-                     constructor</termref>, as described in <specref ref="variable-values"/>.</p>
-
+               
                <note>
                   <p>This specification does not dictate whether and when the default value of a
                      parameter is evaluated. For example, if the default is specified as
@@ -17811,12 +17819,27 @@ return $tree =?> depth()]]></eg>
                      it is not specified whether a distinct <code>foo</code> element node will be
                      created on each invocation of the template, or whether the same
                         <code>foo</code> element node will be used for each invocation. However, it
-                     is permissible for the default value to depend on the values of other
+                     is permissible, at least with template parameters and stylesheet parameters,
+                     for the default value to depend on the values of other
                      parameters, or on the evaluation context, in which case the default must
                      effectively be evaluated on each invocation.</p>
                   
  
                </note>
+               
+               <note><p>It is not possible in a user-defined function to define a default parameter value that 
+          depends on the static or dynamic context of the caller, except for the special 
+          case of the context value itself, which can be referenced as <code>current()</code>.
+          There are system-defined functions that declare such defaults (for example, defaulting
+          a parameter to the default collation or the static base URI of the caller); indeed,
+          some functions such as <function>position</function> or <function>static-base-uri</function>
+          exist for the sole purpose of obtaining information from the context of the caller.
+          User-defined functions are not able to emulate this behavior.</p>
+               <p>Note that <code>select="."</code> in a function parameter definition is
+               a reference to the <termref def="dt-global-context-item"/>, while <code>select="current()"</code>
+               is a reference to the context item of the caller.</p>
+               </note>
+    
 
                <p><termdef id="dt-explicit-default" term="explicit default">An <term>explicit
                         default</term> for a parameter is indicated by the presence of either a


### PR DESCRIPTION
Fix #2853 

This resolves the issue as follows:

* In both XSLT and XQuery, the expression defining the default value of a function parameter (for a user-defined function) is evaluated in the same way as the initializing expression of a global variable. We don't constrain the expression, but it has no access to the static or dynamic context of the function caller, and it defines a fixed default that applies to all calls on that function.
* However, as a special case there is provision to define that the context item/value of the caller is used as the default. In XQuery this is done by defining the default using the custom syntax `$node as node() := context value`. In XSLT we use `select="current()"`.