### PR TITLE
2849 xs:integer vs. restricted subtypes

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -153,14 +153,14 @@
                representation of a node is found.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="line-number" type="xs:positive-integer?">
+      <fos:field name="line-number" type="xs:integer?">
          <fos:meaning>
             <p>Defines the line number within the containing document or external entity at which the lexical representation
   of a node is found. If the lexical representation spans several lines then it is implementation-defined which
   of the relevant line numbers is returned. The first line of a resource is numbered 1 (one)..</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="column-number" type="xs:positive-integer?">
+      <fos:field name="column-number" type="xs:integer?">
          <fos:meaning>
             <p>Defines the column number within the containing document or external entity at which the lexical representation
   of a node is found. Within the range of columns occupied by the lexical representation of a node,
@@ -576,10 +576,10 @@
                   option is <code>true</code>. If there are no data rows in the CSV, the
                   value will be the empty sequence.</p></fos:meaning>
       </fos:field>
-      <fos:field name="get" type="fn($r as xs:positiveInteger, $c as (xs:positiveInteger | xs:string)) as xs:string">
+      <fos:field name="get" type="fn($r as xs:integer, $c as (xs:integer | xs:string)) as xs:string">
          <fos:meaning><p>A function providing ready access to a given field in a given
       row. The <code>get</code> function has signature:</p>
-                     <eg>fn($r as xs:positiveInteger, $c as (xs:positiveInteger | xs:string)) as xs:string</eg>
+                     <eg>fn($r as xs:integer, $c as (xs:integer | xs:string)) as xs:string</eg>
                      <p>The function takes two arguments: <code>$r</code>, an
                      integer giving the row number (1-based), and <code>$c</code>, which
                      identifies a column either by its name or by its 1-based
@@ -599,7 +599,7 @@
                      </gitem>
                      <gitem>
                         <label>Signature</label>
-                        <def><p><code>(xs:positiveInteger, (xs:positiveInteger | xs:string)) => xs:string</code></p></def>
+                        <def><p><code>(xs:integer, (xs:integer | xs:string)) => xs:string</code></p></def>
                      </gitem>
                      <gitem>
                         <label>Non-local variable bindings</label>
@@ -620,12 +620,14 @@
                         <def>
                            <p>The function returns a field in the result.</p>
                            <p>The first argument <code>$r</code> selects a row within the sequence of rows
-                              returned as <var>rows</var> by position (one-based). If the value is out of range for the number
+                              returned as <var>rows</var> by position (one-based). If the value is less than one,
+                              or greater than the number
                               of rows returned, the <code>get</code> function returns a zero-length
                               string.</p>
                            <p>The second argument <code>$c</code> may be either an integer or a string.</p>
                            <p>If <code>$c</code> is an integer then it selects a field within the
-                              selected row by position (one-based). If the value is out of range for the number
+                              selected row by position (one-based). If the value is less than one,
+                              or greater than the number
                               of fields in the selected row, the <code>get</code> function returns a zero-length
                               string.</p>
                            <p>If <code>$c</code> is a string, the string is mapped to an integer using the
@@ -10360,7 +10362,7 @@ satisfies compare($t, replace($token, '^\s*|\s*$', ''), $collation) eq 0
    <fos:function name="unix-dateTime" prefix="fn">
       <fos:signatures>
          <fos:proto name="unix-dateTime" return-type="xs:dateTimeStamp">
-            <fos:arg name="value" type="xs:nonNegativeInteger?" default="0" note="default-on-empty"/>
+            <fos:arg name="value" type="xs:integer?" default="0" note="default-on-empty"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -10387,6 +10389,7 @@ xs:dateTime('1970-01-01T00:00:00Z') + ($value otherwise 0) * seconds(0.001)
             is used for computing the Unix time.</p>
          <p>Note that Unix time does not account for leap seconds. It assumes that every day has
             86,400 seconds.</p>
+         <p>A negative value denotes an instant before <code>1970-01-01T00:00:00Z</code>.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -10403,8 +10406,12 @@ xs:dateTime('1970-01-01T00:00:00Z') + ($value otherwise 0) * seconds(0.001)
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression><eg>unix-dateTime(86400000)</eg></fos:expression>
+               <fos:expression><eg>unix-dateTime(1000 * 60 * 60 * 24)</eg></fos:expression>
                <fos:result>xs:dateTime('1970-01-02T00:00:00Z')</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>unix-dateTime(-1000 * 60 * 60 * 24)</eg></fos:expression>
+               <fos:result>xs:dateTime('1969-12-31T00:00:00Z')</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -10415,6 +10422,8 @@ return ($value - unix-dateTime()) div seconds(0.001)</eg>
       </fos:examples>
       <fos:changes>
          <fos:change issue="959" PR="1358" date="2024-08-01"><p>New in 4.0</p></fos:change>
+         <fos:change issue="2849"><p>Changed the type of <code>$value</code> to <code>xs:integer?</code>,
+            allowing instants before 1970.</p></fos:change>
       </fos:changes>
    </fos:function>
 
@@ -16373,7 +16382,7 @@ filter($input, fn($item, $pos) { $pos ne count($input) })
       <fos:signatures>
          <fos:proto name="replicate" return-type="item()*">
             <fos:arg name="input" type="item()*" usage="navigation"/>
