### PR TITLE
2073 JNodes and Sequences

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1977,6 +1977,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
       <g:string process-value="yes">following-or-self</g:string>
       <g:string process-value="yes">following-sibling</g:string>
       <g:string process-value="yes">following-sibling-or-self</g:string>
+      <g:string process-value="yes">item</g:string>
       <g:string process-value="yes" if="xpath40 xslt40-patterns">namespace</g:string>
       <g:string process-value="yes">parent</g:string>
       <g:string process-value="yes">preceding</g:string>

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -6582,7 +6582,7 @@ position, in the range 1 to the size of the array.</p>
         
         <p>It gets more complicated when sequences of length greater than one appear (this can never
           happen with trees produced by parsing JSON). A sequence of
-          length greater than one is represented by a node with <code>kind='sequence'</code>. For example, consider:</p>
+          length greater than one is represented by a <termref def="dt-sequence-jnode"/>. For example, consider:</p>
         
         <eg>{ "a": 11, "b": [22, 33], "c": (44, 55)}</eg>
         
@@ -6595,7 +6595,7 @@ position, in the range 1 to the size of the array.</p>
       <jnode kind='leaf' key='1' value='22'/>
       <jnode kind='leaf' key='2' value='33'/>
     </jnode>
-    <jnode kind='sequence' key='b' value='(44, 55)'>
+    <jnode kind='sequence' key='c' value='(44, 55)'>
       <jnode kind='leaf' key='1' value='44'/>
       <jnode kind='leaf' key='2' value='55'/>
     </jnode>
@@ -6634,7 +6634,7 @@ position, in the range 1 to the size of the array.</p>
             <sitem><term>·jkey·</term>: <var>K</var></sitem>
           </slist>
         </item>
-        <item><p>For a <termref def='dt-sequence-jnode'/>, then one child JNode for each
+        <item><p>For a <termref def='dt-sequence-jnode'/>, one child JNode for each
         item <var>J</var> in the sequence (retaining order), with the following properties:</p>
           <slist>
             <sitem><term>·jparent·</term>: <var>P</var></sitem>

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -6549,7 +6549,7 @@ position, in the range 1 to the size of the array.</p>
         <item><p><termdef id="dt-sequence-jnode" term="Sequence JNode">A <term>Sequence JNode</term> is a JNode whose <term>·jvalue·</term>
         is a sequence containing two or more items.</termdef></p></item>
         <item><p><termdef id="dt-leaf-jnode" term="Leaf JNode">A <term>Leaf</term> JNode is a JNode whose <term>·jvalue·</term>
-        is either the empty sequence, or a <termref def="dt-singleton"/> item other than a map or array.</termdef>.</p></item>
+        is either the empty sequence, or a <termref def="dt-singleton"/> item other than a map or array.</termdef></p></item>
       </ulist>      
       
       
@@ -6563,7 +6563,7 @@ position, in the range 1 to the size of the array.</p>
         <eg>{ "a": 11, "b": [22, 33], "c": ()}</eg>
         
         <p>We represent a JNode by a <code>jnode</code> element, and we represent its
-          properties using XML attributes. The <term>·parent·</term> property is implied by the XML
+          properties using XML attributes. The <term>·jparent·</term> property is implied by the XML
         hierarchy. Although the kind of JNode can be deduced from its <term>·jvalue·</term>
         property, it is shown as a separate attribute for clarity:</p>
         
