### PR TITLE
2813 [XSLT] Reorganise sections 25 and 26

### DIFF
--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -30154,450 +30154,9 @@ the same group, and the-->
             </div3>
          </div2>
       </div1>
-      <div1 id="result-trees">
-         <head>Transformation Results</head>
-         <p>The output of a transformation includes a <termref def="dt-principal-result"/> and zero or more <termref def="dt-secondary-result">secondary results</termref>.</p>
-         
-         
-         <p>The way in which these results are
-             delivered to an application is <termref def="dt-implementation-defined">implementation-defined</termref>.</p>
-         <imp-def-feature id="idf-api-results">The way in which the results of the transformation
-            are delivered to an application is implementation-defined.</imp-def-feature>
-         <p>Serialization of results
-             is described further in <specref ref="serialization"/>
-         </p>
-         <div2 id="creating-result-trees">
-            <head>Creating Secondary Results</head>
-            
-            <changes>
-               <change issue="530" PR="534" date="2023-06-09">
-                  A new serialization parameter <code>escape-solidus</code> is provided to control
-                  whether the character <code>/</code> is escaped as <code>\/</code> by the
-                  JSON serialization method.
-               </change>
-               <change issue="1534" PR="1549" date="2024-11-12">
-                  The input to the serializer can be defined using the <code>select</code> attribute
-                  of <elcode>xsl:result-document</elcode> as an alternative to using a sequence constructor.
-               </change>
-               <change issue="938" PR="2259" date="2025-11-02">
-                  A new serialization parameter <code>canonical</code> is available to give control
-                  over serialization of XML, XHTML, and JSON.
-               </change>
-               <change issue="1538" PR="1497 1546" date="2024-11-13">
-                  A new serialization parameter <code>json-lines</code> is available to enable
-                  output as one JSON value per line.
-               </change>
-               <change issue="1234" PR="2719" date="2026-07-28">
-                  Added the serialization parameters <code>indent-unit</code>, <code>indent-attributes</code>, and <code>line-ending</code>.
-               </change>
-            </changes>
-            
-            <?element xsl:result-document?>
-            <p>The <elcode>xsl:result-document</elcode> instruction is
-               used to create a <termref def="dt-secondary-result"/>.</p>
-               
-            <p>The <code>select</code> attribute and the contained <termref def="dt-sequence-constructor"/> are
-               mutually exclusive; if the <code>select</code> attribute is present then the
-               sequence constructor must be empty, and if the sequence constructor is non-empty
-               then the <code>select</code> attribute must be absent <errorref spec="XT" class="SE" code="3185"/>. 
-               The value of the <code>select</code> attribute or the <termref def="dt-immediate-result"/>
-               of the contained <termref def="dt-sequence-constructor"/>
-               is referred to as the <termref def="dt-raw-result"/>.</p>
-               
-               
-            
-            <p>As with the <termref def="dt-principal-result"/> of the
-            transformation, a <termref def="dt-secondary-result"/> may be delivered to the calling
-            application in three ways (see <specref ref="post-processing"/>):</p>
-            
-            <olist>
-               <item><p>The <termref def="dt-raw-result"/> may be delivered <emph>as is</emph>.</p></item>
-               <item><p>The <termref def="dt-raw-result"/> may be used to construct a <termref def="dt-final-result-tree"/>
-               by invoking the process of <xtermref spec="SE40" ref="sequence-normalization"/>.</p></item>
-               <item><p>The <termref def="dt-raw-result"/> may be serialized to a sequence of octets (which
-               may then, optionally, be saved to a persistent storage location).</p></item>
-            </olist>
-            
-            <note><p>The name of the instruction, <elcode>xsl:result-document</elcode>, is a little
-            misleading. The instruction does not necessarily deliver either an XML document tree
-            nor a serialized XML document. Instead, for example, it might deliver an array, a map,
-            serialized JSON, or a sequence of atomic items.</p></note>
-            
-            <p>The decision whether or not to serialize the raw result depends on the 
-               <termref def="dt-processor">processor</termref> and on the way it is invoked. This
-               is <termref def="dt-implementation-defined"/>, and it is not controlled by anything
-               in the stylesheet.</p>
-            
-            <p>If the result is not serialized, then the decision whether to
-               return the <termref def="dt-raw-result"/> or to construct a tree depends on the effective
-               value of the <code>build-tree</code> attribute. If the <termref def="dt-effective-value"/> of
-               the <code>build-tree</code> attribute is <code>yes</code>, then 
-                  a <termref def="dt-final-result-tree"/> is created
-               by invoking the process of <xtermref spec="SE40" ref="sequence-normalization"/>. 
-               Conversely, if the result <emph>is</emph> serialized, then 
-                  the decision whether or not to construct a tree depends on the choice of 
-                  serialization method, and the <code>build-tree</code> attribute is then ignored. 
-                  For example, with <code>method="xml"</code> a tree is always constructed, whereas 
-                  with <code>method="json"</code> a tree is never constructed.<!-- [XSLT 3.0 Erratum E14, bug 30208].-->
-               </p>
-
-            
-            <p>The <elcode>xsl:result-document</elcode> instruction
-               defines a URI that may be used to identify the <termref def="dt-secondary-result"/>.
-               The instruction may optionally specify the output format to be used for serializing the result.</p>
-            
-            <p>Technically, the result of evaluating the <elcode>xsl:result-document</elcode>
-               instruction is the empty sequence. This means it does not contribute anything to the
-               result of the sequence constructor it is part of.</p>
-            <p>The <termref def="dt-effective-value"/> of the
-                  <code>format</code> attribute, if specified, <rfc2119>must</rfc2119> be an <termref def="dt-eqname">EQName</termref>. The value is
-               expanded using the namespace declarations in scope for the
-                  <elcode>xsl:result-document</elcode> element. The resulting <termref def="dt-expanded-qname">expanded QName</termref>
-               <rfc2119>must</rfc2119> match the expanded QName of a named <termref def="dt-output-definition">output definition</termref> in the <termref def="dt-stylesheet">stylesheet</termref>. This identifies the
-                  <elcode>xsl:output</elcode> declaration that will control the serialization of the
-                  <termref def="dt-final-result-tree">final result tree</termref> (see <specref ref="serialization"/>), if the result tree is serialized. If the
-                  <code>format</code> attribute is omitted, the unnamed <termref def="dt-output-definition">output definition</termref> is used to control
-               serialization of the result tree.</p>
-            <p>
-               <error spec="XT" type="dynamic" class="DE" code="1460">
-                  <p>It is a <termref def="dt-dynamic-error"> dynamic error</termref> if the <termref def="dt-effective-value"/> of the
-                        <code>format</code> attribute <error.extra>of an
-                           <elcode>xsl:result-document</elcode> element</error.extra> is not a valid
-                        <termref def="dt-eqname">EQName</termref>, or if it does not match the
-                        <termref def="dt-expanded-qname">expanded QName</termref> of an <termref def="dt-output-definition">output definition</termref> in the containing <termref def="dt-package">package</termref>. If the processor is able to detect
-                     the error statically (for example, when the <code>format</code> attribute
-                     contains no curly brackets), then the processor <rfc2119>may</rfc2119>
-                     optionally raise this as a <termref def="dt-static-error">static
-                        error</termref>.</p>
-               </error>
-            </p>
-            <note>
-               <p>The only way to select the unnamed <termref def="dt-output-definition">output
-                     definition</termref> is to omit the <code>format</code> attribute.</p>
-            </note>
-            <p>The <code>parameter-document</code> attribute allows serialization
-               parameters to be supplied in an external document. The external document must contain
-               an <code>output:serialization-parameters</code> element with the format described in
-                  <xspecref spec="SE40" ref="serparams-in-xdm-instance"/>, and the parameters are
-               interpreted as described in that specification.</p>
-            <p>If present, the <termref def="dt-effective-value"/> of the URI supplied in the
-                  <code>parameter-document</code> attribute is dereferenced, after resolution
-               against the base URI of the <elcode>xsl:result-document</elcode> element if it is a
-               relative reference. 
-               The parameter document <rfc2119>should</rfc2119> be read during run-time evaluation of the stylesheet. 
-               If the location of the stylesheet at development time is
-               different from the deployed location, any relative reference should be resolved
-               against the deployed location. A serialization error occurs if the result of
-               dereferencing the URI is ill-formed or invalid; but if no document can be found at
-               the specified location, the attribute <code>should</code> be ignored.</p>
-            <p>A serialization parameter specified in the
-                  <code>parameter-document</code> takes precedence over a value supplied directly as
-               an attribute of <elcode>xsl:result-document</elcode>, which in turn takes precedence
-               over a value supplied in the selected output definition, except that the values of
-               the <code>cdata-section-elements</code> and <code>suppress-indentation</code>
-               attributes are merged in the same way as when multiple <elcode>xsl:output</elcode>
-               declarations are merged.</p>
-            <p>The attributes <code>method</code>, <code>allow-duplicate-names</code>, <code>build-tree</code>, <code>byte-order-mark</code>,
-               <code>canonical</code>, <code>cdata-section-elements</code>,
-               <code diff="add" at="2026-07-02">csv-header</code>, <code diff="add" at="2026-07-02">csv-quote-character</code>,
-               <code diff="add" at="2026-07-02">csv-separator</code>, <code>doctype-public</code>,
-                  <code>doctype-system</code>, <code>encoding</code>,
-               <code diff="add" at="2023-03-31">escape-solidus</code>,
-                  <code>escape-uri-attributes</code>, <code>html-version</code>, <code>indent</code>, <code diff="add" at="2026-06-25">indent-attributes</code>, <code diff="add" at="2026-06-25">indent-unit</code>, <code>item-separator</code>,
-               <code diff="add" at="2024-11-01">json-lines</code>,
-               <code>json-node-output-method</code>,
-                  <code diff="add" at="2026-06-25">line-ending</code>, <code>media-type</code>, <code>normalization-form</code>,
-                  <code>omit-xml-declaration</code>, <code>standalone</code>, <code>suppress-indentation</code>,
-               <!-- see bug 6535 -->
-               <code>undeclare-prefixes</code>, <code>use-character-maps</code>, and
-                  <code>output-version</code> may be used to override attributes defined in the
-               selected <termref def="dt-output-definition">output definition</termref>.</p>
-            <p>With the exception of <code>use-character-maps</code>, these attributes are all
-               defined as <termref def="dt-attribute-value-template">attribute value
-                  templates</termref>, so their values may be set dynamically. For any of these
-               attributes that is present on the <elcode>xsl:result-document</elcode> instruction,
-               the <termref def="dt-effective-value"/> of the attribute
-               overrides or supplements the corresponding value from the output definition. This
-               works in the same way as when one <elcode>xsl:output</elcode> declaration overrides
-               another. Some of the attributes have more specific
-                  rules:</p>
-            <ulist>
-               <item>
-                  <p>In the case of <code>cdata-section-elements</code>
-                     and <code>suppress-indentation</code>, the
-                     value of the serialization parameter is the union of the expanded names of the
-                     elements named in this instruction and the elements named in the selected
-                     output definition.</p>
-               </item>
-               <item>
-                  <p>In the case of <code>use-character-maps</code>, the character maps referenced
-                     in this instruction supplement and take precedence over those defined in the
-                     selected output definition.</p>
-               </item>
-               <item>
-                  <p>In the case of <code>doctype-public</code> and <code>doctype-system</code>,
-                     setting the <termref def="dt-effective-value"/> of the attribute to a zero-length string has the
-                     effect of overriding any value for these attributes obtained from the output
-                     definition. The corresponding serialization parameter is not set (is
-                     “absent”).</p>
-               </item>
-               <item>
-                  <p>In the case of <code>item-separator</code>, setting the <termref def="dt-effective-value"/> of the
-                     attribute to the special value <code>"#absent"</code> has the effect of
-                     overriding any value for this attribute obtained from the output definition.
-                     The corresponding serialization parameter is not set (is “absent”). It is not
-                     possible to set the value of the serialization parameter to the literal
-                     7-character string <code>"#absent"</code>. </p>
-               </item>
-               <item>
-                  <p>In all other cases, the <termref def="dt-effective-value"/> of an attribute actually present on
-                     this instruction takes precedence over the value defined in the selected output
-                     definition.</p>
-               </item>
-            </ulist>
-            
-               <p>In the case of the attributes <code>method</code>, <code>json-node-output-method</code>,
-                     <code>cdata-section-elements</code>, <code>suppress-indentation</code>, and
-                     <code>use-character-maps</code>, the <termref def="dt-effective-value"/> of the attribute
-                  contains an <termref def="dt-eqname">EQName</termref> or a space-separated list of
-                     <termref def="dt-eqname">EQNames</termref>. Where lexical QNames are used in these attributes (whether prefixed
-               or unprefixed), the namespace context is established in the same way as for the corresponding
-               attributes of <elcode>xsl:output</elcode>: see <specref ref="id-default-serialization-parameters"/>.</p>
-            
-            <p>The <code>output-version</code> attribute on the <elcode>xsl:result-document</elcode>
-               instruction overrides the <code>version</code> attribute on
-                  <elcode>xsl:output</elcode> (it has been renamed because <code>version</code> is
-               available with a different meaning as a standard attribute: see <specref ref="standard-attributes"/>). In all other cases, attributes correspond if they
-               have the same name.</p>
-            <p>There are some serialization parameters that apply to some output methods but not to
-               others. For example, the <code>indent</code> attribute has no effect on the
-                  <code>text</code> output method. If a value is supplied for an attribute that is
-               inapplicable to the output method, its value is not passed to the serializer. The
-               processor <rfc2119>may</rfc2119> validate the value of such an attribute, but is not
-                  <rfc2119>required</rfc2119> to do so.</p>
-            
-            <p>The <code>item-separator</code> serialization parameter
-               is used when the <termref def="dt-raw-result"/> is used to construct a result tree
-               by applying sequence normalization, and it is also used when the result tree is
-               serialized. For example, if the sequence constructor delivers a sequence of
-               integers, and the <code>text</code> serialization method is used, then the result of serialization
-               will be a string obtained by converting each integer to a string, and separating the
-               strings using the defined <code>item-separator</code>.</p>
-            
-            
-            <p>The <code>href</code> attribute is optional. The default value is the zero-length
-               string. The <termref def="dt-effective-value"/> of the
-               attribute <rfc2119>must</rfc2119> be a <termref def="dt-uri-reference">URI
-                  Reference</termref>, which may be absolute or relative. If it is relative, then it is resolved against the <termref def="dt-base-output-uri"/>. There <rfc2119>may</rfc2119> be <termref def="dt-implementation-defined">implementation-defined</termref> restrictions on
-               the form of absolute URI that may be used, but the implementation is not
-                  <rfc2119>required</rfc2119> to enforce any restrictions. Any valid relative URI
-                  reference
-               <rfc2119>must</rfc2119> be accepted. Note that the zero-length string is a valid
-               relative URI reference.</p>
-            <imp-def-feature id="idf-api-resultdocumenthref"> It is <termref def="dt-implementation-defined"/> how the URI appearing in the <code>href</code>
-               attribute of <elcode>xsl:result-document</elcode> affects the way in which the result
-               tree is delivered to the application. There <rfc2119>may</rfc2119> be restrictions on
-               the form of this URI. </imp-def-feature>
-            <p>If the implementation provides an API to access <termref def="dt-secondary-result">secondary results</termref>, then it
-                  <rfc2119>must</rfc2119> allow a secondary result to be identified by means of the
-               absolutized value of the <code>href</code> attribute. In addition, if a <termref def="dt-final-result-tree"/> is constructed
-               (that is, if the <termref def="dt-effective-value"/> of
-                  <code>build-tree</code> is <code>yes</code>), then this value is used as the base
-               URI of the document node at the root of the <termref def="dt-final-result-tree">final
-                  result tree</termref>. </p>
-
-
-
-            <note>
-               <p>The base URI of the <termref def="dt-final-result-tree">final result
-                     tree</termref> is not necessarily the same thing as the URI of its serialized
-                  representation on disk, if any. For example, a server (or browser client) might
-                  store final result trees only in memory, or in an internal disk cache. As long as
-                  the processor satisfies requests for those URIs, it is irrelevant where they are
-                  actually written on disk, if at all.</p>
-            </note>
-            <note>
-               <p>It will often be the case that one <termref def="dt-final-result-tree">final
-                     result tree</termref> contains links to another final result tree produced
-                  during the same transformation, in the form of a relative URI reference. The mechanism of associating a URI with a final
-                  result tree has been chosen to allow the integrity of such links to be preserved
-                  when the trees are serialized.</p>
-               <p>As well as being potentially significant in any API that provides access to final
-                  result trees, the base URI of the new document node is relevant if the final
-                  result tree, rather than being serialized, is supplied as input to a further
-                  transformation.</p>
-            </note>
-            <p>The optional attributes <code>type</code> and <code>validation</code> may be used on
-               the <elcode>xsl:result-document</elcode> instruction to validate the contents of
-                  a <termref def="dt-final-result-tree"/>, and to determine the <termref def="dt-type-annotation">type
-                  annotation</termref> that elements and attributes within the <termref def="dt-final-result-tree">final result tree</termref> will carry. The permitted
-               values and their semantics are described in <specref ref="validating-document-nodes"/>. Any such validation is applied to the
-               document node produced as the result of <xtermref spec="SE40" ref="sequence-normalization"/>.
-               If sequence normalization does not take place (typically because the <termref def="dt-raw-result"/>
-               is delivered to the application directly, or because the selected serialization method
-               does not involve sequence normalization) then the <code>validation</code> and
-               <code>type</code> attributes are ignored.</p>
-            
-            <note><p>Validation applies after inserting item separators as determined by the
-            <code>item-separator</code> serialization parameter, and an inappropriate choice
-            of <code>item-separator</code> may cause the result to become invalid.</p></note>
-            
-            <p>A <termref def="dt-processor">processor</termref>
-               <rfc2119>may</rfc2119> allow a <termref def="dt-final-result-tree">final result
-                  tree</termref> to be serialized. Serialization is described in <specref ref="serialization"/>. However, an implementation (for example, a <termref def="dt-processor">processor</termref> running in an environment with no access to
-               writable filestore) is not <rfc2119>required</rfc2119> to support the serialization
-               of <termref def="dt-final-result-tree">final result trees</termref>. An
-               implementation that does not support the serialization of final result trees
-                  <rfc2119>may</rfc2119> ignore the <code>format</code> attribute and the
-               serialization attributes. Such an implementation <rfc2119>must</rfc2119> provide the
-               application with some means of access to the (un-serialized) result tree, using its
-               URI to identify it.</p>
-            <p>Implementations may provide additional mechanisms, outside the scope of this
-               specification, for defining the way in which <termref def="dt-final-result-tree">final result trees</termref> are processed. Such mechanisms
-                  <rfc2119>may</rfc2119> make use of the XSLT-defined attributes on the
-                  <elcode>xsl:result-document</elcode> and/or <elcode>xsl:output</elcode> elements,
-               or they <rfc2119>may</rfc2119> use additional elements or attributes in an <termref def="dt-implementation-defined">implementation-defined</termref> namespace.</p>
-
-            <example>
-               <head>Multiple Result Documents</head>
-               <p> The following example takes an XHTML document as input, and breaks it up so that
-                  the text following each &lt;h1&gt; element is included in a separate document. A
-                  new document <code>toc.html</code> is constructed to act as an index:</p>
-               <eg role="xslt-document" xml:space="preserve">&lt;xsl:stylesheet
-	version="4.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-	xmlns:xhtml="http://www.w3.org/1999/xhtml"&gt;
-	
-&lt;xsl:output name="toc-format" method="xhtml" indent="yes"
-     doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"
-     doctype-public="-//W3C//DTD XHTML 1.0 Strict//EN"/&gt;
-            
-&lt;xsl:output name="section-format" method="xhtml" indent="no"
-     doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"
-     doctype-public="-//W3C//DTD XHTML 1.0 Transitional//EN"/&gt;	
-	 
-&lt;xsl:template match="/"&gt;
-  &lt;xsl:result-document href="toc.html" 
-                       format="toc-format" 
-                       validation="strict"&gt;
-    &lt;html xmlns="http://www.w3.org/1999/xhtml"&gt;
-      &lt;head&gt;&lt;title&gt;Table of Contents&lt;/title&gt;&lt;/head&gt;
-      &lt;body&gt;
-        &lt;h1&gt;Table of Contents&lt;/h1&gt;
-        &lt;xsl:for-each select="/*/xhtml:body/(*[1] | xhtml:h1)"&gt;
-          &lt;p&gt;
-            &lt;a href="section{position()}.html"&gt;
-              &lt;xsl:value-of select="."/&gt;
-            &lt;/a&gt;
-          &lt;/p&gt;
-        &lt;/xsl:for-each&gt;
-      &lt;/body&gt;
-    &lt;/html&gt;
-  &lt;/xsl:result-document&gt;
-  &lt;xsl:for-each-group select="/*/xhtml:body/*" group-starting-with="xhtml:h1"&gt;
-    &lt;xsl:result-document href="section{position()}.html" 
-                         format="section-format" validation="strip"&gt;  	
-      &lt;html xmlns="http://www.w3.org/1999/xhtml"&gt;
-        &lt;head&gt;&lt;title&gt;&lt;xsl:value-of select="."/&gt;&lt;/title&gt;&lt;/head&gt;
-        &lt;body&gt;
-          &lt;xsl:copy-of select="current-group()"/&gt;
-        &lt;/body&gt;
-      &lt;/html&gt;
-    &lt;/xsl:result-document&gt;
-  &lt;/xsl:for-each-group&gt;
-&lt;/xsl:template&gt;
-
-&lt;/xsl:stylesheet&gt;</eg>
-            </example>
-         </div2>
-         <div2 id="result-document-restrictions">
-            <head>Restrictions on the use of <elcode>xsl:result-document</elcode></head>
-            <p>There are restrictions on the use of the <elcode>xsl:result-document</elcode>
-               instruction, designed to ensure that the results are fully interoperable even when
-               processors optimize the sequence in which instructions are evaluated. Informally, the
-               restriction is that the <elcode>xsl:result-document</elcode> instruction can only be
-               used while writing a final result tree, not while writing to a temporary tree or a
-               sequence. This restriction is defined formally as follows.</p>
-            <p>
-               <termdef id="dt-output-state" term="output state">Each instruction in the <termref def="dt-stylesheet">stylesheet</termref> is evaluated in one of two possible
-                     <term>output states</term>: <termref def="dt-final-output-state">final output
-                     state</termref> or <termref def="dt-temporary-output-state">temporary output
-                     state</termref>.</termdef></p>
-            <p>
-               <termdef id="dt-final-output-state" term="final output state">The first of the two
-                     <termref def="dt-output-state">output states</termref> is called <term>final
-                     output</term> state. This state applies when instructions are writing to a
-                     <termref def="dt-final-result-tree">final result tree</termref>.</termdef>
-            </p>
-            <p>
-               <termdef id="dt-temporary-output-state" term="temporary output state">The second of
-                  the two <termref def="dt-output-state">output states</termref> is called
-                     <term>temporary output</term> state. This state applies when instructions are
-                  writing to a <termref def="dt-temporary-tree">temporary tree</termref> or any
-                  other non-final destination.</termdef>
-            </p>
-            <p>The instructions in the <termref def="dt-initial-named-template"/> are evaluated in
-                  <termref def="dt-final-output-state">final output state</termref>. An instruction
-               is evaluated in the same <termref def="dt-output-state">output state</termref> as its
-               calling instruction, except that <elcode>xsl:variable</elcode>,
-                  <elcode>xsl:param</elcode>, <elcode>xsl:with-param</elcode>, 
-               <elcode>xsl:function</elcode>, <elcode>xsl:key</elcode>, <elcode>xsl:sort</elcode>,
-                  <elcode>xsl:accumulator-rule</elcode>, and
-                     <elcode>xsl:merge-key</elcode>
-                always evaluate the instructions in their
-               contained <termref def="dt-sequence-constructor">sequence constructor</termref> in
-                  <termref def="dt-temporary-output-state">temporary output state</termref>.</p>
-            <p>
-               <error spec="XT" type="dynamic" class="DE" code="1480">
-                  <p>It is a <termref def="dt-dynamic-error"> dynamic error</termref> to evaluate the
-                        <elcode>xsl:result-document</elcode> instruction in <termref def="dt-temporary-output-state">temporary output state</termref>.</p>
-               </error>
-            </p>
-            <p>
-               <error spec="XT" type="dynamic" class="DE" code="1490">
-                  <p>It is a <termref def="dt-dynamic-error"> dynamic error</termref> for a transformation to
-                     generate two or more <termref def="dt-final-result-tree">final result
-                        trees</termref> with the same URI.</p>
-               </error>
-            </p>
-            <note>
-               <p>Note, this means that it is an error to evaluate more than one
-                     <elcode>xsl:result-document</elcode> instruction that omits the
-                     <code>href</code> attribute, or to evaluate any
-                     <elcode>xsl:result-document</elcode> instruction that omits the
-                     <code>href</code> attribute if an initial <termref def="dt-final-result-tree">final result tree</termref> is created implicitly.</p>
-            </note>
-            <p>In addition, an implementation <rfc2119>may</rfc2119> raise this
-               error if it is able to detect that two or more final result trees are generated with
-               different URIs that refer to the same physical resource.</p>
-
-
-            
-            <p>
-               <error spec="XT" type="dynamic" class="DE" code="1500">
-                  <p>It is a <termref def="dt-dynamic-error"> dynamic error</termref> for a <termref def="dt-stylesheet">stylesheet</termref> to write to an external resource
-                     and read from the same resource during a single transformation, if the same absolute URI is used to access the resource in
-                        both cases. </p>
-               </error>
-            </p>
-            <p>In addition, an implementation <rfc2119>may</rfc2119> raise this
-               error if it is able to detect that a transformation writes to a resource and reads
-               from the same resource using different URIs that refer to the same physical resource.
-               Note that if the error is not detected, it is <termref def="dt-implementation-dependent"/> whether the document that is read from the
-               resource reflects its state before or after the result tree is written.</p>
-         </div2>
-         <div2 id="current-output-uri">
-            <head>The Current Output URI</head>
-            <p><termdef id="dt-current-output-uri" term="current output URI">The <term>current output URI</term> is the URI
-                  associated with the <termref def="dt-principal-result"/> or <termref def="dt-secondary-result"/> that is currently being written.</termdef></p>
-            <div3 id="func-current-output-uri">
-               <head><?function fn:current-output-uri?></head>
-
-            </div3>
-         </div2>
-
-
-         <div2 id="validation">
+      
+      =================
+      <div1 id="validation">
             <head>Validation</head>
             
             <changes>
