### PR TITLE
2882 load-xquery-module: clarify handling of default parameters

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -33408,6 +33408,17 @@ declare function array:flatten(
   
          <p>The result of the function is a map
          <var>R</var> with two entries, as defined in <specref ref="load-xquery-module-record"/>.</p>
+         
+         <p>If a function declaration <var>F</var> in the loaded module has optional parameters,
+            the result includes one function item for each permitted arity: for example, if there are
+            four parameters and the last is optional, the result will include two function items corresponding to <code>F#3</code>
+            and <code>F#4</code>. In the lower-arity function item, <code>F#3</code>, the fourth parameter will take its
+            default value. The expression defining the default value is evaluated in the same way as a global
+            variable declared within the loaded module; if this expression invokes <function>fn:current</function>
+            to refer to the context value of the caller, this is taken as a reference to the global context
+            value of the loaded module, as established using the <code>context-value</code> and/or
+            <code>context-item</code> options.
+         </p>
 
          
          <p>The static and dynamic context of the library module are established according to the rules in 
@@ -33483,13 +33494,7 @@ declare function array:flatten(
 
       <fos:notes>
          
-         <p>If a function declaration <var>F</var> in the loaded module declares (say) four parameters of which one is optional,
-            its arity range will be from 3 to 4, so the result will include two function items corresponding to <code>F#3</code>
-            and <code>F#4</code>. In the lower-arity function item, <code>F#3</code>, the fourth parameter will take its
-            default value. If the expression that initializes the default value is context sensitive, the static and dynamic
-            context for its evaluation are the static and dynamic contexts of the <function>fn:load-xquery-module</function>
-            function call itself.
-         </p>
+
          
          <p>As with all other functions in this specification, conformance requirements depend on the host language.
          For example, a host language might specify that provision of this function is optional, or that it is excluded entirely,
@@ -33535,9 +33540,12 @@ return $variables( #Q{http://example.com/dyn}value )</eg></fos:expression>
          <fos:change issue="1329" PR="1333" date="2024-07-22">
             <p>A new option is provided to allow the content of the loaded module to be supplied as a string.</p>
          </fos:change>
-         <fos:change issue="2772" date="2026-08-01">
+         <fos:change issue="2772" PR="2826" date="2026-08-01">
             <p>A <code>context-value</code> option has been added, accepting an arbitrary sequence.
                The <code>context-item</code> option is retained for compatibility.</p>
+         </fos:change>
+         <fos:change issue="2882" date="2026-09-08">
+            <p>The way in which default parameters in function declarations are handled has been clarified.</p>
          </fos:change>
       </fos:changes>
       


### PR DESCRIPTION
Fix #2882