@@ -6589,7 +6589,7 @@ position, in the range 1 to the size of the array.</p>
         <p>This is represented as:</p>
         
         <eg><![CDATA[
-  <jnode kind='map' key='()' value='{ "a": 11, "b": [22, 33], "c": ()}'>
+  <jnode kind='map' key='()' value='{ "a": 11, "b": [22, 33], "c": (44, 55)}'>
     <jnode kind='leaf' key='a' value='11'/> 
     <jnode kind='array' key='b' value='[22, 33]'>
       <jnode kind='leaf' key='1' value='22'/>
@@ -6603,7 +6603,8 @@ position, in the range 1 to the size of the array.</p>
         
         <p>Navigating a structure that mixes maps, arrays, and sequences of length greater than one can be awkward,
         because the <code>sequence</code> node will be present for a sequence with multiple items, but
-        absent for a singleton sequence. JTrees and JNodes are designed primarily for manipulating JSON,
+        absent for a singleton sequence. The <code>item</code> axis is provided to make such processing easier.
+          JTrees and JNodes are designed primarily for manipulating JSON,
         where this complication does not arise.</p>
         
         
@@ -6646,233 +6647,7 @@ position, in the range 1 to the size of the array.</p>
       </olist>
       
       
-      <!--
-     
-  
-      <example>
-        <head>A JTree derived by parsing JSON</head>
-        <p>In a JTree derived from JSON, every member of an array will always be either a single item
-          (a string, number, boolean, array, or map),
-        or an empty sequence representing the JSON value <code>null</code>. Similarly, every entry
-        in a map will have a key that is a single <code>xs:string</code>, and a corresponding
-        value that is either a single item (as above) or an empty sequence representing a JSON <code>null</code>.</p>
-        
-        <p>Consider a tree constructed by parsing the following JSON input:</p>
-        
-        <eg role="json">[
-  { "a": 1, "b": "XXX", "c": true, "d": null },
-  { "a": 2, "b": "YYY", "c": false, "d": null }
-]
-  </eg>
-        
-        <p>The resulting JTree can be illustrated using the following XML representation,
-        where a JNode is represented by a <code>&lt;jnode</code> element and the properties
-        of the JNode are represented as XML attributes; JNodes are given an ID attribute so
-        that the parent property can be shown:</p>
-        
-        <eg><![CDATA[
-<jnode id="R" jvalue="[
-  { "a": 1, "b": "XXX", "c": true, "d": null },
-  { "a": 2, "b": "YYY", "c": false, "d": null }
-]">
-   <jnode id="M1" 
-          jparent="R" 
-          jvalue="{ "a": 1, "b": "XXX", "c": true, "d": null }"
-          jposition="1"
-          jkey="1"
-          jleaf="false">
-      <jnode id="M1.1"
-             jparent="M1"
-             jkey="a"
-             jvalue="1"
-             jposition="1"
-             jleaf="false">
-         <jnode id=
-             
-          
-        ]]></eg>
-        <p>Then:</p>
-        <ulist>
-          <item><p>The root JNode <var>R</var> has a ·jvalue· property that is an 
-            array of two maps.</p></item>
-          <item><p>The 
-            result of the <code>dm:j-children</code> accessor applied to <var>R</var> is a sequence of two 
-            JNodes <var>M1</var> and <var>M2</var>, each
-            representing one of the two maps.</p></item>
-          <item><p>For <var>M1</var>:</p>
-            <ulist>
-              <item><p><term>·jparent·</term> is <var>R</var>.</p></item>
-              <item><p><term>·jvalue·</term> is the first map.</p></item>
-              <item><p><term>·jposition·</term> is 1.</p></item>
-              <item><p><term>·jkey·</term> is 1.</p></item>
-              <item><p>The <emph>dm:j-children</emph> accessor returns a sequence of four
-              JNodes, as follows:</p>
-              <ulist>
-                <item><p>All four have <term>·jparent·</term> set to <var>M1</var>.</p></item>
-                <item><p>The <term>·jvalue·</term> properties are respectively <code>1</code>,
-                  <code>"XXX"</code>, <code>true()</code>, and <code>()</code>.</p></item>
-                <item><p>The <term>·jposition·</term> properties are all set to 1.</p></item>
-                <item><p>The <term>·jkey·</term> properties are respectively <code>"a"</code>
-                <code>"b"</code>, <code>"c"</code>, and <code>"d"</code>.</p></item>
-                <item><p>For each of these JNodes, the <emph>dm:j-children</emph> accessor returns
-                an empty sequence.</p></item>
-              </ulist></item>
-            </ulist>
-          </item>
-          <item><p>For <var>M2</var>:</p>
-            <ulist>
-              <item><p><term>·jparent·</term> is <var>R</var>.</p></item>
-              <item><p><term>·jvalue·</term> is the second map.</p></item>
-              <item><p><term>·jposition·</term> is 1.</p></item>
-              <item><p><term>·jkey·</term> is 2.</p></item>
-              <item><p>The <emph>dm:j-children</emph> accessor returns a sequence of four
-              JNodes, as follows:</p>
-              <ulist>
-                <item><p>All four have <term>·jparent·</term> set to <var>M2</var>.</p></item>
-                <item><p>The <term>·jvalue·</term> properties are respectively <code>2</code>,
-                  <code>"YYY"</code>, <code>false()</code>, and <code>()</code>.</p></item>
-                <item><p>The <term>·jposition·</term> properties are all set to 1.</p></item>
-                <item><p>The <term>·jkey·</term> properties are respectively <code>"a"</code>
-                <code>"b"</code>, <code>"c"</code>, and <code>"d"</code>.</p></item>
-                <item><p>For each of these JNodes, the <emph>dm:j-children</emph> accessor returns
-                an empty sequence.</p></item>
-              </ulist></item>
-            </ulist>
-          </item>
-        </ulist>
-        <p>Note that all JNodes in a JTree that represents parsed JSON input will have the
-        <term>·jposition·</term> property set to 1. This is because every construct in JSON 
-        (arrays, objects, strings, number, booleans, and <code>null</code>) maps to an XDM sequence
-        of length 0 or 1.</p>
-
-<p>The following diagram shows the JTree graphically. Each node is connected to
-its <code>dm:j-children</code> with arrows. The arrows are numbered to represent the
-order of the children.</p>
-
-<table>
-  <tbody>
-    <tr>
-      <td><graphic source="jgraph.svg"
-                   alt="Graphical depiction of the JSON JTree example."/>
-      </td>
-    </tr>
-    <tr>
-      <td>Graphic representation of the JSON JTree
-[<loc href="images/jgraph.svg">standalone SVG</loc>]
-      </td>
-    </tr>
-  </tbody>
-</table>
-      </example>
       
-      <example>
-        <head>A JTree representing arbitrary XDM content</head>
-        <p>Consider a JTree that wraps a map constructed by the following XQuery expression:</p>
-        
-        <eg><![CDATA[{
-   "a": 1,
-   "b": ("x", "y"),
-   "c": [ (4, 5), 6 ],
-   "d": (7, [ 8, 9 ]),
-   "e": (<p/>, <q/>)
-}]]></eg>
-        
-        <p>Then:</p>
-        <ulist>
-          <item><p>The root JNode <var>R</var> has a ·jvalue· property that is a 
-            map with five entries.</p></item>
-          <item><p>The result of the <code>dm:j-children</code> accessor applied to <var>R</var>
-          is a sequence of five JNodes <var>J1</var>, <var>J2</var>, <var>J3</var>, <var>J4</var>, and <var>J5</var>,
-          as follows:</p>
-          <ulist>
-            <item>
-              <p><var>J1</var> is a leaf node. It has <term>·jparent·</term>=<var>R</var>,
-              <term>·jvalue·</term>=1, <term>·jposition·</term>=1, and
-              <term>·jkey·</term>="a". Its <code>dm:j-children</code> accessor returns an empty sequence.</p>
-            </item>
-            <item>
-              <p><var>J2</var> is a leaf node. It has <term>·jparent·</term>=<var>R</var>,
-              <term>·jvalue·</term>=("x", "y"), <term>·jposition·</term>=1, and
-              <term>·jkey·</term>="b". Its <code>dm:j-children</code> accessor returns an empty sequence.</p>
-            </item>
-            <item>
-              <p><var>J3</var> has <term>·jparent·</term>=<var>R</var>,
-              <term>·jvalue·</term>=[ (4, 5), 6 ], <term>·jposition·</term>=1, and
-              <term>·jkey·</term>="c". Its <code>dm:j-children</code> accessor returns a sequence of two
-                JNodes <var>J/31</var> and <var>J/32</var>, representing the two members of the contained
-                array, as follows:</p>
-              <ulist>
-                <item>
-                  <p><var>J/31</var> is a leaf node. It has <term>·jparent·</term>=<var>J3</var>,
-                  <term>·jvalue·</term>=(4, 5), <term>·jposition·</term>=1, and <term>·jkey·</term>="1".
-                  Its <code>dm:j-children</code> accessor returns an empty sequence.</p>
-                </item>
-                <item>
-                  <p><var>J/32</var> is a leaf node. It has <term>·jparent·</term>=<var>J3</var>,
-                  <term>·jvalue·</term>=6, <term>·jposition·</term>=1, and <term>·jkey·</term>="2".
-                  Its <code>dm:j-children</code> accessor returns an empty sequence.</p>
-                </item>
-              </ulist>
-            </item>
-            <item>
-              <p><var>J4</var> has <term>·jparent·</term>=<var>R</var>, 
-              <term>·jvalue·</term>=(7, [ 8, 9 ]), <term>·jposition·</term>=1, and
-              <term>·jkey·</term>="d". Its <code>dm:j-children</code> accessor returns a sequence of two
-              JNodes <var>J/41</var> and <var>J/42</var>, representing the two members of the
-              contained array, as follows:</p>
-              <ulist>
-                <item>
-                  <p><var>J/41</var> is a leaf node. It has <term>·jparent·</term>=<var>J4</var>,
-                  <term>·jvalue·</term>=8, <term>·jposition·</term>=2, and <term>·jkey·</term>="1".
-                  Its <code>dm:j-children</code> accessor returns an empty sequence.</p>
-                </item>
-                <item>
-                  <p><var>J/42</var> is a leaf node. It has ·jparent·=<var>J4</var>,
-                  <term>·jvalue·</term>=9, <term>·jposition·</term>=2, and <term>·jkey·</term>="2".
-                  Its <code>dm:j-children</code> accessor returns an empty sequence.</p>
-                </item>
-              </ulist>
-            </item>
-            <item>
-              <p><var>J5</var> is a leaf node. It has ·jparent·=<var>R</var>,
-              a <term>·jvalue·</term> that is a sequence of two element nodes named
-              <code>p</code> and <code>q</code>, <term>·jposition·</term>=1, and <term>·jkey·</term>="e".
-              Its <code>dm:j-children</code> accessor returns an empty sequence.</p>
-            </item>
-          </ulist>
-          </item>
-        </ulist>
-          
-          <note><p>Sequences (as distinct from maps and arrays) are not represented by an 
-          extra layer of JNodes in the tree. This is because the structure is designed primarily to
-          assist navigation of JTrees derived from JSON processing, in which sequence-valued nodes
-          never arise. Generally, JTrees are easier to manipulate if none of the contained arrays
-          or maps contain sequence-valued members or entries. JTrees containing non-homogenous
-          content (for example, sequences that mix arrays, maps, and other items) can be represented
-          using JNodes without loss of information, but may be difficult to navigate.</p></note>
-
-<p>The following diagram shows the JTree graphically. Each node is connected to
-its <code>dm:j-children</code> with arrows. The arrows are numbered to represent the
-order of the children.</p>
-
-<table>
-  <tbody>
-    <tr>
-      <td><graphic source="xgraph.svg"
-                   alt="Graphical depiction of the arbitrary XDM content JTree example."/>
-      </td>
-    </tr>
-    <tr>
-      <td>Graphic representation of arbitrary XDM content JTree
-[<loc href="images/xgraph.svg">standalone SVG</loc>]
-      </td>
-    </tr>
-  </tbody>
-</table>
-          
-      </example>
-      
-      -->
         
           <p>For a JNode representing the root of a JTree, the <term>·jparent·</term>
             and <term>·jkey·</term>
@@ -6885,7 +6660,7 @@ order of the children.</p>
             <term>·jparent·</term>s are identical and their <term>·jkey·</term>
             properties are equal as determined by the <function>atomic-equal</function> function.</p>
           
-          <p>A root JNode is constructed, wrapping a map or array, by a call on the <function>fn:jtree</function>
+          <p>A root JNode is constructed, wrapping any XDM value, by a call on the <function>fn:jtree</function>
           function applied to that map or array. This can be called explicitly, but it is also called
           implicitly in a number of situations: for example when a map or array is used as the left-hand 
           operand of the path operator <code>/</code>.</p>

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -6508,78 +6508,146 @@ position, in the range 1 to the size of the array.</p>
       <termref def="dt-GNode"/> (a generic node).
     JNodes have identity, and are organized into trees called <termref def="dt-JTree">JTrees</termref>.
     </p>
-      <p><termdef id="prop-jnode-value" term="value">Every <termref def="dt-JNode"/> has a property <term>·jvalue·</term> which is an 
-        arbitrary <termref def="dt-value"/> (that is, in general, a <termref def="dt-sequence"/>).</termdef></p>
       
-      <p>In addition a JNode that is not a root JNode has the following properties:</p>
+      <p>The properties of a JNode are as follows:</p>
       
-      <slist>
-        <sitem><term>·jparent·</term>: a JNode</sitem>
-        <sitem><term>·jposition·</term>: a positive integer</sitem>
-        <sitem><term>·jkey·</term>: an atomic item</sitem>
-      </slist>
+      <table>
+        <caption>Properties of JNodes</caption>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Meaning</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>·jparent·</td>
+            <td>JNode</td>
+            <td>The parent JNode in the tree; absent for the root</td>
+          </tr>
+          <tr>
+            <td>·jvalue·</td>
+            <td>An arbitrary XDM value</td>
+            <td>The encapsulated value</td>
+          </tr>
+          <tr>
+            <td>·jkey·</td>
+            <td>Atomic item</td>
+            <td>The key or index indicating how this value can be selected from the parent</td>
+          </tr>
+        </tbody>
+      </table>
       
-      <p>In effect, there are four kinds of JNode (though they are not distinguished
-      as different types in the type system):</p>
+      <p>JNodes can be classified as one of four kinds, based on the <term>·jvalue·</term> property:</p>
       
       <ulist>
-        <item><p>A root JNode that represents a map.</p></item>
-        <item><p>A root JNode that represents an array.</p></item>
-        <item><p>A non-root JNode that represents an entry in a map.</p></item>
-        <item><p>A non-root JNode that represents a member of an array.</p></item>
-      </ulist>
+        <item><p><termdef id="dt-array-jnode" term="Array JNode">An <term>Array JNode</term> is a JNode whose <term>·jvalue·</term>
+        is a <termref def="dt-singleton"/> array.</termdef></p></item>
+        <item><p><termdef id="dt-map-jnode" term="Map JNode">A <term>Map JNode</term> is a JNode whose <term>·jvalue·</term>
+        is a <termref def="dt-singleton"/> map.</termdef></p></item>
+        <item><p><termdef id="dt-sequence-jnode" term="Sequence JNode">A <term>Sequence JNode</term> is a JNode whose <term>·jvalue·</term>
+        is a sequence containing two or more items.</termdef></p></item>
+        <item><p><termdef id="dt-leaf-jnode" term="Leaf JNode">A <term>Leaf</term> JNode is a JNode whose <term>·jvalue·</term>
+        is either the empty sequence, or a <termref def="dt-singleton"/> item other than a map or array.</termdef>.</p></item>
+      </ulist>      
+      
+      
+      <example>
+        <head>XML Representation of a JTree</head>
+        <p>This example illustrates the JTrees corresponding
+        to some simple XDM values, using an XML representation of the JTree structure.</p>
+        
+        <p>The first example is a structure that might derive from JSON:</p>
+        
+        <eg>{ "a": 11, "b": [22, 33], "c": ()}</eg>
+        
+        <p>We represent a JNode by a <code>jnode</code> element, and we represent its
+          properties using XML attributes. The <term>·parent·</term> property is implied by the XML
+        hierarchy. Although the kind of JNode can be deduced from its <term>·jvalue·</term>
+        property, it is shown as a separate attribute for clarity:</p>
+        
+        <eg><![CDATA[
+  <jnode kind='map' key='()' value='{ "a": 11, "b": [22, 33], "c": ()}'>
+    <jnode kind='leaf' key='a' value='11'/> 
+    <jnode kind='array' key='b' value='[22, 33]'>
+      <jnode kind='leaf' key='1' value='22'/>
+      <jnode kind='leaf' key='2' value='33'/>
+    </jnode>
+    <jnode kind='leaf' key="'c' value="()"/>
+  </jnode>]]></eg>
+        
+        <p>So the children of a map correspond to the entries in the map, and the children of an array
+        correspond to the members of the array.</p>
+        
+        <p>It gets more complicated when sequences of length greater than one appear (this can never
+          happen with trees produced by parsing JSON). A sequence of
+          length greater than one is represented by a node with <code>kind='sequence'</code>. For example, consider:</p>
+        
+        <eg>{ "a": 11, "b": [22, 33], "c": (44, 55)}</eg>
+        
+        <p>This is represented as:</p>
+        
+        <eg><![CDATA[
+  <jnode kind='map' key='()' value='{ "a": 11, "b": [22, 33], "c": ()}'>
+    <jnode kind='leaf' key='a' value='11'/> 
+    <jnode kind='array' key='b' value='[22, 33]'>
+      <jnode kind='leaf' key='1' value='22'/>
+      <jnode kind='leaf' key='2' value='33'/>
+    </jnode>
+    <jnode kind='sequence' key='b' value='(44, 55)'>
+      <jnode kind='leaf' key='1' value='44'/>
+      <jnode kind='leaf' key='2' value='55'/>
+    </jnode>
+  </jnode>]]></eg>
+        
+        <p>Navigating a structure that mixes maps, arrays, and sequences of length greater than one can be awkward,
+        because the <code>sequence</code> node will be present for a sequence with multiple items, but
+        absent for a singleton sequence. JTrees and JNodes are designed primarily for manipulating JSON,
+        where this complication does not arise.</p>
+        
+        
+      </example>
+      
+      
       
       <p><termdef id="dt-j-children" term="j-children">The accessor <code>j-children</code>,
-         applied to a JNode <var>$PARENT</var>, returns a sequence of non-root JNodes
-         representing the children of <var>$PARENT</var>.</termdef></p>
+         applied to a JNode <var>P</var>, returns a sequence of non-root JNodes
+         representing the children of <var>P</var>.</termdef>.</p>
       
-      <p>Values are classified as <term>leaf</term> or <term>non-leaf</term>. A value is classified
-        as <term>non-leaf</term> if and only if at least one item in the value
-      is a non-empty map or array. If the ·jvalue· property of a JNode is classified as <term>leaf</term>, then
-      the <code>j-children</code> accessor returns an empty sequence.</p>
+      <p>The nodes returned by the <code>j-children</code> accessor depend on the kind of JNode:</p>
       
-      <note><p>If the <code>j-children</code> accessor of a JNode returns an empty sequence,
-      then it is necessary to examine the ·jvalue· property in order to distinguish whether
-      the value is (for example) an empty sequence, an atomic item, an empty map,
-      or an empty array.</p></note>
+      <olist>
+        <item><p>For an <termref def='dt-array-jnode'/>, one child JNode for each
+        member <var>M</var> of the array (retaining order), with the following properties:</p>
+          <slist>
+            <sitem><term>·jparent·</term>: <var>P</var></sitem>
+            <sitem><term>·jvalue·</term>: <var>M</var></sitem>
+            <sitem><term>·jkey·</term>: the 1-based position of <var>M</var> within <var>P</var></sitem>
+          </slist>
+        </item>
+        <item><p>For a <termref def='dt-map-jnode'/>, one child JNode for each
+        entry (<var>K</var>, <var>V</var>) in the map (retaining order), with the following properties:</p>
+          <slist>
+            <sitem><term>·jparent·</term>: <var>P</var></sitem>
+            <sitem><term>·jvalue·</term>: <var>V</var></sitem>
+            <sitem><term>·jkey·</term>: <var>K</var></sitem>
+          </slist>
+        </item>
+        <item><p>For a <termref def='dt-sequence-jnode'/>, then one child JNode for each
+        item <var>J</var> in the sequence (retaining order), with the following properties:</p>
+          <slist>
+            <sitem><term>·jparent·</term>: <var>P</var></sitem>
+            <sitem><term>·jvalue·</term>: <var>J</var></sitem>
+            <sitem><term>·jkey·</term>: the 1-based position of <var>J</var> within <var>P</var></sitem>
+          </slist>
+        </item>
+        <item><p>For a <termref def='dt-leaf-jnode'/>, the empty sequence.</p></item>
+      </olist>
       
-      <p>If the ·jvalue· property of a JNode <var>P</var> is classified as <term>non-leaf</term>, then
-      the <code>j-children</code> accessor returns a sequence of JNodes that includes
-        one JNode for each member of an array in <var>J</var> and one JNode for each entry
-        of a map in <var>J</var>. More specifically, the result is determined
-        by the expression below. This expression uses
-        the following notation:</p>
       
-      <ulist>
-        <item><p>The function
-        <code>dm:j-value</code> is used to access the ·jvalue· property of a JNode</p></item>
-        <item><p>The function <code>dm:JNode</code> is used to construct (or obtain)
-        a JNode whose properties correspond to the names of the argument keywords.</p></item>
-      </ulist>
-      
-      <eg>
-for $item at $pos in dm:j-value($PARENT)
-return if ($item instance of array(*)) then (
-  for member $member at $index in $item
-  return dm:JNode(
-    jparent   := $PARENT,
-    jposition := $pos,
-    jkey      := $index,
-    jvalue    := $member
-  )
-) else if ($item instance of map(*)) then (
-  for key $key value $value in $item
-  return dm:JNode(
-    jparent   := $PARENT,
-    jposition := $pos,
-    jkey      := $key,
-    jvalue    := $value
-  )
-) else ()
-</eg> 
-      
-      <p>The order of JNodes returned by the <code>j-children</code> accessor is significant, and is
-      as defined by the above expression.</p>
+      <!--
+     
   
       <example>
         <head>A JTree derived by parsing JSON</head>
@@ -6587,7 +6655,7 @@ return if ($item instance of array(*)) then (
           (a string, number, boolean, array, or map),
         or an empty sequence representing the JSON value <code>null</code>. Similarly, every entry
         in a map will have a key that is a single <code>xs:string</code>, and a corresponding
-        value that is either a single item (as above) or an empty sequence representing <code>null</code>.</p>
+        value that is either a single item (as above) or an empty sequence representing a JSON <code>null</code>.</p>
         
         <p>Consider a tree constructed by parsing the following JSON input:</p>
         
@@ -6596,6 +6664,33 @@ return if ($item instance of array(*)) then (
   { "a": 2, "b": "YYY", "c": false, "d": null }
 ]
   </eg>
+        
+        <p>The resulting JTree can be illustrated using the following XML representation,
+        where a JNode is represented by a <code>&lt;jnode</code> element and the properties
+        of the JNode are represented as XML attributes; JNodes are given an ID attribute so
+        that the parent property can be shown:</p>
+        
+        <eg><![CDATA[
+<jnode id="R" jvalue="[
+  { "a": 1, "b": "XXX", "c": true, "d": null },
+  { "a": 2, "b": "YYY", "c": false, "d": null }
+]">
+   <jnode id="M1" 
+          jparent="R" 
+          jvalue="{ "a": 1, "b": "XXX", "c": true, "d": null }"
+          jposition="1"
+          jkey="1"
+          jleaf="false">
+      <jnode id="M1.1"
+             jparent="M1"
+             jkey="a"
+             jvalue="1"
+             jposition="1"
+             jleaf="false">
+         <jnode id=
+             
+          
+        ]]></eg>
         <p>Then:</p>
         <ulist>
           <item><p>The root JNode <var>R</var> has a ·jvalue· property that is an 
@@ -6777,20 +6872,20 @@ order of the children.</p>
           
       </example>
       
-      
+      -->
         
-          <p>For a JNode representing the root of a JTree, the <term>·jparent·</term>, <term>·jposition·</term>,
+          <p>For a JNode representing the root of a JTree, the <term>·jparent·</term>
             and <term>·jkey·</term>
           properties will always be absent. For a non-root JNode, these properties will always be present.</p>
           
           <p>The identity of a root JNode is established when the root JNode is constructed, so that
           every operation that constructs a root JNode returns a JNode with distinct identity. The
-          identity of a non-root JNode is a function of its <term>·jparent·</term>, <term>·jposition·</term>, and <term>·jkey·</term>
+          identity of a non-root JNode is a function of its <term>·jparent·</term> and <term>·jkey·</term>
           properties: two non-root JNodes are identical by definition if and only if their
-            <term>·jparent·</term>s are identical and their <term>·jposition·</term> and <term>·jkey·</term>
+            <term>·jparent·</term>s are identical and their <term>·jkey·</term>
             properties are equal as determined by the <function>atomic-equal</function> function.</p>
           
-          <p>A root JNode is constructed, wrapping a map or array, by a call on the <function>jtree</function>
+          <p>A root JNode is constructed, wrapping a map or array, by a call on the <function>fn:jtree</function>
           function applied to that map or array. This can be called explicitly, but it is also called
           implicitly in a number of situations: for example when a map or array is used as the left-hand 
           operand of the path operator <code>/</code>.</p>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -32547,10 +32547,6 @@ array:build(
                   <td>The root JNode that encapsulates the array as a whole</td>
                </tr>
                <tr>
-                  <td>·jposition·</td>
-                  <td>The integer value 1</td>
-               </tr>
-               <tr>
                   <td>·jkey·</td>
                   <td>The one-based index of the member within the array.</td>
                </tr>
@@ -37384,7 +37380,7 @@ return $result
          <p>The function returns a <xtermref spec="DM40" ref="dt-JNode"/>
             that wraps the supplied <code>$input</code> value. Specifically, it returns a root JNode
             whose <term>·jvalue·</term> property is <code>$input</code>, and whose
-            <term>·jparent·</term>, <term>·jposition·</term>, and <term>·jkey·</term> 
+            <term>·jparent·</term> and <term>·jkey·</term> 
             properties are absent.</p>
 
          <p>The returned JNode acts as the root of a tree. Typical usage is for
@@ -37586,112 +37582,12 @@ return $array/descendant::*[. > 25]/ancestor-or-self::* =!> jkey()
          
       </fos:examples>
       <fos:see-also prefix="fn" name="jvalue"/>
-      <fos:see-also prefix="fn" name="jposition"/>
       <fos:changes>
          <fos:change issue="2025" PR="2031" date="2025-06-12"><p>New in 4.0</p></fos:change>
       </fos:changes>
    </fos:function>
    
-   <fos:function name="jposition" prefix="fn">
-      <fos:signatures>
-         <fos:proto name="jposition" return-type="xs:integer?">
-            <fos:arg name="input" type="jnode()?" default="." usage="inspection"/>
-         </fos:proto>
-      </fos:signatures>
-      <fos:properties>
-         <fos:property>deterministic</fos:property>
-         <fos:property>context-independent</fos:property>
-         <fos:property>focus-independent</fos:property>
-      </fos:properties>
-      <fos:summary>
-         <p>Returns the <term>·jposition·</term> property of a JNode.</p>
-      </fos:summary>
-      <fos:rules>
-         <p>If <code>$input</code> is the empty sequence, the function returns the empty sequence.</p>
-         <p>If <code>$input</code> is a root JNode (one in which the <term>·jposition·</term> property is
-            absent), the function returns the empty sequence.</p>
-         <p>Otherwise, the function returns the <term>·jposition·</term> property of <code>$input</code>.
-            The value of this property will be 1 (one) except in cases where 
-            the value of an entry in a map, or a member in an array, is a sequence that contains
-            multiple items including maps and/or arrays; in such cases
-            the position will be the 1-based position of the relevant map or array.</p>
-      </fos:rules>
-      <fos:errors>
-         <p>The following errors may be raised when <code>$node</code> is omitted:</p>
-         <ulist>
-            <item>
-               <p>If the context value is <xtermref ref="dt-absent" spec="DM40"
-                     >absent</xtermref>,
-                  type error <xerrorref spec="XP"
-                     class="DY" code="0002" type="type"/>.</p>
-            </item>
-            <item>
-               <p>If the context value is not an instance of the sequence type <code>jnode()?</code>, 
-                  type error <xerrorref spec="XP" class="TY"
-                     code="0004" type="type"/>.</p>
-            </item>
-         </ulist>
-      </fos:errors>
-      <fos:notes>
-         <p>This function is relevant only when there are maps whose entries are multi-item
-            sequences that include maps and arrays, or arrays whose members include
-            such multi-item sequences.
-         Such structures are uncommon, and never arise from parsing of JSON source text.
-         It is generally best to avoid such structures by using arrays rather than sequences
-         within array and map content; apart from other considerations, this allows the
-         data to be serialized in JSON format.</p>
-         <p>If an entry within a map, or a member of an array, contains a sequence of items
-         that mixes arrays and maps with other content (for example the array
-          <code>[1, 2, ([1,2], [3,4], 5))</code>, then a lookup using the
-            child axis will only construct JNodes in respect of those items that are
-            non-empty maps or arrays. This may leave gaps in the position numbering sequence,
-            as illustrated in the examples below.</p>
-      </fos:notes>
-      <fos:examples>
-         <fos:example>
-            <fos:test>
-               <fos:expression><eg>
-let $input := {
-   "a": [ 10, 20, 30 ], 
-   "b": ([ 40, 50, 60 ], [], 0, [ 70, 80, (90, 100) ])
-}
-return $input/b/* ! { "position": jposition(), "index": jkey(), "value": jvalue() }
-               </eg></fos:expression>
-               <fos:result><eg>
-{ "position": 1, "index": 1, "value": 40 },
-{ "position": 1, "index": 2, "value": 50 },
-{ "position": 1, "index": 3, "value": 60 },
-{ "position": 4, "index": 1, "value": 70 },
-{ "position": 4, "index": 2, "value": 80 },
-{ "position": 4, "index": 3, "value": (90, 100) }</eg></fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression><eg>
-let $input := {
-   "a": { "x": 10, "y": 20, "z": 30 }, 
-   "b": ({ "x": 40, "y": 50, "z": 60 }, {}, { "x": 70, "y": 80, "z": (90, 100) })
-}
-return $input/b/* ! { "position": jposition(), "key": jkey(), "value": jvalue() }
-               </eg></fos:expression>
-               <fos:result><eg>
-{ "position": 1, "key": "x", "value": 40 },
-{ "position": 1, "key": "y", "value": 50 },
-{ "position": 1, "key": "z", "value": 60 },
-{ "position": 3, "key": "x", "value": 70 },
-{ "position": 3, "key": "y", "value": 80 },
-{ "position": 3, "key": "z", "value": (90, 100) }</eg></fos:result>
-            </fos:test>
-
-            
-         </fos:example>
-         
-      </fos:examples>
-      <fos:see-also prefix="fn" name="jkey"/>
-      <fos:see-also prefix="fn" name="jvalue"/>
-      <fos:changes>
-         <fos:change issue="2025" PR="2031" date="2025-06-12"><p>New in 4.0</p></fos:change>
-      </fos:changes>
-   </fos:function>
+   
    
    <fos:function name="jvalue" prefix="fn">
       <fos:signatures>
@@ -37796,7 +37692,6 @@ return $array/descendant::jnode(*, array(*))[. > 25] =!> jvalue()</eg></fos:expr
          
       </fos:examples>
       <fos:see-also prefix="fn" name="jkey"/>
-      <fos:see-also prefix="fn" name="jposition"/>
       <fos:changes>
          <fos:change issue="2025" PR="2031" date="2025-06-12"><p>New in 4.0</p></fos:change>
       </fos:changes>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -9027,9 +9027,7 @@ map( xs:string,
             <div3 id="func-jvalue">
                <head><?function fn:jvalue?></head>
             </div3>
-            <div3 id="func-jposition">
-               <head><?function fn:jposition?></head>
-            </div3>
+            
          </div2>
          
          

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -12889,7 +12889,7 @@ return if (every $r in $R satisfies $r instance of gnode())
                      of <code><![CDATA[fn:siblings($node)[not(. >> $node)]]></code>.</p>
                   </item>
 
-
+               
 
                   <item>
 
@@ -12935,7 +12935,7 @@ return if (every $r in $R satisfies $r instance of gnode())
                      <p>More formally, <code>$node/preceding-or-self::gnode()</code> delivers the result
                      of <code>$node/(. | preceding::gnode())</code>.</p>
                   </item>  
-
+               
                   <item>
                      <p>The <code>attribute</code> axis is defined only for XNodes.
 			 It returns the attributes of the origin,
@@ -12959,12 +12959,36 @@ return if (every $r in $R satisfies $r instance of gnode())
                      <p>More formally, <code>$node/self::gnode()</code> delivers the result
                      of <code>$node</code>.</p>
                   </item>
-
-
                   
-
-
-                  
+                  <item>
+                     <p>The <code>item</code> axis is defined only for JNodes. It selects
+                     all the items in a sequence, whether the sequence contains zero, one, or multiple
+                     items. Specifically, for an origin node <var>G</var>:</p>
+                     <ulist>
+                        <item><p>If <var>G</var> is a <xtermref spec="DM40" ref="dt-sequence-jnode"/>
+                     (that is, a JNode whose ·jvalue· is a sequence of two or more items)
+                     it selects the same JNodes as the <code>child</code> axis.</p></item>
+                        <item><p>If <var>G</var> is a <xtermref spec="DM40" ref="dt-leaf-jnode"/>
+                        whose ·jvalue· is the empty sequence it returns the empty sequence.</p></item>
+                        <item><p>In all other cases (that is, when the ·jvalue· 
+                              of <var>G</var> is a <termref def="dt-singleton"/>)
+                              it selects a JNode <var>J</var> whose properties are as follows.</p>
+                           <slist>
+                              <sitem><term>·jkey·</term> = 1</sitem>
+                              <sitem><term>·jvalue·</term> = <code>jvalue(<var>G</var>)</code></sitem>
+                              <sitem><term>·jparent·</term> = <var>G</var></sitem>
+                           </slist>
+                           <p>Note that <var>G</var> is the parent of <var>J</var>, but <var>J</var>
+                           is not a child of <var>G</var>.</p>
+                        </item>
+                     </ulist>
+                     <p>If the <code>item</code> axis is applied to an XNode,
+                     a type error <errorref class="TY" code="0004"/> is raised.</p>
+                        
+                     <p>The <code>item</code> axis is useful when processing sequences that might contain zero,
+                        one, or more items, because it selects JNodes corresponding to those items regardless
+                        of the length of the sequence. See <specref ref="id-selectors-for-JNodes"/> for examples.</p>
+                  </item>
 
 
 
@@ -13035,10 +13059,10 @@ return if (every $r in $R satisfies $r instance of gnode())
 
                <p>
                   <termdef id="dt-principal-node-kind" term="principal node kind"
-                        >Every axis has a <term>principal node kind</term>. If an axis can
+                        >Every axis has a <term>principal node kind</term>. If an axis (when starting at an XNode) can
 		  contain elements, then the principal node kind is element; otherwise, it is the
 		  kind of nodes that the axis can contain.</termdef> Thus:</p>
-
+                  
                <ulist>
 
 
@@ -13053,12 +13077,16 @@ return if (every $r in $R satisfies $r instance of gnode())
 				namespace.</p>
                   </item>
 
+                  <item>
+                     <p>For the item axis, the principal node kind is
+				undefined.</p>
+                  </item>          
 
                   <item>
                      <p>For all other axes, the principal node kind is element.</p>
                   </item>
                </ulist>
-
+                  
             </div4>
             <div4 id="node-tests">
                <head>Node Tests</head>
@@ -13275,9 +13303,11 @@ return if (every $r in $R satisfies $r instance of gnode())
                
                <p>When the origin is a JNode, the selector filters the JNodes returned
                by the axis according to the JNode's <term>·jkey·</term> property.
-               For a <xtermref spec="DM40" ref="dt-map-jnode"/>, this can be any
-               atomic item; for an <xtermref spec="DM40" ref="dt-array-jnode"/>, or
-                  a <xtermref spec="DM40" ref="dt-sequence-jnode"/> it will
+               When the origin is a <xtermref spec="DM40" ref="dt-map-jnode"/>, the 
+                  <term>·jkey·</term> of the children can be any
+               atomic item; when the origin is an <xtermref spec="DM40" ref="dt-array-jnode"/>, or
+                  a <xtermref spec="DM40" ref="dt-sequence-jnode"/> the 
+                  <term>·jkey·</term> of the children will
                be a positive integer.</p>
                
                <p>If the selector takes the form <code>*</code>, then it matches
@@ -13372,6 +13402,38 @@ return if (every $r in $R satisfies $r instance of gnode())
                
                <p>All the above expressions return a sequence of JNodes. If the containing
                expression expects atomic items, then the JNodes are automatically atomized.</p>
+               
+               <p>The <code>item</code> axis is provided to enable processing of sequences that
+               might contain zero, one, or more items. Consider the structure:</p>
+               
+               <eg>[(), 1, 5, 10 to 20]</eg>
+               
+               <p>This is an array with four members; the corresponding JTree represents the 
+               first three members with a <xtermref spec="DM40" ref="dt-leaf-jnode"/>, and the
+               fourth with a <xtermref spec="DM40" ref="dt-sequence-jnode"/>. The items within the
+                  sequence <code>10 to 20</code> can be obtained using the child axis,
+                  but for a leaf node, the child axis is empty. The solution is to use the
+                  <code>item</code> axis: for all four members of the array, the item axis
+                  returns the items in the corresponding sequence.</p>
+               
+               <p>Similarly, consider:</p>
+               
+               <eg>let $names := [
+  { "first": "Fanny", "middle": (), "last": "Burney" },
+  { "first": "Margaret", "middle": "Hilda", "last": "Thatcher" },
+  { "first": "Charlotte", "middle": ("Elizabeth", "Diana"), "last": "Wales" }
+]</eg>
+               <p>The path expression <code>$names/*/middle/item::*</code> returns three
+               leaf JNodes, whose <term>·jvalue·</term> properties are respectively
+               <code>"Hilda"</code>, <code>"Elizabeth"</code>, and <code>"Diana"</code>.
+               By contrast, <code>$names/*/middle/child::*</code> delivers only two
+               JNodes, corresponding to <code>"Elizabeth"</code>, and <code>"Diana"</code>.
+               This is because the leaf node representing <code>"Hilda"</code> has no children.</p>
+               
+               <note><p>A JTree produced by parsing JSON input will never contain a
+                     <xtermref spec="DM40" ref="dt-sequence-jnode"/>, so this complication
+                     arises only when processing trees of maps and arrays produced by other means.
+               </p></note>
             </div4>
             <div4 id="id-type-tests">
                <head>Type Tests</head>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -13275,8 +13275,9 @@ return if (every $r in $R satisfies $r instance of gnode())
                
                <p>When the origin is a JNode, the selector filters the JNodes returned
                by the axis according to the JNode's <term>·jkey·</term> property.
-               In the case of a JNode that wraps an entry in a map, this can be any
-               atomic item; for a JNode that wraps a member of an array, it will
+               For a <xtermref spec="DM40" ref="dt-map-jnode"/>, this can be any
+               atomic item; for an <xtermref spec="DM40" ref="dt-array-jnode"/>, or
+                  a <xtermref spec="DM40" ref="dt-sequence-jnode"/> it will
                be a non-negative integer.</p>
                
                <p>If the selector takes the form <code>*</code>, then it matches

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -13278,7 +13278,7 @@ return if (every $r in $R satisfies $r instance of gnode())
                For a <xtermref spec="DM40" ref="dt-map-jnode"/>, this can be any
                atomic item; for an <xtermref spec="DM40" ref="dt-array-jnode"/>, or
                   a <xtermref spec="DM40" ref="dt-sequence-jnode"/> it will
-               be a non-negative integer.</p>
+               be a positive integer.</p>
                
                <p>If the selector takes the form <code>*</code>, then it matches
                every JNode (including one whose <term>·jkey·</term> property

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -29282,7 +29282,6 @@ the same group, and the-->
                         <ulist>
                            <item><p><term>·jvalue·</term> = <var>V1</var></p></item>
                            <item><p><term>·jkey·</term> = absent</p></item>
-                           <item><p><term>·jposition·</term> = absent</p></item>
                            <item><p><term>·jparent·</term> = absent</p></item>
                         </ulist>
                         </item>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -30154,450 +30154,9 @@ the same group, and the-->
             </div3>
          </div2>
       </div1>
-      <div1 id="result-trees">
-         <head>Transformation Results</head>
-         <p>The output of a transformation includes a <termref def="dt-principal-result"/> and zero or more <termref def="dt-secondary-result">secondary results</termref>.</p>
-         
-         
-         <p>The way in which these results are
-             delivered to an application is <termref def="dt-implementation-defined">implementation-defined</termref>.</p>
-         <imp-def-feature id="idf-api-results">The way in which the results of the transformation
-            are delivered to an application is implementation-defined.</imp-def-feature>
-         <p>Serialization of results
-             is described further in <specref ref="serialization"/>
-         </p>
-         <div2 id="creating-result-trees">
-            <head>Creating Secondary Results</head>
-            
-            <changes>
-               <change issue="530" PR="534" date="2023-06-09">
-                  A new serialization parameter <code>escape-solidus</code> is provided to control
-                  whether the character <code>/</code> is escaped as <code>\/</code> by the
-                  JSON serialization method.
-               </change>
-               <change issue="1534" PR="1549" date="2024-11-12">
-                  The input to the serializer can be defined using the <code>select</code> attribute
-                  of <elcode>xsl:result-document</elcode> as an alternative to using a sequence constructor.
-               </change>
-               <change issue="938" PR="2259" date="2025-11-02">
-                  A new serialization parameter <code>canonical</code> is available to give control
-                  over serialization of XML, XHTML, and JSON.
-               </change>
-               <change issue="1538" PR="1497 1546" date="2024-11-13">
-                  A new serialization parameter <code>json-lines</code> is available to enable
-                  output as one JSON value per line.
-               </change>
-               <change issue="1234" PR="2719" date="2026-07-28">
-                  Added the serialization parameters <code>indent-unit</code>, <code>indent-attributes</code>, and <code>line-ending</code>.
-               </change>
-            </changes>
-            
-            <?element xsl:result-document?>
-            <p>The <elcode>xsl:result-document</elcode> instruction is
-               used to create a <termref def="dt-secondary-result"/>.</p>
-               
-            <p>The <code>select</code> attribute and the contained <termref def="dt-sequence-constructor"/> are
-               mutually exclusive; if the <code>select</code> attribute is present then the
-               sequence constructor must be empty, and if the sequence constructor is non-empty
-               then the <code>select</code> attribute must be absent <errorref spec="XT" class="SE" code="3185"/>. 
-               The value of the <code>select</code> attribute or the <termref def="dt-immediate-result"/>
-               of the contained <termref def="dt-sequence-constructor"/>
-               is referred to as the <termref def="dt-raw-result"/>.</p>
-               
-               
-            
-            <p>As with the <termref def="dt-principal-result"/> of the
-            transformation, a <termref def="dt-secondary-result"/> may be delivered to the calling
-            application in three ways (see <specref ref="post-processing"/>):</p>
-            
-            <olist>
-               <item><p>The <termref def="dt-raw-result"/> may be delivered <emph>as is</emph>.</p></item>
-               <item><p>The <termref def="dt-raw-result"/> may be used to construct a <termref def="dt-final-result-tree"/>
-               by invoking the process of <xtermref spec="SE40" ref="sequence-normalization"/>.</p></item>
-               <item><p>The <termref def="dt-raw-result"/> may be serialized to a sequence of octets (which
-               may then, optionally, be saved to a persistent storage location).</p></item>
-            </olist>
-            
-            <note><p>The name of the instruction, <elcode>xsl:result-document</elcode>, is a little
-            misleading. The instruction does not necessarily deliver either an XML document tree
-            nor a serialized XML document. Instead, for example, it might deliver an array, a map,
-            serialized JSON, or a sequence of atomic items.</p></note>
-            
-            <p>The decision whether or not to serialize the raw result depends on the 
-               <termref def="dt-processor">processor</termref> and on the way it is invoked. This
-               is <termref def="dt-implementation-defined"/>, and it is not controlled by anything
-               in the stylesheet.</p>
-            
-            <p>If the result is not serialized, then the decision whether to
-               return the <termref def="dt-raw-result"/> or to construct a tree depends on the effective
-               value of the <code>build-tree</code> attribute. If the <termref def="dt-effective-value"/> of
-               the <code>build-tree</code> attribute is <code>yes</code>, then 
-                  a <termref def="dt-final-result-tree"/> is created
-               by invoking the process of <xtermref spec="SE40" ref="sequence-normalization"/>. 
-               Conversely, if the result <emph>is</emph> serialized, then 
-                  the decision whether or not to construct a tree depends on the choice of 
-                  serialization method, and the <code>build-tree</code> attribute is then ignored. 
-                  For example, with <code>method="xml"</code> a tree is always constructed, whereas 
-                  with <code>method="json"</code> a tree is never constructed.<!-- [XSLT 3.0 Erratum E14, bug 30208].-->
-               </p>
-
-            
-            <p>The <elcode>xsl:result-document</elcode> instruction
-               defines a URI that may be used to identify the <termref def="dt-secondary-result"/>.
-               The instruction may optionally specify the output format to be used for serializing the result.</p>
-            
-            <p>Technically, the result of evaluating the <elcode>xsl:result-document</elcode>
-               instruction is the empty sequence. This means it does not contribute anything to the
-               result of the sequence constructor it is part of.</p>
-            <p>The <termref def="dt-effective-value"/> of the
-                  <code>format</code> attribute, if specified, <rfc2119>must</rfc2119> be an <termref def="dt-eqname">EQName</termref>. The value is
-               expanded using the namespace declarations in scope for the
-                  <elcode>xsl:result-document</elcode> element. The resulting <termref def="dt-expanded-qname">expanded QName</termref>
-               <rfc2119>must</rfc2119> match the expanded QName of a named <termref def="dt-output-definition">output definition</termref> in the <termref def="dt-stylesheet">stylesheet</termref>. This identifies the
-                  <elcode>xsl:output</elcode> declaration that will control the serialization of the
-                  <termref def="dt-final-result-tree">final result tree</termref> (see <specref ref="serialization"/>), if the result tree is serialized. If the
-                  <code>format</code> attribute is omitted, the unnamed <termref def="dt-output-definition">output definition</termref> is used to control
-               serialization of the result tree.</p>
-            <p>
-               <error spec="XT" type="dynamic" class="DE" code="1460">
-                  <p>It is a <termref def="dt-dynamic-error"> dynamic error</termref> if the <termref def="dt-effective-value"/> of the
-                        <code>format</code> attribute <error.extra>of an
-                           <elcode>xsl:result-document</elcode> element</error.extra> is not a valid
-                        <termref def="dt-eqname">EQName</termref>, or if it does not match the
-                        <termref def="dt-expanded-qname">expanded QName</termref> of an <termref def="dt-output-definition">output definition</termref> in the containing <termref def="dt-package">package</termref>. If the processor is able to detect
-                     the error statically (for example, when the <code>format</code> attribute
-                     contains no curly brackets), then the processor <rfc2119>may</rfc2119>
-                     optionally raise this as a <termref def="dt-static-error">static
-                        error</termref>.</p>
-               </error>
-            </p>
-            <note>
-               <p>The only way to select the unnamed <termref def="dt-output-definition">output
-                     definition</termref> is to omit the <code>format</code> attribute.</p>
-            </note>
-            <p>The <code>parameter-document</code> attribute allows serialization
-               parameters to be supplied in an external document. The external document must contain
-               an <code>output:serialization-parameters</code> element with the format described in
-                  <xspecref spec="SE40" ref="serparams-in-xdm-instance"/>, and the parameters are
-               interpreted as described in that specification.</p>
-            <p>If present, the <termref def="dt-effective-value"/> of the URI supplied in the
-                  <code>parameter-document</code> attribute is dereferenced, after resolution
-               against the base URI of the <elcode>xsl:result-document</elcode> element if it is a
-               relative reference. 
-               The parameter document <rfc2119>should</rfc2119> be read during run-time evaluation of the stylesheet. 
-               If the location of the stylesheet at development time is
-               different from the deployed location, any relative reference should be resolved
-               against the deployed location. A serialization error occurs if the result of
-               dereferencing the URI is ill-formed or invalid; but if no document can be found at
-               the specified location, the attribute <code>should</code> be ignored.</p>
-            <p>A serialization parameter specified in the
-                  <code>parameter-document</code> takes precedence over a value supplied directly as
-               an attribute of <elcode>xsl:result-document</elcode>, which in turn takes precedence
-               over a value supplied in the selected output definition, except that the values of
-               the <code>cdata-section-elements</code> and <code>suppress-indentation</code>
-               attributes are merged in the same way as when multiple <elcode>xsl:output</elcode>
-               declarations are merged.</p>
-            <p>The attributes <code>method</code>, <code>allow-duplicate-names</code>, <code>build-tree</code>, <code>byte-order-mark</code>,
-               <code>canonical</code>, <code>cdata-section-elements</code>,
-               <code diff="add" at="2026-07-02">csv-header</code>, <code diff="add" at="2026-07-02">csv-quote-character</code>,
-               <code diff="add" at="2026-07-02">csv-separator</code>, <code>doctype-public</code>,
-                  <code>doctype-system</code>, <code>encoding</code>,
-               <code diff="add" at="2023-03-31">escape-solidus</code>,
-                  <code>escape-uri-attributes</code>, <code>html-version</code>, <code>indent</code>, <code diff="add" at="2026-06-25">indent-attributes</code>, <code diff="add" at="2026-06-25">indent-unit</code>, <code>item-separator</code>,
-               <code diff="add" at="2024-11-01">json-lines</code>,
-               <code>json-node-output-method</code>,
-                  <code diff="add" at="2026-06-25">line-ending</code>, <code>media-type</code>, <code>normalization-form</code>,
-                  <code>omit-xml-declaration</code>, <code>standalone</code>, <code>suppress-indentation</code>,
-               <!-- see bug 6535 -->
-               <code>undeclare-prefixes</code>, <code>use-character-maps</code>, and
-                  <code>output-version</code> may be used to override attributes defined in the
-               selected <termref def="dt-output-definition">output definition</termref>.</p>
-            <p>With the exception of <code>use-character-maps</code>, these attributes are all
-               defined as <termref def="dt-attribute-value-template">attribute value
-                  templates</termref>, so their values may be set dynamically. For any of these
-               attributes that is present on the <elcode>xsl:result-document</elcode> instruction,
-               the <termref def="dt-effective-value"/> of the attribute
-               overrides or supplements the corresponding value from the output definition. This
-               works in the same way as when one <elcode>xsl:output</elcode> declaration overrides
-               another. Some of the attributes have more specific
-                  rules:</p>
-            <ulist>
-               <item>
-                  <p>In the case of <code>cdata-section-elements</code>
-                     and <code>suppress-indentation</code>, the
-                     value of the serialization parameter is the union of the expanded names of the
-                     elements named in this instruction and the elements named in the selected
-                     output definition.</p>
-               </item>
-               <item>
-                  <p>In the case of <code>use-character-maps</code>, the character maps referenced
-                     in this instruction supplement and take precedence over those defined in the
-                     selected output definition.</p>
-               </item>
-               <item>
-                  <p>In the case of <code>doctype-public</code> and <code>doctype-system</code>,
-                     setting the <termref def="dt-effective-value"/> of the attribute to a zero-length string has the
-                     effect of overriding any value for these attributes obtained from the output
-                     definition. The corresponding serialization parameter is not set (is
-                     “absent”).</p>
-               </item>
-               <item>
-                  <p>In the case of <code>item-separator</code>, setting the <termref def="dt-effective-value"/> of the
-                     attribute to the special value <code>"#absent"</code> has the effect of
-                     overriding any value for this attribute obtained from the output definition.
-                     The corresponding serialization parameter is not set (is “absent”). It is not
-                     possible to set the value of the serialization parameter to the literal
-                     7-character string <code>"#absent"</code>. </p>
-               </item>
-               <item>
-                  <p>In all other cases, the <termref def="dt-effective-value"/> of an attribute actually present on
-                     this instruction takes precedence over the value defined in the selected output
-                     definition.</p>
-               </item>
-            </ulist>
-            
-               <p>In the case of the attributes <code>method</code>, <code>json-node-output-method</code>,
-                     <code>cdata-section-elements</code>, <code>suppress-indentation</code>, and
-                     <code>use-character-maps</code>, the <termref def="dt-effective-value"/> of the attribute
-                  contains an <termref def="dt-eqname">EQName</termref> or a space-separated list of
-                     <termref def="dt-eqname">EQNames</termref>. Where lexical QNames are used in these attributes (whether prefixed
-               or unprefixed), the namespace context is established in the same way as for the corresponding
-               attributes of <elcode>xsl:output</elcode>: see <specref ref="id-default-serialization-parameters"/>.</p>
-            
-            <p>The <code>output-version</code> attribute on the <elcode>xsl:result-document</elcode>
-               instruction overrides the <code>version</code> attribute on
-                  <elcode>xsl:output</elcode> (it has been renamed because <code>version</code> is
-               available with a different meaning as a standard attribute: see <specref ref="standard-attributes"/>). In all other cases, attributes correspond if they
-               have the same name.</p>
-            <p>There are some serialization parameters that apply to some output methods but not to
-               others. For example, the <code>indent</code> attribute has no effect on the
-                  <code>text</code> output method. If a value is supplied for an attribute that is
-               inapplicable to the output method, its value is not passed to the serializer. The
-               processor <rfc2119>may</rfc2119> validate the value of such an attribute, but is not
-                  <rfc2119>required</rfc2119> to do so.</p>
-            
-            <p>The <code>item-separator</code> serialization parameter
-               is used when the <termref def="dt-raw-result"/> is used to construct a result tree
-               by applying sequence normalization, and it is also used when the result tree is
-               serialized. For example, if the sequence constructor delivers a sequence of
-               integers, and the <code>text</code> serialization method is used, then the result of serialization
-               will be a string obtained by converting each integer to a string, and separating the
-               strings using the defined <code>item-separator</code>.</p>
-            
-            
-            <p>The <code>href</code> attribute is optional. The default value is the zero-length
-               string. The <termref def="dt-effective-value"/> of the
-               attribute <rfc2119>must</rfc2119> be a <termref def="dt-uri-reference">URI
-                  Reference</termref>, which may be absolute or relative. If it is relative, then it is resolved against the <termref def="dt-base-output-uri"/>. There <rfc2119>may</rfc2119> be <termref def="dt-implementation-defined">implementation-defined</termref> restrictions on
-               the form of absolute URI that may be used, but the implementation is not
-                  <rfc2119>required</rfc2119> to enforce any restrictions. Any valid relative URI
-                  reference
-               <rfc2119>must</rfc2119> be accepted. Note that the zero-length string is a valid
-               relative URI reference.</p>
-            <imp-def-feature id="idf-api-resultdocumenthref"> It is <termref def="dt-implementation-defined"/> how the URI appearing in the <code>href</code>
-               attribute of <elcode>xsl:result-document</elcode> affects the way in which the result
-               tree is delivered to the application. There <rfc2119>may</rfc2119> be restrictions on
-               the form of this URI. </imp-def-feature>
-            <p>If the implementation provides an API to access <termref def="dt-secondary-result">secondary results</termref>, then it
-                  <rfc2119>must</rfc2119> allow a secondary result to be identified by means of the
-               absolutized value of the <code>href</code> attribute. In addition, if a <termref def="dt-final-result-tree"/> is constructed
-               (that is, if the <termref def="dt-effective-value"/> of
-                  <code>build-tree</code> is <code>yes</code>), then this value is used as the base
-               URI of the document node at the root of the <termref def="dt-final-result-tree">final
-                  result tree</termref>. </p>
-
-
-
-            <note>
-               <p>The base URI of the <termref def="dt-final-result-tree">final result
-                     tree</termref> is not necessarily the same thing as the URI of its serialized
-                  representation on disk, if any. For example, a server (or browser client) might
-                  store final result trees only in memory, or in an internal disk cache. As long as
-                  the processor satisfies requests for those URIs, it is irrelevant where they are
-                  actually written on disk, if at all.</p>
-            </note>
-            <note>
-               <p>It will often be the case that one <termref def="dt-final-result-tree">final
-                     result tree</termref> contains links to another final result tree produced
-                  during the same transformation, in the form of a relative URI reference. The mechanism of associating a URI with a final
-                  result tree has been chosen to allow the integrity of such links to be preserved
-                  when the trees are serialized.</p>
-               <p>As well as being potentially significant in any API that provides access to final
-                  result trees, the base URI of the new document node is relevant if the final
-                  result tree, rather than being serialized, is supplied as input to a further
-                  transformation.</p>
-            </note>
-            <p>The optional attributes <code>type</code> and <code>validation</code> may be used on
-               the <elcode>xsl:result-document</elcode> instruction to validate the contents of
-                  a <termref def="dt-final-result-tree"/>, and to determine the <termref def="dt-type-annotation">type
-                  annotation</termref> that elements and attributes within the <termref def="dt-final-result-tree">final result tree</termref> will carry. The permitted
-               values and their semantics are described in <specref ref="validating-document-nodes"/>. Any such validation is applied to the
-               document node produced as the result of <xtermref spec="SE40" ref="sequence-normalization"/>.
-               If sequence normalization does not take place (typically because the <termref def="dt-raw-result"/>
-               is delivered to the application directly, or because the selected serialization method
-               does not involve sequence normalization) then the <code>validation</code> and
-               <code>type</code> attributes are ignored.</p>
-            
-            <note><p>Validation applies after inserting item separators as determined by the
-            <code>item-separator</code> serialization parameter, and an inappropriate choice
-            of <code>item-separator</code> may cause the result to become invalid.</p></note>
-            
-            <p>A <termref def="dt-processor">processor</termref>
-               <rfc2119>may</rfc2119> allow a <termref def="dt-final-result-tree">final result
-                  tree</termref> to be serialized. Serialization is described in <specref ref="serialization"/>. However, an implementation (for example, a <termref def="dt-processor">processor</termref> running in an environment with no access to
-               writable filestore) is not <rfc2119>required</rfc2119> to support the serialization
-               of <termref def="dt-final-result-tree">final result trees</termref>. An
-               implementation that does not support the serialization of final result trees
-                  <rfc2119>may</rfc2119> ignore the <code>format</code> attribute and the
-               serialization attributes. Such an implementation <rfc2119>must</rfc2119> provide the
-               application with some means of access to the (un-serialized) result tree, using its
-               URI to identify it.</p>
-            <p>Implementations may provide additional mechanisms, outside the scope of this
-               specification, for defining the way in which <termref def="dt-final-result-tree">final result trees</termref> are processed. Such mechanisms
-                  <rfc2119>may</rfc2119> make use of the XSLT-defined attributes on the
-                  <elcode>xsl:result-document</elcode> and/or <elcode>xsl:output</elcode> elements,
-               or they <rfc2119>may</rfc2119> use additional elements or attributes in an <termref def="dt-implementation-defined">implementation-defined</termref> namespace.</p>
-
-            <example>
-               <head>Multiple Result Documents</head>
-               <p> The following example takes an XHTML document as input, and breaks it up so that
-                  the text following each &lt;h1&gt; element is included in a separate document. A
-                  new document <code>toc.html</code> is constructed to act as an index:</p>
-               <eg role="xslt-document" xml:space="preserve">&lt;xsl:stylesheet
-	version="4.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-	xmlns:xhtml="http://www.w3.org/1999/xhtml"&gt;
-	
-&lt;xsl:output name="toc-format" method="xhtml" indent="yes"
-     doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"
-     doctype-public="-//W3C//DTD XHTML 1.0 Strict//EN"/&gt;
-            
-&lt;xsl:output name="section-format" method="xhtml" indent="no"
-     doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"
-     doctype-public="-//W3C//DTD XHTML 1.0 Transitional//EN"/&gt;	
-	 
-&lt;xsl:template match="/"&gt;
-  &lt;xsl:result-document href="toc.html" 
-                       format="toc-format" 
-                       validation="strict"&gt;
-    &lt;html xmlns="http://www.w3.org/1999/xhtml"&gt;
-      &lt;head&gt;&lt;title&gt;Table of Contents&lt;/title&gt;&lt;/head&gt;
-      &lt;body&gt;
-        &lt;h1&gt;Table of Contents&lt;/h1&gt;
-        &lt;xsl:for-each select="/*/xhtml:body/(*[1] | xhtml:h1)"&gt;
-          &lt;p&gt;
-            &lt;a href="section{position()}.html"&gt;
-              &lt;xsl:value-of select="."/&gt;
-            &lt;/a&gt;
-          &lt;/p&gt;
-        &lt;/xsl:for-each&gt;
-      &lt;/body&gt;
-    &lt;/html&gt;
-  &lt;/xsl:result-document&gt;
-  &lt;xsl:for-each-group select="/*/xhtml:body/*" group-starting-with="xhtml:h1"&gt;
-    &lt;xsl:result-document href="section{position()}.html" 
-                         format="section-format" validation="strip"&gt;  	
-      &lt;html xmlns="http://www.w3.org/1999/xhtml"&gt;
-        &lt;head&gt;&lt;title&gt;&lt;xsl:value-of select="."/&gt;&lt;/title&gt;&lt;/head&gt;
-        &lt;body&gt;
-          &lt;xsl:copy-of select="current-group()"/&gt;
-        &lt;/body&gt;
-      &lt;/html&gt;
-    &lt;/xsl:result-document&gt;
-  &lt;/xsl:for-each-group&gt;
-&lt;/xsl:template&gt;
-
-&lt;/xsl:stylesheet&gt;</eg>
-            </example>
-         </div2>
-         <div2 id="result-document-restrictions">
-            <head>Restrictions on the use of <elcode>xsl:result-document</elcode></head>
-            <p>There are restrictions on the use of the <elcode>xsl:result-document</elcode>
-               instruction, designed to ensure that the results are fully interoperable even when
-               processors optimize the sequence in which instructions are evaluated. Informally, the
-               restriction is that the <elcode>xsl:result-document</elcode> instruction can only be
-               used while writing a final result tree, not while writing to a temporary tree or a
-               sequence. This restriction is defined formally as follows.</p>
-            <p>
-               <termdef id="dt-output-state" term="output state">Each instruction in the <termref def="dt-stylesheet">stylesheet</termref> is evaluated in one of two possible
-                     <term>output states</term>: <termref def="dt-final-output-state">final output
-                     state</termref> or <termref def="dt-temporary-output-state">temporary output
-                     state</termref>.</termdef></p>
-            <p>
-               <termdef id="dt-final-output-state" term="final output state">The first of the two
-                     <termref def="dt-output-state">output states</termref> is called <term>final
-                     output</term> state. This state applies when instructions are writing to a
-                     <termref def="dt-final-result-tree">final result tree</termref>.</termdef>
-            </p>
-            <p>
-               <termdef id="dt-temporary-output-state" term="temporary output state">The second of
-                  the two <termref def="dt-output-state">output states</termref> is called
-                     <term>temporary output</term> state. This state applies when instructions are
-                  writing to a <termref def="dt-temporary-tree">temporary tree</termref> or any
-                  other non-final destination.</termdef>
-            </p>
-            <p>The instructions in the <termref def="dt-initial-named-template"/> are evaluated in
-                  <termref def="dt-final-output-state">final output state</termref>. An instruction
-               is evaluated in the same <termref def="dt-output-state">output state</termref> as its
-               calling instruction, except that <elcode>xsl:variable</elcode>,
-                  <elcode>xsl:param</elcode>, <elcode>xsl:with-param</elcode>, 
-               <elcode>xsl:function</elcode>, <elcode>xsl:key</elcode>, <elcode>xsl:sort</elcode>,
-                  <elcode>xsl:accumulator-rule</elcode>, and
-                     <elcode>xsl:merge-key</elcode>
-                always evaluate the instructions in their
-               contained <termref def="dt-sequence-constructor">sequence constructor</termref> in
-                  <termref def="dt-temporary-output-state">temporary output state</termref>.</p>
-            <p>
-               <error spec="XT" type="dynamic" class="DE" code="1480">
-                  <p>It is a <termref def="dt-dynamic-error"> dynamic error</termref> to evaluate the
-                        <elcode>xsl:result-document</elcode> instruction in <termref def="dt-temporary-output-state">temporary output state</termref>.</p>
-               </error>
-            </p>
-            <p>
-               <error spec="XT" type="dynamic" class="DE" code="1490">
-                  <p>It is a <termref def="dt-dynamic-error"> dynamic error</termref> for a transformation to
-                     generate two or more <termref def="dt-final-result-tree">final result
-                        trees</termref> with the same URI.</p>
-               </error>
-            </p>
-            <note>
-               <p>Note, this means that it is an error to evaluate more than one
-                     <elcode>xsl:result-document</elcode> instruction that omits the
-                     <code>href</code> attribute, or to evaluate any
-                     <elcode>xsl:result-document</elcode> instruction that omits the
-                     <code>href</code> attribute if an initial <termref def="dt-final-result-tree">final result tree</termref> is created implicitly.</p>
-            </note>
-            <p>In addition, an implementation <rfc2119>may</rfc2119> raise this
-               error if it is able to detect that two or more final result trees are generated with
-               different URIs that refer to the same physical resource.</p>
-
-
-            
-            <p>
-               <error spec="XT" type="dynamic" class="DE" code="1500">
-                  <p>It is a <termref def="dt-dynamic-error"> dynamic error</termref> for a <termref def="dt-stylesheet">stylesheet</termref> to write to an external resource
-                     and read from the same resource during a single transformation, if the same absolute URI is used to access the resource in
-                        both cases. </p>
-               </error>
-            </p>
-            <p>In addition, an implementation <rfc2119>may</rfc2119> raise this
-               error if it is able to detect that a transformation writes to a resource and reads
-               from the same resource using different URIs that refer to the same physical resource.
-               Note that if the error is not detected, it is <termref def="dt-implementation-dependent"/> whether the document that is read from the
-               resource reflects its state before or after the result tree is written.</p>
-         </div2>
-         <div2 id="current-output-uri">
-            <head>The Current Output URI</head>
-            <p><termdef id="dt-current-output-uri" term="current output URI">The <term>current output URI</term> is the URI
-                  associated with the <termref def="dt-principal-result"/> or <termref def="dt-secondary-result"/> that is currently being written.</termdef></p>
-            <div3 id="func-current-output-uri">
-               <head><?function fn:current-output-uri?></head>
-
-            </div3>
-         </div2>
-
-
-         <div2 id="validation">
+      
+      =================
+      <div1 id="validation">
             <head>Validation</head>
             
             <changes>
@@ -30704,9 +30263,9 @@ the same group, and the-->
                The rules for element and attribute nodes are given in <specref ref="validating-constructed-nodes"/>, 
                while those for document nodes are given in
                   <specref ref="validating-document-nodes"/>.</p>
-            <div3 id="validating-constructed-nodes">
+            <div2 id="validating-constructed-nodes">
                <head>Validating Constructed Elements and Attributes</head>
-               <div4 id="validating-using-validation-attribute">
+               <div3 id="validating-using-validation-attribute">
                   <head>Validation using the <code>[xsl:]validation</code> Attribute</head>
                   <p>The <code>[xsl:]validation</code> attribute defines the validation action to be
                      taken. It determines not only the <termref def="dt-type-annotation">type
@@ -30915,8 +30474,8 @@ the same group, and the-->
                   </p></item>
                   </ulist>
                   
-               </div4>
-               <div4 id="validation-xsl-type">
+               </div3>
+               <div3 id="validation-xsl-type">
                   <head>Validation using the <code>[xsl:]type</code> Attribute</head>
                   <p>The <code>[xsl:]type</code> attribute takes as its value an 
                      <phrase diff="chg" at="2022-01-01"><xnt spec="XP40" ref="prod-xpath40-EQName"/></phrase>.
@@ -31011,8 +30570,8 @@ the same group, and the-->
                         statically, it will be raised when the instruction is evaluated.</p>
                   </note></item>
                   </ulist>
-               </div4>
-               <div4 id="id-xsi-schema-location">
+               </div3>
+               <div3 id="id-xsi-schema-location">
                   <head>The <code>xsi:schemaLocation</code> and <code>xsi:noNamespaceSchemaLocation</code> attributes</head>
                   <p>It is <termref def="dt-implementation-defined"/> whether the validity assessment
                   process takes account of any <code>xsi:schemaLocation</code> or <code>xsi:noNamespaceSchemaLocation</code>
@@ -31038,7 +30597,7 @@ the same group, and the-->
                      mean that this is not a problem.</p>
                   
                   
-               </div4>
+               </div3>
                <!--<div4 id="validation-process">
                   <head>The Validation Process</head>
                   <p>As well as checking for validity against the schema, the validity assessment
@@ -31147,8 +30706,8 @@ the same group, and the-->
                      </error>
                   </p>
                </div4>-->
-            </div3>
-            <div3 id="validating-document-nodes">
+            </div2>
+            <div2 id="validating-document-nodes">
                <head>Validating Document Nodes</head>
                <p>It is possible to apply validation to a document node. This happens when a new
                   document node is constructed by one of the XSLT elements <elcode>xsl:source-document</elcode>, <elcode>xsl:merge-source</elcode>, <elcode>xsl:document</elcode>,
@@ -31233,8 +30792,8 @@ the same group, and the-->
                         </p>
                   </error>
                </p>
-            </div3>
-            <div3 id="validating-xml-id">
+            </div2>
+            <div2 id="validating-xml-id">
                <head>Validating <code>xml:id</code> attributes</head>
                <p>This section provides a non-normative summary of the effect of validation on
                attributes named <code>xml:id</code>. The normative rules can be inferred from rules
@@ -31254,10 +30813,30 @@ the same group, and the-->
                   <item><p>Checking <code>xml:id</code> attributes for uniqueness happens if and only if
                   validation is applied at the level of a document node.</p></item>
                </olist>
-            </div3>
-         </div2>
-      </div1>
-      <div1 id="serialization">
+            </div2>
+         </div1>
+      
+ 
+      
+      
+      
+      
+      
+      <div1 id="result-trees">
+         <head>Transformation Results</head>
+         <p>The output of a transformation includes a <termref def="dt-principal-result"/> and zero or more <termref def="dt-secondary-result">secondary results</termref>.</p>
+         
+         
+         <p>The way in which these results are
+             delivered to an application is <termref def="dt-implementation-defined">implementation-defined</termref>.</p>
+         <imp-def-feature id="idf-api-results">The way in which the results of the transformation
+            are delivered to an application is implementation-defined.</imp-def-feature>
+         <p>Serialization of results
+             is described further in <specref ref="serialization"/>
+         </p>
+         
+         
+         <div2 id="serialization">
          <head>Serialization</head>
          
         
@@ -31277,7 +30856,7 @@ the same group, and the-->
                <elcode>xsl:output</elcode>, <elcode>xsl:result-document</elcode>, and
                <elcode>xsl:character-map</elcode> declarations.</p>
          
-         <div2 id="id-xsl-output-declaration">
+         <div3 id="id-xsl-output-declaration">
             <head>The <code>xsl:output</code> declaration</head>
             <changes>
                <change issue="530" PR="534" date="2023-06-09">
@@ -31392,8 +30971,8 @@ the same group, and the-->
                methods or for serialization methods introduced in future versions of this
                specification.</p>
          </note>
-         </div2>
-         <div2 id="id-default-serialization-parameters">
+         </div3>
+         <div3 id="id-default-serialization-parameters">
             <head>Serialization parameters</head>
             <changes>
                <change issue="1548" PR="1560" date="2024-11-09">
@@ -31724,8 +31303,8 @@ the same group, and the-->
          <p>If the processor performs serialization, then it must raise any  serialization errors that occur. These have the same
             effect as <termref def="dt-dynamic-error"> dynamic errors</termref>: that is, the processor must
             raise the error and must not finish as if the transformation had been successful.</p>
-         </div2>
-            <div2 id="character-maps">
+         </div3>
+         <div3 id="character-maps">
             <head>Character Maps</head>
             <p>
                <termdef id="dt-character-map" term="character map">A <term>character map</term>
@@ -31903,8 +31482,8 @@ the same group, and the-->
                the data model allows this, but processors are not <rfc2119>required</rfc2119>
                to support it: see <xspecref spec="DM40" ref="xml-and-xsd-versions"/>.</p>
             </note>   
-         </div2> 
-         <div2 id="character-map-function">
+         </div3> 
+         <div3 id="character-map-function">
             <head>The <function>character-map</function> function</head>
             <changes>
                <change issue="1500" PR="1530" date="2024-10-30">
@@ -31919,9 +31498,9 @@ the same group, and the-->
                <head><?function fn:character-map?></head>
 
             </div3>
-         </div2>
+         </div3>
          
-         <div2 id="disable-output-escaping">
+         <div3 id="disable-output-escaping">
             <head>Disabling Output Escaping</head>
             <p>Normally, when using the XML, HTML, or XHTML output method, the serializer will
                escape special characters such as <code>&amp;</code> and <code>&lt;</code> when
@@ -32022,7 +31601,476 @@ the same group, and the-->
                   that can be used in many situations where disabling of output escaping was
                   previously necessary, without the same difficulties.</p>
             </note>
+         </div3>
+      </div2>
+      
+         
+         <div2 id="creating-result-trees">
+            <head>Creating Secondary Results</head>
+            
+            <changes>
+               <change issue="530" PR="534" date="2023-06-09">
+                  A new serialization parameter <code>escape-solidus</code> is provided to control
+                  whether the character <code>/</code> is escaped as <code>\/</code> by the
+                  JSON serialization method.
+               </change>
+               <change issue="1534" PR="1549" date="2024-11-12">
+                  The input to the serializer can be defined using the <code>select</code> attribute
+                  of <elcode>xsl:result-document</elcode> as an alternative to using a sequence constructor.
+               </change>
+               <change issue="938" PR="2259" date="2025-11-02">
+                  A new serialization parameter <code>canonical</code> is available to give control
+                  over serialization of XML, XHTML, and JSON.
+               </change>
+               <change issue="1538" PR="1497 1546" date="2024-11-13">
+                  A new serialization parameter <code>json-lines</code> is available to enable
+                  output as one JSON value per line.
+               </change>
+               <change issue="1234" PR="2719" date="2026-07-28">
+                  Added the serialization parameters <code>indent-unit</code>, <code>indent-attributes</code>, and <code>line-ending</code>.
+               </change>
+            </changes>
+            
+            <?element xsl:result-document?>
+            <p>The <elcode>xsl:result-document</elcode> instruction is
+               used to create a <termref def="dt-secondary-result"/>.</p>
+               
+            <p>The <code>select</code> attribute and the contained <termref def="dt-sequence-constructor"/> are
+               mutually exclusive; if the <code>select</code> attribute is present then the
+               sequence constructor must be empty, and if the sequence constructor is non-empty
+               then the <code>select</code> attribute must be absent <errorref spec="XT" class="SE" code="3185"/>. 
+               The value of the <code>select</code> attribute or the <termref def="dt-immediate-result"/>
+               of the contained <termref def="dt-sequence-constructor"/>
+               is referred to as the <termref def="dt-raw-result"/>.</p>
+            
+            <note><p>The name of the instruction, <elcode>xsl:result-document</elcode>, is a little
+               misleading. The instruction does not necessarily deliver either an XML document tree
+               nor a serialized XML document. Instead, for example, it might deliver an array, a map,
+               serialized JSON, or a sequence of atomic items.</p></note>
+               
+            <p>Technically, the result of evaluating the <elcode>xsl:result-document</elcode>
+               instruction is the empty sequence. This means it does not contribute anything to the
+               result of the sequence constructor it is part of.</p>
+               
+            <div3 id="delivering-secondary-result">
+               <head>Delivering the Result</head>
+              
+            
+               <p>As with the <termref def="dt-principal-result"/> of the
+               transformation, a <termref def="dt-secondary-result"/> may be delivered to the calling
+               application in three ways (see <specref ref="post-processing"/>):</p>
+               
+               <olist>
+                  <item><p>The <termref def="dt-raw-result"/> may be delivered <emph>as is</emph>.</p></item>
+                  <item><p>The <termref def="dt-raw-result"/> may be used to construct a <termref def="dt-final-result-tree"/>
+                  by invoking the process of <xtermref spec="SE40" ref="sequence-normalization"/>.</p></item>
+                  <item><p>The <termref def="dt-raw-result"/> may be serialized to a sequence of octets (which
+                  may then, optionally, be saved to a persistent storage location).</p></item>
+               </olist>
+               
+               
+               
+               <p>The decision whether or not to serialize the raw result depends on the 
+                  <termref def="dt-processor">processor</termref> and on the way it is invoked. This
+                  is <termref def="dt-implementation-defined"/>, and it is not controlled by anything
+                  in the stylesheet.</p>
+               
+               <p>If the result is not serialized, then the decision whether to
+                  return the <termref def="dt-raw-result"/> or to construct a tree depends on the effective
+                  value of the <code>build-tree</code> attribute. If the <termref def="dt-effective-value"/> of
+                  the <code>build-tree</code> attribute is <code>yes</code>, then 
+                     a <termref def="dt-final-result-tree"/> is created
+                  by invoking the process of <xtermref spec="SE40" ref="sequence-normalization"/>. 
+                  Conversely, if the result <emph>is</emph> serialized, then 
+                     the decision whether or not to construct a tree depends on the choice of 
+                     serialization method, and the <code>build-tree</code> attribute is then ignored. 
+                     For example, with <code>method="xml"</code> a tree is always constructed, whereas 
+                     with <code>method="json"</code> a tree is never constructed.<!-- [XSLT 3.0 Erratum E14, bug 30208].-->
+                  </p>
+               
+               <p>Implementations may provide additional mechanisms, outside the scope of this
+               specification, for defining the way in which <termref def="dt-final-result-tree">final result trees</termref> are processed. Such mechanisms
+                  <rfc2119>may</rfc2119> make use of the XSLT-defined attributes on the
+                  <elcode>xsl:result-document</elcode> and/or <elcode>xsl:output</elcode> elements,
+               or they <rfc2119>may</rfc2119> use additional elements or attributes in an <termref def="dt-implementation-defined">implementation-defined</termref> namespace.</p>
+
+               
+            </div3>
+            <div3 id="result-uri">
+               <head>The Result Document URI</head>
+           
+            
+            <p>The <elcode>xsl:result-document</elcode> instruction
+               defines a URI that may be used to identify the <termref def="dt-secondary-result"/>.
+               </p>
+            
+            <p>The <code>href</code> attribute is optional. The default value is the zero-length
+               string. The <termref def="dt-effective-value"/> of the
+               attribute <rfc2119>must</rfc2119> be a <termref def="dt-uri-reference">URI
+                  Reference</termref>, which may be absolute or relative. If it is relative, then it is resolved against the <termref def="dt-base-output-uri"/>. There <rfc2119>may</rfc2119> be <termref def="dt-implementation-defined">implementation-defined</termref> restrictions on
+               the form of absolute URI that may be used, but the implementation is not
+                  <rfc2119>required</rfc2119> to enforce any restrictions. Any valid relative URI
+                  reference
+               <rfc2119>must</rfc2119> be accepted. Note that the zero-length string is a valid
+               relative URI reference.</p>
+            <imp-def-feature id="idf-api-resultdocumenthref"> It is <termref def="dt-implementation-defined"/> how the URI appearing in the <code>href</code>
+               attribute of <elcode>xsl:result-document</elcode> affects the way in which the result
+               tree is delivered to the application. There <rfc2119>may</rfc2119> be restrictions on
+               the form of this URI. </imp-def-feature>
+            <p>If the implementation provides an API to access <termref def="dt-secondary-result">secondary results</termref>, then it
+                  <rfc2119>must</rfc2119> allow a secondary result to be identified by means of the
+               absolutized value of the <code>href</code> attribute. In addition, if a <termref def="dt-final-result-tree"/> is constructed
+               (that is, if the <termref def="dt-effective-value"/> of
+                  <code>build-tree</code> is <code>yes</code>), then this value is used as the base
+               URI of the document node at the root of the <termref def="dt-final-result-tree">final
+                  result tree</termref>. </p>
+
+
+
+            <note>
+               <p>The base URI of the <termref def="dt-final-result-tree">final result
+                     tree</termref> is not necessarily the same thing as the URI of its serialized
+                  representation on disk, if any. For example, a server (or browser client) might
+                  store final result trees only in memory, or in an internal disk cache. As long as
+                  the processor satisfies requests for those URIs, it is irrelevant where they are
+                  actually written on disk, if at all.</p>
+            </note>
+            <note>
+               <p>It will often be the case that one <termref def="dt-final-result-tree">final
+                     result tree</termref> contains links to another final result tree produced
+                  during the same transformation, in the form of a relative URI reference. The mechanism of associating a URI with a final
+                  result tree has been chosen to allow the integrity of such links to be preserved
+                  when the trees are serialized.</p>
+               <p>As well as being potentially significant in any API that provides access to final
+                  result trees, the base URI of the new document node is relevant if the final
+                  result tree, rather than being serialized, is supplied as input to a further
+                  transformation.</p>
+            </note>
+               
+            </div3>
+            
+            <div3 id="id-validating-secondary-results">
+               <head>Validating Secondary Results</head>
+            
+            
+            <p>The optional attributes <code>type</code> and <code>validation</code> may be used on
+               the <elcode>xsl:result-document</elcode> instruction to validate the contents of
+                  a <termref def="dt-final-result-tree"/>, and to determine the <termref def="dt-type-annotation">type
+                  annotation</termref> that elements and attributes within the <termref def="dt-final-result-tree">final result tree</termref> will carry. The permitted
+               values and their semantics are described in <specref ref="validating-document-nodes"/>. Any such validation is applied to the
+               document node produced as the result of <xtermref spec="SE40" ref="sequence-normalization"/>.
+               If sequence normalization does not take place (typically because the <termref def="dt-raw-result"/>
+               is delivered to the application directly, or because the selected serialization method
+               does not involve sequence normalization) then the <code>validation</code> and
+               <code>type</code> attributes are ignored.</p>
+            
+            <note><p>Validation applies after inserting item separators as determined by the
+               <code>item-separator</code> serialization parameter, and an inappropriate choice
+               of <code>item-separator</code> may cause the result to become invalid.</p></note>
+               
+            </div3>
+            
+            <div3 id="id-serializing-secondary-results">
+               <head>Serializing Secondary Results</head>
+            
+            <p>A <termref def="dt-processor">processor</termref>
+               <rfc2119>may</rfc2119> allow a <termref def="dt-final-result-tree">final result
+                  tree</termref> to be serialized. Serialization is described in <specref ref="serialization"/>.
+               The instruction may optionally specify the output format to be used for serializing the result.
+            </p>
+               
+            <p>However, an implementation is not <rfc2119>required</rfc2119> to support the serialization
+               of <termref def="dt-final-result-tree">final result trees</termref>. An
+               implementation that does not support the serialization of final result trees
+                  <rfc2119>may</rfc2119> ignore the <code>format</code> attribute and the
+               serialization attributes. Such an implementation <rfc2119>must</rfc2119> provide the
+               application with some means of access to the (un-serialized) result tree, using its
+               URI to identify it.</p>
+            
+            <p>The <termref def="dt-effective-value"/> of the
+                  <code>format</code> attribute, if specified, <rfc2119>must</rfc2119> be an <termref def="dt-eqname">EQName</termref>. The value is
+               expanded using the namespace declarations in scope for the
+                  <elcode>xsl:result-document</elcode> element. The resulting <termref def="dt-expanded-qname">expanded QName</termref>
+               <rfc2119>must</rfc2119> match the expanded QName of a named <termref def="dt-output-definition">output definition</termref> in the <termref def="dt-stylesheet">stylesheet</termref>. This identifies the
+                  <elcode>xsl:output</elcode> declaration that will control the serialization of the
+                  <termref def="dt-final-result-tree">final result tree</termref> (see <specref ref="serialization"/>), if the result tree is serialized. If the
+                  <code>format</code> attribute is omitted, the unnamed <termref def="dt-output-definition">output definition</termref> is used to control
+               serialization of the result tree.</p>
+            <p>
+               <error spec="XT" type="dynamic" class="DE" code="1460">
+                  <p>It is a <termref def="dt-dynamic-error"> dynamic error</termref> if the <termref def="dt-effective-value"/> of the
+                        <code>format</code> attribute <error.extra>of an
+                           <elcode>xsl:result-document</elcode> element</error.extra> is not a valid
+                        <termref def="dt-eqname">EQName</termref>, or if it does not match the
+                        <termref def="dt-expanded-qname">expanded QName</termref> of an <termref def="dt-output-definition">output definition</termref> in the containing <termref def="dt-package">package</termref>. If the processor is able to detect
+                     the error statically (for example, when the <code>format</code> attribute
+                     contains no curly brackets), then the processor <rfc2119>may</rfc2119>
+                     optionally raise this as a <termref def="dt-static-error">static
+                        error</termref>.</p>
+               </error>
+            </p>
+            <note>
+               <p>The only way to select the unnamed <termref def="dt-output-definition">output
+                     definition</termref> is to omit the <code>format</code> attribute.</p>
+            </note>
+            <p>The <code>parameter-document</code> attribute allows serialization
+               parameters to be supplied in an external document. The external document must contain
+               an <code>output:serialization-parameters</code> element with the format described in
+                  <xspecref spec="SE40" ref="serparams-in-xdm-instance"/>, and the parameters are
+               interpreted as described in that specification.</p>
+            <p>If present, the <termref def="dt-effective-value"/> of the URI supplied in the
+                  <code>parameter-document</code> attribute is dereferenced, after resolution
+               against the base URI of the <elcode>xsl:result-document</elcode> element if it is a
+               relative reference. 
+               The parameter document <rfc2119>should</rfc2119> be read during run-time evaluation of the stylesheet. 
+               If the location of the stylesheet at development time is
+               different from the deployed location, any relative reference should be resolved
+               against the deployed location. A serialization error occurs if the result of
+               dereferencing the URI is ill-formed or invalid; but if no document can be found at
+               the specified location, the attribute <code>should</code> be ignored.</p>
+            <p>A serialization parameter specified in the
+                  <code>parameter-document</code> takes precedence over a value supplied directly as
+               an attribute of <elcode>xsl:result-document</elcode>, which in turn takes precedence
+               over a value supplied in the selected output definition, except that the values of
+               the <code>cdata-section-elements</code> and <code>suppress-indentation</code>
+               attributes are merged in the same way as when multiple <elcode>xsl:output</elcode>
+               declarations are merged.</p>
+            <p>The attributes <code>method</code>, <code>allow-duplicate-names</code>, <code>build-tree</code>, <code>byte-order-mark</code>,
+               <code>canonical</code>, <code>cdata-section-elements</code>,
+               <code diff="add" at="2026-07-02">csv-header</code>, <code diff="add" at="2026-07-02">csv-quote-character</code>,
+               <code diff="add" at="2026-07-02">csv-separator</code>, <code>doctype-public</code>,
+                  <code>doctype-system</code>, <code>encoding</code>,
+               <code diff="add" at="2023-03-31">escape-solidus</code>,
+                  <code>escape-uri-attributes</code>, <code>html-version</code>, <code>indent</code>, <code diff="add" at="2026-06-25">indent-attributes</code>, <code diff="add" at="2026-06-25">indent-unit</code>, <code>item-separator</code>,
+               <code diff="add" at="2024-11-01">json-lines</code>,
+               <code>json-node-output-method</code>,
+                  <code diff="add" at="2026-06-25">line-ending</code>, <code>media-type</code>, <code>normalization-form</code>,
+                  <code>omit-xml-declaration</code>, <code>standalone</code>, <code>suppress-indentation</code>,
+               <!-- see bug 6535 -->
+               <code>undeclare-prefixes</code>, <code>use-character-maps</code>, and
+                  <code>output-version</code> may be used to override attributes defined in the
+               selected <termref def="dt-output-definition">output definition</termref>.</p>
+            <p>With the exception of <code>use-character-maps</code>, these attributes are all
+               defined as <termref def="dt-attribute-value-template">attribute value
+                  templates</termref>, so their values may be set dynamically. For any of these
+               attributes that is present on the <elcode>xsl:result-document</elcode> instruction,
+               the <termref def="dt-effective-value"/> of the attribute
+               overrides or supplements the corresponding value from the output definition. This
+               works in the same way as when one <elcode>xsl:output</elcode> declaration overrides
+               another. Some of the attributes have more specific
+                  rules:</p>
+            <ulist>
+               <item>
+                  <p>In the case of <code>cdata-section-elements</code>
+                     and <code>suppress-indentation</code>, the
+                     value of the serialization parameter is the union of the expanded names of the
+                     elements named in this instruction and the elements named in the selected
+                     output definition.</p>
+               </item>
+               <item>
+                  <p>In the case of <code>use-character-maps</code>, the character maps referenced
+                     in this instruction supplement and take precedence over those defined in the
+                     selected output definition.</p>
+               </item>
+               <item>
+                  <p>In the case of <code>doctype-public</code> and <code>doctype-system</code>,
+                     setting the <termref def="dt-effective-value"/> of the attribute to a zero-length string has the
+                     effect of overriding any value for these attributes obtained from the output
+                     definition. The corresponding serialization parameter is not set (is
+                     “absent”).</p>
+               </item>
+               <item>
+                  <p>In the case of <code>item-separator</code>, setting the <termref def="dt-effective-value"/> of the
+                     attribute to the special value <code>"#absent"</code> has the effect of
+                     overriding any value for this attribute obtained from the output definition.
+                     The corresponding serialization parameter is not set (is “absent”). It is not
+                     possible to set the value of the serialization parameter to the literal
+                     7-character string <code>"#absent"</code>. </p>
+               </item>
+               <item>
+                  <p>In all other cases, the <termref def="dt-effective-value"/> of an attribute actually present on
+                     this instruction takes precedence over the value defined in the selected output
+                     definition.</p>
+               </item>
+            </ulist>
+            
+               <p>In the case of the attributes <code>method</code>, <code>json-node-output-method</code>,
+                     <code>cdata-section-elements</code>, <code>suppress-indentation</code>, and
+                     <code>use-character-maps</code>, the <termref def="dt-effective-value"/> of the attribute
+                  contains an <termref def="dt-eqname">EQName</termref> or a space-separated list of
+                     <termref def="dt-eqname">EQNames</termref>. Where lexical QNames are used in these attributes (whether prefixed
+               or unprefixed), the namespace context is established in the same way as for the corresponding
+               attributes of <elcode>xsl:output</elcode>: see <specref ref="id-default-serialization-parameters"/>.</p>
+            
+            <p>The <code>output-version</code> attribute on the <elcode>xsl:result-document</elcode>
+               instruction overrides the <code>version</code> attribute on
+                  <elcode>xsl:output</elcode> (it has been renamed because <code>version</code> is
+               available with a different meaning as a standard attribute: see <specref ref="standard-attributes"/>). In all other cases, attributes correspond if they
+               have the same name.</p>
+            <p>There are some serialization parameters that apply to some output methods but not to
+               others. For example, the <code>indent</code> attribute has no effect on the
+                  <code>text</code> output method. If a value is supplied for an attribute that is
+               inapplicable to the output method, its value is not passed to the serializer. The
+               processor <rfc2119>may</rfc2119> validate the value of such an attribute, but is not
+                  <rfc2119>required</rfc2119> to do so.</p>
+            
+            <p>The <code>item-separator</code> serialization parameter
+               is used when the <termref def="dt-raw-result"/> is used to construct a result tree
+               by applying sequence normalization, and it is also used when the result tree is
+               serialized. For example, if the sequence constructor delivers a sequence of
+               integers, and the <code>text</code> serialization method is used, then the result of serialization
+               will be a string obtained by converting each integer to a string, and separating the
+               strings using the defined <code>item-separator</code>.</p>
+            
+            </div3>
+            
+            
+            <div3 id="result-document-example">
+               <head>Result Document Example</head>
+            
+               
+               <example>
+                  <head>Multiple Result Documents</head>
+                  <p> The following example takes an XHTML document as input, and breaks it up so that
+                     the text following each &lt;h1&gt; element is included in a separate document. A
+                     new document <code>toc.html</code> is constructed to act as an index:</p>
+                  <eg role="xslt-document" xml:space="preserve">&lt;xsl:stylesheet
+   	version="4.0"
+   	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+   	xmlns:xhtml="http://www.w3.org/1999/xhtml"&gt;
+   	
+   &lt;xsl:output name="toc-format" method="xhtml" indent="yes"
+        doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"
+        doctype-public="-//W3C//DTD XHTML 1.0 Strict//EN"/&gt;
+               
+   &lt;xsl:output name="section-format" method="xhtml" indent="no"
+        doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"
+        doctype-public="-//W3C//DTD XHTML 1.0 Transitional//EN"/&gt;	
+   	 
+   &lt;xsl:template match="/"&gt;
+     &lt;xsl:result-document href="toc.html" 
+                          format="toc-format" 
+                          validation="strict"&gt;
+       &lt;html xmlns="http://www.w3.org/1999/xhtml"&gt;
+         &lt;head&gt;&lt;title&gt;Table of Contents&lt;/title&gt;&lt;/head&gt;
+         &lt;body&gt;
+           &lt;h1&gt;Table of Contents&lt;/h1&gt;
+           &lt;xsl:for-each select="/*/xhtml:body/(*[1] | xhtml:h1)"&gt;
+             &lt;p&gt;
+               &lt;a href="section{position()}.html"&gt;
+                 &lt;xsl:value-of select="."/&gt;
+               &lt;/a&gt;
+             &lt;/p&gt;
+           &lt;/xsl:for-each&gt;
+         &lt;/body&gt;
+       &lt;/html&gt;
+     &lt;/xsl:result-document&gt;
+     &lt;xsl:for-each-group select="/*/xhtml:body/*" group-starting-with="xhtml:h1"&gt;
+       &lt;xsl:result-document href="section{position()}.html" 
+                            format="section-format" validation="strip"&gt;  	
+         &lt;html xmlns="http://www.w3.org/1999/xhtml"&gt;
+           &lt;head&gt;&lt;title&gt;&lt;xsl:value-of select="."/&gt;&lt;/title&gt;&lt;/head&gt;
+           &lt;body&gt;
+             &lt;xsl:copy-of select="current-group()"/&gt;
+           &lt;/body&gt;
+         &lt;/html&gt;
+       &lt;/xsl:result-document&gt;
+     &lt;/xsl:for-each-group&gt;
+   &lt;/xsl:template&gt;
+   
+   &lt;/xsl:stylesheet&gt;</eg>
+               </example>
+            </div3>
+         
+         <div3 id="result-document-restrictions">
+            <head>Restrictions on the use of <elcode>xsl:result-document</elcode></head>
+            <p>There are restrictions on the use of the <elcode>xsl:result-document</elcode>
+               instruction, designed to ensure that the results are fully interoperable even when
+               processors optimize the sequence in which instructions are evaluated. Informally, the
+               restriction is that the <elcode>xsl:result-document</elcode> instruction can only be
+               used while writing a final result tree, not while writing to a temporary tree or a
+               sequence. This restriction is defined formally as follows.</p>
+            <p>
+               <termdef id="dt-output-state" term="output state">Each instruction in the <termref def="dt-stylesheet">stylesheet</termref> is evaluated in one of two possible
+                     <term>output states</term>: <termref def="dt-final-output-state">final output
+                     state</termref> or <termref def="dt-temporary-output-state">temporary output
+                     state</termref>.</termdef></p>
+            <p>
+               <termdef id="dt-final-output-state" term="final output state">The first of the two
+                     <termref def="dt-output-state">output states</termref> is called <term>final
+                     output</term> state. This state applies when instructions are writing to a
+                     <termref def="dt-final-result-tree">final result tree</termref>.</termdef>
+            </p>
+            <p>
+               <termdef id="dt-temporary-output-state" term="temporary output state">The second of
+                  the two <termref def="dt-output-state">output states</termref> is called
+                     <term>temporary output</term> state. This state applies when instructions are
+                  writing to a <termref def="dt-temporary-tree">temporary tree</termref> or any
+                  other non-final destination.</termdef>
+            </p>
+            <p>The instructions in the <termref def="dt-initial-named-template"/> are evaluated in
+                  <termref def="dt-final-output-state">final output state</termref>. An instruction
+               is evaluated in the same <termref def="dt-output-state">output state</termref> as its
+               calling instruction, except that <elcode>xsl:variable</elcode>,
+                  <elcode>xsl:param</elcode>, <elcode>xsl:with-param</elcode>, 
+               <elcode>xsl:function</elcode>, <elcode>xsl:key</elcode>, <elcode>xsl:sort</elcode>,
+                  <elcode>xsl:accumulator-rule</elcode>, and
+                     <elcode>xsl:merge-key</elcode>
+                always evaluate the instructions in their
+               contained <termref def="dt-sequence-constructor">sequence constructor</termref> in
+                  <termref def="dt-temporary-output-state">temporary output state</termref>.</p>
+            <p>
+               <error spec="XT" type="dynamic" class="DE" code="1480">
+                  <p>It is a <termref def="dt-dynamic-error"> dynamic error</termref> to evaluate the
+                        <elcode>xsl:result-document</elcode> instruction in <termref def="dt-temporary-output-state">temporary output state</termref>.</p>
+               </error>
+            </p>
+            <p>
+               <error spec="XT" type="dynamic" class="DE" code="1490">
+                  <p>It is a <termref def="dt-dynamic-error"> dynamic error</termref> for a transformation to
+                     generate two or more <termref def="dt-final-result-tree">final result
+                        trees</termref> with the same URI.</p>
+               </error>
+            </p>
+            <note>
+               <p>Note, this means that it is an error to evaluate more than one
+                     <elcode>xsl:result-document</elcode> instruction that omits the
+                     <code>href</code> attribute, or to evaluate any
+                     <elcode>xsl:result-document</elcode> instruction that omits the
+                     <code>href</code> attribute if an initial <termref def="dt-final-result-tree">final result tree</termref> is created implicitly.</p>
+            </note>
+            <p>In addition, an implementation <rfc2119>may</rfc2119> raise this
+               error if it is able to detect that two or more final result trees are generated with
+               different URIs that refer to the same physical resource.</p>
+
+
+            
+            <p>
+               <error spec="XT" type="dynamic" class="DE" code="1500">
+                  <p>It is a <termref def="dt-dynamic-error"> dynamic error</termref> for a <termref def="dt-stylesheet">stylesheet</termref> to write to an external resource
+                     and read from the same resource during a single transformation, if the same absolute URI is used to access the resource in
+                        both cases. </p>
+               </error>
+            </p>
+            <p>In addition, an implementation <rfc2119>may</rfc2119> raise this
+               error if it is able to detect that a transformation writes to a resource and reads
+               from the same resource using different URIs that refer to the same physical resource.
+               Note that if the error is not detected, it is <termref def="dt-implementation-dependent"/> whether the document that is read from the
+               resource reflects its state before or after the result tree is written.</p>
+         </div3>
          </div2>
+         <div2 id="current-output-uri">
+            <head>The Current Output URI</head>
+            <p><termdef id="dt-current-output-uri" term="current output URI">The <term>current output URI</term> is the URI
+                  associated with the <termref def="dt-principal-result"/> or <termref def="dt-secondary-result"/> that is currently being written.</termdef></p>
+            <div3 id="func-current-output-uri">
+               <head><?function fn:current-output-uri?></head>
+
+            </div3>
+         </div2>
+
+
+         
       </div1>
       <div1 id="conformance">
          <head>Conformance</head>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -30153,8 +30153,7 @@ the same group, and the-->
             </div3>
          </div2>
       </div1>
-      
-      =================
+
       <div1 id="validation">
             <head>Validation</head>
             


### PR DESCRIPTION
Fix #2073

Supersedes #2160 

This proposal solves the problem of representing JTrees containing sequences of more than one item by introducing an extra JNode for such sequences, called a sequence JNode. The children of a sequence JNode represent the items in the sequence, and their jkey property represents the position of the item in the sequence. This eliminates the need for the jposition property. Navigating trees containing sequence JNodes is awkward because the representation of singleton sequences and non-singleton sequences is not uniform; but such trees never arise in JSON structures and we don't have to optimize their usability. The revised design simplifies mainstream use cases involving JSON by eliminating the jposition property.