@@ -30704,9 +30263,9 @@ the same group, and the-->
                The rules for element and attribute nodes are given in <specref ref="validating-constructed-nodes"/>, 
                while those for document nodes are given in
                   <specref ref="validating-document-nodes"/>.</p>
-            <div3 id="validating-constructed-nodes">
+            <div2 id="validating-constructed-nodes">
                <head>Validating Constructed Elements and Attributes</head>
-               <div4 id="validating-using-validation-attribute">
+               <div3 id="validating-using-validation-attribute">
                   <head>Validation using the <code>[xsl:]validation</code> Attribute</head>
                   <p>The <code>[xsl:]validation</code> attribute defines the validation action to be
                      taken. It determines not only the <termref def="dt-type-annotation">type
@@ -30915,8 +30474,8 @@ the same group, and the-->
                   </p></item>
                   </ulist>
                   
-               </div4>
-               <div4 id="validation-xsl-type">
+               </div3>
+               <div3 id="validation-xsl-type">
                   <head>Validation using the <code>[xsl:]type</code> Attribute</head>
                   <p>The <code>[xsl:]type</code> attribute takes as its value an 
                      <phrase diff="chg" at="2022-01-01"><xnt spec="XP40" ref="prod-xpath40-EQName"/></phrase>.
@@ -31011,8 +30570,8 @@ the same group, and the-->
                         statically, it will be raised when the instruction is evaluated.</p>
                   </note></item>
                   </ulist>
