### PR TITLE
2820 Revise cast expressions to avoid the need for occurrence indicators

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1717,9 +1717,6 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
       <g:string>castable</g:string>
       <g:string>as</g:string>
       <g:ref name="CastTarget"/>
-      <g:optional>
-        <g:ref name="OccurrenceIndicator"/>
-      </g:optional>
     </g:optional>
   </g:production>
   
@@ -1729,9 +1726,6 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
       <g:string>cast</g:string>
       <g:string>as</g:string>
       <g:ref name="CastTarget"/>
-      <g:optional>
-        <g:ref name="OccurrenceIndicator"/>
-      </g:optional>
     </g:optional>
   </g:production>
   
@@ -2899,6 +2893,9 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
       <g:ref name="MapType"/>
       <g:ref name="RecordType"/>
     </g:choice>
+    <g:optional>
+      <g:string>?</g:string>
+    </g:optional>
   </g:production>
 
   <g:production name="TypeName" >

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -13052,15 +13052,9 @@ return if (every $r in $R satisfies $r instance of node())
                            def="dt-xpath-compat-mode"
                            >XPath 1.0
 		compatibility mode</termref> is <code>false</code> must raise
-				a <termref
-                           def="dt-static-error">static
-				error</termref>
-                        <errorref class="ST" code="0010"
-                           /> if it is
-				used. Applications needing information
-				about the <termref
-                           def="dt-in-scope-namespaces"
-                           >in-scope namespaces</termref> of an element
+				a <termref def="dt-static-error">static error</termref>
+            <errorref class="ST" code="0010"/> if it is used. Applications needing information
+				about the <termref def="dt-in-scope-namespaces">in-scope namespaces</termref> of an element
 				should use the function <function>fn:in-scope-namespaces</function>.
                                 </p>
                      

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -24289,9 +24289,9 @@ be used to process an expression in a way that depends on its <termref
                   The specification now insists that the result of a cast to type <var>T</var> must be an
                   instance of <var>T</var>, and not of any subtype of <var>T</var>.
                </change>
-               <change issue="2644" PR="2777" date="2026-07-08">
+               <change issue="2644 2820" PR="2777" date="2026-07-08">
                   The target of a <code>cast</code> or <code>castable</code> expression can now
-                  be a sequence, an array, a map, or a record type.
+                  be a an array, a map, or a record type.
                </change>
             </changes>
             <scrap>
@@ -24301,8 +24301,7 @@ be used to process an expression in a way that depends on its <termref
 creates a new value of a specific type by converting an existing value. A
 <code>cast</code> expression takes two operands: an <term>input
 expression</term> and a <term>target type</term>. The type of the
-input expression is called the <term>input type</term>. The item type of the <term>target type</term>
-            is called the <term>target item type</term>.</p>
+input expression is called the <term>input type</term>. </p>
             
             <p>The target type may be any of the following:</p>
             
@@ -24342,12 +24341,15 @@ input expression is called the <term>input type</term>. The item type of the <te
                <item><p>The name of a <termref def="dt-named-item-type">named item type</termref>
                   defined in the <termref def="dt-static-context"/>, which <rfc2119>must</rfc2119> refer to an item
                   type in one of the categories described above. The semantics are the same as if the target type
-                  were included directly.</p></item>
-               <item>
-                  <p>Any of the above item types followed by an occurrence indicator (<code>*</code>, <code>+</code>, or <code>?</code>). </p>
-               </item>
+                  were specified directly.</p></item>
+               
                
             </ulist>
+            
+            <p>The target type may be followed by the symbol <code>?</code>. This indicates that the input value 
+               may be the empty sequence, in which case the result will also be the empty sequence. For those
+            target types where atomization is performed, this test is applied to the input value after atomization.</p>
+            
                <p>If the target type is not in one of the categories listed, then a static error is raised <errorref class="ST" code="0080"/>.</p> 
            
             
@@ -24368,14 +24370,25 @@ input expression is called the <term>input type</term>. The item type of the <te
                   <p><var>V0</var> is <termref def="dt-atomization"
                         >atomized</termref>, producing a value <var>V1</var>.</p>
                </item>
-
-
-
+               
                <item>