-            <fos:arg name="count" type="xs:nonNegativeInteger"/>
+            <fos:arg name="count" type="xs:integer"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -16392,8 +16401,7 @@ for-each(1 to $count, fn($item, $pos) { $input })
       </fos:equivalent>
       <fos:notes>
          <p>If <code>$input</code> is the empty sequence, the empty sequence is returned.</p>
-         <p>The <code>$count</code> argument is declared as <code>xs:nonNegativeInteger</code>,
-         which means that a type error occurs if it is called with a negative value.</p>
+         <p>If <code>$count</code> is zero or negative, the empty sequence is returned.</p>
          <p>If the input sequence contains nodes, these are not copied: instead, the result sequence contains
          multiple references to the same node. So, for example, <code>fn:count(fn:replicate(/, 6)|())</code>
          returns <code>1</code>, because the <function>fn:replicate</function> call creates duplicates, and the
@@ -16429,7 +16437,13 @@ for-each(1 to $count, fn($item, $pos) { $input })
                <fos:expression>replicate(("A", "B", "C"), 0)</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
-         </fos:example>        
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression>replicate(("A", "B", "C"), -1)</fos:expression>
+               <fos:result>()</fos:result>
+            </fos:test>
+         </fos:example>
       </fos:examples>
       <fos:changes>
          <fos:change date="2022-10-04"><p>New in 4.0</p></fos:change>
@@ -25184,7 +25198,7 @@ declare function transitive-closure (
       <fos:signatures>
          <fos:proto name="partial-apply" return-type="fn(*)">
             <fos:arg name="function" type="fn(*)" usage="inspection"/>
-            <fos:arg name="arguments" type="map(xs:positiveInteger, item()*)" usage="inspection"/>
+            <fos:arg name="arguments" type="map(xs:integer, item()*)" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -25203,8 +25217,8 @@ declare function transitive-closure (
             and value <code>$v</code> causes the argument at position <code>$i</code> (1-based)
             to be bound to <code>$v</code>.
          </p>
-         <p>Any entries in <code>$arguments</code> whose keys are greater than the arity of
-         <code>$function</code> are ignored.</p>
+         <p>Any entries in <code>$arguments</code> whose keys are less than one, or greater than the arity of
+         <code>$function</code>, are ignored.</p>
          
          <p>If <code>$arguments</code> is the empty map then the function returns <code>$function</code>
          unchanged.</p>
@@ -29551,12 +29565,12 @@ element-to-map-plan((<a><b/><b/></a>, <a><b/><c/></a>))
                   while <code>(1, 5, 4)</code> indicates that the output
                   contains three columns, taken from the first, fifth, and fourth columns of the input,
                   in that order. An integer in the sequence is treated as the 1-based 
-                  index of the column to include. Any other columns are dropped. 
-                  If a particular row includes no field at the specified index,
+                  index of the column to include. Any other columns are dropped.
+                  If the index is less than one, or if a particular row includes no field at that index,
                   the empty field is included at the relevant position in the result. If an integer appears
                   more than once then the result will include duplicated columns.
                </fos:meaning>
-               <fos:type>xs:positiveInteger*</fos:type>
+               <fos:type>xs:integer*</fos:type>
                <fos:default>()</fos:default>
             </fos:option>
             <fos:option key="trim-rows">
@@ -34579,7 +34593,7 @@ return every($dl/*, fn($elem, $pos) {
    <fos:function name="char" prefix="fn">
       <fos:signatures>
          <fos:proto name="char" return-type="xs:string">
-            <fos:arg name="value" type="(xs:string | xs:positiveInteger)"/>
+            <fos:arg name="value" type="(xs:string | xs:integer)"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -34625,8 +34639,9 @@ return every($dl/*, fn($elem, $pos) {
       <fos:errors>
          <p>The function fails with a dynamic error <errorref
                class="CH" code="0005"/> if <code>$value</code> is not a valid
-            representation of a <termref def="dt-permitted-character"/> 
-            or sequence of permitted characters.
+            representation of a <termref def="dt-permitted-character"/>
+            or sequence of permitted characters. This includes the case where
+            <code>$value</code> is an integer that is zero or negative.
          </p>
       </fos:errors>
       <fos:notes>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -8462,11 +8462,10 @@ declare record Particle (
                      
                         <p>This differs from previous versions of this specification, where both these calls would fail.</p>
                         
-                        <p>This change allows function arguments to be defined with a
-                           more precise type. For example, the <code>$value</code> argument of
-                           <function>fn:char</function> is declared as
-                           <code>(xs:string | xs:positiveInteger)</code>, which allows a call such as
-                           <code>char(10)</code> to supply an integer literal.</p>
+                        <p>This change allows function parameters to be declared with a
+                           more precise type. For example, a function whose parameter is declared as
+                           <code>(xs:string | xs:positiveInteger)</code> can be called
+                           supplying an integer literal.</p>
                      </note>
                      <note>
                         <p>If <var>T</var>


### PR DESCRIPTION
In this PR, numeric specific subtypes are changed back to the general `xs:integer` (see #2849 for the rationale).

It also fixes an inconsistency in the CSV rules…

`parsed-csv-structure-record?column-index` was `map(xs:string, xs:integer)` with the prose “column positions (as 1-based positive integers)”, while `?get` in the same record type uses `xs:positiveInteger`.

…and it now allows users to also supply negative input for `fn:unix-dateTime` (similarly: “If the value is out of range …”).