-               </div4>
-               <div4 id="id-xsi-schema-location">
+               </div3>
+               <div3 id="id-xsi-schema-location">
                   <head>The <code>xsi:schemaLocation</code> and <code>xsi:noNamespaceSchemaLocation</code> attributes</head>
                   <p>It is <termref def="dt-implementation-defined"/> whether the validity assessment
                   process takes account of any <code>xsi:schemaLocation</code> or <code>xsi:noNamespaceSchemaLocation</code>
@@ -31038,7 +30597,7 @@ the same group, and the-->
                      mean that this is not a problem.</p>
                   
                   
-               </div4>
+               </div3>
                <!--<div4 id="validation-process">
                   <head>The Validation Process</head>
                   <p>As well as checking for validity against the schema, the validity assessment
@@ -31147,8 +30706,8 @@ the same group, and the-->
                      </error>
                   </p>
                </div4>-->
-            </div3>
-            <div3 id="validating-document-nodes">
+            </div2>
+            <div2 id="validating-document-nodes">
                <head>Validating Document Nodes</head>
                <p>It is possible to apply validation to a document node. This happens when a new
                   document node is constructed by one of the XSLT elements <elcode>xsl:source-document</elcode>, <elcode>xsl:merge-source</elcode>, <elcode>xsl:document</elcode>,
