### PR TITLE
2872 Refine supports-dtd option

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19753,12 +19753,16 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                <fos:type>xs:boolean</fos:type>
                <fos:default>false</fos:default>
                <fos:values>
-                  <fos:value value="true">The input is parsed using a validating XML parser.
-                  The input must contain a <code>DOCTYPE</code> declaration to identify
-                  the DTD to be used for validation. The DTD may be internal or external.
+                  <fos:value value="true">The input is parsed using a validating XML parser,
+                     and a dynamic error is reported if there is no
+                     <code>DOCTYPE</code> declaration to identify
+                     the DTD to be used for validation, or if the document is invalid
+                     against the DTD. The DTD may be internal or external. If the processor
+                     does not support DTD validation then it must raise a dynamic error
+                     unconditionally.
                   </fos:value>
                   <fos:value value="false">DTD validation does not take place. However, if a
-                     <code>DOCTYPE</code> declaration is present, then it is read, for example
+                     <code>DOCTYPE</code> declaration is present, then it is read, and is used
                      to perform entity expansion.
                   </fos:value>
                </fos:values>
@@ -21057,8 +21061,8 @@ return { "width": $int16-at($loc + 5),
                   <td><code>#accepts-typed-data</code></td>
                   <td><p><code>xs:boolean</code></p></td>
                   <td><p>Returns <code>true</code> if the processor is capable of handling
-                  nodes with a type annotation other than <code>xs:untyped</code> and <code>xs:untypedAtomic</code>,
-                  or <code>false</code> otherwise.</p></td>
+                  nodes with a type annotation other than <code>xs:untyped</code> and <code>xs:untypedAtomic</code>;
+                  otherwise <code>false</code>.</p></td>
                </tr>
                <tr>
                   <td><code>#supports-xinclude</code></td>
@@ -21068,12 +21072,22 @@ return { "width": $int16-at($loc + 5),
                         </p></td>
                </tr>
                <tr>
-                  <td><code>#supports-dtd</code></td>
+                  <td><code>#supports-dtd-validation</code></td>
                   <td><p><code>xs:boolean</code></p></td>
-                  <td><p>Returns <code>true</code> if the processor fully supports validation, entity expansion,
-                        and attribute typing (recognition of ID and IDREF attributes) based on DTD processing 
-                        during XML parsing. Returns <code>false</code> if there are restrictions, even if some of these 
-                        capabilities are available.</p></td>
+                  <td><p>Returns <code>true</code> if the processor supports DTD-based validation
+                        during XML parsing; specifically if, when the option <code>"dtd-validation":true()</code>
+                        is set on calls to <function>fn:doc</function> and <function>fn:parse-xml</function>,
+                        an invalid document results in a dynamic error. Otherwise returns <code>false</code>.</p></td>
+               </tr>
+               <tr>
+                  <td><code>#supports-dtd-attribute-typing</code></td>
+                  <td><p><code>xs:boolean</code></p></td>
+                  <td><p>Returns <code>true</code> if the processor recognizes ID and IDREF attributes
+                        when processing a source document with DTD-based validation
+                        enabled; specifically, if calls to <function>fn:doc</function> and <function>fn:parse-xml</function>
+                        with the option <code>"dtd-validation":true()</code>
+                        return attribute nodes having the <code>is-id</code> or <code>is-idref</code> properties
+                        where declared as such in the DTD.</p></td>
                </tr>
                <tr>
                   <td><code>#supports-invisible-xml</code></td>
@@ -21290,12 +21304,16 @@ return { "width": $int16-at($loc + 5),
                <fos:type>xs:boolean</fos:type>
                <fos:default>false</fos:default>
                <fos:values>
-                  <fos:value value="true">The input is parsed using a validating XML parser.
-                  The input must contain a <code>DOCTYPE</code> declaration to identify
-                  the DTD to be used for validation. The DTD may be internal or external.
+                  <fos:value value="true">The input is parsed using a validating XML parser,
+                     and a dynamic error is reported if there is no
+                     <code>DOCTYPE</code> declaration to identify
+                     the DTD to be used for validation, or if the document is invalid
+                     against the DTD. The DTD may be internal or external. If the processor
+                     does not support DTD validation then it must raise a dynamic error
+                     unconditionally.
                   </fos:value>
                   <fos:value value="false">DTD validation does not take place. However, if a
-                     <code>DOCTYPE</code> declaration is present, then it is read, for example
+                     <code>DOCTYPE</code> declaration is present, then it is read, and is used
                      to perform entity expansion.
                   </fos:value>
                </fos:values>

--- a/specifications/xslt-40/src/function-catalog.xml
+++ b/specifications/xslt-40/src/function-catalog.xml
@@ -1226,12 +1226,16 @@
                <fos:type>xs:boolean</fos:type>
                <fos:default>false</fos:default>
                <fos:values>
-                  <fos:value value="true">The input is parsed using a validating XML parser.
-                  The input must contain a <code>DOCTYPE</code> declaration to identify
-                  the DTD to be used for validation. The DTD may be internal or external.
+                  <fos:value value="true">The input is parsed using a validating XML parser,
+                     and a dynamic error is reported if there is no
+                     <code>DOCTYPE</code> declaration to identify
+                     the DTD to be used for validation, or if the document is invalid
+                     against the DTD. The DTD may be internal or external. If the processor
+                     does not support DTD validation then it must raise a dynamic error
+                     unconditionally.
                   </fos:value>
                   <fos:value value="false">DTD validation does not take place. However, if a
-                     <code>DOCTYPE</code> declaration is present, then it is read, for example
+                     <code>DOCTYPE</code> declaration is present, then it is read, and is used
                      to perform entity expansion.
                   </fos:value>
                </fos:values>


### PR DESCRIPTION
Splits the supports-dtd option into `supports-dtd-validation` and `supports-dtd-attribute-typing` on the grounds that some commonly used XML parsers (for example the Microsoft .NET parser) support one and not the other.