### PR TITLE
2902 Document option trusted => trust-external

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -1557,7 +1557,7 @@
       </fos:notes>
       <fos:see-also prefix="fn" name="base-uri"/>
       <fos:changes>
-         <fos:change issue="2836">
+         <fos:change issue="2836" PR="2839" date="2026-08-16">
             <p>New in 4.0.</p>
          </fos:change>
       </fos:changes>
@@ -20043,16 +20043,23 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             specification. An implementation may provide configuration options designed to retain backwards-compatible
             behavior when no explicit options are supplied.</p>
          </fos:change>
+         <fos:change issue="2047" PR="2213" date="2025-09-26">
+            <p>An option <code>trust-external</code> has been added, to indicate whether documents
+               are allowed to contain references to external entities (including an external DTD).
+               In the interests of security, the option is false by default: this represents 
+               a backwards incompatibility.</p>
+         </fos:change>
          <fos:change issue="2300" date="2026-07-03">
             <p>The determinism rules have been clarified: the guarantee that two calls return the
             same document node is now stated as a normative rule that is conditional on the
             <code>stable</code> option, and the function is explicitly defined to be nondeterministic
             if <code>stable</code> is set to <code>false</code>.</p>
          </fos:change>
-         <fos:change issue="2836">
+         <fos:change issue="2836" PR="2839" date="2026-08-16">
             <p>An option has been added to request that location information (for example, line numbers)
                be maintained.</p>
          </fos:change>
+         
       </fos:changes>
    </fos:function>
    <fos:function name="doc-available" prefix="fn">
@@ -21519,7 +21526,13 @@ return { "width": $int16-at($loc + 5),
          <fos:change issue="748" PR="2013" date="2025-05-20">
             <p>Support for binary input has been added.</p>
          </fos:change>
-         <fos:change issue="2836">
+         <fos:change issue="2047" PR="2213" date="2025-09-26">
+            <p>An option <code>trust-external</code> has been added, to indicate whether documents
+               are allowed to contain references to external entities (including an external DTD).
+               In the interests of security, the option is false by default: this represents 
+               a backwards incompatibility.</p>
+         </fos:change>
+         <fos:change issue="2836" PR="2839" date="2026-08-16">
             <p>An option has been added to request that location information (for example, line numbers)
                be maintained.</p>
          </fos:change>
@@ -21703,7 +21716,7 @@ return { "width": $int16-at($loc + 5),
          <fos:change issue="748" PR="2013" date="2025-05-20">
             <p>Support for binary input has been added.</p>
          </fos:change>
-         <fos:change issue="2836">
+         <fos:change issue="2836" PR="2839" date="2026-08-16">
             <p>An option has been added to request that location information (for example, line numbers)
                be maintained.</p>
          </fos:change>

--- a/specifications/xslt-40/src/function-catalog.xml
+++ b/specifications/xslt-40/src/function-catalog.xml
@@ -1204,7 +1204,7 @@
                      to resolve the URI. Where the first argument supplies an atomic item,
                      the static base URI of the function call is used.</fos:default-description>
             </fos:option>
-            <fos:option key="trusted">
+            <fos:option key="trust-external">
                <fos:meaning>Indicates whether processing the document may cause other
                   external resources to be fetched (including, for example, external entities, an external DTD,
                   or documents referenced using <code>xsi:schemaLocation</code> or
@@ -1493,7 +1493,14 @@
       </fos:notes>
       <fos:changes>
          <fos:change issue="2292"><p>An options parameter has been added.</p></fos:change>
+         <fos:change issue="2292 2902" PR="2419" date="2026-02-03">
+         <p>An option <code>trust-external</code> has been added, to indicate whether documents
+            are allowed to contain references to external entities (including an external DTD).
+            In the interests of security, the option is false by default: this represents 
+            a backwards incompatibility.</p>
+      </fos:change>
       </fos:changes>
+      
    </fos:function>
 
    <fos:function name="unparsed-entity-uri">

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -33217,6 +33217,11 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
                <code>trusted="yes"</code>. An expression that called
                <function>doc</function> or <function>unparsed-text</function>, for example, will
                fail or deliver a different result.</p>
+               
+               <p>Similarly, the <code>trusted-external</code> option of functions such as
+               <function>document</function>, <function>doc</function>, and <function>parse-xml</function>
+               has been added, and defaults to false. This means that a document read using these
+               functions will not be allowed access to external resources such as DTDs.</p>
             </item>
 
             


### PR DESCRIPTION
Fix #2902 

Rename the option "trusted" on fn:document to "trust-external", to align with fn:doc.

Also updates some of the relevant change metadata.