@@ -31233,8 +30792,8 @@ the same group, and the-->
                         </p>
                   </error>
                </p>
-            </div3>
-            <div3 id="validating-xml-id">
+            </div2>
+            <div2 id="validating-xml-id">
                <head>Validating <code>xml:id</code> attributes</head>
                <p>This section provides a non-normative summary of the effect of validation on
                attributes named <code>xml:id</code>. The normative rules can be inferred from rules
@@ -31254,10 +30813,30 @@ the same group, and the-->
                   <item><p>Checking <code>xml:id</code> attributes for uniqueness happens if and only if
                   validation is applied at the level of a document node.</p></item>
                </olist>
-            </div3>
-         </div2>
-      </div1>
-      <div1 id="serialization">
+            </div2>
+         </div1>
+      
+ 
+      
+      
+      
+      
+      
+      <div1 id="result-trees">
+         <head>Transformation Results</head>
+         <p>The output of a transformation includes a <termref def="dt-principal-result"/> and zero or more <termref def="dt-secondary-result">secondary results</termref>.</p>
+         
+         
+         <p>The way in which these results are
+             delivered to an application is <termref def="dt-implementation-defined">implementation-defined</termref>.</p>
+         <imp-def-feature id="idf-api-results">The way in which the results of the transformation
+            are delivered to an application is implementation-defined.</imp-def-feature>
+         <p>Serialization of results
+             is described further in <specref ref="serialization"/>
+         </p>
+         
+         
+         <div2 id="serialization">
          <head>Serialization</head>
          
         