-                  <p>Each atomic item in <var>V1</var> is cast to the target item type as described in <xspecref
-                        spec="FO40" ref="casting"/>, producing a sequence of atomic items <var>V2</var>.</p>
-                  
-                  
+                  <p>If <var>V1</var> is a sequence of more than one atomic item, 
+                     a <termref def="dt-type-error"/> is raised <errorref code="0004" class="TY"/>.</p>
+               </item>
+               
+               <item>
+                  <p>If <var>V1</var> is the empty sequence, then:</p>
+                  <ulist>
+                     <item><p>If <code>?</code> is specified after the <nt def="CastTarget">CastTarget</nt>,
+                     the result of the cast is the empty sequence.</p></item>
+                     <item><p>Otherwise, a <termref def="dt-type-error"/> is raised <errorref code="0004" class="TY"/>.</p></item>
+                  </ulist>
+               </item>
+               
+               <item>
+                  <p>The atomic item <var>V1</var> is cast to the target item type as described in <xspecref
+                        spec="FO40" ref="casting"/>, producing an atomic item <var>V2</var>.</p>
+                                   
                      <p> 
                         This process may result in a type error, if casting from the source type to the
                         target type is not supported (for example attempting to convert an
@@ -24388,13 +24401,7 @@ input expression is called the <term>input type</term>. The item type of the <te
                   
                </item>
                
-               <item>
-                  <p>If the number of items in <var>V2</var> does not match the requirements of the
-                     (explicit or implicit) occurrence indicator, then a type error <errorref class="TY" code="0004"/>
-                  is raised.</p>
-                  <p>For example, a type error is raised if the input is an empty sequence and the target type
-                  does not include the occurrence indicator <code>?</code> or <code>*</code>.</p>
-               </item>
+              
                
                <item><p>The result of the cast expression is <var>V2</var>.</p></item>
             </olist>
@@ -24438,7 +24445,8 @@ input expression is called the <term>input type</term>. The item type of the <te
                type does not satisfy the conditions making it a <termref def="dt-generalized-atomic-type"/>. (For example,
                it may be a union type that includes a list type in its transitive membership.)</p>
                
-               <p>The rules for casting a single item to a union type are given in <xspecref spec="FO40" ref="casting-to-union"/>.</p>
+               <p>The rules for casting a single item to a union type are given in
+                  <xspecref spec="FO40" ref="casting-to-union"/>, and are repeated here for convenience:</p>
                
                <p>In the general case:</p>
                <olist>
@@ -24450,23 +24458,31 @@ input expression is called the <term>input type</term>. The item type of the <te
                     <p><var>V0</var> is <termref def="dt-atomization"
                        >atomized</termref>, producing a value <var>V1</var>.</p>
                  </item>
+                  
+                  <item>
+                  <p>If <var>V1</var> is a sequence of more than one atomic item, 
+                     a <termref def="dt-type-error"/> is raised <errorref code="0004" class="TY"/>.</p>
+               </item>
+               
+               <item>
+                  <p>If <var>V1</var> is the empty sequence, then:</p>
+                  <ulist>
+                     <item><p>If <code>?</code> is specified after the <nt def="CastTarget">CastTarget</nt>,
+                     the result of the cast is the empty sequence.</p></item>
+                     <item><p>Otherwise, a <termref def="dt-type-error"/> is raised <errorref code="0004" class="TY"/>.</p></item>
+                  </ulist>
+               </item>
   
                  <item>
-                    <p>Each atomic item in <var>V1</var> is cast to the target union type as described 
-                       in <xspecref spec="FO40" ref="casting-to-union"/>, producing a sequence of atomic items <var>V2</var>.</p>
+                    <p>The atomic item <var>V1</var> is cast to the target union type as described 
+                       in <xspecref spec="FO40" ref="casting-to-union"/>, producing an atomic item <var>V2</var>.</p>
                                        
                     <p>The process may result in a dynamic error, if the particular input value cannot be
                        converted to any of the member types of the union type.</p>
                     
                  </item>
                  
-                 <item>
-                    <p>If the number of items in <var>V2</var> does not match the requirements of the
-                       (explicit or implicit) occurrence indicator, then a type error <errorref class="TY" code="0004"/>
-                       is raised.</p>
-                    <p>For example, a type error is raised if the input is an empty sequence and the target type
-                       does not include the occurrence indicator <code>?</code> or <code>*</code>.</p>
-                 </item>
+                
                   
                  <item><p>The result of the cast expression is <var>V2</var>.</p></item>
                </olist>
@@ -24476,20 +24492,89 @@ input expression is called the <term>input type</term>. The item type of the <te
                
                <p>The target type of a cast expression may be a schema-defined list type.</p>
                
-               <p>The rules for casting a single item to a list type are given in <xspecref spec="FO40" ref="casting-to-list"/>.
-               The result is, in general, a sequence of atomic items, each being an instance of the list type's item type.
-               The result of the cast expression is the <termref def="dt-sequence-concatenation"/> of the results of casting
-               the individual items in the input sequence.</p>
                
-               <p>For backwards compatibility, when the target type is a list type, the cardinality of the result is not
-               constrained by the occurrence indicator in the cast expression.</p>
+               <p>The rules for casting a single item to a list type are given in
+                  <xspecref spec="FO40" ref="casting-to-list"/>, and are repeated here for convenience:</p>
                
-               <note>
-                  <p>In earlier versions of the specification, the occurrence indicator <code>?</code> constrained the
-                  number of items in the input of the cast expression, not the number of items in the output.</p>
-               </note>
+               <p>In the general case:</p>
+               <olist>
+               <item>
+                    <p>The input expression is evaluated to provide a value <var>V0</var>.</p>
+                 </item>
+                
+                 <item>
+                    <p><var>V0</var> is <termref def="dt-atomization"
+                       >atomized</termref>, producing a value <var>V1</var>.</p>
+                 </item>
+                  
+                  <item>
+                  <p>If <var>V1</var> is a sequence of more than one atomic item, 
+                     a <termref def="dt-type-error"/> is raised <errorref code="0004" class="TY"/>.</p>
+               </item>
+               
+               <item>
+                  <p>If <var>V1</var> is the empty sequence, then:</p>
+                  <ulist>
+                     <item><p>If <code>?</code> is specified after the <nt def="CastTarget">CastTarget</nt>,
+                     the result of the cast is the empty sequence.</p></item>
+                     <item><p>Otherwise, a <termref def="dt-type-error"/> is raised <errorref code="0004" class="TY"/>.</p></item>
+                  </ulist>
+               </item>
+  
+                 <item>
+                    <p>The atomic item <var>V1</var> is cast to the target list type as described 
+                       in <xspecref spec="FO40" ref="casting-to-list"/>, producing an sequence of 
+                       atomic items <var>V2</var>. This process involves splitting the input on
+                       whitespace boundaries. The type of these items will correspond to the
+                       <code>itemType</code> of the list type.</p>
+                                       
+                    <p>The process may result in a dynamic error, if any tokens in 
+                       the particular input value cannot be
+                       converted to the <code>itemType</code> of the list type.</p>
+                    
+                 </item>
+                 
+                
+                  
+                 <item><p>The result of the cast expression is the sequence <var>V2</var>.</p></item>
+               </olist>
                
                
+               
+               
+            </div4>
+            
+            <div4 id="casting-to-sequence-type">
+               <head>Casting to a Sequence Type</head>
+               <p>There is no specific expression that casts an input value to a sequence type. However,
+               casting to array types, map types, and record types all involve casting of sequences, so the
+               operation is described here for convenience.</p>
+               
+               <p>Given a sequence <var>S0</var> and a sequence type <var>ST</var>, casting of <var>S0</var>
+               to <code>ST</code> proceeds as follows, delivering a result sequence <var>S1</var>:</p>
+               
+               <olist>
+                  <item><p>If <var>ST</var> is the sequence type <code>empty-sequence()</code> then:</p>
+                        <olist>
+                           <item><p>If <var>S0</var> is the empty sequence, then <var>S1</var> is the empty sequence.</p></item>
+                           <item><p>Otherwise, a type error <errorref class="TY" code="0004"/> is raised.</p></item>
+                        </olist>
+                  </item>
+                  <item><p>In other cases let <var>T</var> be the item type of <var>ST</var>.
+                  <var>S1</var> is then obtained as the <termref def="dt-sequence-concatenation"/>
+                        of the results of applying the following process to each item <var>J</var>
+                  in <var>S0</var>:</p>
+                    <olist>
+                     <item><p>If <var>J</var> matches <var>T</var>, then deliver <var>J</var> unchanged.</p></item>
+                     <item><p>Otherwise, if <var>T</var> is a valid <nt def="CastTarget">CastTarget</nt>, 
+                           replace <var>J</var> by the value of <code><var>J</var> cast as <var>T</var></code>.</p></item>
+                     <item><p>Otherwise a type error <errorref class="TY" code="0004"/> is raised.</p></item>
+                    </olist>
+                  </item>
+                  <item><p>If the number of items in <var>S1</var> does not conform to the occurrence
+                  indicator of the sequence type <var>ST</var>, then a type error <errorref class="TY" code="0004"/> 
+                        is raised.</p></item>
+               </olist>
             </div4>
             
             <div4 id="casting-to-array">
@@ -24498,29 +24583,32 @@ input expression is called the <term>input type</term>. The item type of the <te
                <p>The target type of a cast expression may be an <nt def="ArrayType">ArrayType</nt>, for example
                   <code>array(xs:integer)</code><phrase diff="add" at="issue2818"> or <code>array(*)</code></phrase>.</p>
 
-               <p>The input to the cast expression is first <termref def="dt-coercion-rules">coerced</termref> to the required type <code>array(*)*</code>;
-                  if this fails then a type error <errorref class="TY" code="0004"/> is raised.</p>
+               <p>The input to the cast expression is first <termref def="dt-coercion-rules">coerced</termref> to the 
+                  required type <code>array(*)</code> or <code>array(*)?</code> (depending on the presence of 
+                  the <code>?</code> symbol after the <nt def="CastTarget">CastTarget</nt>).
+                  Call the result <var>A0</var>.
+                  If coercion fails then a type error <errorref class="TY" code="0004"/> is raised.
+                  If <var>A0</var> is the empty sequence then the cast expression returns the empty sequence.
+               </p>
 
                <p diff="add" at="issue2818">If the target type is an <nt def="AnyArrayType">AnyArrayType</nt> (<code>array(*)</code>), the
-                  result of the cast expression is the coerced input, unchanged.</p>
+                  result of the cast expression is <var>A0</var>.</p>
 
-               <p diff="chg" at="issue2818">Otherwise, let <var>T</var> be the member type of the array type (<code>xs:integer</code>
-                  in this example). The effect of the cast expression is to process each input array <var>A0</var> by constructing a new array <var>A1</var>,
+               <p diff="chg" at="issue2818">Otherwise, let <var>ST</var> be the member type of the array type (<code>xs:integer</code>
+                  in this example). The effect of the cast expression is to construct a new array <var>A1</var>
                   whose members correspond one-to-one with the members
-               of <var>A0</var>, each member <var>M0</var> of <var>A0</var> being processed to produce a member <var>M1</var> of <var>A1</var> as follows:</p>
+               of <var>A0</var>, each member <var>M0</var> of <var>A0</var> being processed to produce a member
+                  <var>M1</var> of <var>A1</var> by applying the rules of <specref ref="casting-to-sequence-type"/>
+                  with <var>ST</var> as the required type.</p>
                
-               <ulist>
-                  <item><p>If <var>M0</var> matches <var>T</var>, then <var>M1</var> is <var>M0</var>.</p></item>
-                  <item><p>Otherwise, if <var>T</var> is a valid <nt def="CastTarget">CastTarget</nt>, then <var>M1</var> is <code><var>M0</var> cast as <var>T</var></code>.</p></item>
-                  <item><p>Otherwise a type error <errorref class="TY" code="0004"/> is raised.</p></item>
-               </ulist>
+               
              
                
-               <p>For example, <code>[[1], [2], [3]] cast as array(xs:integer)</code> returns <code>[1, 2, 3]</code>, because casting
+               <p>For example, <code>[[1], [2], [3]] cast as array(xs:integer)</code> returns <code>[1, 2, 3]</code>, 
+                  because casting
                   the array <code>[1]</code> to <code>xs:integer</code> produces the integer <code>1</code>.</p>
                
-               <p>The number of arrays in the result (and therefore in the input) must conform with the explicit or implicit occurrence indicator, otherwise
-                  a type error <errorref class="TY" code="0004"/> is raised.</p>
+               
                
                <note><p>If the member type of the array is not a valid <code>CastTarget</code>, for example if the array type
                   is <code>array(function(*))</code> or <code>array(element(*))</code>, then the existing array members must already
@@ -24535,36 +24623,45 @@ input expression is called the <term>input type</term>. The item type of the <te
                <head>Casting to a Map Type</head>
                
                <p>The target type of a cast expression may be a <nt def="MapType">MapType</nt>, for example
-                  <code>map(xs:integer, item()*)</code><phrase diff="add" at="issue2818"> or <code>map(*)</code></phrase>.</p>
+                  <code>map(xs:integer, item()*)</code> 
+                     or <code>map(*)</code>.</p>
                   
-                  <!--Both the key type and the value type (here <code>xs:integer</code> and
-                  <code>item()*</code> respectively) must
-                  be eligible in their own right as the target of a cast expression, otherwise a static error <errorref class="ST" code="0080"/>
-                  is raised.</p>-->
                
                
-               <p>The input to the cast expression is first <termref def="dt-coercion-rules">coerced</termref> to the required type <code>map(*)*</code>;
+               <p>The input to the cast expression is first <termref def="dt-coercion-rules">coerced</termref> 
+                  to the required type <code>map(*)</code> or <code>map(*)?</code> (depending on the presence of 
+                  the <code>?</code> symbol after the <nt def="CastTarget">CastTarget</nt>).
+                  Call the result <var>M0</var>.
+                  If coercion fails then a type error <errorref class="TY" code="0004"/> is raised.
+                  If <var>M0</var> is the empty sequence then the cast expression returns the empty sequence.
                   if this fails then a type error <errorref class="TY" code="0004"/> is raised.</p>
 
                <p diff="add" at="issue2818">If the target type is an <nt def="AnyMapType">AnyMapType</nt> (<code>map(*)</code>), the
-                  result of the cast expression is the coerced input, unchanged.</p>
+                  result of the cast expression is <var>M0</var>.</p>
 
                <p diff="chg" at="issue2818">Otherwise, let <var>T/K</var> and <var>T/V</var> be respectively the key type
                   and the value type of the <nt def="TypedMapType">TypedMapType</nt>, that is, in this example, <code>xs:integer</code>
                   and <code>item()*</code> respectively.</p>
 
-               <p>The effect of the cast expression is to process each input map <var>M0</var> by constructing a new map <var>M1</var>, whose entries correspond one-to-one with the entries
+               <p>The effect of the cast expression is to process the input map <var>M0</var> 
+                  by constructing a new map <var>M1</var>, whose entries correspond one-to-one with the entries
                   of <var>M0</var>, each entry in the result map being obtained as follows. Let (<var>K0</var>, <var>V0</var>) be an entry
-                  in <var>M0</var>, and let (<var>K1</var>, <var>V1</var>) be the corresponding entry in <var>M1</var>. Then:</p>
+                  in <var>A0</var>, and let (<var>K1</var>, <var>V1</var>) be the corresponding entry in <var>A1</var>. Then:</p>
                
-               <ulist>
-                  <item><p>If <var>K0</var> matches <var>T/K</var>, then <var>K1</var> is <var>K0</var>.</p></item>
-                  <item><p>Otherwise, if <var>T/K</var> is a valid <nt def="CastTarget">CastTarget</nt>, then <var>K1</var> is <code><var>K0</var> cast as <var>T/K</var></code>.</p></item>
-                  <item><p>Otherwise a type error <errorref class="TY" code="0004"/> is raised.</p></item>
-                  <item><p>If <var>V0</var> matches <var>T/V</var>, then <var>V1</var> is <var>V0</var>.</p></item>
-                  <item><p>Otherwise, if <var>T/V</var> is a valid <nt def="CastTarget">CastTarget</nt>, then <var>V1</var> is <code><var>V0</var> cast as <var>T/V</var></code>.</p></item>
-                  <item><p>Otherwise a type error <errorref class="TY" code="0004"/> is raised.</p></item>
-               </ulist>
+               <olist>
+                  <item><p>The key <var>K0</var> is processed as follows:</p>
+                     <olist>
+                        <item><p>If <var>K0</var> matches <var>T/K</var>, then <var>K1</var> is <var>K0</var>.</p></item>
+                        <item><p>Otherwise, if <var>T/K</var> is a valid <nt def="CastTarget">CastTarget</nt>, 
+                              then <var>K1</var> is <code><var>K0</var> cast as <var>T/K</var></code>.</p></item>
+                        <item><p>Otherwise a type error <errorref class="TY" code="0004"/> is raised.</p></item>
+                     </olist>
+                  </item>
+                  <item><p>The corresponding value <var>V0</var> is processed to produce <var>V1</var>
+                        by applying the rules of <specref ref="casting-to-sequence-type"/>
+                        with <var>T/V</var> as the required type <var>ST</var>.</p>
+                  </item>
+               </olist>
                
                
               
@@ -24575,8 +24672,6 @@ input expression is called the <term>input type</term>. The item type of the <te
                <p>If the effect of casting is to generate duplicate keys, then a dynamic
                   error is raised <errorref class="DY" code="0137"/>.</p>
                
-               <p>The number of maps in the result (and therefore in the input) must conform with the explicit or implicit occurrence indicator, otherwise
-                  a type error <errorref class="TY" code="0004"/> is raised.</p>
                
                
                
@@ -24586,42 +24681,51 @@ input expression is called the <term>input type</term>. The item type of the <te
                <head>Casting to a Record Type</head>
                
                <p>The target type of a cast expression may be a <nt def="RecordType">RecordType</nt>, for example
-                  <code>record(x as xs:integer, y as item()*)</code><phrase diff="add" at="issue2818"> or <code>record(*)</code></phrase>. <!--The value types for each field  (here <code>xs:integer</code> and
-                  <code>item()*</code> respectively) must
-                  be eligible in their own right as the target of a cast expression, otherwise a static error <errorref class="ST" code="0080"/>
-                  is raised.--></p>
+                  <code>record(x as xs:integer, y as item()*)</code> or <code>record(*)</code>.</p>
 
                <p diff="add" at="issue2818">If the target type is an <nt def="AnyRecordType">AnyRecordType</nt> (<code>record(*)</code>), the input
-                  is <termref def="dt-coercion-rules">coerced</termref> to the required type <code>record(*)*</code>;
-                  if this fails then a type error <errorref class="TY" code="0004"/> is raised. The result of the cast expression
-                  is the coerced input, unchanged.</p>
+                  is <termref def="dt-coercion-rules">coerced</termref> to the required type <code>record(*)</code>
+                  or <code>record(*)?</code> (depending on the presence of 
+                  the <code>?</code> symbol after the <nt def="CastTarget">CastTarget</nt>).
+                  Call the result <var>R0</var>.
+                  If coercion fails then a type error <errorref class="TY" code="0004"/> is raised.
+                  If <var>R0</var> is the empty sequence then the cast expression returns the empty sequence.</p>
 
                <note diff="add" at="issue2818"><p>Because <code>record(*)</code> is an abstract type, there is no record type that the
-                  cast could construct; the effect of the cast is therefore to assert that every item in the input is
-                  a <termref def="dt-record"/>.</p></note>
+                  cast could construct; the effect of the cast is therefore to assert that the input is
+                  an optional <termref def="dt-record"/>.</p></note>
 
-               <p diff="chg" at="issue2818">In all other cases, the input to the cast expression is <termref def="dt-coercion-rules">coerced</termref> to the required type <code>map(*)*</code>;
-                  if this fails then a type error <errorref class="TY" code="0004"/> is raised.
-                  Records are maps, so the input can also include records.</p>
+               <p diff="chg" at="issue2818">In all other cases, the input to the cast expression 
+                  is <termref def="dt-coercion-rules">coerced</termref> to the required type <code>map(*)</code>
+                  or <code>map(*)?</code> (depending on the presence of 
+                  the <code>?</code> symbol after the <nt def="CastTarget">CastTarget</nt>).
+                  Call the result <var>M0</var>.
+                  If coercion fails then a type error <errorref class="TY" code="0004"/> is raised.
+                  If <var>M0</var> is the empty sequence then the cast expression returns the empty sequence.</p>
+                  
+                  <p>Records are maps, so <var>M0</var> may be a record.</p>
 
-               <p>The effect of the cast expression is to process each input map <var>M0</var> by constructing a new record <var>R1</var>of the target record type.
-                  For each field in the definition of the target record type, if <var>K0</var> is the name of the field (as a string)
-                  and <var>T</var> is the required type of the field, then the value of field <var>K0</var> in record <var>R1</var>
-               will be as follows:</p>
+               <p>The effect of the cast expression is to construct a new record <var>R1</var> of the target record type
+                  by processing the input map <var>M0</var>.
+                  For each field in the definition of the target record type, 
+                  if <var>K0</var> is the name of the field (as a string)
+                  and <var>ST</var> is the required type of the field, then the value 
+                  of field <var>K0</var> in record <var>R1</var> will be as follows:</p>
                
                <ulist>
                   <item>
                      <p>If <code>map:contains(<var>M0</var>, <var>K0</var>)</code> is true, let <var>V0</var> be 
                         <code>map:get(<var>M0</var>, <var>K0</var>)</code>:</p>
                      <ulist>
-                        <item><p>If <var>V0</var> matches <var>T</var>, then <var>V0</var>;</p></item>
-                        <item><p>Otherwise, if <var>T</var> is a valid <code>CastTarget</code>, then <code><var>V0</var> cast as <var>T</var></code>;</p></item>
-                        <item><p>Otherwise a type error <errorref class="TY" code="0004"/> is raised.</p></item>
+                        <item><p>If <var>V0</var> matches <var>ST</var>, then <var>V0</var>;</p></item>
+                        <item><p>Otherwise, the result of casting <var>V0</var> to the required type
+                              <var>ST</var> by applying the rules of <specref ref="casting-to-sequence-type"/>.</p></item>
                      </ulist>
                   </item>
                   <item><p>Otherwise:</p>
                      <ulist>
-                        <item><p>If the empty sequence matches <var>T</var>, then the empty sequence;</p></item>
+                        <item><p>If the empty sequence matches <var>ST</var>, then the empty sequence;</p>
+                        <ednote><edtext>TODO: we propose to introduce default values for fields in record types.</edtext></ednote></item>
                         <item><p>Otherwise a type error <errorref class="TY" code="0004"/> is raised.</p></item>
                      </ulist>
                   </item>
@@ -24635,9 +24739,6 @@ input expression is called the <term>input type</term>. The item type of the <te
                
               
                
-               <p>The number of records in the result (and therefore, the number of maps in the input) must conform with the explicit 
-                  or implicit occurrence indicator, otherwise
-                  a type error <errorref class="TY" code="0004"/> is raised.</p>
                
                
                
@@ -24662,9 +24763,8 @@ input expression is called the <term>input type</term>. The item type of the <te
                <prodrecap ref="CastableExpr"/>
             </scrap>
             
-            <p><?inject language?>
-provides an expression that tests whether a given value
-is castable into a given target type. 
+            <p>The <code>castable</code> expression tests whether a given value can be successfully
+               cast to a given target type. 
 
 The <phrase diff="chg" at="A">target type</phrase> is subject to the same
                rules as the target type of a <code>cast</code> expression.</p>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -24640,7 +24640,7 @@ input expression is called the <term>input type</term>. </p>
                <p>The effect of the cast expression is to process the input map <var>M0</var> 
                   by constructing a new map <var>M1</var>, whose entries correspond one-to-one with the entries
                   of <var>M0</var>, each entry in the result map being obtained as follows. Let (<var>K0</var>, <var>V0</var>) be an entry
-                  in <var>A0</var>, and let (<var>K1</var>, <var>V1</var>) be the corresponding entry in <var>A1</var>. Then:</p>
+                  in <var>M0</var>, and let (<var>K1</var>, <var>V1</var>) be the corresponding entry in <var>M1</var>. Then:</p>
                
                <olist>
                   <item><p>The key <var>K0</var> is processed as follows:</p>


### PR DESCRIPTION
Fix #2820 

Issue 2820 reported a syntax ambiguity resulting from the addition of occurrence indicators to cast expressions. This PR solves the issue by dropping the occurrence indicators; casting of a sequence to a sequence type is now an internal operation performed when casting an array, map, or record, but is not exposed in user-visible syntax.