@@ -31277,7 +30856,7 @@ the same group, and the-->
                <elcode>xsl:output</elcode>, <elcode>xsl:result-document</elcode>, and
                <elcode>xsl:character-map</elcode> declarations.</p>
          
-         <div2 id="id-xsl-output-declaration">
+         <div3 id="id-xsl-output-declaration">
             <head>The <code>xsl:output</code> declaration</head>
             <changes>
                <change issue="530" PR="534" date="2023-06-09">
@@ -31392,8 +30971,8 @@ the same group, and the-->
                methods or for serialization methods introduced in future versions of this
                specification.</p>
          </note>
-         </div2>
-         <div2 id="id-default-serialization-parameters">
+         </div3>
+         <div3 id="id-default-serialization-parameters">
             <head>Serialization parameters</head>
             <changes>
                <change issue="1548" PR="1560" date="2024-11-09">
@@ -31724,8 +31303,8 @@ the same group, and the-->
          <p>If the processor performs serialization, then it must raise any  serialization errors that occur. These have the same
             effect as <termref def="dt-dynamic-error"> dynamic errors</termref>: that is, the processor must
             raise the error and must not finish as if the transformation had been successful.</p>
-         </div2>
-            <div2 id="character-maps">
+         </div3>
+         <div3 id="character-maps">
             <head>Character Maps</head>
             <p>
                <termdef id="dt-character-map" term="character map">A <term>character map</term>
@@ -31903,8 +31482,8 @@ the same group, and the-->
                the data model allows this, but processors are not <rfc2119>required</rfc2119>
                to support it: see <xspecref spec="DM40" ref="xml-and-xsd-versions"/>.</p>
             </note>   
-         </div2> 
-         <div2 id="character-map-function">
+         </div3> 
+         <div3 id="character-map-function">
             <head>The <function>character-map</function> function</head>
             <changes>
                <change issue="1500" PR="1530" date="2024-10-30">
@@ -31919,9 +31498,9 @@ the same group, and the-->
                <head><?function fn:character-map?></head>
 
             </div3>
-         </div2>
+         </div3>
          
-         <div2 id="disable-output-escaping">
+         <div3 id="disable-output-escaping">
             <head>Disabling Output Escaping</head>
             <p>Normally, when using the XML, HTML, or XHTML output method, the serializer will
                escape special characters such as <code>&amp;</code> and <code>&lt;</code> when
@@ -32022,7 +31601,476 @@ the same group, and the-->
                   that can be used in many situations where disabling of output escaping was
                   previously necessary, without the same difficulties.</p>
             </note>
+         </div3>
+      </div2>
+      
+         
+         <div2 id="creating-result-trees">
+            <head>Creating Secondary Results</head>
+            
+            <changes>
+               <change issue="530" PR="534" date="2023-06-09">
+                  A new serialization parameter <code>escape-solidus</code> is provided to control
+                  whether the character <code>/</code> is escaped as <code>\/</code> by the
+                  JSON serialization method.
+               </change>
+               <change issue="1534" PR="1549" date="2024-11-12">
+                  The input to the serializer can be defined using the <code>select</code> attribute
+                  of <elcode>xsl:result-document</elcode> as an alternative to using a sequence constructor.
+               </change>
+               <change issue="938" PR="2259" date="2025-11-02">
+                  A new serialization parameter <code>canonical</code> is available to give control
+                  over serialization of XML, XHTML, and JSON.
+               </change>
+               <change issue="1538" PR="1497 1546" date="2024-11-13">
+                  A new serialization parameter <code>json-lines</code> is available to enable
+                  output as one JSON value per line.
+               </change>
+               <change issue="1234" PR="2719" date="2026-07-28">
+                  Added the serialization parameters <code>indent-unit</code>, <code>indent-attributes</code>, and <code>line-ending</code>.
+               </change>
+            </changes>
+            
+            <?element xsl:result-document?>
+            <p>The <elcode>xsl:result-document</elcode> instruction is
+               used to create a <termref def="dt-secondary-result"/>.</p>
+               
+            <p>The <code>select</code> attribute and the contained <termref def="dt-sequence-constructor"/> are
+               mutually exclusive; if the <code>select</code> attribute is present then the
+               sequence constructor must be empty, and if the sequence constructor is non-empty
+               then the <code>select</code> attribute must be absent <errorref spec="XT" class="SE" code="3185"/>. 
+               The value of the <code>select</code> attribute or the <termref def="dt-immediate-result"/>
+               of the contained <termref def="dt-sequence-constructor"/>
+               is referred to as the <termref def="dt-raw-result"/>.</p>
+            
+            <note><p>The name of the instruction, <elcode>xsl:result-document</elcode>, is a little
+               misleading. The instruction does not necessarily deliver either an XML document tree
+               nor a serialized XML document. Instead, for example, it might deliver an array, a map,
+               serialized JSON, or a sequence of atomic items.</p></note>
+               
+            <p>Technically, the result of evaluating the <elcode>xsl:result-document</elcode>
+               instruction is the empty sequence. This means it does not contribute anything to the
+               result of the sequence constructor it is part of.</p>
+               
+            <div3 id="delivering-secondary-result">
+               <head>Delivering the Result</head>
+              
+            
+               <p>As with the <termref def="dt-principal-result"/> of the
+               transformation, a <termref def="dt-secondary-result"/> may be delivered to the calling
+               application in three ways (see <specref ref="post-processing"/>):</p>
+               
+               <olist>
+                  <item><p>The <termref def="dt-raw-result"/> may be delivered <emph>as is</emph>.</p></item>
+                  <item><p>The <termref def="dt-raw-result"/> may be used to construct a <termref def="dt-final-result-tree"/>
+                  by invoking the process of <xtermref spec="SE40" ref="sequence-normalization"/>.</p></item>
+                  <item><p>The <termref def="dt-raw-result"/> may be serialized to a sequence of octets (which
+                  may then, optionally, be saved to a persistent storage location).</p></item>
+               </olist>
+               
+               
+               
+               <p>The decision whether or not to serialize the raw result depends on the 
+                  <termref def="dt-processor">processor</termref> and on the way it is invoked. This
+                  is <termref def="dt-implementation-defined"/>, and it is not controlled by anything
+                  in the stylesheet.</p>
+               
+               <p>If the result is not serialized, then the decision whether to
+                  return the <termref def="dt-raw-result"/> or to construct a tree depends on the effective
+                  value of the <code>build-tree</code> attribute. If the <termref def="dt-effective-value"/> of
+                  the <code>build-tree</code> attribute is <code>yes</code>, then 
+                     a <termref def="dt-final-result-tree"/> is created
+                  by invoking the process of <xtermref spec="SE40" ref="sequence-normalization"/>. 
+                  Conversely, if the result <emph>is</emph> serialized, then 
+                     the decision whether or not to construct a tree depends on the choice of 
+                     serialization method, and the <code>build-tree</code> attribute is then ignored. 
+                     For example, with <code>method="xml"</code> a tree is always constructed, whereas 
+                     with <code>method="json"</code> a tree is never constructed.<!-- [XSLT 3.0 Erratum E14, bug 30208].-->
+                  </p>
+               
+               <p>Implementations may provide additional mechanisms, outside the scope of this
+               specification, for defining the way in which <termref def="dt-final-result-tree">final result trees</termref> are processed. Such mechanisms
+                  <rfc2119>may</rfc2119> make use of the XSLT-defined attributes on the
+                  <elcode>xsl:result-document</elcode> and/or <elcode>xsl:output</elcode> elements,
+               or they <rfc2119>may</rfc2119> use additional elements or attributes in an <termref def="dt-implementation-defined">implementation-defined</termref> namespace.</p>
+
+               
+            </div3>
+            <div3 id="result-uri">
+               <head>The Result Document URI</head>
+           
+            
+            <p>The <elcode>xsl:result-document</elcode> instruction
+               defines a URI that may be used to identify the <termref def="dt-secondary-result"/>.
+               </p>
+            
+            <p>The <code>href</code> attribute is optional. The default value is the zero-length
+               string. The <termref def="dt-effective-value"/> of the
+               attribute <rfc2119>must</rfc2119> be a <termref def="dt-uri-reference">URI
+                  Reference</termref>, which may be absolute or relative. If it is relative, then it is resolved against the <termref def="dt-base-output-uri"/>. There <rfc2119>may</rfc2119> be <termref def="dt-implementation-defined">implementation-defined</termref> restrictions on
+               the form of absolute URI that may be used, but the implementation is not
+                  <rfc2119>required</rfc2119> to enforce any restrictions. Any valid relative URI
+                  reference
+               <rfc2119>must</rfc2119> be accepted. Note that the zero-length string is a valid
+               relative URI reference.</p>
+            <imp-def-feature id="idf-api-resultdocumenthref"> It is <termref def="dt-implementation-defined"/> how the URI appearing in the <code>href</code>
+               attribute of <elcode>xsl:result-document</elcode> affects the way in which the result
+               tree is delivered to the application. There <rfc2119>may</rfc2119> be restrictions on
+               the form of this URI. </imp-def-feature>
+            <p>If the implementation provides an API to access <termref def="dt-secondary-result">secondary results</termref>, then it
+                  <rfc2119>must</rfc2119> allow a secondary result to be identified by means of the
+               absolutized value of the <code>href</code> attribute. In addition, if a <termref def="dt-final-result-tree"/> is constructed
+               (that is, if the <termref def="dt-effective-value"/> of
+                  <code>build-tree</code> is <code>yes</code>), then this value is used as the base
+               URI of the document node at the root of the <termref def="dt-final-result-tree">final
+                  result tree</termref>. </p>
+
+
+
+            <note>
+               <p>The base URI of the <termref def="dt-final-result-tree">final result
+                     tree</termref> is not necessarily the same thing as the URI of its serialized
+                  representation on disk, if any. For example, a server (or browser client) might
+                  store final result trees only in memory, or in an internal disk cache. As long as
+                  the processor satisfies requests for those URIs, it is irrelevant where they are
+                  actually written on disk, if at all.</p>
+            </note>
+            <note>
+               <p>It will often be the case that one <termref def="dt-final-result-tree">final
+                     result tree</termref> contains links to another final result tree produced
+                  during the same transformation, in the form of a relative URI reference. The mechanism of associating a URI with a final
+                  result tree has been chosen to allow the integrity of such links to be preserved
+                  when the trees are serialized.</p>
+               <p>As well as being potentially significant in any API that provides access to final
+                  result trees, the base URI of the new document node is relevant if the final
+                  result tree, rather than being serialized, is supplied as input to a further
+                  transformation.</p>
+            </note>
+               
+            </div3>
+            
+            <div3 id="id-validating-secondary-results">
+               <head>Validating Secondary Results</head>
+            
+            
+            <p>The optional attributes <code>type</code> and <code>validation</code> may be used on
+               the <elcode>xsl:result-document</elcode> instruction to validate the contents of
+                  a <termref def="dt-final-result-tree"/>, and to determine the <termref def="dt-type-annotation">type
+                  annotation</termref> that elements and attributes within the <termref def="dt-final-result-tree">final result tree</termref> will carry. The permitted
+               values and their semantics are described in <specref ref="validating-document-nodes"/>. Any such validation is applied to the
+               document node produced as the result of <xtermref spec="SE40" ref="sequence-normalization"/>.
+               If sequence normalization does not take place (typically because the <termref def="dt-raw-result"/>
+               is delivered to the application directly, or because the selected serialization method
+               does not involve sequence normalization) then the <code>validation</code> and
+               <code>type</code> attributes are ignored.</p>
+            
+            <note><p>Validation applies after inserting item separators as determined by the
+               <code>item-separator</code> serialization parameter, and an inappropriate choice
+               of <code>item-separator</code> may cause the result to become invalid.</p></note>
+               
+            </div3>
+            
+            <div3 id="id-serializing-secondary-results">
+               <head>Serializing Secondary Results</head>
+            
+            <p>A <termref def="dt-processor">processor</termref>
+               <rfc2119>may</rfc2119> allow a <termref def="dt-final-result-tree">final result
+                  tree</termref> to be serialized. Serialization is described in <specref ref="serialization"/>.
+               The instruction may optionally specify the output format to be used for serializing the result.
+            </p>
+               
+            <p>However, an implementation is not <rfc2119>required</rfc2119> to support the serialization
+               of <termref def="dt-final-result-tree">final result trees</termref>. An
+               implementation that does not support the serialization of final result trees
+                  <rfc2119>may</rfc2119> ignore the <code>format</code> attribute and the
+               serialization attributes. Such an implementation <rfc2119>must</rfc2119> provide the
+               application with some means of access to the (un-serialized) result tree, using its
+               URI to identify it.</p>
+            
+            <p>The <termref def="dt-effective-value"/> of the
+                  <code>format</code> attribute, if specified, <rfc2119>must</rfc2119> be an <termref def="dt-eqname">EQName</termref>. The value is
+               expanded using the namespace declarations in scope for the
+                  <elcode>xsl:result-document</elcode> element. The resulting <termref def="dt-expanded-qname">expanded QName</termref>
+               <rfc2119>must</rfc2119> match the expanded QName of a named <termref def="dt-output-definition">output definition</termref> in the <termref def="dt-stylesheet">stylesheet</termref>. This identifies the
+                  <elcode>xsl:output</elcode> declaration that will control the serialization of the
+                  <termref def="dt-final-result-tree">final result tree</termref> (see <specref ref="serialization"/>), if the result tree is serialized. If the
+                  <code>format</code> attribute is omitted, the unnamed <termref def="dt-output-definition">output definition</termref> is used to control
+               serialization of the result tree.</p>
+            <p>
+               <error spec="XT" type="dynamic" class="DE" code="1460">
+                  <p>It is a <termref def="dt-dynamic-error"> dynamic error</termref> if the <termref def="dt-effective-value"/> of the
+                        <code>format</code> attribute <error.extra>of an
+                           <elcode>xsl:result-document</elcode> element</error.extra> is not a valid
+                        <termref def="dt-eqname">EQName</termref>, or if it does not match the
+                        <termref def="dt-expanded-qname">expanded QName</termref> of an <termref def="dt-output-definition">output definition</termref> in the containing <termref def="dt-package">package</termref>. If the processor is able to detect
+                     the error statically (for example, when the <code>format</code> attribute
+                     contains no curly brackets), then the processor <rfc2119>may</rfc2119>
+                     optionally raise this as a <termref def="dt-static-error">static
+                        error</termref>.</p>
+               </error>
+            </p>
+            <note>
+               <p>The only way to select the unnamed <termref def="dt-output-definition">output
+                     definition</termref> is to omit the <code>format</code> attribute.</p>
+            </note>
+            <p>The <code>parameter-document</code> attribute allows serialization
+               parameters to be supplied in an external document. The external document must contain
+               an <code>output:serialization-parameters</code> element with the format described in
+                  <xspecref spec="SE40" ref="serparams-in-xdm-instance"/>, and the parameters are
+               interpreted as described in that specification.</p>
+            <p>If present, the <termref def="dt-effective-value"/> of the URI supplied in the
+                  <code>parameter-document</code> attribute is dereferenced, after resolution
+               against the base URI of the <elcode>xsl:result-document</elcode> element if it is a
+               relative reference. 
+               The parameter document <rfc2119>should</rfc2119> be read during run-time evaluation of the stylesheet. 
+               If the location of the stylesheet at development time is
+               different from the deployed location, any relative reference should be resolved
+               against the deployed location. A serialization error occurs if the result of
+               dereferencing the URI is ill-formed or invalid; but if no document can be found at
+               the specified location, the attribute <code>should</code> be ignored.</p>
+            <p>A serialization parameter specified in the
+                  <code>parameter-document</code> takes precedence over a value supplied directly as
+               an attribute of <elcode>xsl:result-document</elcode>, which in turn takes precedence
+               over a value supplied in the selected output definition, except that the values of
+               the <code>cdata-section-elements</code> and <code>suppress-indentation</code>
+               attributes are merged in the same way as when multiple <elcode>xsl:output</elcode>
+               declarations are merged.</p>
+            <p>The attributes <code>method</code>, <code>allow-duplicate-names</code>, <code>build-tree</code>, <code>byte-order-mark</code>,
+               <code>canonical</code>, <code>cdata-section-elements</code>,
+               <code diff="add" at="2026-07-02">csv-header</code>, <code diff="add" at="2026-07-02">csv-quote-character</code>,
+               <code diff="add" at="2026-07-02">csv-separator</code>, <code>doctype-public</code>,
+                  <code>doctype-system</code>, <code>encoding</code>,
+               <code diff="add" at="2023-03-31">escape-solidus</code>,
+                  <code>escape-uri-attributes</code>, <code>html-version</code>, <code>indent</code>, <code diff="add" at="2026-06-25">indent-attributes</code>, <code diff="add" at="2026-06-25">indent-unit</code>, <code>item-separator</code>,
+               <code diff="add" at="2024-11-01">json-lines</code>,
+               <code>json-node-output-method</code>,
+                  <code diff="add" at="2026-06-25">line-ending</code>, <code>media-type</code>, <code>normalization-form</code>,
+                  <code>omit-xml-declaration</code>, <code>standalone</code>, <code>suppress-indentation</code>,
+               <!-- see bug 6535 -->
+               <code>undeclare-prefixes</code>, <code>use-character-maps</code>, and
+                  <code>output-version</code> may be used to override attributes defined in the
+               selected <termref def="dt-output-definition">output definition</termref>.</p>
+            <p>With the exception of <code>use-character-maps</code>, these attributes are all
+               defined as <termref def="dt-attribute-value-template">attribute value
+                  templates</termref>, so their values may be set dynamically. For any of these
+               attributes that is present on the <elcode>xsl:result-document</elcode> instruction,
+               the <termref def="dt-effective-value"/> of the attribute
+               overrides or supplements the corresponding value from the output definition. This
+               works in the same way as when one <elcode>xsl:output</elcode> declaration overrides
+               another. Some of the attributes have more specific
+                  rules:</p>
+            <ulist>
+               <item>
+                  <p>In the case of <code>cdata-section-elements</code>
+                     and <code>suppress-indentation</code>, the
+                     value of the serialization parameter is the union of the expanded names of the
+                     elements named in this instruction and the elements named in the selected
+                     output definition.</p>
+               </item>
+               <item>
+                  <p>In the case of <code>use-character-maps</code>, the character maps referenced
+                     in this instruction supplement and take precedence over those defined in the
+                     selected output definition.</p>
+               </item>
+               <item>
+                  <p>In the case of <code>doctype-public</code> and <code>doctype-system</code>,
+                     setting the <termref def="dt-effective-value"/> of the attribute to a zero-length string has the
+                     effect of overriding any value for these attributes obtained from the output
+                     definition. The corresponding serialization parameter is not set (is
+                     “absent”).</p>
+               </item>
+               <item>
+                  <p>In the case of <code>item-separator</code>, setting the <termref def="dt-effective-value"/> of the
+                     attribute to the special value <code>"#absent"</code> has the effect of
+                     overriding any value for this attribute obtained from the output definition.
+                     The corresponding serialization parameter is not set (is “absent”). It is not
+                     possible to set the value of the serialization parameter to the literal
+                     7-character string <code>"#absent"</code>. </p>
+               </item>
+               <item>
+                  <p>In all other cases, the <termref def="dt-effective-value"/> of an attribute actually present on
+                     this instruction takes precedence over the value defined in the selected output
+                     definition.</p>
+               </item>
+            </ulist>
+            
+               <p>In the case of the attributes <code>method</code>, <code>json-node-output-method</code>,
+                     <code>cdata-section-elements</code>, <code>suppress-indentation</code>, and
+                     <code>use-character-maps</code>, the <termref def="dt-effective-value"/> of the attribute
+                  contains an <termref def="dt-eqname">EQName</termref> or a space-separated list of
+                     <termref def="dt-eqname">EQNames</termref>. Where lexical QNames are used in these attributes (whether prefixed
+               or unprefixed), the namespace context is established in the same way as for the corresponding
+               attributes of <elcode>xsl:output</elcode>: see <specref ref="id-default-serialization-parameters"/>.</p>
+            
+            <p>The <code>output-version</code> attribute on the <elcode>xsl:result-document</elcode>
+               instruction overrides the <code>version</code> attribute on
+                  <elcode>xsl:output</elcode> (it has been renamed because <code>version</code> is
+               available with a different meaning as a standard attribute: see <specref ref="standard-attributes"/>). In all other cases, attributes correspond if they
+               have the same name.</p>
+            <p>There are some serialization parameters that apply to some output methods but not to
+               others. For example, the <code>indent</code> attribute has no effect on the
+                  <code>text</code> output method. If a value is supplied for an attribute that is
+               inapplicable to the output method, its value is not passed to the serializer. The
+               processor <rfc2119>may</rfc2119> validate the value of such an attribute, but is not
+                  <rfc2119>required</rfc2119> to do so.</p>
+            
+            <p>The <code>item-separator</code> serialization parameter
+               is used when the <termref def="dt-raw-result"/> is used to construct a result tree
+               by applying sequence normalization, and it is also used when the result tree is
+               serialized. For example, if the sequence constructor delivers a sequence of
+               integers, and the <code>text</code> serialization method is used, then the result of serialization
+               will be a string obtained by converting each integer to a string, and separating the
+               strings using the defined <code>item-separator</code>.</p>
+            
+            </div3>
+            
+            
+            <div3 id="result-document-example">
+               <head>Result Document Example</head>
+            
+               
+               <example>
+                  <head>Multiple Result Documents</head>
+                  <p> The following example takes an XHTML document as input, and breaks it up so that
+                     the text following each &lt;h1&gt; element is included in a separate document. A
+                     new document <code>toc.html</code> is constructed to act as an index:</p>
+                  <eg role="xslt-document" xml:space="preserve">&lt;xsl:stylesheet
+   	version="4.0"
+   	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+   	xmlns:xhtml="http://www.w3.org/1999/xhtml"&gt;
+   	
+   &lt;xsl:output name="toc-format" method="xhtml" indent="yes"
+        doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"
+        doctype-public="-//W3C//DTD XHTML 1.0 Strict//EN"/&gt;
+               
+   &lt;xsl:output name="section-format" method="xhtml" indent="no"
+        doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"
+        doctype-public="-//W3C//DTD XHTML 1.0 Transitional//EN"/&gt;	
+   	 
+   &lt;xsl:template match="/"&gt;
+     &lt;xsl:result-document href="toc.html" 
+                          format="toc-format" 
+                          validation="strict"&gt;
+       &lt;html xmlns="http://www.w3.org/1999/xhtml"&gt;
+         &lt;head&gt;&lt;title&gt;Table of Contents&lt;/title&gt;&lt;/head&gt;
+         &lt;body&gt;
+           &lt;h1&gt;Table of Contents&lt;/h1&gt;
+           &lt;xsl:for-each select="/*/xhtml:body/(*[1] | xhtml:h1)"&gt;
+             &lt;p&gt;
+               &lt;a href="section{position()}.html"&gt;
+                 &lt;xsl:value-of select="."/&gt;
+               &lt;/a&gt;
+             &lt;/p&gt;
+           &lt;/xsl:for-each&gt;
+         &lt;/body&gt;
+       &lt;/html&gt;
+     &lt;/xsl:result-document&gt;
+     &lt;xsl:for-each-group select="/*/xhtml:body/*" group-starting-with="xhtml:h1"&gt;
+       &lt;xsl:result-document href="section{position()}.html" 
+                            format="section-format" validation="strip"&gt;  	
+         &lt;html xmlns="http://www.w3.org/1999/xhtml"&gt;
+           &lt;head&gt;&lt;title&gt;&lt;xsl:value-of select="."/&gt;&lt;/title&gt;&lt;/head&gt;
+           &lt;body&gt;
+             &lt;xsl:copy-of select="current-group()"/&gt;
+           &lt;/body&gt;
+         &lt;/html&gt;
+       &lt;/xsl:result-document&gt;
+     &lt;/xsl:for-each-group&gt;
+   &lt;/xsl:template&gt;
+   
+   &lt;/xsl:stylesheet&gt;</eg>
+               </example>
+            </div3>
+         
+         <div3 id="result-document-restrictions">
+            <head>Restrictions on the use of <elcode>xsl:result-document</elcode></head>
+            <p>There are restrictions on the use of the <elcode>xsl:result-document</elcode>
+               instruction, designed to ensure that the results are fully interoperable even when
+               processors optimize the sequence in which instructions are evaluated. Informally, the
+               restriction is that the <elcode>xsl:result-document</elcode> instruction can only be
+               used while writing a final result tree, not while writing to a temporary tree or a
+               sequence. This restriction is defined formally as follows.</p>
+            <p>
+               <termdef id="dt-output-state" term="output state">Each instruction in the <termref def="dt-stylesheet">stylesheet</termref> is evaluated in one of two possible
+                     <term>output states</term>: <termref def="dt-final-output-state">final output
+                     state</termref> or <termref def="dt-temporary-output-state">temporary output
+                     state</termref>.</termdef></p>
+            <p>
+               <termdef id="dt-final-output-state" term="final output state">The first of the two
+                     <termref def="dt-output-state">output states</termref> is called <term>final
+                     output</term> state. This state applies when instructions are writing to a
+                     <termref def="dt-final-result-tree">final result tree</termref>.</termdef>
+            </p>
+            <p>
+               <termdef id="dt-temporary-output-state" term="temporary output state">The second of
+                  the two <termref def="dt-output-state">output states</termref> is called
+                     <term>temporary output</term> state. This state applies when instructions are
+                  writing to a <termref def="dt-temporary-tree">temporary tree</termref> or any
+                  other non-final destination.</termdef>
+            </p>
+            <p>The instructions in the <termref def="dt-initial-named-template"/> are evaluated in
+                  <termref def="dt-final-output-state">final output state</termref>. An instruction
+               is evaluated in the same <termref def="dt-output-state">output state</termref> as its
+               calling instruction, except that <elcode>xsl:variable</elcode>,
+                  <elcode>xsl:param</elcode>, <elcode>xsl:with-param</elcode>, 
+               <elcode>xsl:function</elcode>, <elcode>xsl:key</elcode>, <elcode>xsl:sort</elcode>,
+                  <elcode>xsl:accumulator-rule</elcode>, and
+                     <elcode>xsl:merge-key</elcode>
+                always evaluate the instructions in their
+               contained <termref def="dt-sequence-constructor">sequence constructor</termref> in
+                  <termref def="dt-temporary-output-state">temporary output state</termref>.</p>
+            <p>
+               <error spec="XT" type="dynamic" class="DE" code="1480">
+                  <p>It is a <termref def="dt-dynamic-error"> dynamic error</termref> to evaluate the
+                        <elcode>xsl:result-document</elcode> instruction in <termref def="dt-temporary-output-state">temporary output state</termref>.</p>
+               </error>
+            </p>
+            <p>
+               <error spec="XT" type="dynamic" class="DE" code="1490">
+                  <p>It is a <termref def="dt-dynamic-error"> dynamic error</termref> for a transformation to
+                     generate two or more <termref def="dt-final-result-tree">final result
+                        trees</termref> with the same URI.</p>
+               </error>
+            </p>
+            <note>
+               <p>Note, this means that it is an error to evaluate more than one
+                     <elcode>xsl:result-document</elcode> instruction that omits the
+                     <code>href</code> attribute, or to evaluate any
+                     <elcode>xsl:result-document</elcode> instruction that omits the
+                     <code>href</code> attribute if an initial <termref def="dt-final-result-tree">final result tree</termref> is created implicitly.</p>
+            </note>
+            <p>In addition, an implementation <rfc2119>may</rfc2119> raise this
+               error if it is able to detect that two or more final result trees are generated with
+               different URIs that refer to the same physical resource.</p>
+
+
+            
+            <p>
+               <error spec="XT" type="dynamic" class="DE" code="1500">
+                  <p>It is a <termref def="dt-dynamic-error"> dynamic error</termref> for a <termref def="dt-stylesheet">stylesheet</termref> to write to an external resource
+                     and read from the same resource during a single transformation, if the same absolute URI is used to access the resource in
+                        both cases. </p>
+               </error>
+            </p>
+            <p>In addition, an implementation <rfc2119>may</rfc2119> raise this
+               error if it is able to detect that a transformation writes to a resource and reads
+               from the same resource using different URIs that refer to the same physical resource.
+               Note that if the error is not detected, it is <termref def="dt-implementation-dependent"/> whether the document that is read from the
+               resource reflects its state before or after the result tree is written.</p>
+         </div3>
          </div2>
+         <div2 id="current-output-uri">
+            <head>The Current Output URI</head>
+            <p><termdef id="dt-current-output-uri" term="current output URI">The <term>current output URI</term> is the URI
+                  associated with the <termref def="dt-principal-result"/> or <termref def="dt-secondary-result"/> that is currently being written.</termdef></p>
+            <div3 id="func-current-output-uri">
+               <head><?function fn:current-output-uri?></head>
+
+            </div3>
+         </div2>
+
+
+         
       </div1>
       <div1 id="conformance">
          <head>Conformance</head>


### PR DESCRIPTION
As an initial step to dealing with issue #2813, this PR reorganizes the contents of sections 25 and 26 of the XSLT specification. Section 25 now deals solely with validation, section 26 deals with delivery of primary and secondary result trees, and in the case of the xsl:result-document section, it splits the very monolithic and poorly structured existing text into subsections each dealing with one topic.

This PR does not change any existing text, it merely reorganizes it.The next stage will be some editorial work to improve the text, but in order to get meaningful diff markup, I plan to do that in a separate PR. For this PR, because there is (if I've got it right) no technical change, I propose accepting it without review,